### PR TITLE
plat/common: Fix section variables for .eh_frame and .eh_frame_hdr

### DIFF
--- a/plat/common/include/uk/plat/common/sections.h
+++ b/plat/common/include/uk/plat/common/sections.h
@@ -47,10 +47,10 @@ extern char _dtb[];
 extern char _text[], _etext[];
 
 /* [__eh_frame_start, __eh_frame_end]: contains .eh_frame section */
-extern char __eh_frame_start, __eh_frame_end;
+extern char __eh_frame_start[], __eh_frame_end[];
 
 /* [__eh_frame_hdr_start, __eh_frame_hdr_end]: contains .eh_frame_hdr section */
-extern char __eh_frame_hdr_start, __eh_frame_hdr_end;
+extern char __eh_frame_hdr_start[], __eh_frame_hdr_end[];
 
 /* [_rodata, _erodata]: contains .rodata.* sections */
 extern char _rodata[], _erodata[];


### PR DESCRIPTION
This patch adds missing brackets to the .eh_frame and .eh_frame_hdr variables.

Before:
```
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x100000 - 0x114dab (flags: 0x12, name: text)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0xffffffffffffffe0 - 0xffffffffffffffe0 (flags: 0x12, name: eh_frame)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0xffffffffffffffe0 - 0xffffffffffffffe0 (flags: 0x12, name: eh_frame_hdr)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x116000 - 0x119398 (flags: 0x12, name: rodata)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x119398 - 0x119398 (flags: 0x12, name: ctors)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x11a000 - 0x11a100 (flags: 0x32, name: data)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x11b000 - 0x140000 (flags: 0x32, name: bss)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x140000 - 0x7fd0000 (flags: 0x31, name: heap)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x7fd0000 - 0x7fe0000 (flags: 0x32, name: bstack)...
```

After:
```
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x100000 - 0x114dab (flags: 0x12, name: text)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x115000 - 0x115000 (flags: 0x12, name: eh_frame)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x115000 - 0x115000 (flags: 0x12, name: eh_frame_hdr)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x116000 - 0x119398 (flags: 0x12, name: rodata)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x119398 - 0x119398 (flags: 0x12, name: ctors)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x11a000 - 0x11a100 (flags: 0x32, name: data)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x11b000 - 0x140000 (flags: 0x32, name: bss)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x140000 - 0x7fd0000 (flags: 0x31, name: heap)...
[    0.000000] dbg:  [libukboot] <boot.c @  222> Memory region: 0x7fd0000 - 0x7fe0000 (flags: 0x32, name: bstack)...
```
