### PR TITLE
Skuenzer/ukdebug printonce

### DIFF
--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -354,6 +354,6 @@ default:
 
 int prctl(int option __unused, ...)
 {
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	return 0;
 }

--- a/lib/uktime/time.c
+++ b/lib/uktime/time.c
@@ -189,6 +189,6 @@ int times(struct tm *buf __unused)
 int setitimer(int which __unused, const struct itimerval *new_value __unused,
 		struct itimerval *old_value __unused)
 {
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	return 0;
 }

--- a/lib/uktime/timer.c
+++ b/lib/uktime/timer.c
@@ -40,14 +40,14 @@ int timer_create(clockid_t clockid __unused,
 		struct sigevent *__restrict sevp __unused,
 		timer_t *__restrict timerid __unused)
 {
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	errno = ENOTSUP;
 	return -1;
 }
 
 int timer_delete(timer_t timerid __unused)
 {
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	errno = ENOTSUP;
 	return -1;
 }
@@ -57,7 +57,7 @@ int timer_settime(timer_t timerid __unused,
 		const struct itimerspec *__restrict new_value __unused,
 		struct itimerspec *__restrict old_value __unused)
 {
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	errno = ENOTSUP;
 	return -1;
 }
@@ -65,14 +65,14 @@ int timer_settime(timer_t timerid __unused,
 int timer_gettime(timer_t timerid __unused,
 		struct itimerspec *curr_value __unused)
 {
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	errno = ENOTSUP;
 	return -1;
 }
 
 int timer_getoverrun(timer_t timerid __unused)
 {
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	errno = ENOTSUP;
 	return -1;
 }

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -47,6 +47,7 @@
 #include <vfscore/file.h>
 #include <vfscore/mount.h>
 #include <vfscore/fs.h>
+#include <uk/print.h>
 #include <uk/errptr.h>
 #include <uk/ctors.h>
 #include <uk/trace.h>
@@ -2217,20 +2218,20 @@ UK_TRACEPOINT(trace_vfs_fchown_ret, "");
 int fchown(int fd __unused, uid_t owner __unused, gid_t group __unused)
 {
 	trace_vfs_fchown(fd, owner, group);
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	trace_vfs_fchown_ret();
 	return 0;
 }
 
 int chown(const char *path __unused, uid_t owner __unused, gid_t group __unused)
 {
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	return 0;
 }
 
 int lchown(const char *path __unused, uid_t owner __unused, gid_t group __unused)
 {
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	return 0;
 }
 
@@ -2346,7 +2347,7 @@ fs_noop(void)
 
 int chroot(const char *path __unused)
 {
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	errno = ENOSYS;
 	return -1;
 }

--- a/lib/vfscore/pipe.c
+++ b/lib/vfscore/pipe.c
@@ -593,7 +593,7 @@ int pipe2(int pipefd[2], int flags)
 /* TODO maybe find a better place for this when it will be implemented */
 int mkfifo(const char *path __unused, mode_t mode __unused)
 {
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	errno = ENOTSUP;
 	return -1;
 }


### PR DESCRIPTION
Provide `uk_printd_once()` and `uk_printk_once()` that prints messages just once. This is useful for code paths where otherwise the message printing would cause flooding of the console.