### PR TITLE
solve ukswrand does not generate random numbers

### DIFF
--- a/lib/ukswrand/swrand.c
+++ b/lib/ukswrand/swrand.c
@@ -31,7 +31,6 @@
  */
 #include <string.h>
 #include <uk/swrand.h>
-#include <uk/ctors.h>
 #include <uk/config.h>
 #include <uk/print.h>
 #include <uk/init.h>
@@ -76,7 +75,7 @@ ssize_t uk_swrand_fill_buffer(void *buf, size_t buflen)
 	return buflen;
 }
 
-static void _uk_swrand_ctor(void)
+static int _uk_swrand_init(void)
 {
 	unsigned int i;
 #ifdef CONFIG_LIBUKSWRAND_CHACHA
@@ -92,6 +91,8 @@ static void _uk_swrand_ctor(void)
 		seedv[i] = uk_swrandr_gen_seed32();
 
 	uk_swrand_init_r(&uk_swrand_def, seedc, seedv);
+
+	return seedc;
 }
 
-uk_early_initcall(_uk_swrand_ctor);
+uk_early_initcall(_uk_swrand_init);

--- a/lib/ukswrand/swrand.c
+++ b/lib/ukswrand/swrand.c
@@ -34,6 +34,7 @@
 #include <uk/ctors.h>
 #include <uk/config.h>
 #include <uk/print.h>
+#include <uk/init.h>
 
 __u32 uk_swrandr_gen_seed32(void)
 {
@@ -93,4 +94,4 @@ static void _uk_swrand_ctor(void)
 	uk_swrand_init_r(&uk_swrand_def, seedc, seedv);
 }
 
-UK_CTOR_PRIO(_uk_swrand_ctor, UK_SWRAND_CTOR_PRIO);
+uk_early_initcall(_uk_swrand_ctor);


### PR DESCRIPTION
If you configure ukswrand with the platform timestamp as initial seed, and you'll try to use getrandom function or try to read from /dev/urandom you won't get random numbers. This is because the initialization of the random number generator, which is located in the swrand.c file, is done earlier than the initialization of TSC clock.