### PR TITLE
lib/ukdebug: Provide way to print without library name

### DIFF
--- a/lib/ukdebug/exportsyms.uk
+++ b/lib/ukdebug/exportsyms.uk
@@ -1,7 +1,7 @@
-_uk_vprintd
-_uk_printd
-_uk_vprintk
-_uk_printk
+_uk_vlprintd
+_uk_lprintd
+_uk_vlprintk
+_uk_lprintk
 uk_hexdumpsn
 uk_hexdumpf
 uk_hexdumpd

--- a/lib/ukdebug/exportsyms.uk
+++ b/lib/ukdebug/exportsyms.uk
@@ -1,7 +1,11 @@
 _uk_vlprintd
 _uk_lprintd
+_uk_vprintd
+_uk_printd
 _uk_vlprintk
 _uk_lprintk
+_uk_vprintk
+_uk_printk
 uk_hexdumpsn
 uk_hexdumpf
 uk_hexdumpd

--- a/lib/ukdebug/include/uk/print.h
+++ b/lib/ukdebug/include/uk/print.h
@@ -77,56 +77,56 @@ extern "C" {
  * they compile in the function calls only if debugging
  * is enabled
  */
-void _uk_vprintd(const char *libname, const char *srcname,
+void _uk_vlprintd(const char *libname, const char *srcname,
 		 unsigned int srcline, const char *fmt, va_list ap);
-void _uk_printd(const char *libname, const char *srcname,
+void _uk_lprintd(const char *libname, const char *srcname,
 		unsigned int srcline, const char *fmt, ...) __printf(4, 5);
 
-#define uk_vprintd(fmt, ap)						\
+#define uk_vlprintd(fmt, ap)						\
 	do {								\
-		_uk_vprintd(__STR_LIBNAME__, __STR_BASENAME__,		\
+		_uk_vlprintd(__STR_LIBNAME__, __STR_BASENAME__,		\
 			    __LINE__, (fmt), ap);			\
 	} while (0)
 
-#define uk_vprintd_once(fmt, ap)					\
+#define uk_vlprintd_once(fmt, ap)					\
 	do {								\
 		static int __x;						\
 		if (unlikely(!__x)) {					\
-			_uk_vprintd(__STR_LIBNAME__, __STR_BASENAME__,	\
+			_uk_vlprintd(__STR_LIBNAME__, __STR_BASENAME__,	\
 				    __LINE__, (fmt), ap);		\
 			__x = 1;					\
 		}							\
 	} while (0)
 
-#define uk_printd(fmt, ...)						\
+#define uk_lprintd(fmt, ...)						\
 	do {								\
-		_uk_printd(__STR_LIBNAME__, __STR_BASENAME__,		\
+		_uk_lprintd(__STR_LIBNAME__, __STR_BASENAME__,		\
 			   __LINE__, (fmt), ##__VA_ARGS__);		\
 	} while (0)
 
-#define uk_printd_once(fmt, ...)					\
+#define uk_lprintd_once(fmt, ...)					\
 	do {								\
 		static int __x;						\
 		if (unlikely(!__x)) {					\
-			_uk_printd(__STR_LIBNAME__, __STR_BASENAME__,	\
+			_uk_lprintd(__STR_LIBNAME__, __STR_BASENAME__,	\
 				   __LINE__, (fmt), ##__VA_ARGS__);	\
 			__x = 1;					\
 		}							\
 	} while (0)
 #else
-static inline void uk_vprintd(const char *fmt __unused, va_list ap __unused)
+static inline void uk_vlprintd(const char *fmt __unused, va_list ap __unused)
 {}
 
-static inline void uk_printd(const char *fmt, ...) __printf(1, 2);
-static inline void uk_printd(const char *fmt __unused, ...)
+static inline void uk_lprintd(const char *fmt, ...) __printf(1, 2);
+static inline void uk_lprintd(const char *fmt __unused, ...)
 {}
 
-static inline void uk_vprintd_once(const char *fmt __unused,
+static inline void uk_vlprintd_once(const char *fmt __unused,
 				   va_list ap __unused)
 {}
 
-static inline void uk_printd_once(const char *fmt, ...) __printf(1, 2);
-static inline void uk_printd_once(const char *fmt __unused, ...)
+static inline void uk_lprintd_once(const char *fmt, ...) __printf(1, 2);
+static inline void uk_lprintd_once(const char *fmt __unused, ...)
 {}
 #endif
 
@@ -155,24 +155,24 @@ static inline void uk_printd_once(const char *fmt __unused, ...)
  * they compile in the function calls only if the configured
  * debug level requires it
  */
-void _uk_vprintk(int lvl, const char *libname, const char *srcname,
+void _uk_vlprintk(int lvl, const char *libname, const char *srcname,
 		 unsigned int srcline, const char *fmt, va_list ap);
-void _uk_printk(int lvl, const char *libname, const char *srcname,
+void _uk_lprintk(int lvl, const char *libname, const char *srcname,
 		unsigned int srcline, const char *fmt, ...) __printf(5, 6);
 
-#define uk_vprintk(lvl, fmt, ap)                                               \
+#define uk_vlprintk(lvl, fmt, ap)                                              \
 	do {                                                                   \
 		if ((lvl) <= KLVL_MAX)                                         \
-			_uk_vprintk((lvl), __STR_LIBNAME__, __STR_BASENAME__,  \
+			_uk_vlprintk((lvl), __STR_LIBNAME__, __STR_BASENAME__, \
 				    __LINE__, (fmt), ap);                      \
 	} while (0)
 
-#define uk_vprintk_once(lvl, fmt, ap)                                          \
+#define uk_vlprintk_once(lvl, fmt, ap)                                         \
 	do {                                                                   \
 		if ((lvl) <= KLVL_MAX) {                                       \
 			static int __x;                                        \
 			if (unlikely(!__x)) {                                  \
-				_uk_vprintk((lvl), __STR_LIBNAME__,            \
+				_uk_vlprintk((lvl), __STR_LIBNAME__,           \
 					    __STR_BASENAME__,                  \
 					    __LINE__, (fmt), ap);              \
 				__x = 1;                                       \
@@ -180,19 +180,19 @@ void _uk_printk(int lvl, const char *libname, const char *srcname,
 		}                                                              \
 	} while (0)
 
-#define uk_printk(lvl, fmt, ...)                                               \
+#define uk_lprintk(lvl, fmt, ...)                                              \
 	do {                                                                   \
 		if ((lvl) <= KLVL_MAX)                                         \
-			_uk_printk((lvl), __STR_LIBNAME__, __STR_BASENAME__,   \
+			_uk_lprintk((lvl), __STR_LIBNAME__, __STR_BASENAME__,  \
 				   __LINE__, (fmt), ##__VA_ARGS__);            \
 	} while (0)
 
-#define uk_printk_once(lvl, fmt, ...)                                          \
+#define uk_lprintk_once(lvl, fmt, ...)                                         \
 	do {                                                                   \
 		if ((lvl) <= KLVL_MAX) {                                       \
 			static int __x;                                        \
 			if (unlikely(!__x)) {                                  \
-				_uk_printk((lvl), __STR_LIBNAME__,             \
+				_uk_lprintk((lvl), __STR_LIBNAME__,            \
 					   __STR_BASENAME__,                   \
 					   __LINE__, (fmt), ##__VA_ARGS__);    \
 				__x = 1;                                       \
@@ -200,20 +200,20 @@ void _uk_printk(int lvl, const char *libname, const char *srcname,
 		}                                                              \
 	} while (0)
 #else
-static inline void uk_vprintk(int lvl __unused, const char *fmt __unused,
+static inline void uk_vlprintk(int lvl __unused, const char *fmt __unused,
 				va_list ap __unused)
 {}
 
-static inline void uk_printk(int lvl, const char *fmt, ...) __printf(2, 3);
-static inline void uk_printk(int lvl __unused, const char *fmt __unused, ...)
+static inline void uk_lprintk(int lvl, const char *fmt, ...) __printf(2, 3);
+static inline void uk_lprintk(int lvl __unused, const char *fmt __unused, ...)
 {}
 
-static inline void uk_vprintk_once(int lvl __unused, const char *fmt __unused,
+static inline void uk_vlprintk_once(int lvl __unused, const char *fmt __unused,
 				   va_list ap __unused)
 {}
 
-static inline void uk_printk_once(int lvl, const char *fmt, ...) __printf(2, 3);
-static inline void uk_printk_once(int lvl __unused,
+static inline void uk_lprintk_once(int lvl, const char *fmt, ...) __printf(2, 3);
+static inline void uk_lprintk_once(int lvl __unused,
 				  const char *fmt __unused, ...)
 {}
 #endif /* CONFIG_LIBUKDEBUG_PRINTK */
@@ -222,19 +222,19 @@ static inline void uk_printk_once(int lvl __unused,
  * Convenience wrapper for uk_printk() and uk_printd()
  * This is similar to the pr_* variants that you find in the Linux kernel
  */
-#define uk_pr_debug(fmt, ...) uk_printd((fmt), ##__VA_ARGS__)
-#define uk_pr_debug_once(fmt, ...) uk_printd_once((fmt), ##__VA_ARGS__)
-#define uk_pr_info(fmt, ...)  uk_printk(KLVL_INFO,  (fmt), ##__VA_ARGS__)
-#define uk_pr_info_once(fmt, ...)  uk_printk_once(KLVL_INFO, (fmt), \
+#define uk_pr_debug(fmt, ...) uk_lprintd((fmt), ##__VA_ARGS__)
+#define uk_pr_debug_once(fmt, ...) uk_lprintd_once((fmt), ##__VA_ARGS__)
+#define uk_pr_info(fmt, ...)  uk_lprintk(KLVL_INFO,  (fmt), ##__VA_ARGS__)
+#define uk_pr_info_once(fmt, ...)  uk_lprintk_once(KLVL_INFO, (fmt), \
 						  ##__VA_ARGS__)
-#define uk_pr_warn(fmt, ...)  uk_printk(KLVL_WARN,  (fmt), ##__VA_ARGS__)
-#define uk_pr_warn_once(fmt, ...)  uk_printk_once(KLVL_WARN, (fmt), \
+#define uk_pr_warn(fmt, ...)  uk_lprintk(KLVL_WARN,  (fmt), ##__VA_ARGS__)
+#define uk_pr_warn_once(fmt, ...)  uk_lprintk_once(KLVL_WARN, (fmt), \
 						  ##__VA_ARGS__)
-#define uk_pr_err(fmt, ...)   uk_printk(KLVL_ERR,   (fmt), ##__VA_ARGS__)
-#define uk_pr_err_once(fmt, ...)   uk_printk_once(KLVL_ERR,  (fmt), \
+#define uk_pr_err(fmt, ...)   uk_lprintk(KLVL_ERR,   (fmt), ##__VA_ARGS__)
+#define uk_pr_err_once(fmt, ...)   uk_lprintk_once(KLVL_ERR,  (fmt), \
 						  ##__VA_ARGS__)
-#define uk_pr_crit(fmt, ...)  uk_printk(KLVL_CRIT,  (fmt), ##__VA_ARGS__)
-#define uk_pr_crit_once(fmt, ...)  uk_printk_once(KLVL_CRIT, (fmt), \
+#define uk_pr_crit(fmt, ...)  uk_lprintk(KLVL_CRIT,  (fmt), ##__VA_ARGS__)
+#define uk_pr_crit_once(fmt, ...)  uk_lprintk_once(KLVL_CRIT, (fmt), \
 						  ##__VA_ARGS__)
 
 /* Warning for stubbed functions */

--- a/lib/ukdebug/include/uk/print.h
+++ b/lib/ukdebug/include/uk/print.h
@@ -77,6 +77,12 @@ extern "C" {
  * they compile in the function calls only if debugging
  * is enabled
  */
+void _uk_vprintd(const char *fmt, va_list ap);
+void _uk_printd(const char *fmt, ...) __printf(1, 2);
+
+#define uk_vprintd(fmt, ap) _uk_vprintd((fmt), ap)
+#define uk_printd(fmt, ...) _uk_printd((fmt), ##__VA_ARGS__)
+
 void _uk_vlprintd(const char *libname, const char *srcname,
 		 unsigned int srcline, const char *fmt, va_list ap);
 void _uk_lprintd(const char *libname, const char *srcname,
@@ -155,6 +161,12 @@ static inline void uk_lprintd_once(const char *fmt __unused, ...)
  * they compile in the function calls only if the configured
  * debug level requires it
  */
+void _uk_vprintk(const char *fmt, va_list ap);
+void _uk_printk(const char *fmt, ...) __printf(1, 2);
+
+#define uk_vprintk(fmt, ap) _uk_vprintk((fmt), ap)
+#define uk_printk(fmt, ...) _uk_printk((fmt), ##__VA_ARGS__)
+
 void _uk_vlprintk(int lvl, const char *libname, const char *srcname,
 		 unsigned int srcline, const char *fmt, va_list ap);
 void _uk_lprintk(int lvl, const char *libname, const char *srcname,

--- a/lib/ukdebug/outf.c
+++ b/lib/ukdebug/outf.c
@@ -65,13 +65,13 @@ int outf(struct out_dev *dev, const char *fmt, ...)
 		}
 		break;
 	case OUTDEV_DEBUG:
-		_uk_vprintd(dev->uk_pr.libname,
+		_uk_vlprintd(dev->uk_pr.libname,
 			    dev->uk_pr.srcname, dev->uk_pr.srcline,
 			    fmt, ap);
 		break;
 #if CONFIG_LIBUKDEBUG_PRINTK
 	case OUTDEV_KERN:
-		_uk_vprintk(dev->uk_pr.lvl, dev->uk_pr.libname,
+		_uk_vlprintk(dev->uk_pr.lvl, dev->uk_pr.libname,
 			    dev->uk_pr.srcname, dev->uk_pr.srcline,
 			    fmt, ap);
 		break;

--- a/lib/ukdebug/print.c
+++ b/lib/ukdebug/print.c
@@ -253,10 +253,10 @@ static void _vlprint(struct _vprint_console *cons,
 					   strlen(LVLC_RESET LVLC_SRCNAME) + 1);
 				cons->cout(DECONST(char *, srcname),
 					   strlen(srcname));
-				cons->cout(" @ ", 3);
+				cons->cout(":", 1);
 				cons->cout(lnobuf,
 					   __uk_snprintf(lnobuf, sizeof(lnobuf),
-							 "%4u", srcline));
+							 "%d", srcline));
 				cons->cout("> ", 2);
 			}
 #endif

--- a/lib/ukdebug/print.c
+++ b/lib/ukdebug/print.c
@@ -196,19 +196,19 @@ static void _vlprint(struct _vprint_console *cons,
 	 */
 	switch (lvl) {
 	case KLVL_DEBUG:
-		msghdr = LVLC_RESET LVLC_DEBUG "dbg:" LVLC_RESET "  ";
+		msghdr = LVLC_RESET LVLC_DEBUG "dbug:" LVLC_RESET " ";
 		break;
 	case KLVL_CRIT:
 		msghdr = LVLC_RESET LVLC_CRIT  "CRIT:" LVLC_RESET " ";
 		break;
 	case KLVL_ERR:
-		msghdr = LVLC_RESET LVLC_ERROR "ERR:" LVLC_RESET "  ";
+		msghdr = LVLC_RESET LVLC_ERROR "erro:" LVLC_RESET " ";
 		break;
 	case KLVL_WARN:
-		msghdr = LVLC_RESET LVLC_WARN  "Warn:" LVLC_RESET " ";
+		msghdr = LVLC_RESET LVLC_WARN  "warn:" LVLC_RESET " ";
 		break;
 	case KLVL_INFO:
-		msghdr = LVLC_RESET LVLC_INFO  "Info:" LVLC_RESET " ";
+		msghdr = LVLC_RESET LVLC_INFO  "info:" LVLC_RESET " ";
 		break;
 	default:
 		/* unknown type: ignore */

--- a/lib/ukdebug/print.c
+++ b/lib/ukdebug/print.c
@@ -141,7 +141,7 @@ static void _print_stack(struct _vprint_console *cons)
 }
 #endif
 
-static void _vprint(struct _vprint_console *cons,
+static void _vlprint(struct _vprint_console *cons,
 		    int lvl, const char *libname,
 		    const char *srcname __maybe_unused,
 		    unsigned int srcline __maybe_unused,
@@ -261,24 +261,24 @@ static void _vprint(struct _vprint_console *cons,
  *  We rely on OPTIMIZE_DEADELIM: These symbols are automatically
  *  removed from the final image when there was no usage.
  */
-void _uk_vprintd(const char *libname, const char *srcname,
+void _uk_vlprintd(const char *libname, const char *srcname,
 		 unsigned int srcline, const char *fmt, va_list ap)
 {
 
 #if CONFIG_LIBUKDEBUG_REDIR_PRINTD
-	_vprint(&kern,  KLVL_DEBUG, libname, srcname, srcline, fmt, ap);
+	_vlprint(&kern,  KLVL_DEBUG, libname, srcname, srcline, fmt, ap);
 #else
-	_vprint(&debug, KLVL_DEBUG, libname, srcname, srcline, fmt, ap);
+	_vlprint(&debug, KLVL_DEBUG, libname, srcname, srcline, fmt, ap);
 #endif
 }
 
-void _uk_printd(const char *libname, const char *srcname,
+void _uk_lprintd(const char *libname, const char *srcname,
 		unsigned int srcline, const char *fmt, ...)
 {
 	va_list ap;
 
 	va_start(ap, fmt);
-	_uk_vprintd(libname, srcname, srcline, fmt, ap);
+	_uk_vlprintd(libname, srcname, srcline, fmt, ap);
 	va_end(ap);
 }
 
@@ -289,23 +289,23 @@ void _uk_printd(const char *libname, const char *srcname,
  *  enabled.
  */
 #if CONFIG_LIBUKDEBUG_PRINTK
-void _uk_vprintk(int lvl, const char *libname, const char *srcname,
+void _uk_vlprintk(int lvl, const char *libname, const char *srcname,
 		 unsigned int srcline, const char *fmt, va_list ap)
 {
 #if CONFIG_LIBUKDEBUG_REDIR_PRINTK
-	_vprint(&debug, lvl, libname, srcname, srcline, fmt, ap);
+	_vlprint(&debug, lvl, libname, srcname, srcline, fmt, ap);
 #else
-	_vprint(&kern,  lvl, libname, srcname, srcline, fmt, ap);
+	_vlprint(&kern,  lvl, libname, srcname, srcline, fmt, ap);
 #endif
 }
 
-void _uk_printk(int lvl, const char *libname, const char *srcname,
+void _uk_lprintk(int lvl, const char *libname, const char *srcname,
 		unsigned int srcline, const char *fmt, ...)
 {
 	va_list ap;
 
 	va_start(ap, fmt);
-	_uk_vprintk(lvl, libname, srcname, srcline, fmt, ap);
+	_uk_vlprintk(lvl, libname, srcname, srcline, fmt, ap);
 	va_end(ap);
 }
 #endif /* CONFIG_LIBUKDEBUG_PRINTD */


### PR DESCRIPTION
This series accomplishes a number of goals within `ukdebug`'s print
system.  The first is to allow printing without the library name
prefixed to the desired message.  This is useful for printing
larger in-system information which does not require this grandularity.
The prefix can also distort output which is formatted in multi-line
manner.  To accomplish this, `l` is prefixed to the existing print
methods to indicate "long" or "library" messages and a new method,
`uk_printd` and `uk_printk`, can be used to print without this
information.

The other task accomplished in this series is to cleanup the message
level format styling.

*N.B.*  The warnings in the checkpatch come as a result of the original
source files being non-complaint.  This is a separate issue which
already has an open issue: #199.