### PR TITLE
Do not allocate IRQ handler entries dynamically

### DIFF
--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -77,6 +77,11 @@ endif
 
 endmenu
 
+config KVM_MAX_IRQ_HANDLER_ENTRIES
+       int "Maximum number of handlers per IRQ"
+       default 8
+       depends on (ARCH_X86_64 || ARCH_ARM_64)
+
 config KVM_PCI
        bool "PCI Bus Driver"
        default y

--- a/plat/kvm/irq.c
+++ b/plat/kvm/irq.c
@@ -27,46 +27,54 @@
 
 #include <stdlib.h>
 #include <uk/alloc.h>
-#include <uk/list.h>
 #include <uk/plat/lcpu.h>
 #include <uk/plat/time.h>
-#include <uk/plat/common/cpu.h>
+#include <uk/plat/irq.h>
 #include <uk/plat/common/irq.h>
 #include <kvm/irq.h>
 #include <kvm/intctrl.h>
 #include <uk/assert.h>
+#include <uk/print.h>
 #include <errno.h>
 #include <uk/bitops.h>
 
-static struct uk_alloc *allocator;
-
+/* IRQ handlers declarations */
 struct irq_handler {
 	irq_handler_func_t func;
 	void *arg;
-
-	UK_SLIST_ENTRY(struct irq_handler) entries;
 };
 
