### PR TITLE
vfscore: Verbose reasoning on rootfs mount error

### DIFF
--- a/lib/vfscore/rootfs.c
+++ b/lib/vfscore/rootfs.c
@@ -82,7 +82,7 @@ static int vfscore_rootfs(void)
 
 	uk_pr_info("Mount %s to /...\n", rootfs);
 	if (mount(rootdev, "/", rootfs, rootflags, rootopts) != 0) {
-		uk_pr_crit("Failed to mount /: %d\n", errno);
+		uk_pr_crit("Failed to mount %s (%s) at /: %d\n", rootdev, rootfs, errno);
 		return -1;
 	}
 


### PR DESCRIPTION
I kept on having to check the difference between `rootdev` and `rootfs`,
this provided me with some sanity when instantiating the unikernel.

Signed-off-by: Alexander Jung <a.jung@lancs.ac.uk>