### PR TITLE
lib/ukmmap: Register `madvise` to syscall_shim

### DIFF
--- a/lib/ukmmap/Makefile.uk
+++ b/lib/ukmmap/Makefile.uk
@@ -2,4 +2,4 @@ $(eval $(call addlib_s,libukmmap,$(CONFIG_LIBUKMMAP)))
 
 LIBUKMMAP_SRCS-y += $(LIBUKMMAP_BASE)/mmap.c
 
-UK_PROVIDED_SYSCALLS-$(CONFIG_LIBUKMMAP) += mmap-6 munmap-2
+UK_PROVIDED_SYSCALLS-$(CONFIG_LIBUKMMAP) += mmap-6 munmap-2 madvise-3

--- a/lib/ukmmap/exportsyms.uk
+++ b/lib/ukmmap/exportsyms.uk
@@ -5,3 +5,6 @@ munmap
 uk_syscall_e_munmap
 uk_syscall_r_munmap
 mremap
+madvise
+uk_syscall_e_madvise
+uk_syscall_r_madvise

--- a/lib/ukmmap/mmap.c
+++ b/lib/ukmmap/mmap.c
@@ -175,3 +175,9 @@ void *mremap(void *old_address __unused, size_t old_size __unused,
 {
 	return NULL;
 }
+
+UK_SYSCALL_R_DEFINE(int, madvise, void*, addr, size_t, length, int, advice)
+{
+	WARN_STUBBED();
+	return 0;
+}


### PR DESCRIPTION
Register `madvise` system call to syscall_shim library.

Signed-off-by: Sergiu Moga <sergiu.moga@protonmail.com>