### PR TITLE
Add initial embedded rust support

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -168,6 +168,15 @@ config CROSS_COMPILE
 		need to set this unless you want the configured build
 		directory to select the cross-compiler automatically.
 
+
+config LLVM_TARGET_ARCH
+	string "Custom cross-compiler LLVM target (optional)"
+	help
+		Same as running 'make LLVM_TARGET_ARCH=target' but stored for
+		default make runs in this build directory.  You don't
+		need to set this unless you want the configured build
+		directory to select the cross-compiler automatically.
+		This is used for LLVM based compilers such as clang or rustc.
 #config PARALLEL_JOBS
 #	int "Number of jobs to run simultaneously (0 for auto)"
 #	default "0"

--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,8 @@ CXXINCLUDES :=
 CXXINCLUDES-y :=
 GOCFLAGS :=
 GOCFLAGS-y :=
+RUSTCFLAGS :=
+RUSTCFLAGS-y :=
 GOCINCLUDES :=
 GOCINCLUDES-y :=
 DBGFLAGS :=
@@ -568,6 +570,13 @@ CC		:= $(CONFIG_CROSS_COMPILE)$(CONFIG_COMPILER)
 CPP		:= $(CC)
 CXX		:= $(CPP)
 GOC		:= $(CONFIG_CROSS_COMPILE)gccgo-7
+# We use rustc because the gcc frontend is experimental and missing features such
+# as borrowing checking
+ifneq ("$(origin LLVM_TARGET_ARCH)","undefined")
+RUSTC		:= rustc --target=$(CONFIG_LLVM_TARGET_ARCH)
+else
+RUSTC		:= rustc
+endif
 AS		:= $(CC)
 AR		:= $(CONFIG_CROSS_COMPILE)gcc-ar
 NM		:= $(CONFIG_CROSS_COMPILE)gcc-nm

--- a/Makefile
+++ b/Makefile
@@ -515,6 +515,7 @@ ifeq ($(sub_make_exec), 1)
 ifeq ($(UK_HAVE_DOT_CONFIG),y)
 # Hide troublesome environment variables from sub processes
 unexport CONFIG_CROSS_COMPILE
+unexport CONFIG_LLVM_TARGET_ARCH
 unexport CONFIG_COMPILER
 #unexport CC
 #unexport LD
@@ -546,6 +547,10 @@ unexport MACHINE
 
 ifneq ("$(origin CROSS_COMPILE)","undefined")
 CONFIG_CROSS_COMPILE := $(CROSS_COMPILE:"%"=%)
+endif
+
+ifneq ("$(origin LLVM_TARGET_ARCH)","undefined")
+CONFIG_LLVM_TARGET_ARCH := $(LLVM_TARGET_ARCH:"%"=%)
 endif
 
 ifneq ("$(origin COMPILER)","undefined")

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -21,6 +21,30 @@ CINCLUDES    += -I$(CONFIG_UK_BASE)/include
 CXXINCLUDES  += -I$(CONFIG_UK_BASE)/include
 GOCINCLUDES  += -I$(CONFIG_UK_BASE)/include
 
+RUSTCFLAGS-y	+= --emit=obj --crate-type=rlib --edition=2018 \
+		-Cpanic=abort -Cembed-bitcode=n \
+		-Zbinary_dep_depinfo=y -Zsymbol-mangling-version=v0 \
+		-Cforce-unwind-tables=n -Ccodegen-units=1 \
+		-Dunsafe_op_in_unsafe_fn -Drust_2018_idioms
+
+
+RUSTCFLAGS-$(CONFIG_OPTIMIZE_NONE)         += -Copt-level="0"
+RUSTCFLAGS-$(CONFIG_OPTIMIZE_SIZE)         += -Copt-level="s"
+RUSTCFLAGS-$(CONFIG_OPTIMIZE_PERF)         += -Copt-level="2"
+
+RUSTCFLAGS-$(CONFIG_DEBUG_SYMBOLS_LVL0)     += -Cdebuginfo=0
+RUSTCFLAGS-$(CONFIG_DEBUG_SYMBOLS_LVL1)     += -Cdebuginfo=1
+RUSTCFLAGS-$(CONFIG_DEBUG_SYMBOLS_LVL2)     += -Cdebuginfo=2
+# NOTE: There is not level 3 in rustc
+RUSTCFLAGS-$(CONFIG_DEBUG_SYMBOLS_LVL3)     += -Cdebuginfo=2
+
+# NOTE: rustc supports LTO only with clang
+ifeq ($(call have_clang),y)
+RUSTCFLAGS-$(CONFIG_OPTIMIZE_LTO)	+= -Clinker-plugin-lto
+else
+RUSTCFLAGS-y	+= -Cembed-bitcode=n -Clto=n
+endif
+
 LIBLDFLAGS  += -nostdlib -Wl,-r -Wl,-d -Wl,--build-id=none -no-pie
 LIBLDFLAGS-$(call have_gcc)	+= -nostdinc
 

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -574,6 +574,24 @@ buildrule_CPP = $(call buildrule_cxx,$(1),$(2),$(3),$(4))
 buildrule_C   = $(call buildrule_cxx,$(1),$(2),$(3),$(4))
 buildrule_c$(plus)$(plus) = $(call buildrule_cxx,$(1),$(2),$(3),$(4))
 
+# NOTE: We are not using most of the flags such as COMPFLAGS due to incompatibilities between rustc and GCC.
+define buildrule_rs =
+$(4): $(2) | preprocess
+	$(call build_cmd,RUSTC,$(1),$(4),\
+		$(RUSTC) $$(RUSTCFLAGS) $$(RUSTCFLAGS-y) $$(RUSTCFLAGS_EXTRA) \
+			$$($(call vprefix_lib,$(1),RUSTCFLAGS)) $$($(call vprefix_lib,$(1),RUSTCFLAGS-y)) \
+			$$($(call vprefix_src,$(1),$(2),$(3),FLAGS)) $$($(call vprefix_src,$(1),$(2),$(3),FLAGS-y)) \
+			--cfg '__LIBNAME__="$(1)"' --cfg '__BASENAME__="$(notdir $(2))"' $(if $(3),--cfg '__VARIANT__="$(3)"') \
+			$(2) -o $(4)
+	)
+
+UK_SRCS-y += $(2)
+UK_DEPS-y += $(call out2dep,$(4))
+UK_OBJS-y += $(4)
+$(eval $(call vprefix_lib,$(1),OBJS-y) += $(4))
+$(eval $(call vprefix_lib,$(1),CLEAN-y) += $(call build_clean,$(4)) $(call out2dep,$(4)))
+endef
+
 define add_lds_to_plat =
 $(eval $(call uc,$(2))_LD_SCRIPT-y += $(1))
 endef


### PR DESCRIPTION
This patch adds embedded rust support. Only the core crate is available. Internal libraries may be written in rust now.
Right now, the sources should have #![no_std] and a panic handler but future work will integrate this in a rust internal library.
