### PR TITLE
mritting/fix_ssp

### DIFF
--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -63,7 +63,7 @@
 #ifdef CONFIG_LIBUKLIBPARAM
 #include <uk/libparam.h>
 #endif /* CONFIG_LIBUKLIBPARAM */
-#if CONFIG_LIBUKSP
+#ifdef CONFIG_LIBUKSP
 #include <uk/sp.h>
 #endif
 #include "banner.h"
@@ -102,12 +102,8 @@ static void main_thread_func(void *arg)
 		}
 	}
 
-	/* We use a macro because if we were to use a function we
-	 * would not be able to return from the function if we have
-	 * changed the stack protector inside the function
-	 */
-#if CONFIG_LIBUKSP
-	UKSP_INIT_CANARY();
+#ifdef CONFIG_LIBUKSP
+	uk_stack_chk_guard_setup();
 #endif
 
 	print_banner(stdout);

--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -102,6 +102,14 @@ static void main_thread_func(void *arg)
 		}
 	}
 
+	/* We use a macro because if we were to use a function we
+	 * would not be able to return from the function if we have
+	 * changed the stack protector inside the function
+	 */
+#if CONFIG_LIBUKSP
+	UKSP_INIT_CANARY();
+#endif
+
 	print_banner(stdout);
 	fflush(stdout);
 
@@ -184,13 +192,6 @@ void ukplat_entry(int argc, char *argv[])
 #if CONFIG_LIBUKSCHED
 	struct uk_sched *s = NULL;
 	struct uk_thread *main_thread = NULL;
-#endif
-
-	/* We use a macro because if we were to use a function we
-	 * would not be able to return from the function if we have
-	 * changed the stack protector inside the function */
-#if CONFIG_LIBUKSP
-	UKSP_INIT_CANARY();
 #endif
 
 	uk_ctor_func_t *ctorfn;

--- a/lib/uksp/Config.uk
+++ b/lib/uksp/Config.uk
@@ -39,8 +39,8 @@ config LIBUKSP_VALUE_RANDOM
 endchoice
 
 config LIBUKSP_VALUE_CONSTANT
-	int "Canary value"
+	hex "Canary value"
 	depends on LIBUKSP_VALUE_USECONSTANT
-	default 42
+	default 0xff0a0d00
 
 endif

--- a/lib/uksp/include/uk/sp.h
+++ b/lib/uksp/include/uk/sp.h
@@ -44,12 +44,22 @@ extern "C" {
 
 extern const unsigned long __stack_chk_guard;
 
+/*
+ * Note: This function must always be inlined and may only be called from
+ * a function that never returns.
+ */
+__attribute__((always_inline))
+static inline void uk_stack_chk_guard_setup(void)
+{
 #ifdef CONFIG_LIBUKSP_VALUE_RANDOM
-#define UKSP_INIT_CANARY() (*(DECONST(unsigned long *, &__stack_chk_guard)) \
-		= uk_swrand_randr())
-#else
-#define UKSP_INIT_CANARY()
+	unsigned long guard;
+
+	uk_swrand_fill_buffer(&guard, sizeof(guard));
+	guard &= ~0xFFul; /* Use least significant byte as null terminator */
+
+	(*DECONST(unsigned long *, &__stack_chk_guard)) = guard;
 #endif
+}
 
 #ifdef __cplusplus
 }

--- a/lib/uksp/ssp.c
+++ b/lib/uksp/ssp.c
@@ -39,7 +39,7 @@
 #ifdef CONFIG_LIBUKSP_VALUE_USECONSTANT
 const unsigned long __stack_chk_guard = CONFIG_LIBUKSP_VALUE_CONSTANT;
 #else
-const unsigned long __stack_chk_guard = 0xDEADBEEF;
+const unsigned long __stack_chk_guard = 0xFF0A0D00; /* terminator canary */
 #endif
 
 __attribute__((noreturn))

--- a/lib/ukswrand/exportsyms.uk
+++ b/lib/ukswrand/exportsyms.uk
@@ -3,3 +3,4 @@ uk_swrand_def
 uk_swrand_init_r
 uk_swrand_randr_r
 uk_swrandr_gen_seed32
+uk_swrand_fill_buffer


### PR DESCRIPTION
The current random stack canary implementation is broken. The canary is 0 after initialization. Furthermore, only the lower 32-bits of the canary are used on 64-bit platforms. Using terminator characters would also make sense, especially as part of the default values.

```gdb
Breakpoint 1, ukplat_entry (argc=1, argv=0x7fffffffe498) at unikraft/lib/ukboot/boot.c:193
193             UKSP_INIT_CANARY();
(gdb) p/x __stack_chk_guard
$4 = 0xdeadbeef
(gdb) n
198             uk_pr_info("Unikraft constructor table at %p - %p\n",
(gdb) p/x __stack_chk_guard
$5 = 0x0
```