### PR TITLE
Improvements to the timer driver and timer functions

### DIFF
--- a/include/uk/plat/lcpu.h
+++ b/include/uk/plat/lcpu.h
@@ -89,7 +89,7 @@ void ukplat_lcpu_halt(void);
  * the specified deadline expired
  * @param until deadline in nanoseconds
  */
-void ukplat_lcpu_halt_to(__snsec until);
+void ukplat_lcpu_halt_to(__nsec until);
 
 /**
  * Halts the current logical CPU execution

--- a/include/uk/plat/time.h
+++ b/include/uk/plat/time.h
@@ -35,6 +35,7 @@
 #define __UKPLAT_TIME_H__
 
 #include <uk/arch/time.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,6 +43,7 @@ extern "C" {
 
 void ukplat_time_init(void);
 void ukplat_time_fini(void);
+uint32_t ukplat_time_get_irq(void);
 
 __nsec ukplat_monotonic_clock(void);
 __nsec ukplat_wall_clock(void);

--- a/include/uk/plat/time.h
+++ b/include/uk/plat/time.h
@@ -45,6 +45,7 @@ void ukplat_time_init(void);
 void ukplat_time_fini(void);
 uint32_t ukplat_time_get_irq(void);
 
+__nsec ukplat_time_get_ticks(void);
 __nsec ukplat_monotonic_clock(void);
 __nsec ukplat_wall_clock(void);
 

--- a/plat/common/arm/time.c
+++ b/plat/common/arm/time.c
@@ -94,9 +94,9 @@ uint32_t generic_timer_get_frequency(int fdt_timer)
 
 unsigned long sched_have_pending_events;
 
-void time_block_until(__snsec until)
+void time_block_until(__nsec until)
 {
-	while ((__snsec) ukplat_monotonic_clock() < until) {
+	while (ukplat_monotonic_clock() < until) {
 		generic_timer_cpu_block_until(until);
 		if (__uk_test_and_clear_bit(0, &sched_have_pending_events))
 			break;

--- a/plat/common/arm/time.c
+++ b/plat/common/arm/time.c
@@ -54,6 +54,8 @@ static const char * const arch_timer_list[] = {
 	NULL
 };
 
+static uint32_t timer_irq;
+
 void generic_timer_mask_irq(void)
 {
 	set_el0(cntv_ctl, get_el0(cntv_ctl) | GT_TIMER_MASK_IRQ);
@@ -139,6 +141,8 @@ void ukplat_time_init(void)
 	rc = ukplat_irq_register(irq, generic_timer_irq_handler, NULL);
 	if (rc < 0)
 		UK_CRASH("Failed to register timer interrupt handler\n");
+	else
+		timer_irq = irq;
 
 	/*
 	 * Mask IRQ before scheduler start working. Otherwise we will get
@@ -148,4 +152,9 @@ void ukplat_time_init(void)
 
 	/* Enable timer */
 	generic_timer_enable();
+}
+
+uint32_t ukplat_time_get_irq(void)
+{
+	return timer_irq;
 }

--- a/plat/common/arm/time.c
+++ b/plat/common/arm/time.c
@@ -105,6 +105,11 @@ void time_block_until(__nsec until)
 	}
 }
 
+__nsec ukplat_time_get_ticks(void)
+{
+	return generic_timer_get_ticks();
+}
+
 /* must be called before interrupts are enabled */
 void ukplat_time_init(void)
 {

--- a/plat/common/lcpu.c
+++ b/plat/common/lcpu.c
@@ -40,7 +40,7 @@ void ukplat_lcpu_halt(void)
 	halt();
 }
 
-void ukplat_lcpu_halt_to(__snsec until)
+void ukplat_lcpu_halt_to(__nsec until)
 {
 	unsigned long flags;
 

--- a/plat/kvm/irq.c
+++ b/plat/kvm/irq.c
@@ -29,6 +29,7 @@
 #include <uk/alloc.h>
 #include <uk/list.h>
 #include <uk/plat/lcpu.h>
+#include <uk/plat/time.h>
 #include <uk/plat/common/cpu.h>
 #include <uk/plat/common/irq.h>
 #include <kvm/irq.h>
@@ -83,10 +84,9 @@ void _ukplat_irq_handle(unsigned long irq)
 	struct irq_handler *h;
 
 	UK_SLIST_FOREACH(h, &irq_handlers[irq], entries) {
-		/* TODO define platform wise macro for timer IRQ number */
-		if (irq != 0)
-			/* IRQ 0 is reserved for a timer, responsible to
-			 * wake up cpu from halt, so it can check if
+		if (irq != ukplat_time_get_irq())
+			/* ukplat_time_get_irq() gives the IRQ reserved for a timer,
+			 * responsible to wake up cpu from halt, so it can check if
 			 * it has something to do. Effectively it is OS ticks.
 			 *
 			 * If interrupt comes not from the timer, the

--- a/plat/kvm/x86/time.c
+++ b/plat/kvm/x86/time.c
@@ -83,3 +83,8 @@ void ukplat_time_init(void)
 void ukplat_time_fini(void)
 {
 }
+
+uint32_t ukplat_time_get_irq(void)
+{
+	return 0;
+}


### PR DESCRIPTION
This pull request provides fixes and improvements to the timer driver and timer functions:

- plat/common/arm/generic_timer.c: Fix time conversion functions
- plat/common/arm/generic_timer.c: Keep consistence of delay calculation
- plat/common: Fix time argument types to unsigned
- plat: Fix timer IRQ number provided to _ukplat_irq_handle()
- plat/common/arm: Export function to get system clock ticks

Signed-off-by: Renê de Souza Pinto <Rene.deSouzaPinto@opensynergy.com>