### PR TITLE
plat/kvm/x86: Enable Multiboot v2 as a bootloader

### DIFF
--- a/plat/Config.uk
+++ b/plat/Config.uk
@@ -1,4 +1,10 @@
 menu "Platform Interface Options"
+config UKPLAT_HAVE_MULTIBOOT2
+	bool "Multiboot v2 bootloader"
+	default n
+	help
+		Use the Multiboot v2 bootloader
+
 config UKPLAT_MEMRNAME
 	bool "Memory region names"
 	default n

--- a/plat/kvm/include/kvm-x86/bootinfo.h
+++ b/plat/kvm/include/kvm-x86/bootinfo.h
@@ -1,0 +1,22 @@
+#ifndef __BOOTINFO_H__
+#define __BOOTINFO_H__
+
+#include <uk/arch/types.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct uk_bootinfo {
+	/* Command line information */
+	__u64 u64_cmdline;
+
+	/* Memmory mapping information */
+	size_t max_addr;
+
+	/* Initrd information */
+	__u8 has_initrd;
+	uintptr_t initrd_start;
+	uintptr_t initrd_end;
+	size_t initrd_length;
+};
+
+#endif /* __BOOTINFO_H__ */

--- a/plat/kvm/include/kvm-x86/multiboot2.h
+++ b/plat/kvm/include/kvm-x86/multiboot2.h
@@ -1,0 +1,312 @@
+/*   multiboot2.h - Multiboot 2 header file. */
+/*   Copyright (C) 1999,2003,2007,2008,2009,2010  Free Software Foundation, Inc.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ *  sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL ANY
+ *  DEVELOPER OR DISTRIBUTOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef MULTIBOOT_HEADER
+#define MULTIBOOT_HEADER 1
+
+typedef unsigned char multiboot_uint8_t;
+typedef unsigned short multiboot_uint16_t;
+typedef unsigned int multiboot_uint32_t;
+typedef unsigned long long multiboot_uint64_t;
+
+struct multiboot_header {
+	/*  Must be MULTIBOOT_MAGIC - see above. */
+	multiboot_uint32_t magic;
+
+	/*  ISA */
+	multiboot_uint32_t architecture;
+
+	/*  Total header length. */
+	multiboot_uint32_t header_length;
+
+	/*  The above fields plus this one must equal 0 mod 2^32. */
+	multiboot_uint32_t checksum;
+};
+
+struct multiboot_header_tag {
+	multiboot_uint16_t type;
+	multiboot_uint16_t flags;
+	multiboot_uint32_t size;
+};
+
+struct multiboot_header_tag_information_request {
+	multiboot_uint16_t type;
+	multiboot_uint16_t flags;
+	multiboot_uint32_t size;
+	multiboot_uint32_t requests[0];
+};
+
+struct multiboot_header_tag_address {
+	multiboot_uint16_t type;
+	multiboot_uint16_t flags;
+	multiboot_uint32_t size;
+	multiboot_uint32_t header_addr;
+	multiboot_uint32_t load_addr;
+	multiboot_uint32_t load_end_addr;
+	multiboot_uint32_t bss_end_addr;
+};
+
+struct multiboot_header_tag_entry_address {
+	multiboot_uint16_t type;
+	multiboot_uint16_t flags;
+	multiboot_uint32_t size;
+	multiboot_uint32_t entry_addr;
+};
+
+struct multiboot_header_tag_console_flags {
+	multiboot_uint16_t type;
+	multiboot_uint16_t flags;
+	multiboot_uint32_t size;
+	multiboot_uint32_t console_flags;
+};
+
+struct multiboot_header_tag_framebuffer {
+	multiboot_uint16_t type;
+	multiboot_uint16_t flags;
+	multiboot_uint32_t size;
+	multiboot_uint32_t width;
+	multiboot_uint32_t height;
+	multiboot_uint32_t depth;
+};
+
+struct multiboot_header_tag_module_align {
+	multiboot_uint16_t type;
+	multiboot_uint16_t flags;
+	multiboot_uint32_t size;
+};
+
+struct multiboot_header_tag_relocatable {
+	multiboot_uint16_t type;
+	multiboot_uint16_t flags;
+	multiboot_uint32_t size;
+	multiboot_uint32_t min_addr;
+	multiboot_uint32_t max_addr;
+	multiboot_uint32_t align;
+	multiboot_uint32_t preference;
+};
+
+struct multiboot_color {
+	multiboot_uint8_t red;
+	multiboot_uint8_t green;
+	multiboot_uint8_t blue;
+};
+
+struct multiboot_mmap_entry {
+	multiboot_uint64_t addr;
+	multiboot_uint64_t len;
+#define MULTIBOOT_MEMORY_AVAILABLE 1
+#define MULTIBOOT_MEMORY_RESERVED 2
+#define MULTIBOOT_MEMORY_ACPI_RECLAIMABLE 3
+#define MULTIBOOT_MEMORY_NVS 4
+#define MULTIBOOT_MEMORY_BADRAM 5
+	multiboot_uint32_t type;
+	multiboot_uint32_t zero;
+};
+typedef struct multiboot_mmap_entry multiboot_memory_map_t;
+
+struct multiboot_tag {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+};
+
+struct multiboot_tag_string {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	char string[0];
+};
+
+struct multiboot_tag_module {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint32_t mod_start;
+	multiboot_uint32_t mod_end;
+	char cmdline[0];
+};
+
+struct multiboot_tag_basic_meminfo {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint32_t mem_lower;
+	multiboot_uint32_t mem_upper;
+};
+
+struct multiboot_tag_bootdev {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint32_t biosdev;
+	multiboot_uint32_t slice;
+	multiboot_uint32_t part;
+};
+
+struct multiboot_tag_mmap {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint32_t entry_size;
+	multiboot_uint32_t entry_version;
+	struct multiboot_mmap_entry entries[0];
+};
+
+struct multiboot_vbe_info_block {
+	multiboot_uint8_t external_specification[512];
+};
+
+struct multiboot_vbe_mode_info_block {
+	multiboot_uint8_t external_specification[256];
+};
+
+struct multiboot_tag_vbe {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+
+	multiboot_uint16_t vbe_mode;
+	multiboot_uint16_t vbe_interface_seg;
+	multiboot_uint16_t vbe_interface_off;
+	multiboot_uint16_t vbe_interface_len;
+
+	struct multiboot_vbe_info_block vbe_control_info;
+	struct multiboot_vbe_mode_info_block vbe_mode_info;
+};
+
+struct multiboot_tag_framebuffer_common {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+
+	multiboot_uint64_t framebuffer_addr;
+	multiboot_uint32_t framebuffer_pitch;
+	multiboot_uint32_t framebuffer_width;
+	multiboot_uint32_t framebuffer_height;
+	multiboot_uint8_t framebuffer_bpp;
+#define MULTIBOOT_FRAMEBUFFER_TYPE_INDEXED 0
+#define MULTIBOOT_FRAMEBUFFER_TYPE_RGB 1
+#define MULTIBOOT_FRAMEBUFFER_TYPE_EGA_TEXT 2
+	multiboot_uint8_t framebuffer_type;
+	multiboot_uint16_t reserved;
+};
+
+struct multiboot_tag_framebuffer {
+	struct multiboot_tag_framebuffer_common common;
+
+	union {
+		struct {
+			multiboot_uint16_t framebuffer_palette_num_colors;
+			struct multiboot_color framebuffer_palette[0];
+		};
+		struct {
+			multiboot_uint8_t framebuffer_red_field_position;
+			multiboot_uint8_t framebuffer_red_mask_size;
+			multiboot_uint8_t framebuffer_green_field_position;
+			multiboot_uint8_t framebuffer_green_mask_size;
+			multiboot_uint8_t framebuffer_blue_field_position;
+			multiboot_uint8_t framebuffer_blue_mask_size;
+		};
+	};
+};
+
+struct multiboot_tag_elf_sections {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint32_t num;
+	multiboot_uint32_t entsize;
+	multiboot_uint32_t shndx;
+	char sections[0];
+};
+
+struct multiboot_tag_apm {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint16_t version;
+	multiboot_uint16_t cseg;
+	multiboot_uint32_t offset;
+	multiboot_uint16_t cseg_16;
+	multiboot_uint16_t dseg;
+	multiboot_uint16_t flags;
+	multiboot_uint16_t cseg_len;
+	multiboot_uint16_t cseg_16_len;
+	multiboot_uint16_t dseg_len;
+};
+
+struct multiboot_tag_efi32 {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint32_t pointer;
+};
+
+struct multiboot_tag_efi64 {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint64_t pointer;
+};
+
+struct multiboot_tag_smbios {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint8_t major;
+	multiboot_uint8_t minor;
+	multiboot_uint8_t reserved[6];
+	multiboot_uint8_t tables[0];
+};
+
+struct multiboot_tag_old_acpi {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint8_t rsdp[0];
+};
+
+struct multiboot_tag_new_acpi {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint8_t rsdp[0];
+};
+
+struct multiboot_tag_network {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint8_t dhcpack[0];
+};
+
+struct multiboot_tag_efi_mmap {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint32_t descr_size;
+	multiboot_uint32_t descr_vers;
+	multiboot_uint8_t efi_mmap[0];
+};
+
+struct multiboot_tag_efi32_ih {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint32_t pointer;
+};
+
+struct multiboot_tag_efi64_ih {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint64_t pointer;
+};
+
+struct multiboot_tag_load_base_addr {
+	multiboot_uint32_t type;
+	multiboot_uint32_t size;
+	multiboot_uint32_t load_base_addr;
+};
+
+#endif /*  ! MULTIBOOT_HEADER */

