### PR TITLE
lib/uknetdev: Add network interface instrumentation

### DIFF
--- a/lib/uknetdev/Config.uk
+++ b/lib/uknetdev/Config.uk
@@ -30,4 +30,10 @@ if LIBUKNETDEV
 			When this option is enabled a dispatcher thread is
 			allocated for each configured receive queue.
 			libuksched is required for this option.
+	config LIBUKNETDEV_METRICS
+		bool "Interface metrics for statistics"
+		default n
+		help
+			The metrics instrumented are the same with the ones from
+			/proc/net/dev. The metrics are per interface.
 endif

--- a/lib/uknetdev/exportsyms.uk
+++ b/lib/uknetdev/exportsyms.uk
@@ -15,6 +15,7 @@ uk_netdev_drv_name_get
 uk_netdev_state_get
 uk_netdev_probe
 uk_netdev_info_get
+uk_netdev_metrics_get
 uk_netdev_einfo_get
 uk_netdev_rxq_info_get
 uk_netdev_txq_info_get

--- a/lib/uknetdev/include/uk/netdev.h
+++ b/lib/uknetdev/include/uk/netdev.h
@@ -154,6 +154,9 @@ int uk_netdev_probe(struct uk_netdev *dev);
 void uk_netdev_info_get(struct uk_netdev *dev,
 			struct uk_netdev_info *dev_info);
 
+int uk_netdev_metrics_get(struct uk_netdev *dev,
+			struct uk_netdev_metrics *dev_metrics);
+
 /**
  * Extra information query interface.
  * The user can query the driver for any additional information (e.g,

--- a/lib/uknetdev/include/uk/netdev_core.h
+++ b/lib/uknetdev/include/uk/netdev_core.h
@@ -47,6 +47,10 @@
 #include <uk/sched.h>
 #include <uk/semaphore.h>
 #endif
+#ifdef CONFIG_LIBUKNETDEV_METRICS
+#include <uk/arch/spinlock.h>
+#endif /* CONFIG_LIBUKNETDEV_METRICS */
+
 
 /**
  * Unikraft network API common declarations.
@@ -455,6 +459,42 @@ struct uk_netdev_einfo {
 	const char *ipv4_gw_addr;
 };
 
+struct uk_netdev_tx_metrics {
+	/** The total number of bytes of data transmitted by the interface */
+	size_t bytes;
+
+	/** The total number of packets of data transmitted by the interface */
+	size_t packets;
+
+	/** The total number of transmit errors detected by the device driver */
+	size_t errors;
+
+	/** The number of FIFO buffer errors */
+	size_t fifo;
+};
+
+struct uk_netdev_rx_metrics {
+	/** The total number of bytes of data received by the interface */
+	size_t bytes;
+
+	/** The total number of packets of data received by the interface */
+	size_t packets;
+
+	/** The total number of receive errors detected by the device driver */
+	size_t errors;
+
+	/** The number of FIFO buffer errors */
+	size_t fifo;
+
+	/** The number of packet framing errors */
+	size_t frame;
+};
+
+struct uk_netdev_metrics {
+	struct uk_netdev_tx_metrics tx_m;
+	struct uk_netdev_rx_metrics rx_m;
+};
+
 /**
  * NETDEV
  * A structure used to interact with a network device.
@@ -489,6 +529,11 @@ struct uk_netdev {
 #if (CONFIG_UK_NETDEV_SCRATCH_SIZE > 0)
 	char scratch_pad[CONFIG_UK_NETDEV_SCRATCH_SIZE];
 #endif /* CONFIG_UK_NETDEV_SCRATCH_SIZE */
+
+#ifdef CONFIG_LIBUKNETDEV_METRICS
+	struct uk_netdev_metrics metrics;
+	__spinlock metrics_lock;
+#endif /* CONFIG_LIBUKNETDEV_METRICS */
 };
 
 #ifdef __cplusplus

--- a/lib/uknetdev/netdev.c
+++ b/lib/uknetdev/netdev.c
@@ -344,6 +344,12 @@ int uk_netdev_configure(struct uk_netdev *dev,
 		uk_pr_info("netdev%"PRIu16": Configured interface\n",
 			   dev->_data->id);
 		dev->_data->state = UK_NETDEV_CONFIGURED;
+
+#ifdef CONFIG_LIBUKNETDEV_METRICS
+		memset(&dev->metrics, 0, sizeof(dev->metrics));
+		ukarch_spin_init(&dev->metrics_lock);
+#endif /* CONFIG_LIBUKNETDEV_METRICS */
+
 	} else {
 		uk_pr_err("netdev%"PRIu16": Failed to configure interface: %d\n",
 			  dev->_data->id, ret);

--- a/lib/uknetdev/netdev.c
+++ b/lib/uknetdev/netdev.c
@@ -650,3 +650,18 @@ int uk_netdev_mtu_set(struct uk_netdev *dev, uint16_t mtu)
 
 	return dev->ops->mtu_set(dev, mtu);
 }
+
+#ifdef CONFIG_LIBUKNETDEV_METRICS
+int uk_netdev_metrics_get(struct uk_netdev *dev,
+			struct uk_netdev_metrics *dev_metrics)
+{
+	UK_ASSERT(dev);
+	UK_ASSERT(dev_metrics);
+
+	ukarch_spin_lock(&dev->metrics_lock);
+	memcpy(dev_metrics, &dev->metrics, sizeof(*dev_metrics));
+	ukarch_spin_unlock(&dev->metrics_lock);
+
+	return 0;
+}
+#endif /* CONFIG_LIBUKNETDEV_METRICS */


### PR DESCRIPTION
This commit series adds support for instrumenting the network
interfaces in order to extract metrics from them. The metrics extracted
follow the fields from `/proc/net/dev`. Right now, only the most common
ones are implemented. The rarer ones will be added later.

Interaction with the metrics is thread-safe and the overhead from the
instrumentation should be acceptable.

In order to enable the metrics, a new entry was added inside the
`uknetdev` `KConfig` option.

Signed-off-by: Cezar Craciunoiu <cezar.craciunoiu@gmail.com>