### PR TITLE
Initial implementation of memory ballooning

### DIFF
--- a/include/uk/plat/balloon.h
+++ b/include/uk/plat/balloon.h
@@ -1,0 +1,76 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Authors: Cason Schindler & Jack Raney <cason.j.schindler@gmail.com>
+ *          Cezar Craciunoiu <cezar.craciunoiu@gmail.com>
+ *
+ * Copyright (c) 2019, The University of Texas at Austin. All rights reserved.
+ *               2021, University Politehnica of Bucharest. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __UKPLAT_BALLOON_H__
+#define __UKPLAT_BALLOON_H__
+
+/**
+ * Inflates the memory balloon by 1 extent. After this point, the extent
+ * starting at the specified virtual address will be unavailable to the guest.
+ * The host will then be able to use the extent for its own purposes.
+ *
+ * @param va The starting virtual address to release
+ * @param order The size of the extent to be released
+ * @return >= 0 on success, < 0 otherwise
+ */
+int ukplat_inflate(void *va, int order);
+
+/**
+ * Deflates the memory balloon by 1 extent, and returns a frame to the
+ * hypervisor starting at the specified virtual address.
+ *
+ * @param va The starting virtual address to recover
+ * @param order The size of the extent to be recovered
+ * @return num pages reclaimed on success, < 0 otherwise
+ */
+int ukplat_deflate(void *va, int order);
+
+#if CONFIG_PLAT_KVM && !CONFIG_VIRTIO_BALLOON
+
+#include <errno.h>
+
+static inline int __balloon_not_enabled(void)
+{
+	return -ENOSYS;
+}
+
+#define ukplat_inflate(va, order)	\
+	__balloon_not_enabled()
+
+#define ukplat_inflate(va, order)	\
+	__balloon_not_enabled()
+
+#endif /* CONFIG_PLAT_KVM && !CONFIG_VIRTIO_BALLOON */
+
+#endif /* __UKPLAT_BALLOON_H__ */

--- a/lib/ukallocbbuddy/bbuddy.c
+++ b/lib/ukallocbbuddy/bbuddy.c
@@ -49,6 +49,8 @@
 #include <uk/assert.h>
 #include <uk/page.h>
 
+#include <uk/plat/balloon.h>
+
 typedef struct chunk_head_st chunk_head_t;
 typedef struct chunk_tail_st chunk_tail_t;
 