--- a/plat/kvm/include/kvm-x86/multiboot2_defs.h
+++ b/plat/kvm/include/kvm-x86/multiboot2_defs.h
@@ -1,0 +1,84 @@
+/*   Copyright (C) 1999,2003,2007,2008,2009,2010  Free Software Foundation, Inc.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ *  sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL ANY
+ *  DEVELOPER OR DISTRIBUTOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*  How many bytes from the start of the file we search for the header. */
+#define MULTIBOOT_SEARCH 32768
+#define MULTIBOOT_HEADER_ALIGN 8
+
+/*  The magic field should contain this. */
+#define MULTIBOOT2_HEADER_MAGIC 0xe85250d6
+
+/*  This should be in %eax. */
+#define MULTIBOOT2_BOOTLOADER_MAGIC 0x36d76289
+
+/*  Alignment of multiboot modules. */
+#define MULTIBOOT_MOD_ALIGN 0x00001000
+
+/*  Alignment of the multiboot info structure. */
+#define MULTIBOOT_INFO_ALIGN 0x00000008
+
+/*  Flags set in the ’flags’ member of the multiboot header. */
+#define MULTIBOOT_TAG_ALIGN                 0x8
+#define MULTIBOOT_TAG_TYPE_END              0x0
+#define MULTIBOOT_TAG_TYPE_CMDLINE          0x1
+#define MULTIBOOT_TAG_TYPE_BOOT_LOADER_NAME 0x2
+#define MULTIBOOT_TAG_TYPE_MODULE           0x3
+#define MULTIBOOT_TAG_TYPE_BASIC_MEMINFO    0x4
+#define MULTIBOOT_TAG_TYPE_BOOTDEV          0x5
+#define MULTIBOOT_TAG_TYPE_MMAP             0x6
+#define MULTIBOOT_TAG_TYPE_VBE              0x7
+#define MULTIBOOT_TAG_TYPE_FRAMEBUFFER      0x8
+#define MULTIBOOT_TAG_TYPE_ELF_SECTIONS     0x9
+#define MULTIBOOT_TAG_TYPE_APM              0xA
+#define MULTIBOOT_TAG_TYPE_EFI32            0xB
+#define MULTIBOOT_TAG_TYPE_EFI64            0xC
+#define MULTIBOOT_TAG_TYPE_SMBIOS           0xD
+#define MULTIBOOT_TAG_TYPE_ACPI_OLD         0xE
+#define MULTIBOOT_TAG_TYPE_ACPI_NEW         0xF
+#define MULTIBOOT_TAG_TYPE_NETWORK          0x10
+#define MULTIBOOT_TAG_TYPE_EFI_MMAP         0x11
+#define MULTIBOOT_TAG_TYPE_EFI_BS           0x12
+#define MULTIBOOT_TAG_TYPE_EFI32_IH         0x13
+#define MULTIBOOT_TAG_TYPE_EFI64_IH         0x14
+#define MULTIBOOT_TAG_TYPE_LOAD_BASE_ADDR   0x15
+
+#define MULTIBOOT_HEADER_TAG_END			0
+#define MULTIBOOT_HEADER_TAG_INFORMATION_REQUEST	1
+#define MULTIBOOT_HEADER_TAG_ADDRESS			2
+#define MULTIBOOT_HEADER_TAG_ENTRY_ADDRESS		3
+#define MULTIBOOT_HEADER_TAG_CONSOLE_FLAGS		4
+#define MULTIBOOT_HEADER_TAG_FRAMEBUFFER		5
+#define MULTIBOOT_HEADER_TAG_MODULE_ALIGN		6
+#define MULTIBOOT_HEADER_TAG_EFI_BS			7
+#define MULTIBOOT_HEADER_TAG_ENTRY_ADDRESS_EFI32	8
+#define MULTIBOOT_HEADER_TAG_ENTRY_ADDRESS_EFI64	9
+#define MULTIBOOT_HEADER_TAG_RELOCATABLE		10
+
+#define MULTIBOOT_ARCHITECTURE_I386	0
+#define MULTIBOOT_ARCHITECTURE_MIPS32	4
+#define MULTIBOOT_HEADER_TAG_OPTIONAL	1
+
+#define MULTIBOOT_LOAD_PREFERENCE_NONE	0
+#define MULTIBOOT_LOAD_PREFERENCE_LOW	1
+#define MULTIBOOT_LOAD_PREFERENCE_HIGH	2
+
+#define MULTIBOOT_CONSOLE_FLAGS_CONSOLE_REQUIRED	1
+#define MULTIBOOT_CONSOLE_FLAGS_EGA_TEXT_SUPPORTED	2

