### PR TITLE
lib/vfscore: Split readv/write from preadv/pwritev

### DIFF
--- a/lib/vfscore/include/vfscore/file.h
+++ b/lib/vfscore/include/vfscore/file.h
@@ -46,7 +46,7 @@ extern "C" {
 
 struct vfscore_file;
 
-/* Set this flag if vfs should NOt handle POSition for this file. The
+/* Set this flag if vfs should not handle position for this file. The
  * file is not seek-able, updating f_offset does not make sense for
  * it */
 #define UK_VFSCORE_NOPOS ((int) (1 << 0))

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -337,7 +337,7 @@ UK_SYSCALL_R_DEFINE(ssize_t, preadv, int, fd, const struct iovec*, iov,
 		goto out_error;
 
 	/* Check if the file is indeed seekable. */
-	if (!(fp->f_vfs_flags & UK_VFSCORE_NOPOS)) {
+	if (fp->f_vfs_flags & UK_VFSCORE_NOPOS) {
 		error = ESPIPE;
 		goto out_error_fdrop;
 	}
@@ -427,7 +427,7 @@ UK_SYSCALL_R_DEFINE(ssize_t, pwritev, int, fd, const struct iovec*, iov,
 		goto out_error;
 
 	/* Check if the file is indeed seekable. */
-	if (!(fp->f_vfs_flags & UK_VFSCORE_NOPOS)) {
+	if (fp->f_vfs_flags & UK_VFSCORE_NOPOS) {
 		error = ESPIPE;
 		goto out_error_fdrop;
 	}


### PR DESCRIPTION
The patch series split the readv/writev implementation
from preadv/pwritev. We split them up to separate the
different error checks required on the different flavors
of read/write call. The patch also make it consistent on
the different patches of the read/write to return negative
error values and let the syscall shim library to the conversion
of error value to appropriate errno values.

Change in V1
- lib/vfscore: UK_VFSCORE_NOPOS flag to check seek
- lib/vfscore: Perform readv and writev operations
- lib/vfscore: Implement readv and writev
- lib/vfscore: Neg error and use UK_SYSCALL_R_DEFINE
