### PR TITLE
support: checkpatch: Prefer raw system call definitions

### DIFF
--- a/support/scripts/checkpatch.pl
+++ b/support/scripts/checkpatch.pl
@@ -6370,6 +6370,12 @@ sub process {
 				     "unknown module license " . $extracted_string . "\n" . $herecurr);
 			}
 		}
+
+# check for UK_(LL)SYSCALL_DEFINE(), raw implementation should be preferred
+		if ($line =~ /\bUK_(LL)?SYSCALL_DEFINE\s*\(/) {
+			WARN("NON_RAW_SYSCALL",
+			     "Prefer using raw system call definitions: 'UK_SYSCALL_R_DEFINE', 'UK_LLSYSCALL_R_DEFINE'\n" . $herecurr);
+		}
 	}
 
 	# If we have no input at all, then there is nothing to report on


### PR DESCRIPTION
Introduces a warning for system call definitions when `UK_SYSCALL_DEFINE` and `UK_LLSYSCALL_DEFINE` was used:
Raw system call definitions are preferred because `errno` is not used.