--- a/plat/kvm/x86/entry64.S
+++ b/plat/kvm/x86/entry64.S
@@ -27,22 +27,31 @@
  * SUCH DAMAGE.
  */
 
-#include <x86/cpu_defs.h>
-#include <kvm-x86/traps.h>
-#include <kvm-x86/multiboot_defs.h>
-
 /* necessary for CONFIG_ macros to be accessible */
 #include <uk/config.h>
+
+#include <x86/cpu_defs.h>
+#include <kvm-x86/traps.h>
+#ifndef CONFIG_UKPLAT_HAVE_MULTIBOOT2
+#include <kvm-x86/multiboot_defs.h>
+#else
+#include <kvm-x86/multiboot2_defs.h>
+#endif /* CONFIG_UKPLAT_HAVE_MULTIBOOT2 */
 
 #define ENTRY(x) .globl x; .type x,%function; x:
 #define END(x)   .size x, . - x
 
+#ifndef CONFIG_UKPLAT_HAVE_MULTIBOOT2
 #define MYMULTIBOOT_FLAGS \
     (MULTIBOOT_PAGE_ALIGN | MULTIBOOT_MEMORY_INFO | MULTIBOOT_AOUT_KLUDGE)
+#else
+#define AOUT_KLUDGE MULTIBOOT_AOUT_KLUDGE
+#endif /* CONFIG_UKPLAT_HAVE_MULTIBOOT2 */
 
 .section .data.boot
 
 .align 4
