### PR TITLE
lib/uksched: Fixes for thread inittab

### DIFF
--- a/lib/uksched/extra.ld
+++ b/lib/uksched/extra.ld
@@ -1,7 +1,6 @@
 SECTIONS
 {
 	.uk_thread_inittab : {
-		. = ALIGN(0x8);
 		PROVIDE(_uk_thread_inittab_start = .);
 		KEEP (*(.uk_thread_inittab0))
 		KEEP (*(.uk_thread_inittab0.*))

--- a/lib/uksched/include/uk/thread.h
+++ b/lib/uksched/include/uk/thread.h
@@ -152,7 +152,7 @@ struct uk_thread_inittab_entry {
 #define __UK_THREAD_INITTAB_ENTRY(init_fn, fini_fn, prio)		\
 	static const struct uk_thread_inittab_entry			\
 	__used __section(".uk_thread_inittab" # prio) __align(8)	\
-		__uk_thread_inittab ## prio ## _ ## entry = {		\
+		__uk_thread_inittab ## prio ## _ ## init_fn ## _ ## fini_fn = {\
 		.init = (init_fn),					\
 		.fini = (fini_fn)					\
 	}


### PR DESCRIPTION
This series fixes two issues when building the thread inittab:
- An unnecessary alignment in the linker script caused some broken binaries. This is a fix for issue #197.
- `UK_THREAD_INIT()` or `UK_THREAD_INIT_PRIO` could only be specified once for each priority level. This is fixed by generating unique names for each entry.