### PR TITLE
support/build: Extend preprules for external language support

### DIFF
--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -647,9 +647,10 @@ endef
 #
 # preprule $libname,$source,$preptarget,$extraflags(optional)
 define preprule =
-$(if $(filter %.m4   ,$(2)),$(call preprule_m4 ,$(1),$(2),$(3),$(4)),\
-$(error $(3): missing pre-processing rule for source type $(suffix $(2))) \
-)
+$(if $(filter preprule_$(call fileext,$(strip $(2))),$(.VARIABLES)),\
+$(call preprule_$(call fileext,$(strip $(2))),$(strip $(1)),$(strip $(2)),$(strip $(3)),$(strip $(4)),$(strip $(5))),\
+$(error Cannot compile $(strip $(2)). No rule defined for .$(call fileext,$(strip $(2))) format. Please create a Makefile.rules\
+that defines the necessary rules))
 endef
 
 


### PR DESCRIPTION
We extend the build system to load preparation rules from external
libraries. This enables Unikraft to support preparation rules for
different formats without modifying the core Makefile.rules.

Usage: If we want to add a new external preparation rule, we create
in the root of the library a  Makefile.rules. Inside Makefile.rules
we define a preprule_{format}.

The preprule should be similar to the preprule_m4 defined in
support/build/Makefile.rules.

Signed-off-by: Vlad-Andrei Badoiu <vlad_andrei.badoiu@upb.ro>