@@ -232,12 +234,60 @@ static inline unsigned long num_pages_to_order(unsigned long num_pages)
 }
 
 /*********************
+ * BALLOON SUPPORT
+ */
+
+static char using_balloon;
+
+/**
+ * Initializes the balloon once it is ready. Immediate for Xen,
+ * but later for KVM driver.
+ */
+static void balloon_init(struct uk_alloc *a)
+{
+	struct uk_bbpalloc *b;
+	size_t i;
+	int order = order;
+	chunk_head_t *chunk;
+	int r;
+
+	b = (struct uk_bbpalloc *)&a->priv;
+
+#ifdef CONFIG_PLAT_KVM
+	using_balloon = 1;
+#endif /* CONFIG_PLAT_KVM */
+
+	if (using_balloon != 0)
+		return;
+
+	for (i = 0; i < FREELIST_SIZE; i++) {
+		if (!FREELIST_EMPTY(b->free_head[i])) {
+			chunk = b->free_head[i];
+			order = chunk->level;
+
+			r = ukplat_inflate((void *)chunk, order);
+			if (r < 0) {
+				/* The balloon is ready but
+				 * failed for another reason.
+				 */
+				return;
+			}
+		}
+
+	}
+	using_balloon = 1;
+}
+
+
+
+/*********************
  * BINARY BUDDY PAGE ALLOCATOR
  */
 static void *bbuddy_palloc(struct uk_alloc *a, unsigned long num_pages)
 {
 	struct uk_bbpalloc *b;
 	size_t i;
+	int r = r;
 	chunk_head_t *alloc_ch, *spare_ch;
 	chunk_tail_t *spare_ct;
 
@@ -281,6 +331,31 @@ static void *bbuddy_palloc(struct uk_alloc *a, unsigned long num_pages)
 	map_alloc(b, (uintptr_t)alloc_ch, 1UL << order);
 
 	uk_alloc_stats_count_palloc(a, (void *) alloc_ch, num_pages);
+	/* Remove the chunk from the balloon - not for KVM */
+#ifndef CONFIG_PLAT_KVM
+	r = ukplat_deflate((void *)alloc_ch, (int)order);
+	if (r < 0) {
+		if (r == -ENXIO) {
+			/* The balloon isn't ready yet!
+				* We don't need to do anything.
+				*/
+		} else if (r == -ENOSYS) {
+			/* deflation not implemented */
+		} else {
+			/* The balloon is ready but
+				* failed for another reason.
+				*/
+			return NULL;
+		}
+	} else if (using_balloon == 0) {
+		/* Deflate succeeded for the first time.
+			* The balloon driver is ready! We need to move
+			* all of the freelist data to the balloon.
+			*/
+		balloon_init(a);
+	}
+#endif /* CONFIG_PLAT_KVM */
+
 	return ((void *)alloc_ch);
 
 no_memory:
@@ -298,6 +373,7 @@ static void bbuddy_pfree(struct uk_alloc *a, void *obj, unsigned long num_pages)
 	chunk_head_t *freed_ch, *to_merge_ch;
 	chunk_tail_t *freed_ct;
 	unsigned long mask;
+	int r;
 
 	UK_ASSERT(a != NULL);
 
@@ -311,6 +387,29 @@ static void bbuddy_pfree(struct uk_alloc *a, void *obj, unsigned long num_pages)
 
 	/* First free the chunk */
 	map_free(b, (uintptr_t)obj, 1UL << order);
+
+	/* Add the free chunk to the balloon */
+	r = ukplat_inflate((void *)obj, (int)order);
+	if (r < 0) {
+		if (r == -ENXIO) {
+			/* The balloon isn't ready yet!
+			 * We don't need to do anything.
+			 */
+		} else if (r == -ENOSYS) {
+			/* inflation not implemented */
+		} else {
+			/* The balloon is ready but
+			 * failed for another reason.
+			 */
+			return;
+		}
+	} else if (using_balloon == 0) {
+		/* Inflate succeeded for the first time.
+		 * The balloon driver is now ready!
+		 * We need to move all of the free list data to the balloon.
+		 */
+		balloon_init(a);
+	}
 
 	/* Create free chunk */
 	freed_ch = (chunk_head_t *)obj;
@@ -395,6 +494,7 @@ static int bbuddy_addmem(struct uk_alloc *a, void *base, size_t len)
 	chunk_head_t *ch;
 	chunk_tail_t *ct;
 	uintptr_t min, max, range;
+	int r;
 
 	UK_ASSERT(a != NULL);
 	UK_ASSERT(base != NULL);
@@ -455,8 +555,9 @@ static int bbuddy_addmem(struct uk_alloc *a, void *base, size_t len)
 	memset(memr->mm_alloc_bitmap, (unsigned char) ~0,
 			memr->mm_alloc_bitmap_size);
 
-	/* free up the memory we've been given to play with */
-	map_free(b, min, memr->nr_pages);
+	/* Mock call to check if the balloon is implemented */
+	if (ukplat_inflate(NULL, 0) == -ENOSYS)
+		map_free(b, min, memr->nr_pages);
 
 	count = 0;
 	while (range != 0) {
@@ -471,6 +572,39 @@ static int bbuddy_addmem(struct uk_alloc *a, void *base, size_t len)
 		uk_pr_debug("%"__PRIuptr": Add allocate unit %"__PRIuptr" - %"__PRIuptr" (order %lu)\n",
 			    (uintptr_t)a, min, (uintptr_t)(min + (1UL << i)),
 			    (i - __PAGE_SHIFT));
+
+		/*
+		 * For each free block we attempt to add it to the balloon
+		 * Afterwards, if successful, all of our usable memory will be
+		 * in the balloon. It will become accessible by calling deflate
+		 * in ukpalloc, or directly for KVM.
+		 *
+		 * If the balloon device has not yet been added then the
+		 * allocator will proceed without ballooning support until
+		 * the device has been added (KVM).
+		 */
+		r = ukplat_inflate((void *)min, (int)(i - __PAGE_SHIFT));
+		if (r < 0) {
+			if (r == -ENXIO) {
+				/* The balloon isn't ready yet!
+				 * We don't need to do anything.
+				 */
+			} else if (r == -ENOSYS) {
+				/* inflation not implemented */
+			} else {
+				/* The balloon is ready but failed
+				 * for another reason.
+				 */
+				return r;
+			}
+		} else if (using_balloon == 0) {
+			/* Inflate succeeded for the first time.
+			 * The balloon driver is now ready!
+			 * We need to move all of the free list
+			 * data to the balloon.
+			 */
+			balloon_init(a);
+		}
 
 		ch = (chunk_head_t *)min;
 		min += 1UL << i;

--- a/plat/drivers/balloon/balloon_drv.c
+++ b/plat/drivers/balloon/balloon_drv.c
@@ -1,0 +1,372 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Authors: Cason Schindler & Jack Raney <cason.j.schindler@gmail.com>
+ *          Cezar Craciunoiu <cezar.craciunoiu@gmail.com>
+ *
+ * Copyright (c) 2019, The University of Texas at Austin. All rights reserved.
+ *               2021, University Politehnica of Bucharest. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <inttypes.h>
+
+#include <uk/plat/common/sections.h>
+#include <sys/types.h>
+#include <uk/assert.h>
+#include <kvm/config.h>
+#include <uk/alloc.h>
+#include <uk/sglist.h>
+#include <uk/list.h>
+#include <uk/assert.h>
+#include <uk/mutex.h>
+#include <virtio/virtio_ids.h>
+#include <virtio/virtio_bus.h>
+#include <virtio/virtqueue.h>
+
+#include <balloon/balloon.h>
+
+#define DRIVER_NAME "virtio-balloon"
+#define VTBALLOON_PAGES_PER_REQUEST	8192
+
+static struct uk_alloc *a;
+
+static struct virtio_balloon_device *global_vb;
+
+/* pages given to hypervisor (in the balloon) */
+struct balloon_pages {
+
+	uint32_t num_pages;
+
+};
+
+/* temporary storage for pages with which we are either
+ * inflating or deflating the balloon
+ */
+struct transport_pages {
+
+	uint32_t num_pages;
+	uint32_t *pages;
+
+};
+
+/* wrapper for virtio device */
+struct virtio_balloon_device {
+
+	struct virtio_dev *vdev;
+
+	struct virtqueue *inflate_vq, *deflate_vq;
+
+	__u16 infvq_id;
+	__u16 defvq_id;
+
+	char *tag;
+
+	struct balloon_pages *balloon;
+
+	struct transport_pages *transport;
+
+	uint64_t features;
+	uint32_t flags;
+
+	struct uk_mutex lock;
+};
+
+static void clear_transport(struct virtio_balloon_device *vb)
+{
+	int num = vb->transport->num_pages;
+	int i;
+
+	for (i = 0; i < num; i++) {
+		(vb->transport->pages)[i] = 0;
+		vb->transport->num_pages -= 1;
+	}
+}
+
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2011, Bryan Venteicher <bryanv@FreeBSD.org>
+ * All rights reserved.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* The above copyright notice applies only to the below function,
+ * vtballoon_send_page_frames, which is based on FreeBSD's function
+ * of the same name.
+ */
+
+static void vtballoon_send_page_frames(struct virtio_balloon_device *vb,
+			struct virtqueue *vq, int npages)
+{
+	struct uk_sglist sg;
+	struct uk_sglist_seg segs[1];
+	int c;
+	void *vq_cookie;
+	__u32 len = 0;
+
+	uk_sglist_init(&sg, 1, segs);
+
+	uk_sglist_append(&sg, vb->transport->pages, npages * sizeof(uint32_t));
+
+	virtqueue_buffer_enqueue(vq, &vq_cookie, &sg, 1, 0);
+
+	virtqueue_host_notify(vq);
+
+	/* wait on KVM to respond. Need a safer method for this */
+	while ((c = virtqueue_buffer_dequeue(vq, &vq_cookie, &len)) < 0)
+		;
+
+}
+
+/**
+ * This is equivalent to leaking from the balloon and
+ * increasing memory reservation for guest.
+ */
+int deflate_balloon(uintptr_t *pages_to_guest, uint32_t num)
+{
+	struct virtio_balloon_device *vb = global_vb;
+	int num_pages_taken;
+	uint32_t i;
+
+	/* check if device is ready */
+	if (!global_vb)
+		return -ENXIO;
+
+	uk_mutex_lock(&vb->lock);
+
+	clear_transport(vb);
+
+	if (vb->balloon->num_pages < num)
+		num = vb->balloon->num_pages;
+
+	for (i = 0; i < num; i++) {
+		vb->transport->pages[i] = pages_to_guest[i];
+		vb->balloon->num_pages -= 1;
+		vb->transport->num_pages += 1;
+	}
+
+	num_pages_taken = vb->transport->num_pages;
+
+	if (vb->transport->num_pages != 0) {
+		vtballoon_send_page_frames(vb, vb->deflate_vq,
+			vb->transport->num_pages);
+	}
+
+	uk_mutex_unlock(&vb->lock);
+
+	return num_pages_taken;
+}
+
+/**
+ * This is equivalent to filling the balloon and
+ * decreasing memory reservation for guest.
+ */
+int inflate_balloon(uintptr_t *pages_to_host, uint32_t num)
+{
+	struct virtio_balloon_device *vb = global_vb;
+	int num_pages_given;
+	uint32_t i;
+
+	/* check if device is ready */
+	if (!global_vb)
+		return -ENXIO;
+
+	uk_mutex_lock(&vb->lock);
+
+	clear_transport(vb);
+
+	for (i = 0; i < num; i++) {
+		vb->transport->pages[i] = pages_to_host[i] / __PAGE_SIZE;
+		vb->balloon->num_pages += 1;
+		vb->transport->num_pages += 1;
+	}
+
+	num_pages_given = vb->transport->num_pages;
+
+	if (vb->transport->num_pages != 0) {
+		vtballoon_send_page_frames(vb, vb->inflate_vq,
+			vb->transport->num_pages);
+	}
+
+	uk_mutex_unlock(&vb->lock);
+
+	return num_pages_given;
+}
+
+
+static inline void virtio_balloon_feature_set(struct virtio_balloon_device *vb)
+{
+	vb->features = 0;
+	vb->flags = 0;
+	vb->vdev->features = 0;
+}
+
+static int virtio_balloon_vq_alloc(struct virtio_balloon_device *vb)
+{
+	int vq_avail = 0;
+	int rc = 0;
+	__u16 qdesc_size[2];
+
+	vq_avail = virtio_find_vqs(vb->vdev, 2, &(qdesc_size[0]));
+	if (unlikely(vq_avail != 2)) {
+		uk_pr_err(DRIVER_NAME": Expected: %d queues, found %d\n",
+			  2, vq_avail);
+		rc = -ENOMEM;
+		goto exit;
+	}
+
+	vb->infvq_id = 0;
+	vb->defvq_id = 1;
+
+	vb->inflate_vq = virtio_vqueue_setup(vb->vdev, vb->infvq_id,
+			qdesc_size[0], NULL, a);
+	vb->inflate_vq->priv = vb;
+
+	if (unlikely(PTRISERR(vb->inflate_vq))) {
+		uk_pr_err(DRIVER_NAME": Failed to set up virtqueue %"PRIu16"\n",
+			vb->infvq_id);
+		rc = PTR2ERR(vb->inflate_vq);
+	}
+
+	vb->deflate_vq = virtio_vqueue_setup(vb->vdev, vb->defvq_id,
+			qdesc_size[1], NULL, a);
+	vb->deflate_vq->priv = vb;
+
+	if (unlikely(PTRISERR(vb->deflate_vq))) {
+		uk_pr_err(DRIVER_NAME": Failed to set up virtqueue %"PRIu16"\n",
+			vb->defvq_id);
+		rc = PTR2ERR(vb->deflate_vq);
+	}
+
+exit:
+	return rc;
+}
+
+static int virtio_balloon_start(struct virtio_balloon_device *vb)
+{
+	/* Disable interrupts for queues to suppress error messages */
+	virtqueue_intr_disable(vb->inflate_vq);
+	virtqueue_intr_disable(vb->deflate_vq);
+	virtio_dev_drv_up(vb->vdev);
+	uk_pr_info(DRIVER_NAME": %s started\n", vb->tag);
+
+	return 0;
+}
+
+static int virtio_balloon_add_dev(struct virtio_dev *vdev)
+{
+
+	struct virtio_balloon_device *vbdev;
+	int rc = 0;
+	void *alc;
+
+	UK_ASSERT(vdev != NULL);
+
+	vbdev = uk_calloc(a, 1, sizeof(*vbdev));
+
+	if (!vbdev) {
+		rc = -ENOMEM;
+		goto err_out;
+	}
+
+	vbdev->tag = "VIRTIO_BALLOON_DRV_DEV";
+
+	uk_mutex_init(&vbdev->lock);
+
+	vbdev->vdev = vdev;
+	virtio_balloon_feature_set(vbdev);
+	rc = virtio_balloon_vq_alloc(vbdev);
+	if (rc)
+		goto err_out;
+
+	vbdev->transport = uk_calloc(a, 1, sizeof(struct transport_pages));
+	if (!(vbdev->transport)) {
+		rc = -ENOMEM;
+		goto err_out;
+	}
+	vbdev->transport->pages = uk_calloc(a, 1,
+			VTBALLOON_PAGES_PER_REQUEST * sizeof(uint32_t));
+	if (!(vbdev->transport->pages)) {
+		rc = -ENOMEM;
+		goto err_out;
+	}
+	vbdev->balloon = uk_calloc(a, 1, sizeof(struct balloon_pages));
+	if (!(vbdev->balloon)) {
+		rc = -ENOMEM;
+		goto err_out;
+	}
+
+	rc = virtio_balloon_start(vbdev);
+	if (rc)
+		goto err_out;
+
+exit:
+	global_vb = vbdev;
+	/* initial alloc and free to trigger ballon init */
+	alc = uk_palloc(a, 1);
+	uk_pfree(a, alc, 1);
+	return rc;
+err_out:
+	uk_free(a, vbdev->transport->pages);
+	uk_free(a, vbdev->transport);
+	uk_free(a, vbdev->balloon);
+	uk_free(a, vbdev);
+	goto exit;
+
+}
+
+static int virtio_balloon_drv_init(struct uk_alloc *drv_allocator)
+{
+	if (!drv_allocator)
+		return -EINVAL;
+
+	a = drv_allocator;
+	return 0;
+
+}
+
+static const struct virtio_dev_id vballoon_dev_id[] = {
+	{VIRTIO_ID_BALLOON},
+	{VIRTIO_ID_INVALID} /* List Terminator */
+};
+
+static struct virtio_driver virtio_balloon_driver = {
+	.dev_ids = vballoon_dev_id,
+	.init	 = virtio_balloon_drv_init,
+	.add_dev = virtio_balloon_add_dev
+};
+VIRTIO_BUS_REGISTER_DRIVER(&virtio_balloon_driver);

--- a/plat/drivers/include/balloon/balloon.h
+++ b/plat/drivers/include/balloon/balloon.h
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Authors: Cason Schindler & Jack Raney <cason.j.schindler@gmail.com>
+ *          Cezar Craciunoiu <cezar.craciunoiu@gmail.com>
+ *
+ * Copyright (c) 2019, The University of Texas at Austin. All rights reserved.
+ *               2021, University Politehnica of Bucharest. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _PLAT_DRV_BALLOON_H_
+#define _PLAT_DRV_BALLOON_H_
+
+#include <inttypes.h>
+#include <sys/types.h>
+
+/**
+ * Deflates the balloon and asks for pages from the host
+ *
+ * @param pages_to_guest the pages to give to the guest
+ * @param num the number of pages
+ * @return the number of pages taken from host or < 0 on error
+ */
+int deflate_balloon(uintptr_t *pages_to_guest, uint32_t num);
+
+/**
+ * Inflates the balloon and returns unused pages to the host
+ *
+ * @param pages_to_host the pages to give to the host
+ * @param num the number of pages
+ * @return the number of pages taken from guest or < 0 on error
+ */
+int inflate_balloon(uintptr_t *pages_to_host, uint32_t num);
+
+#endif /* _PLAT_DRV_BALLOON_H_ */

--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -112,7 +112,7 @@ config VIRTIO_BUS
 menu "Virtio"
 config VIRTIO_PCI
        bool "Virtio PCI device support"
-       default y if (VIRTIO_NET || VIRTIO_9P || VIRTIO_BLK)
+       default y if (VIRTIO_NET || VIRTIO_9P || VIRTIO_BLK || VIRTIO_BALLOON)
        default n
        depends on KVM_PCI
        select VIRTIO_BUS
@@ -150,6 +150,18 @@ config VIRTIO_9P
        select LIBUKSGLIST
        help
               Virtio 9P driver.
+
+config VIRTIO_BALLOON
+	bool "Virtio Balloon device"
+	default y if LIBUKALLOCBBUDDY
+	default n
+       depends on LIBUKALLOCBBUDDY
+	select LIBUKLOCK_MUTEX
+       select VIRTIO_BUS
+	help
+		Virtio Memory ballooning device driver for returning memory
+		to the host.
+
 endmenu
 
 config RTC_PL031

--- a/plat/kvm/Makefile.uk
+++ b/plat/kvm/Makefile.uk
@@ -16,6 +16,7 @@ $(eval $(call addplatlib_s,kvm,libkvmvirtio9p,$(CONFIG_VIRTIO_9P)))
 $(eval $(call addplatlib_s,kvm,libkvmofw,$(CONFIG_LIBOFW)))
 $(eval $(call addplatlib_s,kvm,libkvmgic,$(CONFIG_LIBGIC)))
 $(eval $(call addplatlib_s,kvm,libkvmpl031,$(CONFIG_RTC_PL031)))
+$(eval $(call addplatlib_s,kvm,libkvmballoon,$(CONFIG_VIRTIO_BALLOON)))
 
 ##
 ## Platform library definitions
@@ -230,3 +231,13 @@ LIBKVMPL031_CINCLUDES-y		+= -I$(UK_PLAT_DRIVERS_BASE)/include
 
 LIBKVMPL031_SRCS-y		+= $(UK_PLAT_DRIVERS_BASE)/rtc/pl031.c
 LIBKVMPL031_SRCS-y		+= $(UK_PLAT_DRIVERS_BASE)/rtc/rtc.c
+
+##
+## BALLOON library definitions
+##
+LIBKVMBALLOON_CINCLUDES-y += -I$(LIBKVMPLAT_BASE)/include
+LIBKVMBALLOON_CINCLUDES-y += -I$(UK_PLAT_DRIVERS_BASE)/include
+LIBKVMBALLOON_CINCLUDES-y += -I$(UK_PLAT_COMMON_BASE)/include
+
+LIBKVMBALLOON_SRCS-y += $(UK_PLAT_DRIVERS_BASE)/balloon/balloon_drv.c
+LIBKVMBALLOON_SRCS-y += $(LIBKVMPLAT_BASE)/balloon.c

--- a/plat/kvm/balloon.c
+++ b/plat/kvm/balloon.c
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Authors: Cason Schindler & Jack Raney <cason.j.schindler@gmail.com>
+ *          Cezar Craciunoiu <cezar.craciunoiu@gmail.com>
+ *
+ * Copyright (c) 2019, The University of Texas at Austin. All rights reserved.
+ *               2021, University Politehnica of Bucharest. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <inttypes.h>
+#include <errno.h>
+#include <stddef.h>
+
+#include <balloon/balloon.h>
+#include <uk/plat/balloon.h>
+#include <uk/asm/limits.h>
+
+/**
+ * Fills addresses for page range starting at first_page
+ *
+ * @param pages_array the array to fill
+ * @param first_page the page to start the fill from
+ * @param num_pages number of pages in the array
+ */
+static inline void fill_page_array(uintptr_t *pages_array,
+			void *first_page, int num_pages)
+{
+	uint64_t current_pg = (uint64_t) first_page;
+	int i;
+
+	for (i = 0; i < num_pages; i++) {
+		pages_array[i] = current_pg;
+		current_pg += __PAGE_SIZE;
+	}
+}
+
+int ukplat_inflate(void *page, int order)
+{
+	int num_pages = 1 << order;
+	uintptr_t pages_to_host[num_pages];
+
+	if (!page)
+		return -EINVAL;
+
+	fill_page_array(pages_to_host, page, num_pages);
+	return inflate_balloon(pages_to_host, num_pages);
+}
+
+int ukplat_deflate(void *page, int order)
+{
+	int num_pages = 1 << order;
+	uintptr_t pages_to_guest[num_pages];
+
+	if (!page)
+		return -EINVAL;
+
+	fill_page_array(pages_to_guest, page, num_pages);
+	return deflate_balloon(pages_to_guest, num_pages);
+}

--- a/plat/linuxu/Makefile.uk
+++ b/plat/linuxu/Makefile.uk
@@ -39,6 +39,7 @@ LIBLINUXUPLAT_SRCS-y              += $(LIBLINUXUPLAT_BASE)/setup.c
 LIBLINUXUPLAT_SRCS-y              += $(LIBLINUXUPLAT_BASE)/console.c
 LIBLINUXUPLAT_SRCS-y              += $(LIBLINUXUPLAT_BASE)/shutdown.c
 LIBLINUXUPLAT_SRCS-y              += $(LIBLINUXUPLAT_BASE)/memory.c
+LIBLINUXUPLAT_SRCS-y              += $(LIBLINUXUPLAT_BASE)/balloon.c
 LIBLINUXUPLAT_SRCS-y              += $(LIBLINUXUPLAT_BASE)/lcpu.c
 LIBLINUXUPLAT_SRCS-y              += $(LIBLINUXUPLAT_BASE)/irq.c
 LIBLINUXUPLAT_SRCS-y              += $(LIBLINUXUPLAT_BASE)/time.c

--- a/plat/linuxu/balloon.c
+++ b/plat/linuxu/balloon.c
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Authors: Cason Schindler & Jack Raney <cason.j.schindler@gmail.com>
+ *          Cezar Craciunoiu <cezar.craciunoiu@gmail.com>
+ *
+ * Copyright (c) 2019, The University of Texas at Austin. All rights reserved.
+ *               2021, University Politehnica of Bucharest. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stddef.h>
+
+#include <uk/plat/balloon.h>
+#include <uk/assert.h>
+
+/* Memory ballooning is not yet supported for linuxu */
+
+int ukplat_inflate(void *va __unused, int order __unused)
+{
+	return -ENOSYS;
+}
+
+int ukplat_deflate(void *va __unused, int order __unused)
+{
+	return -ENOSYS;
+}

--- a/plat/xen/Makefile.uk
+++ b/plat/xen/Makefile.uk
@@ -42,6 +42,7 @@ LIBXENPLAT_CINCLUDES-y         += -I$(UK_PLAT_COMMON_BASE)/include
 LIBXENPLAT_SRCS-y              += $(UK_PLAT_XEN_DEF_LDS)
 LIBXENPLAT_SRCS-y              += $(LIBXENPLAT_BASE)/hypervisor.c
 LIBXENPLAT_SRCS-y              += $(LIBXENPLAT_BASE)/memory.c
+LIBXENPLAT_SRCS-y              += $(LIBXENPLAT_BASE)/balloon.c
 LIBXENPLAT_SRCS-y              += $(LIBXENPLAT_BASE)/io.c
 LIBXENPLAT_SRCS-y              += $(UK_PLAT_COMMON_BASE)/lcpu.c|common
 LIBXENPLAT_SRCS-y              += $(UK_PLAT_COMMON_BASE)/memory.c|common

--- a/plat/xen/balloon.c
+++ b/plat/xen/balloon.c
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Authors: Cason Schindler & Jack Raney <cason.j.schindler@gmail.com>
+ *          Cezar Craciunoiu <cezar.craciunoiu@gmail.com>
+ *
+ * Copyright (c) 2019, The University of Texas at Austin. All rights reserved.
+ *               2021, University Politehnica of Bucharest. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <uk/plat/common/sections.h>
+
+#include <common/gnttab.h>
+#if (defined __X86_32__) || (defined __X86_64__)
+#include <xen-x86/setup.h>
+#include <xen-x86/mm_pv.h>
+#include <xen-x86/mm.h>
+#elif (defined __ARM_32__) || (defined __ARM_64__)
+#include <xen-arm/setup.h>
+#include <xen-arm/mm.h>
+#endif
+
+#include <xen/memory.h>
+#include <uk/plat/balloon.h>
+#include <common/hypervisor.h>
+
+/**
+ * Set up and call Xen hypercall to ask for memory back from Xen.
+ */
+static int xenmem_reservation_increase(int count, xen_pfn_t *frames, int order)
+{
+	struct xen_memory_reservation res = {
+#if __XEN_INTERFACE_VERSION__ >= 0x00030209
+		.memflags = 0;
+#else
+		.address_bits = 0,
+#endif
+		.extent_order = order,
+		.domid        = DOMID_SELF
+	};
+
+	set_xen_guest_handle(res.extent_start, frames);
+	res.nr_extents = count;
+
+	/* Needs physical frame number */
+	return HYPERVISOR_memory_op(XENMEM_populate_physmap, &res);
+}
+
+/**
+ * Set up and call Xen hypercall to give memory to Xen.
+ */
+static int xenmem_reservation_decrease(int count, xen_pfn_t *frames, int order)
+{
+	struct xen_memory_reservation res = {
+#if __XEN_INTERFACE_VERSION__ >= 0x00030209
+		.mem_flags = 0,
+#else
+		.address_bits = 0,
+#endif
+		.extent_order = order,
+		.domid        = DOMID_SELF
+	};
+
+	set_xen_guest_handle(res.extent_start, frames);
+	res.nr_extents = count;
+
+	/* Needs guest frame number */
+	return HYPERVISOR_memory_op(XENMEM_decrease_reservation, &res);
+}
+
+/**
+ * When we inflate we will be decreasing the memory available to the VM
+ * We will give the extent of extent order = order starting at va to the host.
+ */
+int ukplat_inflate(void *va, int order)
+{
+	xen_pfn_t pfn = virt_to_pfn(va);
+
+	if (!va)
+		return -EINVAL;
+
+	return xenmem_reservation_decrease(1, &pfn, order);
+}
+
+/**
+ * When we deflate we will be increasing the memory available to the VM
+ * We will ask for 1 extent of extent order = order back from the host.
+ * It will map the extent to the address va.
+ */
+int ukplat_deflate(void *va, int order)
+{
+	/* Make sure we are sending the correct frame number. Should be a GFN */
+	xen_pfn_t pfn = virt_to_pfn(va);
+
+	if (!va)
+		return -EINVAL;
+
+	return xenmem_reservation_increase(1, &pfn, order);
+}


### PR DESCRIPTION
This is the second iteration of the memory ballooning patches first
added back in 2019. This second version restructures the code the
initial authors worked on and separates it in different files
across Unikraft.

The balloon is implemented for two of the three available platforms.
For KVM it is tested and it works. The Xen version should work, but
it is untested and the Linuxu version is stubbed.

The ideas from the original authors were kept, only that the content
was restructured. There might be a need for a additional reformating,
but it is up to the reviewer.

To test the balloon on KVM, `-device virtio-balloon` will have to be
added to the launch script.

Link to the patch series cover letter on the mailing list:
https://patchwork.unikraft.org/cover/738033/

Link to the original patch series cover letter:
https://patchwork.unikraft.org/cover/736918/

Signed-off-by: Jack Raney <raney.jack99@gmail.com>
Signed-off-by: Cason Schindler <cason.j.schindler@gmail.com>
Signed-off-by: Cezar Craciunoiu <cezar.craciunoiu@gmail.com>
