### PR TITLE
lib/vfscore: Reduce pread() and pwrite() to their -v() counterparts. 

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -311,25 +311,18 @@ ssize_t pread(int fd, void *buf, size_t count, off_t offset)
 			.iov_base	= buf,
 			.iov_len	= count,
 	};
-	struct vfscore_file *fp;
-	size_t bytes;
-	int error;
+	int bytes;
 
-	error = fget(fd, &fp);
-	if (error)
-		goto out_errno;
+	bytes = preadv(fd, &iov, 1, offset);
+	if (bytes < 0)
+		goto out_error;
 
-	error = sys_read(fp, &iov, 1, offset, &bytes);
-	fdrop(fp);
-
-	if (has_error(error, bytes))
-		goto out_errno;
 	trace_vfs_pread_ret(bytes);
 	return bytes;
 
-	out_errno:
-	trace_vfs_pread_err(error);
-	errno = error;
+out_errno:
+	trace_vfs_pread_err(bytes);
+	errno = bytes;
 	return -1;
 }
 
@@ -382,25 +375,16 @@ ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset)
 			.iov_base	= (void *)buf,
 			.iov_len	= count,
 	};
-	struct vfscore_file *fp;
-	size_t bytes;
-	int error;
+	int bytes;
 
-	error = fget(fd, &fp);
-	if (error)
-		goto out_errno;
+	bytes = pwritev(fd, &iov, 1, offset);
 
-	error = sys_write(fp, &iov, 1, offset, &bytes);
-	fdrop(fp);
-
-	if (has_error(error, bytes))
-		goto out_errno;
 	trace_vfs_pwrite_ret(bytes);
 	return bytes;
 
-	out_errno:
-	trace_vfs_pwrite_err(error);
-	errno = error;
+out_errno:
+	trace_vfs_pwrite_err(bytes);
+	errno = bytes;
 	return -1;
 }
 


### PR DESCRIPTION
This commit series reorganizes the `pread()` and `pwrite()` method such that they rely on `preadv()` and `pwritev()`, respectively.  This is due the overlap in functionality, where `pread()` and `pwrite()` simply create a struct iovec method 
which is to be passed in their relevant `sys_` method.

In addition to this, it discards the `has_error` method in favour of in-line checks against the file descriptor.  In BSD's internal implementation, the error is simply passed upwards from `dofilewrite` and `dofileread`.  Additionally, the `has_error` method would return a false positive in the circumstance where an error was non-zero and did not constitute a EWOULDBLOCK or EINTR and the number of bytes read was greater than zero.  This scenario was discovered when a buffer greater than the number of bytes available was read from a vnop read op which returns the number of bytes read (as per POSIX requirements).

Additional checks inline with FreeBSD's[0][1] implementation are for whether the fd is seekable; the offset of the file is non-zero; and, the file type is not a character device.

0: https://github.com/freebsd/freebsd/blob/6af4a8cb884975f65a51b3b6d766e084faf55d4f/sys/kern/sys_generic.c#L320
1: https://github.com/freebsd/freebsd/blob/6af4a8cb884975f65a51b3b6d766e084faf55d4f/sys/kern/sys_generic.c#L522