+#ifndef CONFIG_UKPLAT_HAVE_MULTIBOOT2
 _multiboot_header:
 .long MULTIBOOT_HEADER_MAGIC
 .long MYMULTIBOOT_FLAGS
@@ -52,6 +61,48 @@ _multiboot_header:
 .long _edata                                      /* load end addr */
 .long _end                                        /* bss end addr */
 .long _libkvmplat_start32                         /* entry addr */
+#else
+_multiboot_header:
+        /*  magic */
+        .long   MULTIBOOT2_HEADER_MAGIC
+        /*  ISA: i386 */
+        .long   MULTIBOOT_ARCHITECTURE_I386
+        /*  Header length. */
+        .long   multiboot_header_end - _multiboot_header
+        /*  checksum */
+        .long   -(MULTIBOOT2_HEADER_MAGIC + MULTIBOOT_ARCHITECTURE_I386 + (multiboot_header_end - _multiboot_header))
+.align 8
+address_tag_start:
+        .short MULTIBOOT_HEADER_TAG_ADDRESS
+        .short MULTIBOOT_HEADER_TAG_OPTIONAL
+        .long address_tag_end - address_tag_start
+        /*  header_addr */
+        .long   _multiboot_header
+        /*  load_addr */
+        .long   _text
+        /*  load_end_addr */
+        .long   _edata
+        /*  bss_end_addr */
+        .long   _end
+address_tag_end:
+.align 8
+entry_address_tag_start:
+        .short MULTIBOOT_HEADER_TAG_ENTRY_ADDRESS
+        .short MULTIBOOT_HEADER_TAG_OPTIONAL
+        .long entry_address_tag_end - entry_address_tag_start
+        /*  entry_addr */
+        .long _libkvmplat_start32
+entry_address_tag_end:
+.align 8
+information_request_tag_start:
+		.short MULTIBOOT_HEADER_TAG_INFORMATION_REQUEST
+		.short MULTIBOOT_HEADER_TAG_OPTIONAL
+		.long information_request_tag_end - information_request_tag_start
+		/* command line */
+		.long 1
+information_request_tag_end:
+multiboot_header_end:
+#endif /* CONFIG_UKPLAT_HAVE_MULTIBOOT2 */
 
 .section .bss
 
@@ -73,9 +124,14 @@ ENTRY(_libkvmplat_start32)
 	cld
 
 	/* only multiboot is supported for now */
+#ifndef CONFIG_UKPLAT_HAVE_MULTIBOOT2
 	cmpl $MULTIBOOT_BOOTLOADER_MAGIC, %eax
+#else
+	cmpl $MULTIBOOT2_BOOTLOADER_MAGIC, %eax
+#endif /* CONFIG_UKPLAT_HAVE_MULTIBOOT2 */
 	jne nomultiboot
 
+have_multiboot:
 	/*
 	 * Multiboot drops us off in 32-bit protected mode with some sane
 	 * initial settings, good enough to go straight for the only thing

--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -34,8 +34,13 @@
 #include <kvm/console.h>
 #include <kvm/intctrl.h>
 #include <kvm-x86/bootinfo.h>
+#ifndef CONFIG_UKPLAT_HAVE_MULTIBOOT2
 #include <kvm-x86/multiboot.h>
 #include <kvm-x86/multiboot_defs.h>
+#else
+#include <kvm-x86/multiboot2.h>
+#include <kvm-x86/multiboot2_defs.h>
+#endif /* CONFIG_UKPLAT_HAVE_MULTIBOOT2 */
 #include <uk/arch/limits.h>
 #include <uk/arch/types.h>
 #include <uk/plat/console.h>
@@ -55,6 +60,7 @@ struct uk_bootinfo bootinfo = { 0 };
 extern void _libkvmplat_newstack(uintptr_t stack_start, void (*tramp)(void *),
 				 void *arg);
 
