### PR TITLE
lib/*: Change `libc-style` syscalls to their `raw` variant

### DIFF
--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -225,44 +225,39 @@ UK_SYSCALL_R_DEFINE(pid_t, getppid)
 	return UNIKRAFT_PPID;
 }
 
-UK_SYSCALL_DEFINE(pid_t, setsid)
+UK_SYSCALL_R_DEFINE(pid_t, setsid)
 {
 	/* We have a single "session" with a single "process" */
-	errno = EPERM;
-	return (pid_t) -1;
+	return (pid_t) -EPERM;
 }
 
-UK_SYSCALL_DEFINE(pid_t, getsid, pid_t, pid)
+UK_SYSCALL_R_DEFINE(pid_t, getsid, pid_t, pid)
 {
 	if (pid != 0) {
 		/* We support only calls for the only calling "process" */
-		errno = ESRCH;
-		return (pid_t) -1;
+		return (pid_t) -ESRCH;
 	}
 	return UNIKRAFT_SID;
 }
 
-UK_SYSCALL_DEFINE(int, setpgid, pid_t, pid, pid_t, pgid)
+UK_SYSCALL_R_DEFINE(int, setpgid, pid_t, pid, pid_t, pgid)
 {
 	if (pid != 0) {
 		/* We support only calls for the only calling "process" */
-		errno = ESRCH;
-		return (pid_t) -1;
+		return (pid_t) -ESRCH;
 	}
 	if (pgid != 0) {
 		/* We have a single "group" with a single "process" */
-		errno = EPERM;
-		return (pid_t) -1;
+		return (pid_t) -EPERM;
 	}
 	return 0;
 }
 
-UK_SYSCALL_DEFINE(pid_t, getpgid, pid_t, pid)
+UK_SYSCALL_R_DEFINE(pid_t, getpgid, pid_t, pid)
 {
 	if (pid != 0) {
 		/* We support only calls for the only calling "process" */
-		errno = ESRCH;
-		return (pid_t) -1;
+		return (pid_t) -ESRCH;
 	}
 	return UNIKRAFT_PGID;
 }
@@ -300,7 +295,7 @@ int nice(int inc __unused)
 	return -1;
 }
 
-UK_SYSCALL_DEFINE(int, getpriority, int, which, id_t, who)
+UK_SYSCALL_R_DEFINE(int, getpriority, int, which, id_t, who)
 {
 	int rc = 0;
 
@@ -312,20 +307,18 @@ UK_SYSCALL_DEFINE(int, getpriority, int, which, id_t, who)
 			/* Allow only for the calling "process" */
 			rc = UNIKRAFT_PROCESS_PRIO;
 		else {
-			errno = ESRCH;
-			rc = -1;
+			rc = -ESRCH;
 		}
 		break;
 	default:
-		errno = EINVAL;
-		rc = -1;
+		rc = -EINVAL;
 		break;
 	}
 
 	return rc;
 }
 
-UK_SYSCALL_DEFINE(int, setpriority, int, which, id_t, who, int, prio)
+UK_SYSCALL_R_DEFINE(int, setpriority, int, which, id_t, who, int, prio)
 {
 	int rc = 0;
 
@@ -337,17 +330,14 @@ UK_SYSCALL_DEFINE(int, setpriority, int, which, id_t, who, int, prio)
 			/* Allow only for the calling "process" */
 			if (prio != UNIKRAFT_PROCESS_PRIO) {
 				/* Allow setting only the default prio */
-				errno = EACCES;
-				rc = -1;
+				rc = -EACCES;
 			}
 		} else {
-			errno = ESRCH;
-			rc = -1;
+			rc = -ESRCH;
 		}
 		break;
 default:
-		errno = EINVAL;
-		rc = -1;
+		rc = -EINVAL;
 		break;
 	}
 

--- a/lib/posix-sysinfo/sysinfo.c
+++ b/lib/posix-sysinfo/sysinfo.c
@@ -117,16 +117,14 @@ UK_SYSCALL_R_DEFINE(int, uname, struct utsname *, buf)
 	return 0;
 }
 
-UK_SYSCALL_DEFINE(int, sethostname, const char*, name, size_t, len)
+UK_SYSCALL_R_DEFINE(int, sethostname, const char*, name, size_t, len)
 {
 	if (name == NULL) {
-		errno = EFAULT;
-		return -1;
+		return -EFAULT;
 	}
 
 	if (len > sizeof(utsname.nodename)) {
-		errno = EINVAL;
-		return -1;
+		return -EINVAL;
 	}
 
 	strncpy(utsname.nodename, name, len);

--- a/lib/uktime/time.c
+++ b/lib/uktime/time.c
@@ -70,13 +70,12 @@ static void __spin_wait(__nsec nsec)
 }
 #endif
 
-UK_SYSCALL_DEFINE(int, nanosleep, const struct timespec*, req, struct timespec*, rem)
+UK_SYSCALL_R_DEFINE(int, nanosleep, const struct timespec*, req, struct timespec*, rem)
 {
 	__nsec before, after, diff, nsec;
 
 	if (!req || req->tv_nsec < 0 || req->tv_nsec > 999999999) {
-		errno = EINVAL;
-		return -1;
+		return -EINVAL;
 	}
 
 	nsec = (__nsec) req->tv_sec * 1000000000L;
@@ -97,8 +96,7 @@ UK_SYSCALL_DEFINE(int, nanosleep, const struct timespec*, req, struct timespec*,
 			rem->tv_sec = ukarch_time_nsec_to_sec(nsec - diff);
 			rem->tv_nsec = ukarch_time_subsec(nsec - diff);
 		}
-		errno = EINTR;
-		return -1;
+		return -EINTR;
 	}
 	return 0;
 }

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -2076,7 +2076,7 @@ UK_TRACEPOINT(trace_vfs_utimensat, "\"%s\"", const char*);
 UK_TRACEPOINT(trace_vfs_utimensat_ret, "");
 UK_TRACEPOINT(trace_vfs_utimensat_err, "%d", int);
 
-UK_SYSCALL_DEFINE(int, utimensat, int, dirfd, const char*, pathname, const struct timespec*, times, int, flags)
+UK_SYSCALL_R_DEFINE(int, utimensat, int, dirfd, const char*, pathname, const struct timespec*, times, int, flags)
 {
 	int error;
 
@@ -2086,8 +2086,7 @@ UK_SYSCALL_DEFINE(int, utimensat, int, dirfd, const char*, pathname, const struc
 
 	if (error) {
 		trace_vfs_utimensat_err(error);
-		errno = error;
-		return -1;
+		return -error;
 	}
 
 	trace_vfs_utimensat_ret();


### PR DESCRIPTION
This commit changes the recently merged `libc-style` syscall registrations to syscall-shim to their `raw` variant.

Signed-off-by: Sergiu Moga <sergiu.moga@protonmail.com>