### PR TITLE
build: Introduce `mk_sub_libbuild_dir`

### DIFF
--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -226,6 +226,14 @@ define addplatlib_s =
 $(if $(filter y,$(3)),$(call addplatlib,$(1),$(2)),)
 endef
 
+# creates a sub build directory for a library
+# $libname,$subdir
+define mk_sub_libbuild_dir =
+$(if $(shell mkdir -p "$(BUILD_DIR)/$(1)/$(2)" && cd "$(BUILD_DIR)/$(1)/$(2)" >/dev/null && pwd),,\
+     $(error could not create directory "$(BUILD_DIR)/$(1)/$(2)"))
+endef
+
+sub_libbuild_dir = $(BUILD_DIR)/$(1)/$(2)
 
 ################################################################################
 #


### PR DESCRIPTION
Inline with `mk_sub_build_dir`, this commit introduces `mk_sub_libbuild_dir` that enables creating a sub build directory for a library. This new Makefile command has two parameters: (1) library name, (2) sub directory structure.

This can be handy when writing library `Makefile.uk`'s that require additional directory structures within the build target directory:
``` Makefile
$(eval $(call addlib_s,libexample,$(CONFIG_LIBUKSTORE)))
$(call mk_sub_libbuild_dir,libexample,include/uk)

LIBEXAMPLE_GEN_INCLUDES := $(call sub_libbuild_dir,libexample,include/uk)

# <...>
```
