### PR TITLE
plat/common: Fix struct name in `sw_ctx_size()`

### DIFF
--- a/plat/common/sw_ctx.c
+++ b/plat/common/sw_ctx.c
@@ -51,7 +51,7 @@ extern void asm_thread_starter(void);
 
 static size_t sw_ctx_size(void)
 {
-	return sizeof(struct ukplat_ctx) + arch_extregs_size();
+	return sizeof(struct sw_ctx) + arch_extregs_size();
 }
 
 static void sw_ctx_init(void *ctx,


### PR DESCRIPTION
By mistake, a wrong struct name (`ukplat_ctx`) was used instead
of `sw_ctx` in `sw_ctx_size()`. The issue was introduced with
commit 9ca0659f6 and caused a Unikraft build to fail.

Signed-off-by: Simon Kuenzer <simon.kuenzer@neclab.eu>