### PR TITLE
lib/ukboot: add bindings for Mimalloc allocator

### DIFF
--- a/lib/ukboot/Config.uk
+++ b/lib/ukboot/Config.uk
@@ -92,6 +92,11 @@ if LIBUKBOOT
 		  Satisfy allocation as fast as possible. No support for free().
 		  Refer to help in ukallocregion for more information.
 
+		config LIBUKBOOT_INITMIMALLOC
+		bool "Mimalloc"
+		depends on LIBMIMALLOC_INCLUDED
+		select LIBMIMALLOC
+
 		config LIBUKBOOT_INITTLSF
 		bool "TLSF"
 		depends on LIBTLSF_INCLUDED

--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -43,6 +43,8 @@
 #include <uk/allocbbuddy.h>
 #elif CONFIG_LIBUKBOOT_INITREGION
 #include <uk/allocregion.h>
+#elif CONFIG_LIBUKBOOT_INITMIMALLOC
+#include <uk/mimalloc.h>
 #elif CONFIG_LIBUKBOOT_INITTLSF
 #include <uk/tlsf.h>
 #endif
@@ -236,6 +238,8 @@ void ukplat_entry(int argc, char *argv[])
 			a = uk_allocbbuddy_init(md.base, md.len);
 #elif CONFIG_LIBUKBOOT_INITREGION
 			a = uk_allocregion_init(md.base, md.len);
+#elif CONFIG_LIBUKBOOT_INITMIMALLOC
+			a = uk_mimalloc_init(md.base, md.len);
 #elif CONFIG_LIBUKBOOT_INITTLSF
 			a = uk_tlsf_init(md.base, md.len);
 #endif


### PR DESCRIPTION
This commits allows users to select Mimalloc as default system
allocator. Previously users had to patch the main tree to achieve this.
While adding more an more "hardcoded" allocators like this is certainly
not a long term solution, this is the only one we have for now.

Signed-off-by: Hugo Lefeuvre <hugo.lefeuvre@manchester.ac.uk>