### PR TITLE
lib/vfscore: Fix goto label issues in preadv() and pwritev()

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -301,7 +301,7 @@ ssize_t pread(int fd, void *buf, size_t count, off_t offset)
 
 	bytes = preadv(fd, &iov, 1, offset);
 	if (bytes < 0)
-		goto out_error;
+		goto out_errno;
 
 	trace_vfs_pread_ret(bytes);
 	return bytes;

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -390,6 +390,8 @@ ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset)
 	int bytes;
 
 	bytes = pwritev(fd, &iov, 1, offset);
+	if (bytes < 0)
+		goto out_errno;
 
 	trace_vfs_pwrite_ret(bytes);
 	return bytes;


### PR DESCRIPTION
There are two issues fixed by the two commits:
* The `out_error` label used in `preadv()` in `lib/vfscore/main.c` is not properly named. It should be `out_errno`.
* The `out_errno` label in `pwrite()` is unused.

Signed-off-by: Razvan Deaconescu <razvan.deaconescu@cs.pub.ro>