-UK_SLIST_HEAD(irq_handler_head, struct irq_handler);
-static struct irq_handler_head irq_handlers[__MAX_IRQ];
+static struct irq_handler irq_handlers[__MAX_IRQ]
+				[CONFIG_KVM_MAX_IRQ_HANDLER_ENTRIES];
+
+static inline struct irq_handler *allocate_handler(unsigned long irq)
+{
+	UK_ASSERT(irq < __MAX_IRQ);
+	for (int i = 0; i < CONFIG_KVM_MAX_IRQ_HANDLER_ENTRIES; i++)
+		if (irq_handlers[irq][i].func == NULL)
+			return &irq_handlers[irq][i];
+	return NULL;
+}
 
 int ukplat_irq_register(unsigned long irq, irq_handler_func_t func, void *arg)
 {
 	struct irq_handler *h;
 	unsigned long flags;
 
-	UK_ASSERT(irq < __MAX_IRQ);
-	UK_ASSERT(allocator != NULL);
+	UK_ASSERT(func);
+	if (irq >= __MAX_IRQ)
+		return -EINVAL;
 
-	h = uk_malloc(allocator, sizeof(struct irq_handler));
-	if (!h)
+	flags = ukplat_lcpu_save_irqf();
+	h = allocate_handler(irq);
+	if (!h) {
+		ukplat_lcpu_restore_irqf(flags);
 		return -ENOMEM;
+	}
 
 	h->func = func;
 	h->arg = arg;
 
-	flags = ukplat_lcpu_save_irqf();
-	UK_SLIST_INSERT_HEAD(&irq_handlers[irq], h, entries);
 	ukplat_lcpu_restore_irqf(flags);
 
 	intctrl_clear_irq(irq);
@@ -82,8 +90,14 @@ extern unsigned long sched_have_pending_events;
 void _ukplat_irq_handle(unsigned long irq)
 {
 	struct irq_handler *h;
+	int i;
 
-	UK_SLIST_FOREACH(h, &irq_handlers[irq], entries) {
+	UK_ASSERT(irq < __MAX_IRQ);
+
+	for (i = 0; i < CONFIG_KVM_MAX_IRQ_HANDLER_ENTRIES; i++) {
+		if (irq_handlers[irq][i].func == NULL)
+			break;
+		h = &irq_handlers[irq][i];
 		if (irq != ukplat_time_get_irq())
 			/* ukplat_time_get_irq() gives the IRQ reserved for a timer,
 			 * responsible to wake up cpu from halt, so it can check if
@@ -112,9 +126,10 @@ exit_ack:
 	intctrl_ack_irq(irq);
 }
 
-int ukplat_irq_init(struct uk_alloc *a)
+int ukplat_irq_init(struct uk_alloc *a __unused)
 {
-	UK_ASSERT(allocator == NULL);
-	allocator = a;
+	UK_ASSERT(ukplat_lcpu_irqs_disabled());
+
+	/* Nothing for now */
 	return 0;
 }

--- a/plat/linuxu/Config.uk
+++ b/plat/linuxu/Config.uk
@@ -36,4 +36,8 @@ if (PLAT_LINUXU)
 	depends on TAP_NET
 	help
 		Enable debug messages from the tap device.
+
+	config LINUXU_MAX_IRQ_HANDLER_ENTRIES
+	int "Maximum number of handlers per IRQ"
+	default 8
 endif

--- a/plat/linuxu/irq.c
+++ b/plat/linuxu/irq.c
@@ -31,10 +31,11 @@
  */
 #include <string.h>
 #include <uk/alloc.h>
-#include <uk/list.h>
+#include <errno.h>
 #include <uk/plat/lcpu.h>
 #include <uk/plat/irq.h>
 #include <uk/assert.h>
+#include <uk/print.h>
 #include <linuxu/syscall.h>
 #include <linuxu/signal.h>
 #if defined(__X86_32__) || defined(__x86_64__)
@@ -46,23 +47,34 @@
 #endif
 
 #define IRQS_NUM    16
+#define HANDLER_RESERVED ((void *) 0x1)
 
 /* IRQ handlers declarations */
 struct irq_handler {
+	/* func() special values:
+	 *   NULL: free,
+	 *   HANDLER_RESERVED: reserved
+	 */
 	irq_handler_func_t func;
 	void *arg;
 
 	struct uk_sigaction oldaction;
-
-	UK_SLIST_ENTRY(struct irq_handler) entries;
 };
 
-UK_SLIST_HEAD(irq_handler_head, struct irq_handler);
-static struct irq_handler_head irq_handlers[IRQS_NUM];
+static struct irq_handler irq_handlers[IRQS_NUM]
+				[CONFIG_LINUXU_MAX_IRQ_HANDLER_ENTRIES];
 
-static struct uk_alloc *allocator;
 static k_sigset_t handled_signals_set;
 static unsigned long irq_enabled;
+
+static inline struct irq_handler *allocate_handler(unsigned long irq)
+{
+	UK_ASSERT(irq < IRQS_NUM);
+	for (int i = 0; i < CONFIG_LINUXU_MAX_IRQ_HANDLER_ENTRIES; i++)
+		if (irq_handlers[irq][i].func == NULL)
+			return &irq_handlers[irq][i];
+	return NULL;
+}
 
 void ukplat_lcpu_enable_irq(void)
 {
@@ -135,10 +147,16 @@ asm("__restorer:mov r7, #0x77\nsvc 0x0");
 static void _irq_handle(int irq)
 {
 	struct irq_handler *h;
+	int i;
 
 	UK_ASSERT(irq >= 0 && irq < IRQS_NUM);
 
-	UK_SLIST_FOREACH(h, &irq_handlers[irq], entries) {
+	for (i = 0; i < CONFIG_LINUXU_MAX_IRQ_HANDLER_ENTRIES; i++) {
+		if (irq_handlers[irq][i].func == NULL)
+			break;
+		else if (irq_handlers[irq][i].func == HANDLER_RESERVED)
+			continue; /* reserved entry */
+		h = &irq_handlers[irq][i];
 		if (h->func(h->arg) == 1)
 			return;
 	}
@@ -163,11 +181,15 @@ int ukplat_irq_register(unsigned long irq, irq_handler_func_t func, void *arg)
 		return -EINVAL;
 
 	/* New handler */
-	h = uk_malloc(allocator, sizeof(struct irq_handler));
-	if (!h)
-		return -ENOMEM;
-	h->func = func;
-	h->arg = arg;
+	flags = ukplat_lcpu_save_irqf();
+	h = allocate_handler(irq);
+	if (!h) {
+		ukplat_lcpu_restore_irqf(flags);
+		return -EINVAL;
+	}
+
+	h->func = HANDLER_RESERVED; /* reserve */
+	ukplat_lcpu_restore_irqf(flags);
 
 	/* Register signal action */
 	memset(&action, 0, sizeof(action));
@@ -176,12 +198,14 @@ int ukplat_irq_register(unsigned long irq, irq_handler_func_t func, void *arg)
 	action.k_sa_restorer = __restorer;
 
 	rc = sys_sigaction((int) irq, &action, &h->oldaction);
-	if (rc != 0)
+	if (rc != 0) {
+		h->func = NULL; /* give back */
 		goto err;
+	}
 
-	flags = ukplat_lcpu_save_irqf();
-	UK_SLIST_INSERT_HEAD(&irq_handlers[irq], h, entries);
-	ukplat_lcpu_restore_irqf(flags);
+	/* Enable the handler */
+	h->func = func;
+	h->arg = arg;
 
 	/* Unblock the signal */
 	k_sigemptyset(&set);
@@ -197,22 +221,12 @@ int ukplat_irq_register(unsigned long irq, irq_handler_func_t func, void *arg)
 	return 0;
 
 err:
-	uk_free(allocator, h);
 	return -rc;
 }
 
-int ukplat_irq_init(struct uk_alloc *a)
+int ukplat_irq_init(struct uk_alloc *a __unused)
 {
-	UK_ASSERT(!irq_enabled);
-	UK_ASSERT(!allocator);
-
-	allocator = a;
-
-	/* Clear list head */
-	for (int i = 0; i < IRQS_NUM; i++)
-		UK_SLIST_INIT(&irq_handlers[i]);
-
+	UK_ASSERT(ukplat_lcpu_irqs_disabled());
 	k_sigemptyset(&handled_signals_set);
-
 	return 0;
 }

--- a/plat/linuxu/irq.c
+++ b/plat/linuxu/irq.c
@@ -46,7 +46,7 @@
 #error "Unsupported architecture"
 #endif
 
-#define IRQS_NUM    16
+#define __MAX_IRQ 16
 #define HANDLER_RESERVED ((void *) 0x1)
 
 /* IRQ handlers declarations */
@@ -61,7 +61,7 @@ struct irq_handler {
 	struct uk_sigaction oldaction;
 };
 
-static struct irq_handler irq_handlers[IRQS_NUM]
+static struct irq_handler irq_handlers[__MAX_IRQ]
 				[CONFIG_LINUXU_MAX_IRQ_HANDLER_ENTRIES];
 
 static k_sigset_t handled_signals_set;
@@ -69,7 +69,7 @@ static unsigned long irq_enabled;
 
 static inline struct irq_handler *allocate_handler(unsigned long irq)
 {
-	UK_ASSERT(irq < IRQS_NUM);
+	UK_ASSERT(irq < __MAX_IRQ);
 	for (int i = 0; i < CONFIG_LINUXU_MAX_IRQ_HANDLER_ENTRIES; i++)
 		if (irq_handlers[irq][i].func == NULL)
 			return &irq_handlers[irq][i];
@@ -149,7 +149,7 @@ static void _irq_handle(int irq)
 	struct irq_handler *h;
 	int i;
 
-	UK_ASSERT(irq >= 0 && irq < IRQS_NUM);
+	UK_ASSERT(irq >= 0 && irq < __MAX_IRQ);
 
 	for (i = 0; i < CONFIG_LINUXU_MAX_IRQ_HANDLER_ENTRIES; i++) {
 		if (irq_handlers[irq][i].func == NULL)
@@ -177,7 +177,7 @@ int ukplat_irq_register(unsigned long irq, irq_handler_func_t func, void *arg)
 	unsigned long flags;
 	int rc;
 
-	if (irq >= IRQS_NUM)
+	if (irq >= __MAX_IRQ)
 		return -EINVAL;
 
 	/* New handler */

--- a/plat/xen/events.c
+++ b/plat/xen/events.c
@@ -38,6 +38,7 @@
 #include <common/events.h>
 #include <xen/xen.h>
 #include <uk/print.h>
+#include <uk/assert.h>
 #include <uk/bitops.h>
 
 #define NR_EVS 1024
@@ -332,6 +333,8 @@ struct uk_alloc;
 
 int ukplat_irq_init(struct uk_alloc *a __unused)
 {
+	UK_ASSERT(ukplat_lcpu_irqs_disabled());
+
 	/* Nothing for now */
 	return 0;
 }


### PR DESCRIPTION
IRQ handler entries are currently allocated dynamically. This has two undesired consequences: (1) this requires the dynamic memory allocator to be initialized when `ukplat_irq_init()` is called, which happens quite early, and (2) this makes the registering of IRQ handlers quite expensive.

Pre-allocate IRQ handles statically. Their number can be configured via a new config variable `KVM_MAX_IRQ_HANDLER_ENTRIES`.

This PR contains patches for KVM and linuxu but not Xen.

This PR is a simple re-upload of the fairly old [patch series 1431](https://patchwork.unikraft.org/project/unikraft/list/?series=1431). I rebased on top of staging, but it probably deserves a closer look and a bit more testing.