### PR TITLE
build: Option to compile as PIE

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -86,6 +86,15 @@ config OPTIMIZE_LTO
 		will increase overall building time but creates more efficient
 		Unikraft binaries.
 
+config ENABLE_PIE
+	bool "PIE - Postition-Independent Executable"
+	default n
+	help
+		Enables the unikernel to be compiled as a position-independent executable.
+		Note that certain parts of the entry64.S file will be eliminated, and the unikernel
+		will need to be loaded into memory from initrd by the bootloader (which will be compiled
+		separately).
+
 choice
 	prompt "Debug information level"
 	default DEBUG_SYMBOLS_LVL3

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -27,7 +27,7 @@ LIBLDFLAGS-$(call have_gcc)	+= -nostdinc
 # Set the text and data sections to be readable and writable. Also,
 # do not page-align the data segment. If the output format supports
 # Unix style magic numbers, mark the output as OMAGIC.
-LDFLAGS	+= -nostdlib -Wl,--omagic -Wl,--build-id=none
+LDFLAGS	+= -nostdlib -Wl,--build-id=none
 LDFLAGS-$(call have_gcc)	+= -nostdinc
 
 COMPFLAGS-$(CONFIG_OPTIMIZE_NONE)         += -O0 -fno-optimize-sibling-calls -fno-tree-vectorize
@@ -58,13 +58,20 @@ M4FLAGS      += -DUK_VERSION=$(UK_VERSION).$(UK_SUBVERSION)
 # If GCC supports "-no-pie" flag, we will add this flag to link flags to
 # override "pie" option, because some distributions will set
 # "--enable-default-pie" by default.
+ifeq ($(CONFIG_ENABLE_PIE),y)
+COMPFLAGS-$(call gcc_version_ge,6,1)	+= -fPIC
+LDFLAGS-$(call gcc_version_ge,6,1)	+= -static-pie
+else
+# "--omagic" is not compatible with the -static-pie option
+LDFLAGS     += -Wl,--omagic
 COMPFLAGS-$(call gcc_version_ge,6,1)	+= -fno-PIC
 LDFLAGS-$(call gcc_version_ge,6,1)	+= -no-pie
+COMPFLAGS-$(call have_clang)	+= -fno-builtin -fno-PIC
+LDFLAGS-$(call have_clang)	+= -no-pie
+endif
+
 ifeq ($(call gcc_version_ge,10,0),y)
 COMPFLAGS-y += -fhosted -ffreestanding -fno-tree-loop-distribute-patterns
 LIBLDFLAGS-$(CONFIG_OPTIMIZE_LTO) += -flinker-output=nolto-rel
 LDFLAGS-$(CONFIG_OPTIMIZE_LTO) += -flinker-output=nolto-rel
 endif
-
-COMPFLAGS-$(call have_clang)	+= -fno-builtin -fno-PIC
-LDFLAGS-$(call have_clang)	+= -no-pie

--- a/plat/kvm/x86/entry64.S
+++ b/plat/kvm/x86/entry64.S
@@ -40,6 +40,8 @@
 #define MYMULTIBOOT_FLAGS \
     (MULTIBOOT_PAGE_ALIGN | MULTIBOOT_MEMORY_INFO | MULTIBOOT_AOUT_KLUDGE)
 
+#ifndef CONFIG_ENABLE_PIE
+
 .section .data.boot
 
 .align 4
@@ -260,6 +262,8 @@ nopku:
 	cli
 	hlt
 END(_libkvmplat_start64)
+
+#endif /* CONFIG_ENABLE_PIE */
 
 .text
 ENTRY(_libkvmplat_newstack)


### PR DESCRIPTION
This patch adds the option to compile the unikernel as
a position-independent executable so we can have ASLR.
If the unikernel is compiled as PIE, it cannot run on it's
own. A bootloader will be needed that will come in a future PR.

Signed-off-by: Daniel Dinca <dincadaniel97@gmail.com>