### PR TITLE
support: checkpatch: Unikraft subject format

### DIFF
--- a/support/scripts/checkpatch.pl
+++ b/support/scripts/checkpatch.pl
@@ -2536,6 +2536,13 @@ sub process {
 			     "A patch subject line should describe the change not the tool that found it\n" . $herecurr);
 		}
 
+# Check if Unikraft subject format is used on commit message
+		if ($in_header_lines &&
+		    $line =~ /^Subject:[^:]+$/i) {
+			ERROR("UNIKRAFT_SUBJECT_FORMAT",
+			     "Patch subject line does not follow Unikraft scheme: '[Selector]/[Component]: [Short message]'\n" . $herecurr);
+		}
+
 # Check for old stable address
 		if ($line =~ /^\s*cc:\s*.*<?\bstable\@kernel\.org\b>?.*$/i) {
 			ERROR("STABLE_ADDRESS",


### PR DESCRIPTION
Checks and fails with an error when the subject line format is not
following the Unikraft scheme.
This check should be disabled for repositories that are not the
Unikraft core with `--ignore UNIKRAFT_SUBJECT_FORMAT`.