### PR TITLE
plat/common/x86: Provide rdmsr and wrmsr wrappers

### DIFF
--- a/plat/common/include/x86/msr.h
+++ b/plat/common/include/x86/msr.h
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Authors: Cristian Vijelie <cristianvijelie@gmail.com>
+ *
+ * Copyright (c) 2021, University Politehnica of Bucharest. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef __MSR_H__
+#define __MSR_H__
+
+#include <uk/arch/types.h>
+
+inline void uk_wrmsr(__u32 ecx, __u32 eax, __u32 edx)
+{
+	__asm__ __volatile__("wrmsr;" : : "c"(ecx), "a"(eax), "d"(edx) :);
+}
+
+inline void uk_rdmsr(__u32 ecx, __u32 *eax, __u32 *edx)
+{
+	__asm__ __volatile__("rdmsr;" : "=a"(*eax), "=d"(*edx) : "c"(ecx) :);
+}
+
+#endif /* __MSR_H__ */


### PR DESCRIPTION
Wrappers for using the 'rdmsr' and 'wrmsr' instructions, because no one likes inline assembly