+#ifndef CONFIG_UKPLAT_HAVE_MULTIBOOT2
 static void _convert_mbinfo(struct multiboot_info *mi)
 {
 	multiboot_memory_map_t *m;
@@ -86,7 +92,7 @@ static void _convert_mbinfo(struct multiboot_info *mi)
 	bootinfo.max_addr = m->addr + m->len;
 	if (bootinfo.max_addr > PLATFORM_MAX_MEM_ADDR)
 		bootinfo.max_addr = PLATFORM_MAX_MEM_ADDR;
-	UK_ASSERT((size_t) __END <= bootinfo.max_addr);
+	UK_ASSERT((size_t)__END <= bootinfo.max_addr);
 
 	/*
 	 * Reserve space for boot stack at the end of found memory
@@ -114,17 +120,79 @@ static void _convert_mbinfo(struct multiboot_info *mi)
 
 	if (mod1->mod_end == mod1->mod_start) {
 		uk_pr_debug("Ignoring empty initrd\n");
-		bootinfo.initrd_start = 0;
-		bootinfo.initrd_end = 0;
+		bootinfo.initrd_start  = 0;
+		bootinfo.initrd_end    = 0;
 		bootinfo.initrd_length = 0;
-		bootinfo.has_initrd = 0;
+		bootinfo.has_initrd    = 0;
 	} else {
-		bootinfo.initrd_start = mod1->mod_start;
-		bootinfo.initrd_end = mod1->mod_end;
+		bootinfo.initrd_start  = mod1->mod_start;
+		bootinfo.initrd_end    = mod1->mod_end;
 		bootinfo.initrd_length = mod1->mod_end - mod1->mod_start;
-		bootinfo.has_initrd = 1;
+		bootinfo.has_initrd    = 1;
 	}
 }
+#else
+static void _convert_mbitags(unsigned long addr)
+{
+	struct multiboot_tag *tag;
+	multiboot_memory_map_t *mmap;
+
+	for (tag = (struct multiboot_tag *)(addr + 8);
+	     tag->type != MULTIBOOT_TAG_TYPE_END;
+	     tag = (struct multiboot_tag *)((multiboot_uint8_t *)tag
+					    + ((tag->size + 7) & ~7))) {
+		uk_pr_debug("Tag 0x%x, Size 0x%x\n", tag->type, tag->size);
+		switch (tag->type) {
+		case MULTIBOOT_TAG_TYPE_CMDLINE:
+			uk_pr_debug("Cmdline detected: %p\n", tag);
+			bootinfo.u64_cmdline =
+			    (__u64)((struct multiboot_tag_string *)tag)->string;
+			break;
+		case MULTIBOOT_TAG_TYPE_MODULE:
+			if (!bootinfo.has_initrd) {
+				uk_pr_debug("Initrd found: %p\n", tag);
+				bootinfo.has_initrd = 1;
+				bootinfo.initrd_start =
+				    ((struct multiboot_tag_module *)tag)
+					->mod_start;
+				bootinfo.initrd_end =
+				    ((struct multiboot_tag_module *)tag)
+					->mod_end;
+				bootinfo.initrd_length =
+				    bootinfo.initrd_end - bootinfo.initrd_start;
+			} else
+				uk_pr_debug("Additional module found at %p, "
+					    "cmdline: %s\n",
+					    tag,
+					    ((struct multiboot_tag_module *)tag)
+						->cmdline);
+			break;
+		case MULTIBOOT_TAG_TYPE_MMAP:
+			for (mmap = ((struct multiboot_tag_mmap *)tag)->entries;
+			     (multiboot_uint8_t *)mmap
+			     < (multiboot_uint8_t *)tag + tag->size;
+			     mmap = (multiboot_memory_map_t
+					 *)((unsigned long)mmap
+					    + ((struct multiboot_tag_mmap *)tag)
+						  ->entry_size))
+				if (mmap->addr == PLATFORM_MEM_START
+				    && mmap->type == MULTIBOOT_MEMORY_AVAILABLE)
+					break;
+
+			bootinfo.max_addr = mmap->addr + mmap->len;
+
+			if (bootinfo.max_addr > PLATFORM_MAX_MEM_ADDR)
+				bootinfo.max_addr = PLATFORM_MAX_MEM_ADDR;
+			UK_ASSERT(bootinfo.max_addr >= (size_t)__END);
+
+			if ((bootinfo.max_addr - mmap->addr) < __STACK_SIZE)
+				UK_CRASH("Not enough memory to allocate boot "
+					 "stack\n");
+			break;
+		}
+	}
+}
+#endif /* CONFIG_UKPLAT_HAVE_MULTIBOOT2 */
 
 static inline void _get_cmdline(struct uk_bootinfo *bi)
 {
@@ -149,12 +217,12 @@ static inline void _get_cmdline(struct uk_bootinfo *bi)
 static inline void _init_mem(struct uk_bootinfo *bi)
 {
 	_libkvmplat_cfg.heap.start = ALIGN_UP((uintptr_t)__END, __PAGE_SIZE);
-	_libkvmplat_cfg.heap.end = (uintptr_t)bi->max_addr - __STACK_SIZE;
-	_libkvmplat_cfg.heap.len =
+	_libkvmplat_cfg.heap.end   = (uintptr_t)bi->max_addr - __STACK_SIZE;
+	_libkvmplat_cfg.heap.len   =
 	    _libkvmplat_cfg.heap.end - _libkvmplat_cfg.heap.start;
 	_libkvmplat_cfg.bstack.start = _libkvmplat_cfg.heap.end;
-	_libkvmplat_cfg.bstack.end = bi->max_addr;
-	_libkvmplat_cfg.bstack.len = __STACK_SIZE;
+	_libkvmplat_cfg.bstack.end   = bi->max_addr;
+	_libkvmplat_cfg.bstack.len   = __STACK_SIZE;
 }
 
 static inline void _init_initrd(struct uk_bootinfo *bi)
@@ -202,7 +270,7 @@ static inline void _init_initrd(struct uk_bootinfo *bi)
 			/* End of initrd within heap range;
 			 * Use the remaining left piece as heap */
 			heap1_start = ALIGN_UP(_libkvmplat_cfg.initrd.end,
-				      	       __PAGE_SIZE);
+					       __PAGE_SIZE);
 			heap1_end   = _libkvmplat_cfg.heap.end;
 		}
 	} else {
@@ -255,7 +323,8 @@ static inline void _init_initrd(struct uk_bootinfo *bi)
 	 * places the initrd close to the beginning of the heap region. One need
 	 * to assign just more memory in order to avoid this crash.
 	 */
-	if (RANGE_OVERLAP(_libkvmplat_cfg.heap.start, _libkvmplat_cfg.heap.len,
+	if (RANGE_OVERLAP(_libkvmplat_cfg.heap.start,
+			  _libkvmplat_cfg.heap.len,
 			  _libkvmplat_cfg.initrd.start,
 			  _libkvmplat_cfg.initrd.len))
 		UK_CRASH("Not enough space at end of memory for boot stack\n");
@@ -279,17 +348,35 @@ static void _libkvmplat_entry2(void *arg __attribute__((unused)))
 
 void _libkvmplat_entry(void *arg)
 {
+#ifndef CONFIG_UKPLAT_HAVE_MULTIBOOT2
 	struct multiboot_info *mi = (struct multiboot_info *)arg;
+#else
+	unsigned long ulong_arg = (unsigned long)arg;
+	unsigned mbi_size;
+#endif /* CONFIG_UKPLAT_HAVE_MULTIBOOT2 */
 
 	_init_cpufeatures();
 	_libkvmplat_init_console();
 	traps_init();
 	intctrl_init();
 
+#ifndef CONFIG_UKPLAT_HAVE_MULTIBOOT2
 	uk_pr_info("Entering from KVM (x86)...\n");
 	uk_pr_info("     multiboot: %p\n", mi);
 
 	_convert_mbinfo(mi);
+#else
+	if (ulong_arg & 7)
+		UK_CRASH("Unaligned mbi: 0x%lx\n", ulong_arg);
+
+	mbi_size = *(unsigned *)ulong_arg;
+
+	uk_pr_info("Entering from KVM (x86)...\n");
+	uk_pr_info("     multiboot v2: 0x%lx\n", ulong_arg);
+	uk_pr_info("	 Announced mbi size: 0x%x\n", mbi_size);
+
+	_convert_mbitags(ulong_arg);
+#endif /* CONFIG_UKPLAT_HAVE_MULTIBOOT2 */
 
 	/*
 	 * The multiboot structures may be anywhere in memory, so take a copy of

--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -33,6 +33,7 @@
 #include <kvm/config.h>
 #include <kvm/console.h>
 #include <kvm/intctrl.h>
+#include <kvm-x86/bootinfo.h>
 #include <kvm-x86/multiboot.h>
 #include <kvm-x86/multiboot_defs.h>
 #include <uk/arch/limits.h>
@@ -49,35 +50,21 @@
 static char cmdline[MAX_CMDLINE_SIZE];
 
 struct kvmplat_config _libkvmplat_cfg = { 0 };
+struct uk_bootinfo bootinfo = { 0 };
 
 extern void _libkvmplat_newstack(uintptr_t stack_start, void (*tramp)(void *),
 				 void *arg);
 
-static inline void _mb_get_cmdline(struct multiboot_info *mi)
-{
-	char *mi_cmdline;
-
-	if (mi->flags & MULTIBOOT_INFO_CMDLINE) {
-		mi_cmdline = (char *)(__u64)mi->cmdline;
-
-		if (strlen(mi_cmdline) > sizeof(cmdline) - 1)
-			uk_pr_err("Command line too long, truncated\n");
-		strncpy(cmdline, mi_cmdline,
-			sizeof(cmdline));
-	} else {
-		/* Use image name as cmdline to provide argv[0] */
-		uk_pr_debug("No command line present\n");
-		strncpy(cmdline, CONFIG_UK_NAME, sizeof(cmdline));
-	}
-
-	/* ensure null termination */
-	cmdline[(sizeof(cmdline) - 1)] = '\0';
-}
-
-static inline void _mb_init_mem(struct multiboot_info *mi)
+static void _convert_mbinfo(struct multiboot_info *mi)
 {
 	multiboot_memory_map_t *m;
-	size_t offset, max_addr;
+	multiboot_module_t *mod1;
+	size_t offset;
+
+	if (mi->flags & MULTIBOOT_INFO_CMDLINE)
+		bootinfo.u64_cmdline = (__u64)mi->cmdline;
+	else
+		bootinfo.u64_cmdline = 0;
 
 	/*
 	 * Look for the first chunk of memory at PLATFORM_MEM_START.
@@ -96,39 +83,24 @@ static inline void _mb_init_mem(struct multiboot_info *mi)
 	 * Cap our memory size to PLATFORM_MAX_MEM_SIZE which boot.S defines
 	 * page tables for.
 	 */
-	max_addr = m->addr + m->len;
-	if (max_addr > PLATFORM_MAX_MEM_ADDR)
-		max_addr = PLATFORM_MAX_MEM_ADDR;
-	UK_ASSERT((size_t) __END <= max_addr);
+	bootinfo.max_addr = m->addr + m->len;
+	if (bootinfo.max_addr > PLATFORM_MAX_MEM_ADDR)
+		bootinfo.max_addr = PLATFORM_MAX_MEM_ADDR;
+	UK_ASSERT((size_t) __END <= bootinfo.max_addr);
 
 	/*
 	 * Reserve space for boot stack at the end of found memory
 	 */
-	if ((max_addr - m->addr) < __STACK_SIZE)
+	if ((bootinfo.max_addr - m->addr) < __STACK_SIZE)
 		UK_CRASH("Not enough memory to allocate boot stack\n");
 
-	_libkvmplat_cfg.heap.start = ALIGN_UP((uintptr_t) __END, __PAGE_SIZE);
-	_libkvmplat_cfg.heap.end   = (uintptr_t) max_addr - __STACK_SIZE;
-	_libkvmplat_cfg.heap.len   = _libkvmplat_cfg.heap.end
-				     - _libkvmplat_cfg.heap.start;
-	_libkvmplat_cfg.bstack.start = _libkvmplat_cfg.heap.end;
-	_libkvmplat_cfg.bstack.end   = max_addr;
-	_libkvmplat_cfg.bstack.len   = __STACK_SIZE;
-}
-
-static inline void _mb_init_initrd(struct multiboot_info *mi)
-{
-	multiboot_module_t *mod1;
-	uintptr_t heap0_start, heap0_end;
-	uintptr_t heap1_start, heap1_end;
-	size_t    heap0_len,   heap1_len;
-
 	/*
-	 * Search for initrd (called boot module according multiboot)
+	 * Search for initrd (called boot module according to multiboot)
 	 */
 	if (mi->mods_count == 0) {
 		uk_pr_debug("No initrd present\n");
-		goto no_initrd;
+		bootinfo.has_initrd = 0;
+		return;
 	}
 
 	/*
@@ -137,17 +109,66 @@ static inline void _mb_init_initrd(struct multiboot_info *mi)
 	 */
 	UK_ASSERT(mi->mods_addr);
 
-	mod1 = (multiboot_module_t *)((uintptr_t) mi->mods_addr);
+	mod1 = (multiboot_module_t *)((uintptr_t)mi->mods_addr);
 	UK_ASSERT(mod1->mod_end >= mod1->mod_start);
 
 	if (mod1->mod_end == mod1->mod_start) {
 		uk_pr_debug("Ignoring empty initrd\n");
-		goto no_initrd;
+		bootinfo.initrd_start = 0;
+		bootinfo.initrd_end = 0;
+		bootinfo.initrd_length = 0;
+		bootinfo.has_initrd = 0;
+	} else {
+		bootinfo.initrd_start = mod1->mod_start;
+		bootinfo.initrd_end = mod1->mod_end;
+		bootinfo.initrd_length = mod1->mod_end - mod1->mod_start;
+		bootinfo.has_initrd = 1;
+	}
+}
+
+static inline void _get_cmdline(struct uk_bootinfo *bi)
+{
+	char *mi_cmdline;
+
+	if (bi->u64_cmdline) {
+		mi_cmdline = (char *)bi->u64_cmdline;
+
+		if (strlen(mi_cmdline) > sizeof(cmdline) - 1)
+			uk_pr_err("Command line too long, truncated\n");
+		strncpy(cmdline, mi_cmdline, sizeof(cmdline));
+	} else {
+		/* Use image name as cmdline to provide argv[0] */
+		uk_pr_debug("No command line present\n");
+		strncpy(cmdline, CONFIG_UK_NAME, sizeof(cmdline));
 	}
 
-	_libkvmplat_cfg.initrd.start = (uintptr_t) mod1->mod_start;
-	_libkvmplat_cfg.initrd.end = (uintptr_t) mod1->mod_end;
-	_libkvmplat_cfg.initrd.len = (size_t) (mod1->mod_end - mod1->mod_start);
+	/* ensure null termination */
+	cmdline[(sizeof(cmdline) - 1)] = '\0';
+}
+
+static inline void _init_mem(struct uk_bootinfo *bi)
+{
+	_libkvmplat_cfg.heap.start = ALIGN_UP((uintptr_t)__END, __PAGE_SIZE);
+	_libkvmplat_cfg.heap.end = (uintptr_t)bi->max_addr - __STACK_SIZE;
+	_libkvmplat_cfg.heap.len =
+	    _libkvmplat_cfg.heap.end - _libkvmplat_cfg.heap.start;
+	_libkvmplat_cfg.bstack.start = _libkvmplat_cfg.heap.end;
+	_libkvmplat_cfg.bstack.end = bi->max_addr;
+	_libkvmplat_cfg.bstack.len = __STACK_SIZE;
+}
+
+static inline void _init_initrd(struct uk_bootinfo *bi)
+{
+	uintptr_t heap0_start, heap0_end;
+	uintptr_t heap1_start, heap1_end;
+	size_t heap0_len, heap1_len;
+
+	if (!bi->has_initrd)
+		goto no_initrd;
+
+	_libkvmplat_cfg.initrd.start = bi->initrd_start;
+	_libkvmplat_cfg.initrd.end   = bi->initrd_end;
+	_libkvmplat_cfg.initrd.len   = bi->initrd_length;
 
 	/*
 	 * Check if initrd is part of heap
@@ -181,7 +202,7 @@ static inline void _mb_init_initrd(struct multiboot_info *mi)
 			/* End of initrd within heap range;
 			 * Use the remaining left piece as heap */
 			heap1_start = ALIGN_UP(_libkvmplat_cfg.initrd.end,
-					       __PAGE_SIZE);
+				      	       __PAGE_SIZE);
 			heap1_end   = _libkvmplat_cfg.heap.end;
 		}
 	} else {
@@ -209,9 +230,9 @@ static inline void _mb_init_initrd(struct multiboot_info *mi)
 			_libkvmplat_cfg.heap.end   = 0;
 			_libkvmplat_cfg.heap.len   = 0;
 		}
