### PR TITLE
build: Option to switch stack frame pointers on and off

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -67,6 +67,15 @@ endchoice
 comment "Hint: Specify a CPU type to get most benefits from performance optimization"
 	depends on OPTIMIZE_PERF && (MARCH_X86_64_GENERIC || MARCH_ARM64_GENERIC)
 
+config OPTIMIZE_NOOMITFP
+	bool "Keep stack frame pointers"
+	default y
+	help
+		Reserves one CPU register for using it as stack frame pointer.
+		Functions are instrumented to save, set up, and restore frame
+		pointers. This option simplifies doing stack walks for
+		debugging for instance.
+
 config OPTIMIZE_DEADELIM
 	bool "Drop unused functions and data"
 	default n
@@ -119,6 +128,9 @@ config DEBUG_SYMBOLS_LVL3
 		macro definitions present in the program. Some debuggers
 		support macro expansion.
 endchoice
+
+comment "Hint: Keep frame pointers to ease debugging"
+	depends on !OPTIMIZE_NOOMITFP && !DEBUG_SYMBOLS_LVL0
 
 config OPTIMIZE_SYMFILE
 	bool "Create a symbols file"

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -6,7 +6,6 @@
 
 COMPFLAGS    += -nostdlib
 COMPFLAGS    += -U __linux__ -U __FreeBSD__ -U __sun__
-COMPFLAGS    += -fno-omit-frame-pointer
 COMPFLAGS-$(call have_gcc)	+= -fno-tree-sra -fno-split-stack -nostdinc
 
 ifneq ($(HAVE_STACKPROTECTOR),y)
@@ -57,6 +56,11 @@ LDFLAGS-$(call have_gcc)	+= -nostdinc
 COMPFLAGS-$(CONFIG_OPTIMIZE_NONE)         += -O0 -fno-optimize-sibling-calls -fno-tree-vectorize
 COMPFLAGS-$(CONFIG_OPTIMIZE_SIZE)         += -Os
 COMPFLAGS-$(CONFIG_OPTIMIZE_PERF)         += -O2
+ifeq ($(CONFIG_OPTIMIZE_NOOMITFP),y)
+COMPFLAGS-y  += -fno-omit-frame-pointer
+else
+COMPFLAGS-y  += -fomit-frame-pointer -D __OMIT_FRAMEPOINTER__
+endif
 
 COMPFLAGS-$(CONFIG_OPTIMIZE_DEADELIM)     += -fdata-sections -ffunction-sections
 LDFLAGS-$(CONFIG_OPTIMIZE_DEADELIM)       += -Wl,--gc-sections

--- a/plat/common/include/uk/plat/common/trace.h
+++ b/plat/common/include/uk/plat/common/trace.h
@@ -36,7 +36,9 @@
 
 void dump_regs(struct __regs *regs);
 void dump_mem(unsigned long addr);
+#if !__OMIT_FRAMEPOINTER__
 void stack_walk(void);
 void stack_walk_for_frame(unsigned long frame_base);
+#endif /* !__OMIT_FRAMEPOINTER__ */
 
 #endif /* __PLAT_CMN_TRACE_H__ */

--- a/plat/common/x86/trace.c
+++ b/plat/common/x86/trace.c
@@ -69,6 +69,7 @@ void dump_mem(unsigned long addr)
 	uk_pr_crit("\n");
 }
 
+#if !__OMIT_FRAMEPOINTER__
 void stack_walk(void)
 {
 	unsigned long bp;
@@ -87,3 +88,4 @@ void stack_walk_for_frame(unsigned long frame_base)
 	if (frame[0])
 		stack_walk_for_frame(frame[0]);
 }
+#endif /* !__OMIT_FRAMEPOINTER__ */

--- a/plat/common/x86/traps.c
+++ b/plat/common/x86/traps.c
@@ -103,7 +103,9 @@ void do_gp_fault(struct __regs *regs, long error_code)
 	uk_pr_crit("GPF rip: %lx, error_code=%lx\n",
 		   regs->rip, error_code);
 	dump_regs(regs);
+#if !__OMIT_FRAMEPOINTER__
 	stack_walk_for_frame(regs->rbp);
+#endif /* !__OMIT_FRAMEPOINTER__ */
 	uk_asmdumpk(KLVL_CRIT, (void *) regs->rip, 6);
 	dump_mem(regs->rsp);
 	dump_mem(regs->rbp);
@@ -121,7 +123,9 @@ void do_page_fault(struct __regs *regs, unsigned long error_code)
 		   addr, regs->rip, regs, regs->rsp, &addr, error_code);
 
 	dump_regs(regs);
+#if !__OMIT_FRAMEPOINTER__
 	stack_walk_for_frame(regs->rbp);
+#endif /* !__OMIT_FRAMEPOINTER__ */
 	uk_asmdumpk(KLVL_CRIT, (void *) regs->rip, 6);
 	dump_mem(regs->rsp);
 	dump_mem(regs->rbp);


### PR DESCRIPTION
Introduces a configuration option for activating or deactivating the use of stack frame pointers. Frame pointers reserve one CPU register permanently but simplify stack walks for debugging purposes.