### PR TITLE
Fix `UK_LIBC_SYSCALL` to `UK_LIBC_SYSCALLS` in docs, `sync` and `ioctl` system call registration.

### DIFF
--- a/doc/guides/developers-app.rst
+++ b/doc/guides/developers-app.rst
@@ -449,16 +449,16 @@ libc-style wrapper on top:
         return ret;
     }
 
-    #if UK_LIBC_SYSCALL
+    #if UK_LIBC_SYSCALLS
     ssize_t write(int fd, const void *buf, size_t count)
     {
         return (ssize_t) uk_syscall_e_write((long) fd,
                                             (long) buf, (long) count);
     }
-    #endif /* UK_LIBC_SYSCALL */
+    #endif /* UK_LIBC_SYSCALLS */
 
 Note: Please note that the implementation of custom libc-style wrappers have to
-be guarded with ``#if UK_LIBC_SYSCALL``. This macro is provided by the
+be guarded with ``#if UK_LIBC_SYSCALLS``. This macro is provided by the
 ``<uk/syscall.h>`` header. Some libC ports (e.g., musl) deactivate this option
 whenever their provide own wrapper functions. For such cases, the syscall_shim
 library will only provide the ``uk_syscall_e_<syscall_name>`` and

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -673,7 +673,7 @@ out_errno:
 	return -error;
 }
 
-#if UK_LIBC_SYSCALL
+#if UK_LIBC_SYSCALLS
 int ioctl(int fd, unsigned long int request, ...)
 {
 	va_list ap;

--- a/lib/vfscore/mount.c
+++ b/lib/vfscore/mount.c
@@ -380,7 +380,7 @@ UK_LLSYSCALL_R_DEFINE(int, sync)
 	uk_mutex_unlock(&mount_lock);
 }
 
-#if UK_LIBC_SYSCALL
+#if UK_LIBC_SYSCALLS
 void sync(void)
 {
    uk_syscall_e_sync();


### PR DESCRIPTION
This patch updates the documentation and the system call registration of `sync` to syscall_shim to have `UK_LIBC_SYSCALL` changed to `UK_LIBC_SYSCALLS`.