### PR TITLE
lib/ukboot: add bindings for tinyalloc allocator

### DIFF
--- a/lib/ukboot/Config.uk
+++ b/lib/ukboot/Config.uk
@@ -97,6 +97,17 @@ if LIBUKBOOT
 		depends on LIBMIMALLOC_INCLUDED
 		select LIBMIMALLOC
 
+		config LIBUKBOOT_INITTINYALLOC
+		bool "tinyalloc"
+		depends on LIBTINYALLOC_INCLUDED
+		select LIBTINYALLOC
+		help
+		  Minimalist allocator implementation, meant for use in systems
+		  with unmanaged linear memory such as WebAssembly or embedded
+		  systems. tinyalloc is highly configurable and offers high
+		  performance and reasonable memory usage when used and
+		  configured appropriately.
+
 		config LIBUKBOOT_INITTLSF
 		bool "TLSF"
 		depends on LIBTLSF_INCLUDED

--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -47,6 +47,8 @@
 #include <uk/mimalloc.h>
 #elif CONFIG_LIBUKBOOT_INITTLSF
 #include <uk/tlsf.h>
+#elif CONFIG_LIBUKBOOT_INITTINYALLOC
+#include <uk/tinyalloc.h>
 #endif
 #if CONFIG_LIBUKSCHED
 #include <uk/sched.h>
@@ -242,6 +244,8 @@ void ukplat_entry(int argc, char *argv[])
 			a = uk_mimalloc_init(md.base, md.len);
 #elif CONFIG_LIBUKBOOT_INITTLSF
 			a = uk_tlsf_init(md.base, md.len);
+#elif CONFIG_LIBUKBOOT_INITTINYALLOC
+			a = uk_tinyalloc_init(md.base, md.len);
 #endif
 		} else {
 			uk_alloc_addmem(a, md.base, md.len);


### PR DESCRIPTION
This commits allows users to select tinyalloc as default system
allocator. Previously users had to patch the main tree to achieve this.

This is the tinyalloc counter part of 4b31168 (Mimalloc).

Signed-off-by: Hugo Lefeuvre <hugo.lefeuvre@manchester.ac.uk>