### PR TITLE
plat/common/x86: Fix control protection trap

### DIFF
--- a/plat/common/include/x86/traps.h
+++ b/plat/common/include/x86/traps.h
@@ -55,7 +55,7 @@
 #define TRAP_machine_check       18
 #define TRAP_simd_error          19
 #define TRAP_virt_error          20
-#define TRAP_security_error      30
+#define TRAP_security_error      21
 
 #define ASM_TRAP_SYM(trapname)   asm_trap_##trapname
 
@@ -87,7 +87,7 @@ DECLARE_ASM_TRAP(alignment_check);
 DECLARE_ASM_TRAP(machine_check);
 DECLARE_ASM_TRAP(simd_error);
 DECLARE_ASM_TRAP(virt_error);
-
+DECLARE_ASM_TRAP(security_error);
 
 void do_unhandled_trap(int trapnr, char *str, struct __regs *regs,
 		unsigned long error_code);


### PR DESCRIPTION
The current trap number for the control protection exception (in Unikraft called security trap) is wrong and the asm trap is missing. This patch fixes these issues.

From the Intel manual:
![image](https://user-images.githubusercontent.com/8928900/121873783-0490dd80-cd07-11eb-94f8-a190fb497d0d.png)
![image](https://user-images.githubusercontent.com/8928900/121873827-107c9f80-cd07-11eb-9219-ebcb45cbe894.png)
