### PR TITLE
Provide GIC v3 support

### DIFF
--- a/plat/Config.uk
+++ b/plat/Config.uk
@@ -37,3 +37,19 @@ config FPSIMD
 	depends on ARCH_ARM_64
 	help
 		Enable support FPU usage in application
+
+menuconfig LIBGIC
+	bool "Arm GIC (generic interrupt controller) support"
+	select LIBOFW
+	default y if ARCH_ARM_64
+	depends on ARCH_ARM_64
+	depends on PLAT_KVM
+if LIBGIC
+config LIBGICV2
+	bool "Version 2"
+	default y
+
+config LIBGICV3
+	bool "Version 3"
+	default y
+endif

--- a/plat/common/arm/time.c
+++ b/plat/common/arm/time.c
@@ -40,7 +40,7 @@
 #include <uk/plat/common/cpu.h>
 #include <ofw/gic_fdt.h>
 #include <uk/plat/common/irq.h>
-#include <gic/gic-v2.h>
+#include <gic/gic.h>
 #include <arm/time.h>
 
 /* TODO: For now this file is KVM dependent. As soon as we have more

--- a/plat/common/arm/traps.c
+++ b/plat/common/arm/traps.c
@@ -23,7 +23,10 @@
 #include <string.h>
 #include <uk/print.h>
 #include <uk/assert.h>
-#include <gic/gic-v2.h>
+#include <gic/gic.h>
+
+/** GIC driver to call interrupt handler */
+extern struct _gic_dev *gic;
 
 static const char *exception_modes[]= {
 	"Synchronous Abort",
@@ -72,5 +75,10 @@ void trap_el1_sync(struct __regs *regs, uint64_t far)
 
 void trap_el1_irq(void)
 {
-	gic_handle_irq();
+	if (!gic) {
+		uk_pr_crit("GIC driver is not initialized!\n");
+		ukplat_crash();
+	} else {
+		gic->ops.handle_irq();
+	}
 }

--- a/plat/drivers/gic/gic-v2.c
+++ b/plat/drivers/gic/gic-v2.c
@@ -39,37 +39,22 @@
 #include <uk/asm.h>
 #include <uk/plat/lcpu.h>
 #include <uk/plat/common/irq.h>
-#if defined(CONFIG_PLAT_KVM)
+#ifdef CONFIG_PLAT_KVM
 #include <kvm/irq.h>
 #endif
 #include <uk/plat/spinlock.h>
 #include <arm/cpu.h>
-#include <gic/gic.h>
 #include <gic/gic-v2.h>
 #include <ofw/fdt.h>
 
 /* Max CPU interface for GICv2 */
 #define GIC_MAX_CPUIF		8
 
-#define GIC_DIST_REG(r)	((void *)(gic_dist_addr + (r)))
-#define GIC_CPU_REG(r)	((void *)(gic_cpuif_addr + (r)))
-#define IRQ_TYPE_MASK	0x0000000f
-
-static uint64_t gic_dist_addr, gic_cpuif_addr;
-static uint64_t gic_dist_size, gic_cpuif_size;
-#ifdef CONFIG_HAVE_SMP
-static char gic_is_initialized;
-__spinlock gic_dist_lock;
-inline void dist_lock(void) { ukarch_spin_lock(&gic_dist_lock); };
-inline void dist_unlock(void) { ukarch_spin_unlock(&gic_dist_lock); };
-#else
-inline void dist_lock(void) {};
-inline void dist_unlock(void) {};
-#endif
+#define GIC_CPU_REG(gdev, r)	((void *)(gdev.cpuif_mem_addr + (r)))
 
 #ifdef CONFIG_HAVE_SMP
 __spinlock gicv2_dist_lock;
-#endif
+#endif /* CONFIG_HAVE_SMP */
 
 /** GICv2 driver */
 struct _gic_dev gicv2_drv = {
@@ -83,7 +68,7 @@ struct _gic_dev gicv2_drv = {
 	.cpuif_mem_size = 0,
 #ifdef CONFIG_HAVE_SMP
 	.dist_lock      = &gicv2_dist_lock,
-#endif
+#endif /* CONFIG_HAVE_SMP */
 };
 
 static const char * const gic_device_list[] = {
@@ -91,35 +76,33 @@ static const char * const gic_device_list[] = {
 	NULL
 };
 
-/* inline functions to access GICC & GICD registers */
+/* Inline functions to access GICC & GICD registers */
 static inline void write_gicd8(uint64_t offset, uint8_t val)
 {
-	ioreg_write8(GIC_DIST_REG(offset), val);
+	ioreg_write8(GIC_DIST_REG(gicv2_drv, offset), val);
 }
 
 static inline void write_gicd32(uint64_t offset, uint32_t val)
 {
-	ioreg_write32(GIC_DIST_REG(offset), val);
+	ioreg_write32(GIC_DIST_REG(gicv2_drv, offset), val);
 }
 
 static inline uint32_t read_gicd32(uint64_t offset)
 {
-	return ioreg_read32(GIC_DIST_REG(offset));
+	return ioreg_read32(GIC_DIST_REG(gicv2_drv, offset));
 }
 
 static inline void write_gicc32(uint64_t offset, uint32_t val)
 {
-	ioreg_write32(GIC_CPU_REG(offset), val);
+	ioreg_write32(GIC_CPU_REG(gicv2_drv, offset), val);
 }
 
 static inline uint32_t read_gicc32(uint64_t offset)
 {
-	return ioreg_read32(GIC_CPU_REG(offset));
+	return ioreg_read32(GIC_CPU_REG(gicv2_drv, offset));
 }
 
-/*
- * Functions of GIC CPU interface
- */
+/* Functions of GIC CPU interface */
 
 /* Enable GIC cpu interface */
 static void gic_enable_cpuif(void)
@@ -140,7 +123,7 @@ static void gic_set_threshold_priority(uint32_t threshold_prio)
  * Acknowledging irq equals reading GICC_IAR also
  * get the interrupt ID as the side effect.
  */
-uint32_t gic_ack_irq(void)
+static uint32_t gic_ack_irq(void)
 {
 	return read_gicc32(GICC_IAR);
 }
@@ -150,7 +133,7 @@ uint32_t gic_ack_irq(void)
  * of interrupt processing. If GICC_CTLR.EOImode sets to 1
  * this func just gets priority drop.
  */
-void gic_eoi_irq(uint32_t irq)
+static void gic_eoi_irq(uint32_t irq)
 {
 	write_gicc32(GICC_EOIR, irq);
 }
@@ -181,9 +164,9 @@ static void gic_sgi_gen(uint32_t sgintid, enum sgi_filter targetfilter,
 	val |= sgintid;
 
 	/* Generate SGI */
-	dist_lock();
+	dist_lock(gicv2_drv);
 	write_gicd32(GICD_SGIR, val);
-	dist_unlock();
+	dist_unlock(gicv2_drv);
 }
 
 /*
@@ -196,11 +179,11 @@ void gic_sgi_gen_to_list(uint32_t sgintid, uint8_t targetlist)
 	unsigned long irqf;
 
 	/* spin lock here is needed when smp is supported */
-	dist_lock();
+	dist_lock(gicv2_drv);
 	irqf = ukplat_lcpu_save_irqf();
 	gic_sgi_gen(sgintid, GICD_SGI_FILTER_TO_LIST, targetlist);
 	ukplat_lcpu_restore_irqf(irqf);
-	dist_unlock();
+	dist_unlock(gicv2_drv);
 }
 
 /*
@@ -213,11 +196,11 @@ void gic_sgi_gen_to_others(uint32_t sgintid)
 	unsigned long irqf;
 
 	/* spin lock here is needed when smp is supported */
-	dist_lock();
+	dist_lock(gicv2_drv);
 	irqf = ukplat_lcpu_save_irqf();
 	gic_sgi_gen(sgintid, GICD_SGI_FILTER_TO_OTHERS, 0);
 	ukplat_lcpu_restore_irqf(irqf);
-	dist_unlock();
+	dist_unlock(gicv2_drv);
 }
 
 /*
@@ -234,81 +217,85 @@ void gic_sgi_gen_to_self(uint32_t sgintid)
  * @target: bitmask value, bit 1 indicates target to
  * corresponding cpu interface
  */
-void gic_set_irq_target(uint32_t irq, uint8_t target)
+static void gic_set_irq_target(uint32_t irq, uint32_t target)
 {
 	if (irq < GIC_SPI_BASE)
 		UK_CRASH("Bad irq number: should not less than %u",
 			GIC_SPI_BASE);
 
-	dist_lock();
-	write_gicd8(GICD_ITARGETSR(irq), target);
-	dist_unlock();
+	dist_lock(gicv2_drv);
+	write_gicd8(GICD_ITARGETSR(irq), (uint8_t)target);
+	dist_unlock(gicv2_drv);
 }
 
 /* set priority for irq in distributor */
-void gic_set_irq_prio(uint32_t irq, uint8_t priority)
+static void gic_set_irq_prio(uint32_t irq, uint8_t priority)
 {
-	dist_lock();
+	dist_lock(gicv2_drv);
 	write_gicd8(GICD_IPRIORITYR(irq), priority);
-	dist_unlock();
+	dist_unlock(gicv2_drv);
 }
 
 /*
  * Enable an irq in distributor, each irq occupies one bit
  * to configure in corresponding register
  */
-void gic_enable_irq(uint32_t irq)
+static void gic_enable_irq(uint32_t irq)
 {
-	dist_lock();
+	dist_lock(gicv2_drv);
 
 	write_gicd32(GICD_ISENABLER(irq),
 		UK_BIT(irq % GICD_I_PER_ISENABLERn));
 
-	dist_unlock();
+	dist_unlock(gicv2_drv);
 }
 
 /*
  * Disable an irq in distributor, one bit reserved for an irq
  * to configure in corresponding register
  */
-void gic_disable_irq(uint32_t irq)
+static void gic_disable_irq(uint32_t irq)
 {
-	dist_lock();
+	dist_lock(gicv2_drv);
 	write_gicd32(GICD_ICENABLER(irq),
 		UK_BIT(irq % GICD_I_PER_ICENABLERn));
-	dist_unlock();
+	dist_unlock(gicv2_drv);
 }
 
 /* Enable distributor */
 static void gic_enable_dist(void)
 {
 	/* just set bit 0 to 1 to enable distributor */
-	dist_lock();
+	dist_lock(gicv2_drv);
 	write_gicd32(GICD_CTLR, read_gicd32(GICD_CTLR) | GICD_CTLR_ENABLE);
-	dist_unlock();
+	dist_unlock(gicv2_drv);
 }
 
 /* disable distributor */
 static void gic_disable_dist(void)
 {
 	/* just clear bit 0 to 0 to disable distributor */
-	dist_lock();
+	dist_lock(gicv2_drv);
 	write_gicd32(GICD_CTLR, read_gicd32(GICD_CTLR) & (~GICD_CTLR_ENABLE));
-	dist_unlock();
+	dist_unlock(gicv2_drv);
 }
 
-/* Config interrupt trigger type */
-void gic_set_irq_type(uint32_t irq, int trigger)
+
+/**
+ * Config trigger type for an interrupt
+ *
+ * @param irq interrupt number [GIC_PPI_BASE..GIC_MAX_IRQ-1]
+ * @param trigger trigger type (UK_IRQ_TRIGGER_*)
+ */
+static void gic_set_irq_type(uint32_t irq, enum uk_irq_trigger trigger)
 {
 	uint32_t val, mask, oldmask;
 
-	if (irq < GIC_PPI_BASE)
-		UK_CRASH("Bad irq number: should not less than %u",
-			GIC_PPI_BASE);
-	if (trigger >= UK_IRQ_TRIGGER_MAX)
-		return;
+	UK_ASSERT(irq >= GIC_PPI_BASE && irq < GIC_MAX_IRQ);
+	UK_ASSERT(trigger == UK_IRQ_TRIGGER_EDGE ||
+		  trigger == UK_IRQ_TRIGGER_LEVEL);
 
-	dist_lock();
+	dist_lock(gicv2_drv);
 
 	val = read_gicd32(GICD_ICFGR(irq));
 	mask = oldmask = (val >> ((irq % GICD_I_PER_ICFGRn) * 2)) &
@@ -324,40 +311,18 @@ void gic_set_irq_type(uint32_t irq, int trigger)
 
 	/* Check if nothing changed */
 	if (mask == oldmask)
-		return;
+		goto EXIT_UNLOCK;
 
 	/* Update new interrupt type */
 	val &= (~(GICD_ICFGR_MASK << (irq % GICD_I_PER_ICFGRn) * 2));
 	val |= (mask << (irq % GICD_I_PER_ICFGRn) * 2);
 	write_gicd32(GICD_ICFGR(irq), val);
 
-	dist_unlock();
+EXIT_UNLOCK:
+	dist_unlock(gicv2_drv);
 }
 
-int32_t gic_irq_translate(uint32_t type, uint32_t hw_irq)
-{
-	uint32_t irq;
-
-	switch (type) {
-	case GIC_SPI_TYPE:
-		irq = hw_irq + GIC_SPI_BASE;
-		if (irq >= GIC_SPI_BASE && irq < __MAX_IRQ)
-			return irq;
-		break;
-	case GIC_PPI_TYPE:
-		irq = hw_irq + GIC_PPI_BASE;
-		if (irq >= GIC_PPI_BASE && irq < GIC_SPI_BASE)
-			return irq;
-		break;
-	default:
-		uk_pr_warn("Invalid IRQ type [%d]\n", type);
-	}
-
-	uk_pr_err("irq is out of range\n");
-	return -EINVAL;
-}
-
-void gic_handle_irq(void)
+static void gic_handle_irq(void)
 {
 	uint32_t stat, irq;
 
@@ -366,21 +331,25 @@ void gic_handle_irq(void)
 		irq = stat & GICC_IAR_INTID_MASK;
 
 #ifndef CONFIG_HAVE_SMP
-		uk_pr_debug("Unikraft: EL1 IRQ#%d trap caught\n", irq);
-#else
-		uk_pr_debug("Unikraft (Core %ld): EL1 IRQ#%d trap caught\n",
+		uk_pr_debug("EL1 IRQ#%d trap caught\n", irq);
+#else /* !CONFIG_HAVE_SMP */
+		uk_pr_debug("Core %d: EL1 IRQ#%d trap caught\n",
 				ukplat_lcpu_id(), irq);
-#endif
+#endif /* CONFIG_HAVE_SMP */
 
-		/*
-		 * TODO: Handle IPI&SGI interrupts here
-		 */
+		/* Ensure interrupt processing starts only after ACK */
+		isb();
+
 		if (irq < GIC_MAX_IRQ) {
-			isb();
 			_ukplat_irq_handle((unsigned long)irq);
 			gic_eoi_irq(stat);
+
 			continue;
 		}
+
+		/* EoI should only be signaled for non-spurious interrupts */
+		if (irq != GICC_IAR_INTID_SPURIOUS)
+			gic_eoi_irq(stat);
 
 		break;
 	} while (1);
@@ -391,7 +360,7 @@ static void gic_init_dist(void)
 	uint32_t val, cpuif_number, irq_number;
 	uint32_t i;
 
-	/* Turn down distributor */
+	/* Turn off distributor */
 	gic_disable_dist();
 
 	/* Get GIC CPU interface */
@@ -407,104 +376,79 @@ static void gic_init_dist(void)
 		irq_number = GIC_MAX_IRQ;
 	uk_pr_info("GICv2 Max interrupt lines:%d\n", irq_number);
 
-	/*
-	 * Set all SPI interrupts targets to all CPU.
-	 */
+	/* Set all SPI's interrupt target to all CPUs */
 	for (i = GIC_SPI_BASE; i < irq_number; i += GICD_I_PER_ITARGETSRn)
 		write_gicd32(GICD_ITARGETSR(i), GICD_ITARGETSR_DEF);
 
-	/*
-	 * Set all SPI interrupts type to be level triggered
-	 */
+	/* Set all SPI's interrupt type to be level-sensitive */
 	for (i = GIC_SPI_BASE; i < irq_number; i += GICD_I_PER_ICFGRn)
 		write_gicd32(GICD_ICFGR(i), GICD_ICFGR_DEF_TYPE);
 
-	/*
-	 * Set all SPI priority to a default value.
-	 */
+	/* Set all SPI's priority to a default value */
 	for (i = GIC_SPI_BASE; i < irq_number; i += GICD_I_PER_IPRIORITYn)
 		write_gicd32(GICD_IPRIORITYR(i), GICD_IPRIORITY_DEF);
 
-	/*
-	 * Deactivate and disable all SPIs.
-	 */
+	/* Deactivate and disable all SPIs */
 	for (i = GIC_SPI_BASE; i < irq_number; i += GICD_I_PER_ICACTIVERn) {
 		write_gicd32(GICD_ICACTIVER(i), GICD_DEF_ICACTIVERn);
 		write_gicd32(GICD_ICENABLER(i), GICD_DEF_ICENABLERn);
 	}
 
-	/* turn on distributor */
+	/* Turn on distributor */
 	gic_enable_dist();
+
+	uk_pr_info("GICv2 distributor initialized.\n");
 }
 
 static void gic_init_cpuif(void)
 {
-	/* TODO: need to extend for smp support */
 	uint32_t i;
 
-	/*
-	 * set priority mask to the lowest priority to let all irq
-	 * visible to cpu interface
+	/* Set priority threshold to the lowest to make all IRQs visible to
+	 * the CPU interface. Note: Higher priority corresponds to a lower
+	 * priority field value.
 	 */
 	gic_set_threshold_priority(GICC_PMR_PRIO_MAX);
 
-	/* set PPI and SGI to a default value */
+	/* Set PPI and SGI to the default value */
 	for (i = 0; i < GIC_SPI_BASE; i += GICD_I_PER_IPRIORITYn)
 		write_gicd32(GICD_IPRIORITYR(i), GICD_IPRIORITY_DEF);
 
-	/*
-	 * Deactivate SGIs and PPIs and disable all PPIs.
-	 */
+	/* Deactivate SGIs and PPIs as the state is unknown at boot */
 	write_gicd32(GICD_ICACTIVER(0), GICD_DEF_ICACTIVERn);
 	write_gicd32(GICD_ICENABLER(0), GICD_DEF_PPI_ICENABLERn);
 
-	/* enable all SGIs */
+	/* Enable all SGIs */
 	write_gicd32(GICD_ISENABLER(0), GICD_DEF_SGI_ISENABLERn);
 
-	/* enable cpu interface */
+	/* Enable CPU interface */
 	gic_enable_cpuif();
+
+	isb();
+
+	uk_pr_info("GICv2 CPU interface initialized.\n");
 }
 
-int _dtb_init_gic(const void *fdt)
-{
-	int fdt_gic, ret;
 
+/**
+ * Initialize GICv2
+ * NOTE: First time must not be called from multiple CPUs in parallel
+ *
+ * @return 0 on success, a non-zero error otherwise
+ */
+static int gic_initialize(void)
+{
 #ifdef CONFIG_HAVE_SMP
-	if (gic_is_initialized) {
+	if (gicv2_drv.is_initialized) {
 		/* GIC is already initialized, we just need to initialize
 		 * the CPU interface
 		 */
 		gic_init_cpuif();
 		return 0;
 	}
-	gic_is_initialized = 1;
-#endif
+#endif /* CONFIG_HAVE_SMP */
 
-	uk_pr_info("Probing GICv2...\n");
-
-	/* Currently, we only support 1 GIC per system */
-	fdt_gic = fdt_node_offset_by_compatible_list(fdt, -1,
-				gic_device_list);
-	if (fdt_gic < 0)
-		UK_CRASH("Could not find GICv2 Interrupt Controller!\n");
-
-	/* Get device address and size at regs region */
-	ret = fdt_get_address(fdt, fdt_gic, 0,
-			&gic_dist_addr, &gic_dist_size);
-	if (ret < 0)
-		UK_CRASH("Could not find GICv2 distributor region!\n");
-
-	ret = fdt_get_address(fdt, fdt_gic, 1,
-			&gic_cpuif_addr, &gic_cpuif_size);
-	if (ret < 0)
-		UK_CRASH("Could not find GICv2 cpuif region!\n");
-
-	uk_pr_info("Found GICv2 on:\n");
-	uk_pr_info("\tDistributor  : 0x%lx - 0x%lx\n",
-		gic_dist_addr, gic_dist_addr + gic_dist_size - 1);
-	uk_pr_info("\tCPU interface: 0x%lx - 0x%lx\n",
-		gic_cpuif_addr, gic_cpuif_addr + gic_cpuif_size - 1);
-
+	gicv2_drv.is_initialized = 1;
 
 	/* Initialize GICv2 distributor */
 	gic_init_dist();
@@ -512,5 +456,96 @@ int _dtb_init_gic(const void *fdt)
 	/* Initialize GICv2 CPU interface */
 	gic_init_cpuif();
 
+	return 0;
+}
+
+static int gicv2_do_probe(const void *fdt)
+{
+	int fdt_gic, r;
+	struct _gic_operations drv_ops = {
+		.initialize        = gic_initialize,
+		.ack_irq           = gic_ack_irq,
+		.eoi_irq           = gic_eoi_irq,
+		.enable_irq        = gic_enable_irq,
+		.disable_irq       = gic_disable_irq,
+		.set_irq_type      = gic_set_irq_type,
+		.set_irq_prio      = gic_set_irq_prio,
+		.set_irq_affinity  = gic_set_irq_target,
+		.irq_translate     = gic_irq_translate,
+		.handle_irq        = gic_handle_irq,
+	};
+
+	/* Set driver functions */
+	gicv2_drv.ops = drv_ops;
+
+	/* Currently, we only support 1 GIC per system */
+	fdt_gic = fdt_node_offset_by_compatible_list(fdt, -1, gic_device_list);
+	if (fdt_gic < 0)
+		return -FDT_ERR_NOTFOUND; /* GICv2 not present */
+
+	/* Get address and size of the GIC's register regions */
+	r = fdt_get_address(fdt, fdt_gic, 0, &gicv2_drv.dist_mem_addr,
+			    &gicv2_drv.dist_mem_size);
+	if (unlikely(r < 0)) {
+		uk_pr_err("Could not find GICv2 distributor region!\n");
+		return r;
+	}
+
+	r = fdt_get_address(fdt, fdt_gic, 1, &gicv2_drv.cpuif_mem_addr,
+			    &gicv2_drv.cpuif_mem_size);
+	if (unlikely(r < 0)) {
+		uk_pr_err("Could not find GICv2 cpuif region!\n");
+		return r;
+	}
+
+	uk_pr_info("Found GICv2 on:\n");
+	uk_pr_info("\tDistributor  : 0x%lx - 0x%lx\n",
+		   gicv2_drv.dist_mem_addr,
+		   gicv2_drv.dist_mem_addr + gicv2_drv.dist_mem_size - 1);
+	uk_pr_info("\tCPU interface: 0x%lx - 0x%lx\n",
+		   gicv2_drv.cpuif_mem_addr,
+		   gicv2_drv.cpuif_mem_addr + gicv2_drv.cpuif_mem_size - 1);
+
+	/* GICv2 is present */
+	gicv2_drv.is_present = 1;
+
+	return 0;
+}
+
+/**
+ * Probe device tree for GICv2
+ * NOTE: First time must not be called from multiple CPUs in parallel
+ *
+ * @param [in] fdt pointer to device tree
+ * @param [out] dev receives pointer to GICv2 if available, NULL otherwise
+ *
+ * @return 0 if device is available, an FDT (FDT_ERR_*) error otherwise
+ */
+int gicv2_probe(const void *fdt, struct _gic_dev **dev)
+{
+	int rc;
+
+#ifdef CONFIG_HAVE_SMP
+	if (gicv2_drv.is_probed) {
+		/* GIC is already probed, we don't need to probe again */
+		if (gicv2_drv.is_present) {
+			*dev = &gicv2_drv;
+			return 0;
+		}
+
+		*dev = NULL;
+		return -FDT_ERR_NOTFOUND;
+	}
+#endif /* CONFIG_HAVE_SMP */
+
+	gicv2_drv.is_probed = 1;
+
+	rc = gicv2_do_probe(fdt);
+	if (rc) {
+		*dev = NULL;
+		return rc;
+	}
+
+	*dev = &gicv2_drv;
 	return 0;
 }

--- a/plat/drivers/gic/gic-v2.c
+++ b/plat/drivers/gic/gic-v2.c
@@ -320,7 +320,7 @@ void gic_handle_irq(void)
 		stat = gic_ack_irq();
 		irq = stat & GICC_IAR_INTID_MASK;
 
-		uk_pr_info("Unikraft: EL1 IRQ#%d trap caught\n", irq);
+		uk_pr_debug("Unikraft: EL1 IRQ#%d trap caught\n", irq);
 
 		/*
 		 * TODO: Handle IPI&SGI interrupts here

--- a/plat/drivers/gic/gic-v2.c
+++ b/plat/drivers/gic/gic-v2.c
@@ -44,22 +44,12 @@
 #endif
 #include <uk/plat/spinlock.h>
 #include <arm/cpu.h>
+#include <gic/gic.h>
 #include <gic/gic-v2.h>
 #include <ofw/fdt.h>
 
 /* Max CPU interface for GICv2 */
 #define GIC_MAX_CPUIF		8
-
-/* SPI interrupt definitions */
-#define GIC_SPI_TYPE		0
-#define GIC_SPI_BASE		32
-
-/* PPI interrupt definitions */
-#define GIC_PPI_TYPE		1
-#define GIC_PPI_BASE		16
-
-/* Max support interrupt number for GICv2 */
-#define GIC_MAX_IRQ		__MAX_IRQ
 
 #define GIC_DIST_REG(r)	((void *)(gic_dist_addr + (r)))
 #define GIC_CPU_REG(r)	((void *)(gic_cpuif_addr + (r)))
@@ -76,6 +66,25 @@ inline void dist_unlock(void) { ukarch_spin_unlock(&gic_dist_lock); };
 inline void dist_lock(void) {};
 inline void dist_unlock(void) {};
 #endif
+
+#ifdef CONFIG_HAVE_SMP
+__spinlock gicv2_dist_lock;
+#endif
+
+/** GICv2 driver */
+struct _gic_dev gicv2_drv = {
+	.version        = GIC_V2,
+	.is_present     = 0,
+	.is_probed      = 0,
+	.is_initialized = 0,
+	.dist_mem_addr  = 0,
+	.dist_mem_size  = 0,
+	.cpuif_mem_addr = 0,
+	.cpuif_mem_size = 0,
+#ifdef CONFIG_HAVE_SMP
+	.dist_lock      = &gicv2_dist_lock,
+#endif
+};
 
 static const char * const gic_device_list[] = {
 	"arm,cortex-a15-gic",

--- a/plat/drivers/gic/gic-v2.c
+++ b/plat/drivers/gic/gic-v2.c
@@ -224,7 +224,7 @@ void gic_set_irq_prio(uint32_t irq, uint8_t priority)
 
 /*
  * Enable an irq in distributor, each irq occupies one bit
- * to configure in corresponding registor
+ * to configure in corresponding register
  */
 void gic_enable_irq(uint32_t irq)
 {

--- a/plat/drivers/gic/gic-v3.c
+++ b/plat/drivers/gic/gic-v3.c
@@ -43,7 +43,6 @@
 #include <uk/assert.h>
 #include <uk/bitops.h>
 #include <uk/asm.h>
-#include <uk/plat/common/irq.h>
 #include <uk/plat/lcpu.h>
 #include <uk/plat/common/irq.h>
 #ifdef CONFIG_PLAT_KVM
@@ -51,19 +50,9 @@
 #endif
 #include <uk/plat/spinlock.h>
 #include <arm/cpu.h>
+#include <gic/gic.h>
 #include <gic/gic-v3.h>
 #include <ofw/fdt.h>
-
-/* SPI interrupt definitions */
-#define GIC_SPI_TYPE		0
-#define GIC_SPI_BASE		32
-
-/* PPI interrupt definitions */
-#define GIC_PPI_TYPE		1
-#define GIC_PPI_BASE		16
-
-/* Max support interrupt number for GICv3 */
-#define GIC_MAX_IRQ		__MAX_IRQ
 
 #define GIC_DIST_REG(r)	 ((void *)(gic_dist_addr + (r)))
 #define GIC_RDIST_REG(r) ((void *)(gic_rdist_addr + (r)))
@@ -86,6 +75,25 @@ inline void dist_unlock(void) { ukarch_spin_unlock(&gic_dist_lock); };
 inline void dist_lock(void) {};
 inline void dist_unlock(void) {};
 #endif /* CONFIG_HAVE_SMP */
+
+#ifdef CONFIG_HAVE_SMP
+__spinlock gicv3_dist_lock;
+#endif
+
+/** GICv3 driver */
+struct _gic_dev gicv3_drv = {
+	.version        = GIC_V3,
+	.is_present     = 0,
+	.is_probed      = 0,
+	.is_initialized = 0,
+	.dist_mem_addr  = 0,
+	.dist_mem_size  = 0,
+	.rdist_mem_addr = 0,
+	.rdist_mem_size = 0,
+#ifdef CONFIG_HAVE_SMP
+	.dist_lock      = &gicv3_dist_lock,
+#endif
+};
 
 static const char * const gic_device_list[] = {
 	"arm,gic-v3",

--- a/plat/drivers/gic/gic-v3.c
+++ b/plat/drivers/gic/gic-v3.c
@@ -54,31 +54,15 @@
 #include <gic/gic-v3.h>
 #include <ofw/fdt.h>
 
-#define GIC_DIST_REG(r)	 ((void *)(gic_dist_addr + (r)))
-#define GIC_RDIST_REG(r) ((void *)(gic_rdist_addr + (r)))
-#define IRQ_TYPE_MASK	0x0000000f
-#define GIC_DIST_ADDR  (gic_dist_addr)
-#define GIC_RDIST_ADDR (gic_rdist_addr)
+#define GIC_RDIST_REG(gdev, r) ((void *)(gdev.rdist_mem_addr + (r)))
 
 #define GIC_AFF_TO_ROUTER(aff, mode)				\
 	((((uint64_t)(aff) << 8) & MPIDR_AFF3_MASK) | ((aff) & 0xffffff) | \
 	 ((uint64_t)(mode) << 31))
 
-static uint64_t gic_dist_addr, gic_rdist_addr;
-static uint64_t gic_dist_size, gic_rdist_size;
-#ifdef CONFIG_HAVE_SMP
-static char gic_is_initialized;
-__spinlock gic_dist_lock;
-inline void dist_lock(void) { ukarch_spin_lock(&gic_dist_lock); };
-inline void dist_unlock(void) { ukarch_spin_unlock(&gic_dist_lock); };
-#else
-inline void dist_lock(void) {};
-inline void dist_unlock(void) {};
-#endif /* CONFIG_HAVE_SMP */
-
 #ifdef CONFIG_HAVE_SMP
 __spinlock gicv3_dist_lock;
-#endif
+#endif /* CONFIG_HAVE_SMP */
 
 /** GICv3 driver */
 struct _gic_dev gicv3_drv = {
@@ -92,7 +76,7 @@ struct _gic_dev gicv3_drv = {
 	.rdist_mem_size = 0,
 #ifdef CONFIG_HAVE_SMP
 	.dist_lock      = &gicv3_dist_lock,
-#endif
+#endif /* CONFIG_HAVE_SMP */
 };
 
 static const char * const gic_device_list[] = {
@@ -103,37 +87,37 @@ static const char * const gic_device_list[] = {
 /* Inline functions to access GICD & GICR registers */
 static inline void write_gicd8(uint64_t offset, uint8_t val)
 {
-	ioreg_write8(GIC_DIST_REG(offset), val);
+	ioreg_write8(GIC_DIST_REG(gicv3_drv, offset), val);
 }
 
 static inline void write_gicrd8(uint64_t offset, uint8_t val)
 {
-	ioreg_write8(GIC_RDIST_REG(offset), val);
+	ioreg_write8(GIC_RDIST_REG(gicv3_drv, offset), val);
 }
 
 static inline void write_gicd32(uint64_t offset, uint32_t val)
 {
-	ioreg_write32(GIC_DIST_REG(offset), val);
+	ioreg_write32(GIC_DIST_REG(gicv3_drv, offset), val);
 }
 
 static inline void write_gicd64(uint64_t offset, uint64_t val)
 {
-	ioreg_write64(GIC_DIST_REG(offset), val);
+	ioreg_write64(GIC_DIST_REG(gicv3_drv, offset), val);
 }
 
 static inline uint32_t read_gicd32(uint64_t offset)
 {
-	return ioreg_read32(GIC_DIST_REG(offset));
+	return ioreg_read32(GIC_DIST_REG(gicv3_drv, offset));
 }
 
 static inline void write_gicrd32(uint64_t offset, uint32_t val)
 {
-	ioreg_write32(GIC_RDIST_REG(offset), val);
+	ioreg_write32(GIC_RDIST_REG(gicv3_drv, offset), val);
 }
 
 static inline uint32_t read_gicrd32(uint64_t offset)
 {
-	return ioreg_read32(GIC_RDIST_REG(offset));
+	return ioreg_read32(GIC_RDIST_REG(gicv3_drv, offset));
 }
 
 /**
@@ -175,7 +159,7 @@ static uint32_t get_cpu_affinity(void)
  *
  * @return the ID of the signaled interrupt
  */
-uint32_t gic_ack_irq(void)
+static uint32_t gicv3_ack_irq(void)
 {
 	uint32_t irq;
 
@@ -191,7 +175,7 @@ uint32_t gic_ack_irq(void)
  * @param irq the ID of the interrupt to complete. Must be from a corresponding
  *    call to gicv3_ack_irq()
  */
-void gic_eoi_irq(uint32_t irq)
+static void gicv3_eoi_irq(uint32_t irq)
 {
 	/* Lower the priority */
 	SYSREG_WRITE32(ICC_EOIR1_EL1, irq);
@@ -207,11 +191,11 @@ void gic_eoi_irq(uint32_t irq)
  *
  * @param irq interrupt number [0..GIC_MAX_IRQ-1]
  */
-void gic_enable_irq(uint32_t irq)
+static void gicv3_enable_irq(uint32_t irq)
 {
 	UK_ASSERT(irq < GIC_MAX_IRQ);
 
-	dist_lock();
+	dist_lock(gicv3_drv);
 
 #ifdef CONFIG_HAVE_SMP
 	/* Route this IRQ to the running core, i.e., route to the CPU interface
@@ -225,7 +209,7 @@ void gic_enable_irq(uint32_t irq)
 		uk_pr_debug("IRQ %d routed to 0x%lx (REG: 0x%lx)\n",
 				irq, aff, irouter_val);
 	}
-#endif
+#endif /* CONFIG_HAVE_SMP */
 
 	if (irq >= GIC_SPI_BASE)
 		write_gicd32(GICD_ISENABLER(irq),
@@ -234,7 +218,7 @@ void gic_enable_irq(uint32_t irq)
 		write_gicrd32(GICR_ISENABLER0,
 				UK_BIT(irq % GICR_I_PER_ISENABLERn));
 
-	dist_unlock();
+	dist_unlock(gicv3_drv);
 }
 
 /**
@@ -242,11 +226,11 @@ void gic_enable_irq(uint32_t irq)
  *
  * @param irq interrupt number [0..GIC_MAX_IRQ-1]
  */
-void gic_disable_irq(uint32_t irq)
+static void gicv3_disable_irq(uint32_t irq)
 {
 	UK_ASSERT(irq < GIC_MAX_IRQ);
 
-	dist_lock();
+	dist_lock(gicv3_drv);
 
 	if (irq >= GIC_SPI_BASE)
 		write_gicd32(GICD_ICENABLER(irq),
@@ -255,7 +239,7 @@ void gic_disable_irq(uint32_t irq)
 		write_gicrd32(GICR_ICENABLER0,
 				UK_BIT(irq % GICR_I_PER_ICENABLERn));
 
-	dist_unlock();
+	dist_unlock(gicv3_drv);
 }
 
 /**
@@ -265,13 +249,13 @@ void gic_disable_irq(uint32_t irq)
  * @param affinity target CPU affinity in 32 bits format
  * (AFF3|AFF2|AFF1|AFF0), as returned by get_cpu_affinity()
  */
-void gic_set_irq_affinity(uint32_t irq, uint32_t affinity)
+static void gicv3_set_irq_affinity(uint32_t irq, uint32_t affinity)
 {
 	UK_ASSERT(irq >= GIC_SPI_BASE && irq < GIC_MAX_IRQ);
 
-	dist_lock();
+	dist_lock(gicv3_drv);
 	write_gicd64(GICD_IROUTER(irq), GIC_AFF_TO_ROUTER(affinity, 0));
-	dist_unlock();
+	dist_unlock(gicv3_drv);
 }
 
 /**
@@ -283,20 +267,20 @@ void gic_set_irq_affinity(uint32_t irq, uint32_t affinity)
  *    (e.g., 0 and 1) map to the same effective value. Lower values correspond
  *    to higher priority
  */
-void gic_set_irq_prio(uint32_t irq, uint8_t priority)
+static void gicv3_set_irq_prio(uint32_t irq, uint8_t priority)
 {
-	dist_lock();
+	dist_lock(gicv3_drv);
 
 	if (irq < GIC_SPI_BASE) /* Change in redistributor */
 		write_gicrd8(GICR_IPRIORITYR(irq), priority);
 	else
 		write_gicd8(GICD_IPRIORITYR(irq), priority);
 
-	dist_unlock();
+	dist_unlock(gicv3_drv);
 }
 
 /**
- * Config trigger type for an interrupt
+ * Configure trigger type for an interrupt
  *
  * @param irq interrupt number [GIC_PPI_BASE..GIC_MAX_IRQ-1]
  * @param trigger trigger type (UK_IRQ_TRIGGER_*)
@@ -309,7 +293,7 @@ static void gicv3_set_irq_type(uint32_t irq, enum uk_irq_trigger trigger)
 	UK_ASSERT(trigger == UK_IRQ_TRIGGER_EDGE ||
 			trigger == UK_IRQ_TRIGGER_LEVEL);
 
-	dist_lock();
+	dist_lock(gicv3_drv);
 
 	val = read_gicd32(GICD_ICFGR(irq));
 	mask = oldmask = (val >> ((irq % GICD_I_PER_ICFGRn) * 2)) &
@@ -333,27 +317,27 @@ static void gicv3_set_irq_type(uint32_t irq, enum uk_irq_trigger trigger)
 	write_gicd32(GICD_ICFGR(irq), val);
 
 EXIT_UNLOCK:
-	dist_unlock();
+	dist_unlock(gicv3_drv);
 }
 
 /** Enable distributor */
-static void gic_enable_dist(void)
+static void gicv3_enable_dist(void)
 {
-	dist_lock();
+	dist_lock(gicv3_drv);
 	write_gicd32(GICD_CTLR, GICD_CTLR_ARE_NS |
 			GICD_CTLR_ENABLE_G0 | GICD_CTLR_ENABLE_G1NS);
-	wait_for_rwp(GIC_DIST_ADDR);
-	dist_unlock();
+	wait_for_rwp(gicv3_drv.dist_mem_addr);
+	dist_unlock(gicv3_drv);
 }
 
 /** Disable distributor */
-static void gic_disable_dist(void)
+static void gicv3_disable_dist(void)
 {
 	/* Write 0 to disable distributor */
-	dist_lock();
+	dist_lock(gicv3_drv);
 	write_gicd32(GICD_CTLR, 0);
-	wait_for_rwp(GIC_DIST_ADDR);
-	dist_unlock();
+	wait_for_rwp(gicv3_drv.dist_mem_addr);
+	dist_unlock(gicv3_drv);
 }
 
 /** Enable the redistributor */
@@ -378,7 +362,7 @@ static void gicv3_init_redist(void)
 	/* Deactivate SGIs and PPIs as the state is unknown at boot */
 	write_gicrd32(GICR_ICACTIVER0, GICD_DEF_ICACTIVERn);
 
-	/* Disable all PPI interrupts */
+	/* Disable all PPIs */
 	write_gicrd32(GICR_ICENABLER0, GICD_DEF_PPI_ICENABLERn);
 
 	/* Configure SGIs and PPIs as non-secure Group 1 */
@@ -388,7 +372,7 @@ static void gicv3_init_redist(void)
 	write_gicrd32(GICR_ISENABLER0, GICD_DEF_SGI_ISENABLERn);
 
 	/* Wait for completion */
-	wait_for_rwp(GIC_RDIST_ADDR);
+	wait_for_rwp(gicv3_drv.rdist_mem_addr);
 
 	/* Enable system register access */
 	val  = SYSREG_READ32(ICC_SRE_EL1);
@@ -413,69 +397,14 @@ static void gicv3_init_redist(void)
 	uk_pr_info("GICv3 redistributor initialized.\n");
 }
 
-int32_t gic_irq_translate(uint32_t type, uint32_t hw_irq)
-{
-	uint32_t irq;
-
-	switch (type) {
-	case GIC_SPI_TYPE:
-		irq = hw_irq + GIC_SPI_BASE;
-		if (irq >= GIC_SPI_BASE && irq < __MAX_IRQ)
-			return irq;
-		break;
-	case GIC_PPI_TYPE:
-		irq = hw_irq + GIC_PPI_BASE;
-		if (irq >= GIC_PPI_BASE && irq < GIC_SPI_BASE)
-			return irq;
-		break;
-	default:
-		uk_pr_warn("Invalid IRQ type [%d]\n", type);
-	}
-
-	uk_pr_err("irq is out of range\n");
-	return -EINVAL;
-}
-
-void gic_handle_irq(void)
-{
-	uint32_t stat, irq;
-
-	do {
-		stat = gic_ack_irq();
-		irq = stat & GICC_IAR_INTID_MASK;
-
-#ifndef CONFIG_HAVE_SMP
-		uk_pr_debug("EL1 IRQ#%d trap caught\n", irq);
-#else /* !CONFIG_HAVE_SMP */
-		uk_pr_debug("Core %d: EL1 IRQ#%d trap caught\n",
-				ukplat_lcpu_id(), irq);
-#endif /* CONFIG_HAVE_SMP */
-
-		/* Ensure interrupt processing starts only after ACK */
-		isb();
-
-		if (irq < GIC_MAX_IRQ) {
-			_ukplat_irq_handle((unsigned long)irq);
-			gic_eoi_irq(stat);
-			continue;
-		}
-
-		/* EoI should only be signaled for non-spurious interrupts */
-		if (irq != GICC_IAR_INTID_SPURIOUS)
-			gic_eoi_irq(stat);
-
-		break;
-	} while (1);
-}
-
-/** Enable the distributor */
-static void gic_init_dist(void)
+/** Initialize the distributor */
+static void gicv3_init_dist(void)
 {
 	uint32_t val, irq_number;
 	uint32_t i;
 
 	/* Disable the distributor */
-	gic_disable_dist();
+	gicv3_disable_dist();
 
 	/* Get GIC redistributor interface */
 	val = read_gicd32(GICD_TYPER);
@@ -496,6 +425,7 @@ static void gic_init_dist(void)
 	/* Route all global SPIs to this CPU */
 	uint64_t aff = (uint64_t)get_cpu_affinity();
 	uint64_t irouter_val = GIC_AFF_TO_ROUTER(aff, 0);
+
 	for (i = GIC_SPI_BASE; i < irq_number; i++)
 		write_gicd64(GICD_IROUTER(i), irouter_val);
 #endif /* CONFIG_HAVE_SMP */
@@ -515,45 +445,114 @@ static void gic_init_dist(void)
 	}
 
 	/* Wait for completion */
-	wait_for_rwp(GIC_DIST_ADDR);
+	wait_for_rwp(gicv3_drv.dist_mem_addr);
 
 	/* Enable the distributor */
-	gic_enable_dist();
+	gicv3_enable_dist();
+
+	uk_pr_info("GICv3 distributor initialized.\n");
 }
 
-int _dtb_init_gic(const void *fdt)
+static void gicv3_handle_irq(void)
 {
-	int fdt_gic, ret;
+	uint32_t stat, irq;
 
+	do {
+		stat = gicv3_ack_irq();
+		irq = stat & GICC_IAR_INTID_MASK;
+
+#ifndef CONFIG_HAVE_SMP
+		uk_pr_debug("EL1 IRQ#%d trap caught\n", irq);
+#else /* !CONFIG_HAVE_SMP */
+		uk_pr_debug("Core %d: EL1 IRQ#%d trap caught\n",
+				ukplat_lcpu_id(), irq);
+#endif /* CONFIG_HAVE_SMP */
+
+		/* Ensure interrupt processing starts only after ACK */
+		isb();
+
+		if (irq < GIC_MAX_IRQ) {
+			_ukplat_irq_handle((unsigned long)irq);
+			gicv3_eoi_irq(stat);
+
+			continue;
+		}
+
+		/* EoI should only be signaled for non-spurious interrupts */
+		if (irq != GICC_IAR_INTID_SPURIOUS)
+			gicv3_eoi_irq(stat);
+
+		break;
+	} while (1);
+}
+
+/**
+ * Initialize GICv3
+ * NOTE: First time must not be called from multiple CPUs in parallel
+ *
+ * @return 0 on success, a non-zero error otherwise
+ */
+static int gicv3_initialize(void)
+{
 #ifdef CONFIG_HAVE_SMP
-	if (gic_is_initialized) {
+	if (gicv3_drv.is_initialized) {
 		/* Distributor is already initialized, we just need to
 		 * initialize the CPU redistributor interface
 		 */
-		gic_init_redist();
+		gicv3_init_redist();
 		return 0;
 	}
-	gic_is_initialized = 1;
 #endif /* CONFIG_HAVE_SMP */
 
-	uk_pr_info("Probing GICv3...\n");
+	gicv3_drv.is_initialized = 1;
+
+	/* Initialize GICv3 distributor */
+	gicv3_init_dist();
+
+	/* Initialize GICv3 CPU redistributor */
+	gicv3_init_redist();
+
+	return 0;
+}
+
+static int gicv3_do_probe(const void *fdt)
+{
+	int fdt_gic, r;
+	struct _gic_operations drv_ops = {
+		.initialize        = gicv3_initialize,
+		.ack_irq           = gicv3_ack_irq,
+		.eoi_irq           = gicv3_eoi_irq,
+		.enable_irq        = gicv3_enable_irq,
+		.disable_irq       = gicv3_disable_irq,
+		.set_irq_type      = gicv3_set_irq_type,
+		.set_irq_prio      = gicv3_set_irq_prio,
+		.set_irq_affinity  = gicv3_set_irq_affinity,
+		.irq_translate     = gic_irq_translate,
+		.handle_irq        = gicv3_handle_irq,
+	};
+
+	/* Set driver functions */
+	gicv3_drv.ops = drv_ops;
 
 	/* Currently, we only support 1 GIC per system */
-	fdt_gic = fdt_node_offset_by_compatible_list(fdt, -1,
-				gic_device_list);
+	fdt_gic = fdt_node_offset_by_compatible_list(fdt, -1, gic_device_list);
 	if (fdt_gic < 0)
-		UK_CRASH("Could not find GICv3 Interrupt Controller!\n");
+		return -FDT_ERR_NOTFOUND; /* GICv3 not present */
 
-	/* Get device address and size at regs region */
-	ret = fdt_get_address(fdt, fdt_gic, 0,
-			&gic_dist_addr, &gic_dist_size);
-	if (ret < 0)
-		UK_CRASH("Could not find GICv3 distributor region!\n");
+	/* Get address and size of the GIC's register regions */
+	r = fdt_get_address(fdt, fdt_gic, 0, &gicv3_drv.dist_mem_addr,
+				&gicv3_drv.dist_mem_size);
+	if (r < 0) {
+		uk_pr_err("Could not find GICv3 distributor region!\n");
+		return r;
+	}
 
-	ret = fdt_get_address(fdt, fdt_gic, 1,
-			&gic_rdist_addr, &gic_rdist_size);
-	if (ret < 0)
-		UK_CRASH("Could not find GICv3 redistributor region!\n");
+	r = fdt_get_address(fdt, fdt_gic, 1, &gicv3_drv.rdist_mem_addr,
+				&gicv3_drv.rdist_mem_size);
+	if (r < 0) {
+		uk_pr_err("Could not find GICv3 redistributor region!\n");
+		return r;
+	}
 
 	uk_pr_info("Found GICv3 on:\n");
 	uk_pr_info("\tDistributor  : 0x%lx - 0x%lx\n",
@@ -566,11 +565,44 @@ int _dtb_init_gic(const void *fdt)
 	/* GICv3 is present */
 	gicv3_drv.is_present = 1;
 
-	/* Initialize GICv3 distributor */
-	gic_init_dist();
-
-	/* Initialize GICv3 CPU redistributor */
-	gic_enable_redist();
-
 	return 0;
+}
+
+/**
+ * Probe device tree for GICv3
+ * NOTE: First time must not be called from multiple CPUs in parallel
+ *
+ * @param [in] fdt pointer to device tree
+ * @param [out] dev receives pointer to GICv3 if available, NULL otherwise
+ *
+ * @return 0 if device is available, an FDT (FDT_ERR_*) error otherwise
+ */
+int gicv3_probe(const void *fdt, struct _gic_dev **dev)
+{
+	int rc;
+
+#ifdef CONFIG_HAVE_SMP
+	if (gicv3_drv.is_probed) {
+		/* GIC is already probed, we don't need to probe again */
+		if (gicv3_drv.is_present) {
+			*dev = &gicv3_drv;
+			return 0;
+		}
+
+		*dev = NULL;
+		return -FDT_ERR_NOTFOUND;
+	}
+#endif /* CONFIG_HAVE_SMP */
+
+	gicv3_drv.is_probed = 1;
+
+	rc = gicv3_do_probe(fdt);
+	if (rc) {
+		*dev = NULL;
+		return rc;
+	}
+
+	*dev = &gicv3_drv;
+	return 0;
+
 }

--- a/plat/drivers/gic/gic-v3.c
+++ b/plat/drivers/gic/gic-v3.c
@@ -1,0 +1,568 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2020, OpenSynergy GmbH. All rights reserved.
+ *
+ * ARM Generic Interrupt Controller support v3 version
+ * based on plat/drivers/gic/gic-v2.c:
+ *
+ * Authors: Wei Chen <Wei.Chen@arm.com>
+ *          Jianyong Wu <Jianyong.Wu@arm.com>
+ *
+ * Copyright (c) 2018, Arm Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <string.h>
+#include <libfdt.h>
+#include <uk/config.h>
+#include <uk/essentials.h>
+#include <uk/print.h>
+#include <uk/assert.h>
+#include <uk/bitops.h>
+#include <uk/asm.h>
+#include <uk/plat/common/irq.h>
+#include <uk/plat/lcpu.h>
+#include <uk/plat/common/irq.h>
+#ifdef CONFIG_PLAT_KVM
+#include <kvm/irq.h>
+#endif
+#include <uk/plat/spinlock.h>
+#include <arm/cpu.h>
+#include <gic/gic-v3.h>
+#include <ofw/fdt.h>
+
+/* SPI interrupt definitions */
+#define GIC_SPI_TYPE		0
+#define GIC_SPI_BASE		32
+
+/* PPI interrupt definitions */
+#define GIC_PPI_TYPE		1
+#define GIC_PPI_BASE		16
+
+/* Max support interrupt number for GICv3 */
+#define GIC_MAX_IRQ		__MAX_IRQ
+
+#define GIC_DIST_REG(r)	 ((void *)(gic_dist_addr + (r)))
+#define GIC_RDIST_REG(r) ((void *)(gic_rdist_addr + (r)))
+#define IRQ_TYPE_MASK	0x0000000f
+#define GIC_DIST_ADDR  (gic_dist_addr)
+#define GIC_RDIST_ADDR (gic_rdist_addr)
+
+#define GIC_AFF_TO_ROUTER(aff, mode)				\
+	((((uint64_t)(aff) << 8) & MPIDR_AFF3_MASK) | ((aff) & 0xffffff) | \
+	 ((uint64_t)(mode) << 31))
+
+static uint64_t gic_dist_addr, gic_rdist_addr;
+static uint64_t gic_dist_size, gic_rdist_size;
+#ifdef CONFIG_HAVE_SMP
+static char gic_is_initialized;
+__spinlock gic_dist_lock;
+inline void dist_lock(void) { ukarch_spin_lock(&gic_dist_lock); };
+inline void dist_unlock(void) { ukarch_spin_unlock(&gic_dist_lock); };
+#else
+inline void dist_lock(void) {};
+inline void dist_unlock(void) {};
+#endif /* CONFIG_HAVE_SMP */
+
+static const char * const gic_device_list[] = {
+	"arm,gic-v3",
+	NULL
+};
+
+/* Inline functions to access GICD & GICR registers */
+static inline void write_gicd8(uint64_t offset, uint8_t val)
+{
+	ioreg_write8(GIC_DIST_REG(offset), val);
+}
+
+static inline void write_gicrd8(uint64_t offset, uint8_t val)
+{
+	ioreg_write8(GIC_RDIST_REG(offset), val);
+}
+
+static inline void write_gicd32(uint64_t offset, uint32_t val)
+{
+	ioreg_write32(GIC_DIST_REG(offset), val);
+}
+
+static inline void write_gicd64(uint64_t offset, uint64_t val)
+{
+	ioreg_write64(GIC_DIST_REG(offset), val);
+}
+
+static inline uint32_t read_gicd32(uint64_t offset)
+{
+	return ioreg_read32(GIC_DIST_REG(offset));
+}
+
+static inline void write_gicrd32(uint64_t offset, uint32_t val)
+{
+	ioreg_write32(GIC_RDIST_REG(offset), val);
+}
+
+static inline uint32_t read_gicrd32(uint64_t offset)
+{
+	return ioreg_read32(GIC_RDIST_REG(offset));
+}
+
+/**
+ * Wait for a write completion in [re]distributor
+ *
+ * @param offset Memory address of distributor or redistributor
+ */
+static void wait_for_rwp(uint64_t offset)
+{
+	uint32_t val;
+
+	do {
+		val = ioreg_read32((void *)(offset + GICD_CTLR));
+	} while ((val & GICD_CTLR_RWP));
+}
+
+#ifdef CONFIG_HAVE_SMP
+/**
+ * Get affinity value for the calling CPU
+ *
+ * @return uint32_t (AFF3|AFF2|AFF1|AFF0)
+ */
+static uint32_t get_cpu_affinity(void)
+{
+	uint64_t aff;
+	uint64_t mpidr = SYSREG_READ64(MPIDR_EL1);
+
+	aff = ((mpidr & MPIDR_AFF3_MASK) >> 8) |
+		(mpidr & MPIDR_AFF2_MASK) |
+		(mpidr & MPIDR_AFF1_MASK) |
+		(mpidr & MPIDR_AFF0_MASK);
+
+	return (uint32_t)aff;
+}
+#endif /* CONFIG_HAVE_SMP */
+
+/**
+ * Acknowledge IRQ and retrieve highest priority pending interrupt
+ *
+ * @return the ID of the signaled interrupt
+ */
+uint32_t gic_ack_irq(void)
+{
+	uint32_t irq;
+
+	irq = SYSREG_READ32(ICC_IAR1_EL1);
+	dsb(sy);
+
+	return irq;
+}
+
+/**
+ * Signal completion of interrupt processing
+ *
+ * @param irq the ID of the interrupt to complete. Must be from a corresponding
+ *    call to gicv3_ack_irq()
+ */
+void gic_eoi_irq(uint32_t irq)
+{
+	/* Lower the priority */
+	SYSREG_WRITE32(ICC_EOIR1_EL1, irq);
+	isb();
+
+	/* Deactivate */
+	SYSREG_WRITE32(ICC_DIR_EL1, irq);
+	isb();
+}
+
+/**
+ * Enable an interrupt
+ *
+ * @param irq interrupt number [0..GIC_MAX_IRQ-1]
+ */
+void gic_enable_irq(uint32_t irq)
+{
+	UK_ASSERT(irq < GIC_MAX_IRQ);
+
+	dist_lock();
+
+#ifdef CONFIG_HAVE_SMP
+	/* Route this IRQ to the running core, i.e., route to the CPU interface
+	 * of the core calling this function
+	 */
+	if (irq >= GIC_SPI_BASE) {
+		uint64_t aff = (uint64_t)get_cpu_affinity();
+		uint64_t irouter_val = GIC_AFF_TO_ROUTER(aff, 0);
+
+		write_gicd64(GICD_IROUTER(irq), irouter_val);
+		uk_pr_debug("IRQ %d routed to 0x%lx (REG: 0x%lx)\n",
+				irq, aff, irouter_val);
+	}
+#endif
+
+	if (irq >= GIC_SPI_BASE)
+		write_gicd32(GICD_ISENABLER(irq),
+				UK_BIT(irq % GICD_I_PER_ISENABLERn));
+	else
+		write_gicrd32(GICR_ISENABLER0,
+				UK_BIT(irq % GICR_I_PER_ISENABLERn));
+
+	dist_unlock();
+}
+
+/**
+ * Disable an interrupt
+ *
+ * @param irq interrupt number [0..GIC_MAX_IRQ-1]
+ */
+void gic_disable_irq(uint32_t irq)
+{
+	UK_ASSERT(irq < GIC_MAX_IRQ);
+
+	dist_lock();
+
+	if (irq >= GIC_SPI_BASE)
+		write_gicd32(GICD_ICENABLER(irq),
+				UK_BIT(irq % GICD_I_PER_ICENABLERn));
+	else
+		write_gicrd32(GICR_ICENABLER0,
+				UK_BIT(irq % GICR_I_PER_ICENABLERn));
+
+	dist_unlock();
+}
+
+/**
+ * Set interrupt affinity
+ *
+ * @param irq interrupt number [GIC_SPI_BASE..GIC_MAX_IRQ-1]
+ * @param affinity target CPU affinity in 32 bits format
+ * (AFF3|AFF2|AFF1|AFF0), as returned by get_cpu_affinity()
+ */
+void gic_set_irq_affinity(uint32_t irq, uint32_t affinity)
+{
+	UK_ASSERT(irq >= GIC_SPI_BASE && irq < GIC_MAX_IRQ);
+
+	dist_lock();
+	write_gicd64(GICD_IROUTER(irq), GIC_AFF_TO_ROUTER(affinity, 0));
+	dist_unlock();
+}
+
+/**
+ * Set priority for an interrupt
+ *
+ * @param irq interrupt number [0..GIC_MAX_IRQ-1]
+ * @param priority priority [0..255]. The GIC implementation may not support
+ *    all levels. For example, if only 128 levels are supported every two levels
+ *    (e.g., 0 and 1) map to the same effective value. Lower values correspond
+ *    to higher priority
+ */
+void gic_set_irq_prio(uint32_t irq, uint8_t priority)
+{
+	dist_lock();
+
+	if (irq < GIC_SPI_BASE) /* Change in redistributor */
+		write_gicrd8(GICR_IPRIORITYR(irq), priority);
+	else
+		write_gicd8(GICD_IPRIORITYR(irq), priority);
+
+	dist_unlock();
+}
+
+/**
+ * Config trigger type for an interrupt
+ *
+ * @param irq interrupt number [GIC_PPI_BASE..GIC_MAX_IRQ-1]
+ * @param trigger trigger type (UK_IRQ_TRIGGER_*)
+ */
+static void gicv3_set_irq_type(uint32_t irq, enum uk_irq_trigger trigger)
+{
+	uint32_t val, mask, oldmask;
+
+	UK_ASSERT(irq >= GIC_PPI_BASE && irq < GIC_MAX_IRQ);
+	UK_ASSERT(trigger == UK_IRQ_TRIGGER_EDGE ||
+			trigger == UK_IRQ_TRIGGER_LEVEL);
+
+	dist_lock();
+
+	val = read_gicd32(GICD_ICFGR(irq));
+	mask = oldmask = (val >> ((irq % GICD_I_PER_ICFGRn) * 2)) &
+			GICD_ICFGR_MASK;
+
+	if (trigger == UK_IRQ_TRIGGER_LEVEL) {
+		mask &= ~GICD_ICFGR_TRIG_MASK;
+		mask |= GICD_ICFGR_TRIG_LVL;
+	} else if (trigger == UK_IRQ_TRIGGER_EDGE) {
+		mask &= ~GICD_ICFGR_TRIG_MASK;
+		mask |= GICD_ICFGR_TRIG_EDGE;
+	}
+
+	/* Check if nothing changed */
+	if (mask == oldmask)
+		goto EXIT_UNLOCK;
+
+	/* Update new interrupt type */
+	val &= (~(GICD_ICFGR_MASK << (irq % GICD_I_PER_ICFGRn) * 2));
+	val |= (mask << (irq % GICD_I_PER_ICFGRn) * 2);
+	write_gicd32(GICD_ICFGR(irq), val);
+
+EXIT_UNLOCK:
+	dist_unlock();
+}
+
+/** Enable distributor */
+static void gic_enable_dist(void)
+{
+	dist_lock();
+	write_gicd32(GICD_CTLR, GICD_CTLR_ARE_NS |
+			GICD_CTLR_ENABLE_G0 | GICD_CTLR_ENABLE_G1NS);
+	wait_for_rwp(GIC_DIST_ADDR);
+	dist_unlock();
+}
+
+/** Disable distributor */
+static void gic_disable_dist(void)
+{
+	/* Write 0 to disable distributor */
+	dist_lock();
+	write_gicd32(GICD_CTLR, 0);
+	wait_for_rwp(GIC_DIST_ADDR);
+	dist_unlock();
+}
+
+/** Enable the redistributor */
+static void gicv3_init_redist(void)
+{
+	uint32_t i, val;
+
+	/* Wake up CPU redistributor */
+	val  = read_gicrd32(GICR_WAKER);
+	val &= ~GICR_WAKER_ProcessorSleep;
+	write_gicrd32(GICR_WAKER, val);
+
+	/* Poll GICR_WAKER.ChildrenAsleep */
+	do {
+		val = read_gicrd32(GICR_WAKER);
+	} while ((val & GICR_WAKER_ChildrenAsleep));
+
+	/* Set PPI and SGI to a default value */
+	for (i = 0; i < GIC_SPI_BASE; i += GICD_I_PER_IPRIORITYn)
+		write_gicrd32(GICR_IPRIORITYR4(i), GICD_IPRIORITY_DEF);
+
+	/* Deactivate SGIs and PPIs as the state is unknown at boot */
+	write_gicrd32(GICR_ICACTIVER0, GICD_DEF_ICACTIVERn);
+
+	/* Disable all PPI interrupts */
+	write_gicrd32(GICR_ICENABLER0, GICD_DEF_PPI_ICENABLERn);
+
+	/* Configure SGIs and PPIs as non-secure Group 1 */
+	write_gicrd32(GICR_IGROUPR0, GICD_DEF_IGROUPRn);
+
+	/* Enable all SGIs */
+	write_gicrd32(GICR_ISENABLER0, GICD_DEF_SGI_ISENABLERn);
+
+	/* Wait for completion */
+	wait_for_rwp(GIC_RDIST_ADDR);
+
+	/* Enable system register access */
+	val  = SYSREG_READ32(ICC_SRE_EL1);
+	val |= 0x7;
+	SYSREG_WRITE32(ICC_SRE_EL1, val);
+	isb();
+
+	/* No priority grouping */
+	SYSREG_WRITE32(ICC_BPR1_EL1, 0);
+
+	/* Set priority mask register */
+	SYSREG_WRITE32(ICC_PMR_EL1, 0xff);
+
+	/* EOI drops priority, DIR deactivates the interrupt (mode 1) */
+	SYSREG_WRITE32(ICC_CTLR_EL1, GICC_CTLR_EL1_EOImode_drop);
+
+	/* Enable Group 1 interrupts */
+	SYSREG_WRITE32(ICC_IGRPEN1_EL1, 1);
+
+	isb();
+
+	uk_pr_info("GICv3 redistributor initialized.\n");
+}
+
+int32_t gic_irq_translate(uint32_t type, uint32_t hw_irq)
+{
+	uint32_t irq;
+
+	switch (type) {
+	case GIC_SPI_TYPE:
+		irq = hw_irq + GIC_SPI_BASE;
+		if (irq >= GIC_SPI_BASE && irq < __MAX_IRQ)
+			return irq;
+		break;
+	case GIC_PPI_TYPE:
+		irq = hw_irq + GIC_PPI_BASE;
+		if (irq >= GIC_PPI_BASE && irq < GIC_SPI_BASE)
+			return irq;
+		break;
+	default:
+		uk_pr_warn("Invalid IRQ type [%d]\n", type);
+	}
+
+	uk_pr_err("irq is out of range\n");
+	return -EINVAL;
+}
+
+void gic_handle_irq(void)
+{
+	uint32_t stat, irq;
+
+	do {
+		stat = gic_ack_irq();
+		irq = stat & GICC_IAR_INTID_MASK;
+
+#ifndef CONFIG_HAVE_SMP
+		uk_pr_debug("EL1 IRQ#%d trap caught\n", irq);
+#else /* !CONFIG_HAVE_SMP */
+		uk_pr_debug("Core %d: EL1 IRQ#%d trap caught\n",
+				ukplat_lcpu_id(), irq);
+#endif /* CONFIG_HAVE_SMP */
+
+		/* Ensure interrupt processing starts only after ACK */
+		isb();
+
+		if (irq < GIC_MAX_IRQ) {
+			_ukplat_irq_handle((unsigned long)irq);
+			gic_eoi_irq(stat);
+			continue;
+		}
+
+		/* EoI should only be signaled for non-spurious interrupts */
+		if (irq != GICC_IAR_INTID_SPURIOUS)
+			gic_eoi_irq(stat);
+
+		break;
+	} while (1);
+}
+
+/** Enable the distributor */
+static void gic_init_dist(void)
+{
+	uint32_t val, irq_number;
+	uint32_t i;
+
+	/* Disable the distributor */
+	gic_disable_dist();
+
+	/* Get GIC redistributor interface */
+	val = read_gicd32(GICD_TYPER);
+	irq_number = GICD_TYPER_LINE_NUM(val);
+	if (irq_number > GIC_MAX_IRQ)
+		irq_number = GIC_MAX_IRQ;
+	uk_pr_info("GICv3 Max interrupt lines: %d\n", irq_number);
+
+	/* Check for LPI support */
+	if (val & GICD_TYPE_LPIS)
+		uk_pr_warn("LPI support is not implemented by this driver!\n");
+
+	/* Configure all SPIs as non-secure Group 1 */
+	for (i = GIC_SPI_BASE; i < irq_number; i += GICD_I_PER_IGROUPRn)
+		write_gicd32(GICD_IGROUPR(i), GICD_DEF_IGROUPRn);
+
+#ifdef CONFIG_HAVE_SMP
+	/* Route all global SPIs to this CPU */
+	uint64_t aff = (uint64_t)get_cpu_affinity();
+	uint64_t irouter_val = GIC_AFF_TO_ROUTER(aff, 0);
+	for (i = GIC_SPI_BASE; i < irq_number; i++)
+		write_gicd64(GICD_IROUTER(i), irouter_val);
+#endif /* CONFIG_HAVE_SMP */
+
+	/* Set all SPI's interrupt type to be level-sensitive */
+	for (i = GIC_SPI_BASE; i < irq_number; i += GICD_I_PER_ICFGRn)
+		write_gicd32(GICD_ICFGR(i), GICD_ICFGR_DEF_TYPE);
+
+	/* Set all SPI's priority to a default value */
+	for (i = GIC_SPI_BASE; i < irq_number; i += GICD_I_PER_IPRIORITYn)
+		write_gicd32(GICD_IPRIORITYR4(i), GICD_IPRIORITY_DEF);
+
+	/* Deactivate and disable all SPIs */
+	for (i = GIC_SPI_BASE; i < irq_number; i += GICD_I_PER_ICACTIVERn) {
+		write_gicd32(GICD_ICACTIVER(i), GICD_DEF_ICACTIVERn);
+		write_gicd32(GICD_ICENABLER(i), GICD_DEF_ICENABLERn);
+	}
+
+	/* Wait for completion */
+	wait_for_rwp(GIC_DIST_ADDR);
+
+	/* Enable the distributor */
+	gic_enable_dist();
+}
+
+int _dtb_init_gic(const void *fdt)
+{
+	int fdt_gic, ret;
+
+#ifdef CONFIG_HAVE_SMP
+	if (gic_is_initialized) {
+		/* Distributor is already initialized, we just need to
+		 * initialize the CPU redistributor interface
+		 */
+		gic_init_redist();
+		return 0;
+	}
+	gic_is_initialized = 1;
+#endif /* CONFIG_HAVE_SMP */
+
+	uk_pr_info("Probing GICv3...\n");
+
+	/* Currently, we only support 1 GIC per system */
+	fdt_gic = fdt_node_offset_by_compatible_list(fdt, -1,
+				gic_device_list);
+	if (fdt_gic < 0)
+		UK_CRASH("Could not find GICv3 Interrupt Controller!\n");
+
+	/* Get device address and size at regs region */
+	ret = fdt_get_address(fdt, fdt_gic, 0,
+			&gic_dist_addr, &gic_dist_size);
+	if (ret < 0)
+		UK_CRASH("Could not find GICv3 distributor region!\n");
+
+	ret = fdt_get_address(fdt, fdt_gic, 1,
+			&gic_rdist_addr, &gic_rdist_size);
+	if (ret < 0)
+		UK_CRASH("Could not find GICv3 redistributor region!\n");
+
+	uk_pr_info("Found GICv3 on:\n");
+	uk_pr_info("\tDistributor  : 0x%lx - 0x%lx\n",
+		gicv3_drv.dist_mem_addr,
+		gicv3_drv.dist_mem_addr + gicv3_drv.dist_mem_size - 1);
+	uk_pr_info("\tRedistributor: 0x%lx - 0x%lx\n",
+		gicv3_drv.rdist_mem_addr,
+		gicv3_drv.rdist_mem_addr + gicv3_drv.rdist_mem_size - 1);
+
+	/* GICv3 is present */
+	gicv3_drv.is_present = 1;
+
+	/* Initialize GICv3 distributor */
+	gic_init_dist();
+
+	/* Initialize GICv3 CPU redistributor */
+	gic_enable_redist();
+
+	return 0;
+}

--- a/plat/drivers/include/gic/gic-v3.h
+++ b/plat/drivers/include/gic/gic-v3.h
@@ -38,6 +38,8 @@
 #ifndef __PLAT_DRV_ARM_GICV3_H__
 #define __PLAT_DRV_ARM_GICV3_H__
 
+#include <gic/gic.h>
+
 /** Affinity AFF3 bit mask */
 #define MPIDR_AFF3_MASK			0xff00000000
 /** Affinity AFF2 bit mask */
@@ -356,37 +358,20 @@
  * reading processor.
  */
 #define GICD_SPENDSGIRn		(0x0F20 + 4 * ((n) >> 2))
-#define GICD_I_PER_SPENDSGIRn   4
+#define GICD_I_PER_SPENDSGIRn	4
 
 /* Interrupt Acknowledge Register */
-#define GICC_IAR_INTID_MASK	    0x3FF
+#define GICC_IAR_INTID_MASK		0x3FF
 #define GICC_IAR_INTID_SPURIOUS	1023
 
-/* Acknowledging IRQ */
-uint32_t gic_ack_irq(void);
-
-/* Finish interrupt handling: Drop priority and deactivate the interrupt */
-void gic_eoi_irq(uint32_t irq);
-
-/* Enable IRQ in distributor (SPIs) or redistributor (SGIs and PPIS) */
-void gic_enable_irq(uint32_t irq);
-
-/* Disable an IRQ in distributor (SPIs) or in redistributor (SGIs and PPIs) */
-void gic_disable_irq(uint32_t irq);
-
-/* Set IRQ affinity routing */
-void gic_set_irq_affinity(uint32_t irq, uint8_t affinity);
-
-/* Set priority for IRQ in [re]distributor */
-void gic_set_irq_prio(uint32_t irq, uint8_t priority);
-
-/* Translate to hwirq according to type e.g. PPI SPI SGI */
-int gic_irq_translate(uint32_t type, uint32_t hw_irq);
-
-/* Handle IRQ entry */
-void gic_handle_irq(void);
-
-/* Initialize GICv3 from device tree */
-int _dtb_init_gic(const void *fdt);
+/**
+ * Probe device tree for GICv3
+ * NOTE: First time must not be called from multiple CPUs in parallel
+ *
+ * @param [in] fdt pointer to device tree
+ * @param [out] dev receives pointer to GICv3 if available, NULL otherwise
+ * @return 0 if device is available, an FDT (FDT_ERR_*) error otherwise
+ */
+int gicv3_probe(const void *fdt, struct _gic_dev **dev);
 
 #endif /* __PLAT_DRV_ARM_GICV3_H__ */

--- a/plat/drivers/include/gic/gic.h
+++ b/plat/drivers/include/gic/gic.h
@@ -31,6 +31,7 @@
 #define __PLAT_DRV_ARM_GIC_COMMON_H__
 
 #include <stdint.h>
+#include <uk/config.h>
 #include <uk/plat/spinlock.h>
 #include <uk/plat/common/irq.h>
 
@@ -138,8 +139,6 @@ struct _gic_dev {
 	/** Driver operations */
 	struct _gic_operations ops;
 };
-
-/* Prototypes */
 
 /**
  * Initialize GIC driver from device tree

--- a/plat/drivers/include/gic/gic.h
+++ b/plat/drivers/include/gic/gic.h
@@ -1,0 +1,168 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2020, OpenSynergy GmbH. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __PLAT_DRV_ARM_GIC_COMMON_H__
+#define __PLAT_DRV_ARM_GIC_COMMON_H__
+
+#include <stdint.h>
+#include <uk/plat/spinlock.h>
+#include <uk/plat/common/irq.h>
+
+/* Shared Peripheral Interrupt (SPI) definitions */
+#define GIC_SPI_TYPE 0
+#define GIC_SPI_BASE 32
+
+/* Private Peripheral Interrupt (PPI) definitions */
+#define GIC_PPI_TYPE 1
+#define GIC_PPI_BASE 16
+
+/**
+ * Max supported interrupt number for GIC
+ * Interrupts 1020-1023 are reserved for special purposes, with 1023 being the
+ * spurious interrupt
+ */
+#define GIC_MAX_IRQ  __MAX_IRQ
+
+/** Distributor register address */
+#define GIC_DIST_REG(gdev, r) ((void *)(gdev.dist_mem_addr + (r)))
+
+/** IRQ type mask */
+#define IRQ_TYPE_MASK 0x0000000f
+
+/* Distributor lock functions */
+#ifdef CONFIG_HAVE_SMP
+#define dist_lock(gdev) ukarch_spin_lock(gdev.dist_lock)
+#define dist_unlock(gdev) ukarch_spin_unlock(gdev.dist_lock)
+#else /* CONFIG_HAVE_SMP */
+#define dist_lock(gdev) {}
+#define dist_unlock(gdev) {}
+#endif /* !CONFIG_HAVE_SMP */
+
+/** GIC hardware version */
+typedef enum _GIC_HW_VER {
+	/** GIC version 2 */
+	GIC_V2 = 2,
+	/** GIC version 3 */
+	GIC_V3
+} GIC_HW_VER;
+
+/** GIC driver operations */
+struct _gic_operations {
+	/** Initialize GIC controller */
+	int (*initialize)(void);
+	/** Acknowledging IRQ */
+	uint32_t (*ack_irq)(void);
+	/** Finish interrupt handling */
+	void (*eoi_irq)(uint32_t irq);
+	/** Enable IRQ */
+	void (*enable_irq)(uint32_t irq);
+	/** Disable IRQ */
+	void (*disable_irq)(uint32_t irq);
+	/** Set IRQ trigger type */
+	void (*set_irq_type)(uint32_t irq, enum uk_irq_trigger trigger);
+	/** Set priority for IRQ */
+	void (*set_irq_prio)(uint32_t irq, uint8_t priority);
+	/** Set IRQ affinity (or "target" for GICv2) */
+	void (*set_irq_affinity)(uint32_t irq, uint32_t affinity);
+	/** Translate to absolute IRQ according to type e.g. PPI SPI SGI */
+	uint32_t (*irq_translate)(uint32_t type, uint32_t irq);
+	/** Handle IRQ */
+	void (*handle_irq)(void);
+};
+
+/** GIC controller structure */
+struct _gic_dev {
+	/** GIC hardware version */
+	GIC_HW_VER version;
+	/** Indicates if GIC is present */
+	uint8_t is_present;
+	/** Probe status */
+	uint8_t is_probed;
+	/** GIC status */
+	uint8_t is_initialized;
+	/** Distributor base address */
+	uint64_t dist_mem_addr;
+	/** Distributor memory size */
+	uint64_t dist_mem_size;
+	union {
+		/**
+		 * CPU Interface base address. This field is used only by
+		 * GICv2 driver since in versions above the CPU interface
+		 * is accessed through system registers (not memory mapped)
+		 */
+		uint64_t cpuif_mem_addr;
+		/** Redistributor's base address (GICv3) */
+		uint64_t rdist_mem_addr;
+	};
+	union {
+		/**
+		 * CPU Interface memory size. This field is used only by
+		 * GICv2 driver since in versions above the CPU interface
+		 * is accessed through system registers (not memory mapped)
+		 */
+		uint64_t cpuif_mem_size;
+		/** Redistributor's memory size (GICv3) */
+		uint64_t rdist_mem_size;
+	};
+#ifdef CONFIG_HAVE_SMP
+	/** Pointer to the lock for distributor access */
+	__spinlock * dist_lock;
+#endif /* CONFIG_HAVE_SMP */
+
+	/** Driver operations */
+	struct _gic_operations ops;
+};
+
+/* Prototypes */
+
+/**
+ * Initialize GIC driver from device tree
+ *
+ * @param [in] fdt Pointer to fdt structure
+ * @param [out] dev receives pointer to GIC device driver on success, NULL
+ *    otherwise
+ *
+ * @return 0 on success, a non-zero error code otherwise
+ */
+int _dtb_init_gic(const void *fdt, struct _gic_dev **dev);
+
+/**
+ * Translate a type-relative interrupt number to the corresponding absolute
+ * interrupt number. For example, first SPI (irq=0, type=GIC_SPI_TYPE) will
+ * return 32.
+ *
+ * @param type interrupt type (i.e., GIC_SPI_TYPE or GIC_PPI_TYPE)
+ * @param irq type-relative interrupt number
+ *
+ * @return absolute interrupt number or (uint32_t)-1 if the interrupt number
+ *    cannot be translated
+ */
+uint32_t gic_irq_translate(uint32_t type, uint32_t irq);
+
+#endif /* __PLAT_DRV_ARM_GIC_COMMON_H__ */

--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -135,12 +135,6 @@ config VIRTIO_9P
               Virtio 9P driver.
 endmenu
 
-config LIBGICV2
-       bool "Arm GIC (generic interrupt controller) v2 library support"
-       default y if ARCH_ARM_64
-       select LIBOFW
-       depends on ARCH_ARM_64
-
 config LIBOFW
        bool "Open Firmware library support"
        default n

--- a/plat/kvm/Makefile.uk
+++ b/plat/kvm/Makefile.uk
@@ -15,7 +15,6 @@ $(eval $(call addplatlib_s,kvm,libkvmvirtioblk,$(CONFIG_VIRTIO_BLK)))
 $(eval $(call addplatlib_s,kvm,libkvmvirtio9p,$(CONFIG_VIRTIO_9P)))
 $(eval $(call addplatlib_s,kvm,libkvmofw,$(CONFIG_LIBOFW)))
 $(eval $(call addplatlib_s,kvm,libkvmgic,$(CONFIG_LIBGIC)))
-$(eval $(call addplatlib_s,kvm,libkvmgicv2,$(CONFIG_LIBGICV2)))
 
 ##
 ## Platform library definitions
@@ -194,16 +193,21 @@ LIBKVMOFW_CINCLUDES-y         += -I$(LIBKVMPLAT_BASE)/include
 LIBKVMOFW_CINCLUDES-y         += -I$(UK_PLAT_COMMON_BASE)/include
 LIBKVMOFW_CINCLUDES-y         += -I$(UK_PLAT_DRIVERS_BASE)/include
 
-LIBKVMOFW_SRCS-y                  += $(UK_PLAT_DRIVERS_BASE)/ofw/fdt.c
-LIBKVMOFW_SRCS-$(CONFIG_LIBGICV2) += $(UK_PLAT_DRIVERS_BASE)/ofw/gic_fdt.c
+LIBKVMOFW_SRCS-y                += $(UK_PLAT_DRIVERS_BASE)/ofw/fdt.c
+LIBKVMOFW_SRCS-$(CONFIG_LIBGIC) += $(UK_PLAT_DRIVERS_BASE)/ofw/gic_fdt.c
 
 ##
-## GICv2 library definitions
+## GIC library definitions
 ##
+ifeq ($(findstring y,$(CONFIG_LIBGIC)),y)
+LIBKVMGIC_CINCLUDES-y         += -I$(LIBKVMPLAT_BASE)/include
+LIBKVMGIC_CINCLUDES-y         += -I$(UK_PLAT_COMMON_BASE)/include
+LIBKVMGIC_CINCLUDES-y         += -I$(UK_PLAT_DRIVERS_BASE)/include
+LIBKVMGIC_SRCS-y += $(UK_PLAT_DRIVERS_BASE)/gic/gic-common.c
 ifeq ($(findstring y,$(CONFIG_LIBGICV2)),y)
-LIBKVMGICV2_CINCLUDES-y         += -I$(LIBKVMPLAT_BASE)/include
-LIBKVMGICV2_CINCLUDES-y         += -I$(UK_PLAT_COMMON_BASE)/include
-LIBKVMGICV2_CINCLUDES-y         += -I$(UK_PLAT_DRIVERS_BASE)/include
-LIBKVMGICV2_SRCS-y += $(UK_PLAT_DRIVERS_BASE)/gic/gic-v2.c
-LIBKVMGICV2_SRCS-y += $(UK_PLAT_DRIVERS_BASE)/gic/gic-common.c
+LIBKVMGIC_SRCS-y += $(UK_PLAT_DRIVERS_BASE)/gic/gic-v2.c
+endif
+ifeq ($(findstring y,$(CONFIG_LIBGICV3)),y)
+LIBKVMGIC_SRCS-y += $(UK_PLAT_DRIVERS_BASE)/gic/gic-v3.c
+endif
 endif

--- a/plat/kvm/Makefile.uk
+++ b/plat/kvm/Makefile.uk
@@ -14,6 +14,7 @@ $(eval $(call addplatlib_s,kvm,libkvmvirtionet,$(CONFIG_VIRTIO_NET)))
 $(eval $(call addplatlib_s,kvm,libkvmvirtioblk,$(CONFIG_VIRTIO_BLK)))
 $(eval $(call addplatlib_s,kvm,libkvmvirtio9p,$(CONFIG_VIRTIO_9P)))
 $(eval $(call addplatlib_s,kvm,libkvmofw,$(CONFIG_LIBOFW)))
+$(eval $(call addplatlib_s,kvm,libkvmgic,$(CONFIG_LIBGIC)))
 $(eval $(call addplatlib_s,kvm,libkvmgicv2,$(CONFIG_LIBGICV2)))
 
 ##
@@ -199,8 +200,10 @@ LIBKVMOFW_SRCS-$(CONFIG_LIBGICV2) += $(UK_PLAT_DRIVERS_BASE)/ofw/gic_fdt.c
 ##
 ## GICv2 library definitions
 ##
+ifeq ($(findstring y,$(CONFIG_LIBGICV2)),y)
 LIBKVMGICV2_CINCLUDES-y         += -I$(LIBKVMPLAT_BASE)/include
 LIBKVMGICV2_CINCLUDES-y         += -I$(UK_PLAT_COMMON_BASE)/include
 LIBKVMGICV2_CINCLUDES-y         += -I$(UK_PLAT_DRIVERS_BASE)/include
-
 LIBKVMGICV2_SRCS-y += $(UK_PLAT_DRIVERS_BASE)/gic/gic-v2.c
+LIBKVMGICV2_SRCS-y += $(UK_PLAT_DRIVERS_BASE)/gic/gic-common.c
+endif


### PR DESCRIPTION
This patch series implements GIC v3 device driver support:

* Enable affinity IRQ routing
* Implement basic functions from GICv2 to GICv3
* Introduces a common GIC driver infrastructure in order to allow both GICv2 and GICv3 drivers on the same binary. The corresponding version is chosen according to device tree configuration.

Note: LPI's are not supported.

GICv3 can be tested with qemu using _-machine gic-version=3_ argument, for instance:
qemu-system-aarch64 -M virt-2.7 -cpu cortex-a57 -machine gic-version=3 -nographic -kernel <unikraft-kernel.dbg>
