### PR TITLE
lib/uktime: Register `nanosleep` to syscall_shim

### DIFF
--- a/lib/uktime/Makefile.uk
+++ b/lib/uktime/Makefile.uk
@@ -13,4 +13,5 @@ LIBUKTIME_SRCS-y += $(LIBUKTIME_BASE)/musl-imported/src/__year_to_secs.c
 LIBUKTIME_SRCS-y += $(LIBUKTIME_BASE)/time.c
 LIBUKTIME_SRCS-y += $(LIBUKTIME_BASE)/timer.c
 
+UK_PROVIDED_SYSCALLS-$(CONFIG_LIBUKTIME) += nanosleep-2
 UK_PROVIDED_SYSCALLS-$(CONFIG_LIBUKTIME) += clock_gettime-2

--- a/lib/uktime/exportsyms.uk
+++ b/lib/uktime/exportsyms.uk
@@ -5,6 +5,8 @@ uk_syscall_r_clock_gettime
 clock_settime
 gettimeofday
 nanosleep
+uk_syscall_e_nanosleep
+uk_syscall_r_nanosleep
 setitimer
 sleep
 timegm

--- a/lib/uktime/time.c
+++ b/lib/uktime/time.c
@@ -70,7 +70,7 @@ static void __spin_wait(__nsec nsec)
 }
 #endif
 
-int nanosleep(const struct timespec *req, struct timespec *rem)
+UK_SYSCALL_DEFINE(int, nanosleep, const struct timespec*, req, struct timespec*, rem)
 {
 	__nsec before, after, diff, nsec;
 


### PR DESCRIPTION
Register `nanosleep` system call to syscall_shim library.

Signed-off-by: Sergiu Moga <sergiu.moga@protonmail.com>