### PR TITLE
lib: Clean up library names and put them in the same format

### DIFF
--- a/lib/posix-process/Config.uk
+++ b/lib/posix-process/Config.uk
@@ -1,5 +1,5 @@
 config LIBPOSIX_PROCESS
-	bool "POSIX process-related functions"
+	bool "posix-process: Process-related functions"
 	default n
 	select LIBNOLIBC if !HAVE_LIBC
 	select LIBUKTIME

--- a/lib/posix-sysinfo/Config.uk
+++ b/lib/posix-sysinfo/Config.uk
@@ -1,4 +1,4 @@
 config LIBPOSIX_SYSINFO
-	bool "POSIX sysinfo: Information about system parameters"
+	bool "posix-sysinfo: Information about system parameters"
 	select LIBNOLIBC if !HAVE_LIBC
 	default n

--- a/lib/posix-user/Config.uk
+++ b/lib/posix-user/Config.uk
@@ -1,3 +1,3 @@
 config LIBPOSIX_USER
-	bool "POSIX user-related functions"
+	bool "posix-user: User-related functions"
 	default n

--- a/lib/syscall_shim/Config.uk
+++ b/lib/syscall_shim/Config.uk
@@ -1,5 +1,5 @@
 menuconfig LIBSYSCALL_SHIM
-	bool "syscall_shim: Syscall shim layer"
+	bool "syscall-shim: Syscall shim layer"
 	default n
 
 if LIBSYSCALL_SHIM


### PR DESCRIPTION
Clean up library names and put them in the same format.
This PR fix #54.

Signed-off-by: Gabriel Mocanu <gabi.mocanu98@gmail.com>