-		 _libkvmplat_cfg.heap2.start = 0;
-		 _libkvmplat_cfg.heap2.end   = 0;
-		 _libkvmplat_cfg.heap2.len   = 0;
+		_libkvmplat_cfg.heap2.start = 0;
+		_libkvmplat_cfg.heap2.end   = 0;
+		_libkvmplat_cfg.heap2.len   = 0;
 	} else {
 		/* Heap piece 0 has memory */
 		_libkvmplat_cfg.heap.start = heap0_start;
@@ -234,8 +255,7 @@ static inline void _mb_init_initrd(struct multiboot_info *mi)
 	 * places the initrd close to the beginning of the heap region. One need
 	 * to assign just more memory in order to avoid this crash.
 	 */
-	if (RANGE_OVERLAP(_libkvmplat_cfg.heap.start,
-			  _libkvmplat_cfg.heap.len,
+	if (RANGE_OVERLAP(_libkvmplat_cfg.heap.start, _libkvmplat_cfg.heap.len,
 			  _libkvmplat_cfg.initrd.start,
 			  _libkvmplat_cfg.initrd.len))
 		UK_CRASH("Not enough space at end of memory for boot stack\n");
@@ -269,24 +289,25 @@ void _libkvmplat_entry(void *arg)
 	uk_pr_info("Entering from KVM (x86)...\n");
 	uk_pr_info("     multiboot: %p\n", mi);
 
+	_convert_mbinfo(mi);
+
 	/*
 	 * The multiboot structures may be anywhere in memory, so take a copy of
 	 * everything necessary before we initialise memory allocation.
 	 */
-	_mb_get_cmdline(mi);
-	_mb_init_mem(mi);
-	_mb_init_initrd(mi);
+	_get_cmdline(&bootinfo);
+	_init_mem(&bootinfo);
+	_init_initrd(&bootinfo);
 
 	if (_libkvmplat_cfg.initrd.len)
 		uk_pr_info("        initrd: %p\n",
-			   (void *) _libkvmplat_cfg.initrd.start);
-	uk_pr_info("    heap start: %p\n",
-		   (void *) _libkvmplat_cfg.heap.start);
+			   (void *)_libkvmplat_cfg.initrd.start);
+	uk_pr_info("    heap start: %p\n", (void *)_libkvmplat_cfg.heap.start);
 	if (_libkvmplat_cfg.heap2.len)
 		uk_pr_info(" heap start (2): %p\n",
-			   (void *) _libkvmplat_cfg.heap2.start);
+			   (void *)_libkvmplat_cfg.heap2.start);
 	uk_pr_info("     stack top: %p\n",
-		   (void *) _libkvmplat_cfg.bstack.start);
+		   (void *)_libkvmplat_cfg.bstack.start);
 
 #ifdef CONFIG_HAVE_SMP
 	acpi_init();
@@ -304,7 +325,6 @@ void _libkvmplat_entry(void *arg)
 	 * Switch away from the bootstrap stack as early as possible.
 	 */
 	uk_pr_info("Switch from bootstrap stack to stack @%p\n",
-		   (void *) _libkvmplat_cfg.bstack.end);
-	_libkvmplat_newstack(_libkvmplat_cfg.bstack.end,
-			     _libkvmplat_entry2, 0);
+		   (void *)_libkvmplat_cfg.bstack.end);
+	_libkvmplat_newstack(_libkvmplat_cfg.bstack.end, _libkvmplat_entry2, 0);
 }


### PR DESCRIPTION
To run the image with Multiboot 2, GRUB is required. Until I figure out how to make the build system create a GRUB image, I provided a script to create the needed files and run only the Unikraft image: support/scripts/run_multiboot2.sh

Known issue: no command line is detected