### PR TITLE
plat/x86: Use event-based trap interface

### DIFF
--- a/arch/x86/x86_64/include/uk/asm/traps.h
+++ b/arch/x86/x86_64/include/uk/asm/traps.h
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Author(s): Marc Rittinghaus <marc.rittinghaus@kit.edu>
+ *
+ * Copyright (c) 2021, Karlsruhe Institute of Technology. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __UKARCH_TRAPS_H__
+#error Do not include this header directly
+#endif
+
+#ifndef __ASSEMBLY__
+
+/**
+ * This structure stores trap context information. It is supplied as data
+ * for trap event handlers.
+ */
+struct ukarch_trap_ctx {
+	struct __regs *regs;
+	int trapnr;
+	int error_code;
+
+	unsigned long fault_address; /* for page faults */
+};
+
+#endif /* !__ASSEMBLY__ */
+
+/*
+ * An x86 platform library may define events for the following traps. Use
+ * UK_EVENT_HANDLER(UKARCH_TRAP_*) to register a handler for a trap event.
+ */
+#define UKARCH_TRAP_INVALID_OP		trap_invalid_op
+#define UKARCH_TRAP_DEBUG		trap_debug
+
+#define UKARCH_TRAP_PAGE_FAULT		trap_page_fault
+#define UKARCH_TRAP_BUS_ERROR		trap_bus_error
+
+#define UKARCH_TRAP_MATH		trap_math
+
+#define UKARCH_TRAP_SECURITY		trap_security

--- a/include/uk/arch/traps.h
+++ b/include/uk/arch/traps.h
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Author(s): Marc Rittinghaus <marc.rittinghaus@kit.edu>
+ *
+ * Copyright (c) 2021, Karlsruhe Institute of Technology. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __UKARCH_TRAPS_H__
+#define __UKARCH_TRAPS_H__
+
+#ifndef __ASSEMBLY__
+#include <uk/arch/lcpu.h>
+#include <uk/event.h>
+#endif /* !__ASSEMBLY__ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <uk/asm/traps.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __UKARCH_TRAPS_H__ */

--- a/plat/kvm/x86/traps.c
+++ b/plat/kvm/x86/traps.c
@@ -96,9 +96,9 @@ static void tss_init(void)
 
 
 /* Declare the traps used only by this platform: */
-DECLARE_TRAP_EC(nmi,           "NMI")
-DECLARE_TRAP_EC(double_fault,  "double fault")
-DECLARE_TRAP_EC(virt_error,    "virtualization error")
+DECLARE_TRAP_EC(nmi,           "NMI",                  NULL)
+DECLARE_TRAP_EC(double_fault,  "double fault",         NULL)
+DECLARE_TRAP_EC(virt_error,    "virtualization error", NULL)
 
 
 static struct seg_gate_desc64 cpu_idt[IDT_NUM_ENTRIES] __align64b;

--- a/plat/xen/x86/traps.c
+++ b/plat/xen/x86/traps.c
@@ -30,8 +30,8 @@
 
 /* Traps used only on Xen */
 
-DECLARE_TRAP_EC(coproc_seg_overrun, "coprocessor segment overrun")
-DECLARE_TRAP   (spurious_int,       "spurious interrupt bug")
+DECLARE_TRAP_EC(coproc_seg_overrun, "coprocessor segment overrun", NULL)
+DECLARE_TRAP   (spurious_int,       "spurious interrupt bug",      NULL)
 
 
 #ifdef CONFIG_PARAVIRT


### PR DESCRIPTION
This PR changes the trap handling in KVM and XEN to use the event-based trap interface. This means, it adds code to raise the corresponding trap event in the architectural trap. A list of implemented trap events and a context data structure that is supplied to handlers is provided in `uk/arch/traps.h`.

For example, adding a page fault handler can be done in the following way:
```
#include <uk/arch/traps.h>
static int my_pagefault_handler(void *data)
{
	struct ukarch_trap_ctx *ctx = (struct ukarch_trap_ctx *)data;

	return UK_EVENT_HANDLED;
}
UK_EVENT_HANDLER_PRIO(UKARCH_TRAP_PAGE_FAULT, my_pagefault_handler, UK_PRIO_LATEST);
````
The same code will work with other architectures (e.g., arm64). However, the `ukarch_trap_ctx` structure may change.

**NOTE**: This PR depends on #227.