### PR TITLE
support: Introduce editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 8
+indent_style = tab
+max_line_length = 80
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[.git/**]
+max_line_length = 75
+


### PR DESCRIPTION
EditorConfig [specifies](https://editorconfig.org) how an IDE configures generic styling for files for a project.  This is done by introducing a top-level `.editorconfig` file within the repository. This PR sets the Unikraft standards using EditorConfig:

 * indentation using tabs with spacing of 8 characters;
 * max line lenfth of 75 characters for git commit messages;
 * max line length of 80 characters for standard files;
 * adding a new line to the end of files; and,
 * trimming of whitespace.

I'm more of a "spaces" guy myself, so my editor is set up that way.  With this file, and when working on Unikraft, I don't have to think twice about what happens when hitting the "tab" key.