### PR TITLE
lib/syscall_shim: Adjust the sign of `errno` to be positive

### DIFF
--- a/lib/syscall_shim/include/uk/syscall.h
+++ b/lib/syscall_shim/include/uk/syscall.h
@@ -201,7 +201,7 @@ typedef long uk_syscall_arg_t;
 		long ret = rname(					\
 			UK_ARG_MAPx(x, UK_S_ARG_CAST_LONG, __VA_ARGS__)); \
 		if (ret < 0 && PTRISERR(ret)) {				\
-			errno = (int) PTR2ERR(ret);			\
+			errno = -(int) PTR2ERR(ret);			\
 			return -1;					\
 		}							\
 		return ret;						\


### PR DESCRIPTION
Ensure that `errno` is assigned the positive value of what the raw
system calls return.

Signed-off-by: Sergiu Moga <sergiu.moga@protonmail.com>