### PR TITLE
Enabling SMP support on kvm x86

### DIFF
--- a/include/uk/plat/lcpu.h
+++ b/include/uk/plat/lcpu.h
@@ -97,6 +97,8 @@ void ukplat_lcpu_halt_to(__snsec until);
  */
 void ukplat_lcpu_halt_irq(void);
 
+int ukplat_lcpu_rstart(__u8 lcpuid, struct ukplat_ctx *ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/plat/common/include/x86/acpi.h
+++ b/plat/common/include/x86/acpi.h
@@ -1,0 +1,36 @@
+#include <uk/arch/types.h>
+
+struct RSDPDescriptor {
+	char Signature[8];
+	__u8 Checksum;
+	char OEMID[6];
+	__u8 Revision;
+	__u32 RsdtAddress;
+} __attribute__((packed));
+
+struct RSDPDescriptor20 {
+	RSDPDescriptor firstPart;
+
+	__u32 Length;
+	__u64 XsdtAddress;
+	__u8 ExtendedChecksum;
+	__u8 reserved[3];
+} __attribute__((packed));
+
+struct ACPISDTHeader {
+	char Signature[4];
+	__u32 Length;
+	__u8 Revision;
+	__u8 Checksum;
+	char OEMID[6];
+	char OEMTableID[8];
+	__u32 OEMRevision;
+	__u32 CreatorID;
+	__u32 CreatorRevision;
+};
+
+char RSDTChecksum(ACPISDTHeader *header);
+
+char RSDP20Checksum(RSDPDescriptor20 *str);
+
+char RSDPChecksum(RSDPDescriptor *str);

--- a/plat/kvm/include/kvm-x86/multiboot_defs.h
+++ b/plat/kvm/include/kvm-x86/multiboot_defs.h
@@ -41,7 +41,7 @@
 /* is the command-line defined? */
 #define MULTIBOOT_INFO_CMDLINE			0x00000004
 
-/* Give us the memory map provided by the BIOS */
+/* Is the mmap area valid? */
 #define MULTIBOOT_INFO_MMAP             0x00000040
 
 #endif /* ! MULTIBOOT_DEFS_HEADER */

--- a/plat/kvm/include/kvm-x86/multiboot_defs.h
+++ b/plat/kvm/include/kvm-x86/multiboot_defs.h
@@ -41,4 +41,7 @@
 /* is the command-line defined? */
 #define MULTIBOOT_INFO_CMDLINE			0x00000004
 
+/* Give us the memory map provided by the BIOS */
+#define MULTIBOOT_INFO_MMAP             0x00000040
+
 #endif /* ! MULTIBOOT_DEFS_HEADER */

--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -73,6 +73,24 @@ static inline void _mb_get_cmdline(struct multiboot_info *mi)
 	cmdline[(sizeof(cmdline) - 1)] = '\0';
 }
 
+static inline void _mb_get_acpi(struct multiboot_info *mi)
+{
+	size_t *mi_mmap_lenght, *mi_mmap_addr;
+	multiboot_mmap_entry *m;
+
+	/*
+	 * Find the entry with the type 3, that is memory 
+	 * containing ACPI information
+	 */
+	for (offset = 0; offset < mi->mmap_length;
+		 offset += m->size + sizeof(m->size)) {
+		m = (void *)(__uptr)(mi->mmap_addr + offset);
+		if (m->type == MULTIBOOT_MEMORY_ACPI_RECLAIMABLE) {
+			uk_pr_debug("ACPI memory zone found!\n");
+		}
+	}
+}
+
 static inline void _mb_init_mem(struct multiboot_info *mi)
 {
 	multiboot_memory_map_t *m;
@@ -273,6 +291,7 @@ void _libkvmplat_entry(void *arg)
 	 * everything necessary before we initialise memory allocation.
 	 */
 	_mb_get_cmdline(mi);
+	_mb_get_acpi(mi);
 	_mb_init_mem(mi);
 	_mb_init_initrd(mi);
 

--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -75,20 +75,21 @@ static inline void _mb_get_cmdline(struct multiboot_info *mi)
 
 static inline void _mb_get_acpi(struct multiboot_info *mi)
 {
-	size_t *mi_mmap_lenght, *mi_mmap_addr;
-	multiboot_mmap_entry *m;
+	size_t *mi_mmap_lenght, *mi_mmap_addr, offset;
+	multiboot_memory_map_t *m;
 
 	/*
 	 * Find the entry with the type 3, that is memory 
 	 * containing ACPI information
 	 */
-	for (offset = 0; offset < mi->mmap_length;
-		 offset += m->size + sizeof(m->size)) {
-		m = (void *)(__uptr)(mi->mmap_addr + offset);
-		if (m->type == MULTIBOOT_MEMORY_ACPI_RECLAIMABLE) {
-			uk_pr_debug("ACPI memory zone found!\n");
+	if (mi->flags & MULTIBOOT_INFO_MMAP)
+		for (offset = 0; offset < mi->mmap_length;
+			offset += m->size + sizeof(m->size)) {
+			m = (void *)(__uptr)(mi->mmap_addr + offset);
+			if (m->type == MULTIBOOT_MEMORY_ACPI_RECLAIMABLE) {
+				uk_pr_info("ACPI memory zone found!\n");
+			}
 		}
-	}
 }
 
 static inline void _mb_init_mem(struct multiboot_info *mi)

--- a/plat/kvm/x86/smp.c
+++ b/plat/kvm/x86/smp.c
@@ -1,0 +1,52 @@
+#include <uk/plat/lcpu.h>
+#include <uk/arch/types.h>
+
+#define CPUID_FEAT_EDX_APIC (1 << 9)
+
+static inline char check_apic()
+{
+	unsigned int eax, ebx, ecx, edx;
+
+	eax = 1;
+	asm volatile("cpuid"
+		     : "=a"(*eax), "=b"(*ebx), "=c"(*ecx), "=d"(*edx)
+		     : "0"(*eax), "2"(*ecx));
+
+	/* return 1 if the 9th bit of EDX is set,
+	 * meaning that the CPU supports apic
+	 */
+	return (edx & CPUID_FEAT_EDX_APIC);
+}
+
+__u8 ukplat_lcpu_count()
+{
+	__u8 numcore;
+
+	__u8 *ptr, *ptr2;
+	__u32 len;
+
+	__u8 *rsdt;
+
+	// iterate on ACPI table pointers
+	for (len = *((__u32 *)(rsdt + 4)), ptr2 = rsdt + 36; ptr2 < rsdt + len;
+	     ptr2 += rsdt[0] == 'X' ? 8 : 4) {
+		ptr = (__u8 *)(__uptr)(rsdt[0] == 'X' ? *((__u64 *)ptr2)
+						      : *((__u32 *)ptr2));
+		if (!memcmp(ptr, "APIC", 4)) {
+			// found MADT
+			lapic_ptr = (__u64)(*((__u32)(ptr + 0x24)));
+			ptr2 = ptr + *((__u32 *)(ptr + 4));
+
+			// iterate on variable length records
+			for (ptr += 44; ptr < ptr2; ptr += ptr[1]) {
+				if (ptr[0] == 0) {
+					if (ptr[4] & 1) // found Processor Local APIC
+						numcore++;
+				}
+			}
+			break;
+		}
+	}
+
+	return numcore;
+}


### PR DESCRIPTION
I've added the headers needed by the API, currently with no implementation, some structures needed to hold and parse the ACPI tables, and some code to get the memory map from multiboot, and find the memory zone that contains the ACPI information.