### PR TITLE
support: Explicitly dictate use of libdl for KConfig menu.

### DIFF
--- a/support/kconfig/Makefile.br
+++ b/support/kconfig/Makefile.br
@@ -42,7 +42,7 @@ host-cobjs := $(addprefix $(obj)/,$(host-cobjs))
 host-cxxobjs := $(addprefix $(obj)/,$(host-cxxobjs))
 fixdep-objs := $(obj)/fixdep.o
 
-HOST_EXTRACFLAGS += -I$(src) -I$(obj) -DCONFIG_=\"\"
+HOST_EXTRACFLAGS += -ldl -I$(src) -I$(obj) -DCONFIG_=\"\"
 
 _hostc_flags = $(HOSTCFLAGS) $(HOST_EXTRACFLAGS) $(HOSTCFLAGS_$(basetarget).o)
 _hostcxx_flags = $(HOSTCXXFLAGS) $(HOST_EXTRACFLAGS) $(HOSTCXXFLAGS_$(basetarget).o)


### PR DESCRIPTION
Without such flag can result in the following error via `make menuconfig`:

```
make: Entering directory '/usr/src/unikraft/unikraft'
  LN      Makefile
mkdir -p /usr/src/unikraft/apps/helloworld/build/kconfig/lxdialog
make --no-print-directory CC="/bin/gcc" HOSTCC="/bin/gcc" \
    obj=/usr/src/unikraft/apps/helloworld/build/kconfig -C /usr/src/unikraft/unikraft/support/kconfig -f Makefile.br /usr/
src/unikraft/apps/helloworld/build/kconfig/mconf
/bin/gcc -I. -I/usr/src/unikraft/apps/helloworld/build/kconfig -DCONFIG_=\"\"   -c fixdep.c -o /usr/src/unikraft/apps/helloworld/build/kconfig/fixdep.o
/bin/gcc -I. -I/usr/src/unikraft/apps/helloworld/build/kconfig -DCONFIG_=\"\"   /usr/src/unikraft/apps/helloworld/build/kconfig/fixdep.o -o /usr/src/unikraft/apps/helloworld/build/kconfig/fixdep
  UPD     /usr/src/unikraft/apps/helloworld/build/kconfig/mconf-cfg
/bin/ld: warning: libdl.so.2, needed by /bin/../lib/gcc/x86_64-linux-gnu/9.2.0/../../../x86_64-linux-gnu/libncursesw.so.6, not found (try using -rpath or -rpath-link)
/bin/ld: /bin/../lib/gcc/x86_64-linux-gnu/9.2.0/../../../x86_64-linux-gnu/libncursesw.so.6: undefined reference to `dlopen@GLIBC_2.2.5'
/bin/ld: /bin/../lib/gcc/x86_64-linux-gnu/9.2.0/../../../x86_64-linux-gnu/libncursesw.so.6: undefined reference to `dlclose@GLIBC_2.2.5'
/bin/ld: /bin/../lib/gcc/x86_64-linux-gnu/9.2.0/../../../x86_64-linux-gnu/libncursesw.so.6: undefined reference to `dlsym@GLIBC_2.2.5'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile.br:77: /usr/src/unikraft/apps/helloworld/build/kconfig/mconf] Error 1
make[1]: *** [/usr/src/unikraft/apps/helloworld/build/Makefile:746: /usr/src/unikraft/apps/helloworld/build/kconfig/mconf] Error 2
make: *** [Makefile:974: sub-make] Error 2
make: Leaving directory '/usr/src/unikraft/unikraft'
```

This is simply a more explicit indication to use said library.

Signed-off-by: Alexander Jung <a.jung@lancs.ac.uk>