### PR TITLE
lib/uknetdev: Define and implement burst transactions for netdevice

### DIFF
--- a/lib/uknetdev/Config.uk
+++ b/lib/uknetdev/Config.uk
@@ -30,4 +30,11 @@ if LIBUKNETDEV
 			When this option is enabled a dispatcher thread is
 			allocated for each configured receive queue.
 			libuksched is required for this option.
+
+	config LIBUKNETDEV_MAX_PKT_BURST
+		int "Netdev burst transaction"
+		default 64
+		help
+			The maximum number of packets to be sent/received on a
+			single burst transaction.
 endif

--- a/lib/uknetdev/include/uk/netdev.h
+++ b/lib/uknetdev/include/uk/netdev.h
@@ -620,6 +620,21 @@ static inline int uk_netdev_tx_one(struct uk_netdev *dev, uint16_t queue_id,
 	uk_netdev_status_test_set((status), (UK_NETDEV_STATUS_SUCCESS	\
 					     | UK_NETDEV_STATUS_MORE))
 
+/**
+ * Test if the return status of `uk_netdev_rx_burst` or `uk_netdev_tx_burst`
+ * indicates that the operation was completed successfully for a certain
+ * number of packets and not on all packets.
+ *
+ * @param status
+ *   Return status (int)
+ * @return
+ *   - (True): Flag UK_NETDEV_STATUS_UNDERRUN is set
+ *   - (False): Operation was completed fully or error happened
+ */
+#define uk_netdev_status_underrun(status)				\
+	uk_netdev_status_test_set((status), (UK_NETDEV_STATUS_SUCCESS	\
+					     | UK_NETDEV_STATUS_UNDERRUN))
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/uknetdev/include/uk/netdev_core.h
+++ b/lib/uknetdev/include/uk/netdev_core.h
@@ -357,6 +357,8 @@ typedef int (*uk_netdev_rxq_intr_disable_t)(struct uk_netdev *dev,
 #define UK_NETDEV_STATUS_MORE     (0x2)
 /** Queue underrun (e.g., out-of-memory when allocating new receive buffers). */
 #define UK_NETDEV_STATUS_UNDERRUN (0x4)
+/** Some erroneous packet were received. */
+#define UK_NETDEV_STATUS_PKT_ERR  (0x8)
 
 /** Driver callback type to retrieve one packet from a RX queue. */
 typedef int (*uk_netdev_rx_t)(struct uk_netdev *dev,

--- a/lib/uknetdev/include/uk/netdev_core.h
+++ b/lib/uknetdev/include/uk/netdev_core.h
@@ -359,9 +359,9 @@ typedef int (*uk_netdev_rxq_intr_disable_t)(struct uk_netdev *dev,
 #define UK_NETDEV_STATUS_UNDERRUN (0x4)
 
 /** Driver callback type to retrieve one packet from a RX queue. */
-typedef int (*uk_netdev_rx_one_t)(struct uk_netdev *dev,
+typedef int (*uk_netdev_rx_t)(struct uk_netdev *dev,
 				  struct uk_netdev_rx_queue *queue,
-				  struct uk_netbuf **pkt);
+				  struct uk_netbuf **pkt, __u16 *cnt);
 
 /** Driver callback type to submit one packet to a TX queue. */
 typedef int (*uk_netdev_tx_t)(struct uk_netdev *dev,
@@ -454,7 +454,7 @@ struct uk_netdev {
 	uk_netdev_tx_t        tx; /* by driver */
 
 	/** Packet reception. */
-	uk_netdev_rx_one_t          rx_one; /* by driver */
+	uk_netdev_rx_t          rx; /* by driver */
 
 	/** Pointer to API-internal state data. */
 	struct uk_netdev_data       *_data;

--- a/lib/uknetdev/include/uk/netdev_core.h
+++ b/lib/uknetdev/include/uk/netdev_core.h
@@ -364,9 +364,10 @@ typedef int (*uk_netdev_rx_one_t)(struct uk_netdev *dev,
 				  struct uk_netbuf **pkt);
 
 /** Driver callback type to submit one packet to a TX queue. */
-typedef int (*uk_netdev_tx_one_t)(struct uk_netdev *dev,
+typedef int (*uk_netdev_tx_t)(struct uk_netdev *dev,
 				  struct uk_netdev_tx_queue *queue,
-				  struct uk_netbuf *pkt);
+				  struct uk_netbuf **pkt,
+				  __u16 *cnt);
 
 /**
  * A structure containing the functions exported by a driver.
@@ -450,7 +451,7 @@ struct uk_netdev_einfo {
  */
 struct uk_netdev {
 	/** Packet transmission. */
-	uk_netdev_tx_one_t          tx_one; /* by driver */
+	uk_netdev_tx_t        tx; /* by driver */
 
 	/** Packet reception. */
 	uk_netdev_rx_one_t          rx_one; /* by driver */

--- a/lib/uknetdev/include/uk/netdev_core.h
+++ b/lib/uknetdev/include/uk/netdev_core.h
@@ -253,6 +253,20 @@ typedef void (*uk_netdev_queue_event_t)(struct uk_netdev *dev,
 typedef uint16_t (*uk_netdev_alloc_rxpkts)(void *argp,
 					   struct uk_netbuf *pkts[],
 					   uint16_t count);
+/**
+ * User callback used by the driver to free netbufs
+ * that are used to cleanup the tx buffer.
+ *
+ * @param argp
+ *   User-provided argument.
+ * @param pkts
+ *   Array for netbuf pointers that the function should allocate.
+ * @param count
+ *   Number of netbufs requested (equal to length of pkts).
+ */
+typedef void (*uk_netdev_free_txpkts)(void *argp,
+				      struct uk_netbuf *pkts[],
+				      uint16_t count);
 
 /**
  * A structure used to configure an Unikraft network device RX queue.
@@ -275,6 +289,8 @@ struct uk_netdev_rxqueue_conf {
  */
 struct uk_netdev_txqueue_conf {
 	struct uk_alloc *a;               /* Allocator for descriptors. */
+	uk_netdev_free_txpkts free_txpkts; /**< Free up the tx free buffer */
+	void *free_txpkts_argp;		   /**< Argument for the free buffer */
 };
 
 /** Driver callback type to read device/driver capabilities,

--- a/lib/uknetdev/netdev.c
+++ b/lib/uknetdev/netdev.c
@@ -153,7 +153,7 @@ int uk_netdev_drv_register(struct uk_netdev *dev, struct uk_alloc *a,
 		  || (!dev->ops->rxq_intr_enable
 		      && !dev->ops->rxq_intr_disable));
 	UK_ASSERT(dev->rx_one);
-	UK_ASSERT(dev->tx_one);
+	UK_ASSERT(dev->tx);
 
 	dev->_data = _alloc_data(a, netdev_count,  drv_name);
 	if (!dev->_data)

--- a/lib/uknetdev/netdev.c
+++ b/lib/uknetdev/netdev.c
@@ -152,7 +152,7 @@ int uk_netdev_drv_register(struct uk_netdev *dev, struct uk_alloc *a,
 	UK_ASSERT((dev->ops->rxq_intr_enable && dev->ops->rxq_intr_disable)
 		  || (!dev->ops->rxq_intr_enable
 		      && !dev->ops->rxq_intr_disable));
-	UK_ASSERT(dev->rx_one);
+	UK_ASSERT(dev->rx);
 	UK_ASSERT(dev->tx);
 
 	dev->_data = _alloc_data(a, netdev_count,  drv_name);

--- a/lib/uksglist/include/uk/sglist.h
+++ b/lib/uksglist/include/uk/sglist.h
@@ -274,10 +274,11 @@ int uk_sglist_slice(struct uk_sglist *original, struct uk_sglist **slice,
  * The function create a scatter gather list from the netbuf
  * @param sg
  *	A reference to the scatter gather list.
- * @param m0
+ * @param netbuf
  *	A reference to the netbuf
  * @return
- *	0, on successful creation of the scatter gather list
+ *	> 0, total length of the netbuf packet on successful creation of
+ *	the scatter gather list
  *	-EINVAL, Invalid sg list.
  */
 int uk_sglist_append_netbuf(struct uk_sglist *sg, struct uk_netbuf *netbuf);

--- a/lib/uksglist/sglist.c
+++ b/lib/uksglist/sglist.c
@@ -537,6 +537,7 @@ int uk_sglist_append_netbuf(struct uk_sglist *sg, struct uk_netbuf *netbuf)
 {
 	struct sgsave save;
 	struct uk_netbuf *nb;
+	int len = 0;
 	int error;
 
 	if (sg->sg_maxseg == 0)
@@ -545,14 +546,14 @@ int uk_sglist_append_netbuf(struct uk_sglist *sg, struct uk_netbuf *netbuf)
 	error = 0;
 	SGLIST_SAVE(sg, save);
 	UK_NETBUF_CHAIN_FOREACH(nb, netbuf) {
-		if (likely(nb->len > 0)) {
-			error = uk_sglist_append(sg, nb->data, nb->len);
-			if (unlikely(error)) {
-				SGLIST_RESTORE(sg, save);
-				return error;
-			}
+		UK_ASSERT(nb->len > 0);
+		error = uk_sglist_append(sg, nb->data, nb->len);
+		if (unlikely(error)) {
+			SGLIST_RESTORE(sg, save);
+			return error;
 		}
+		len += nb->len;
 	}
-	return 0;
+	return len;
 }
 #endif /* CONFIG_LIBUKNETDEV */

--- a/plat/drivers/include/virtio/virtio_config.h
+++ b/plat/drivers/include/virtio/virtio_config.h
@@ -49,6 +49,9 @@ extern "C" {
 #define VIRTIO_CONFIG_STATUS_NEEDS_RESET   0x40 /* device needs reset */
 #define VIRTIO_CONFIG_STATUS_FAIL          0x80 /* device something's wrong*/
 
+/* Can the device handle any descriptor layout? */
+#define VIRTIO_F_ANY_LAYOUT         27
+
 #define VIRTIO_TRANSPORT_F_START    28
 #define VIRTIO_TRANSPORT_F_END      32
 

--- a/plat/drivers/include/virtio/virtqueue.h
+++ b/plat/drivers/include/virtio/virtqueue.h
@@ -134,6 +134,30 @@ int virtqueue_notify_enabled(struct virtqueue *vq);
 int virtqueue_buffer_dequeue(struct virtqueue *vq, void **cookie, __u32 *len);
 
 /**
+ * Remove a list of user buffer from the virtqueue.
+ *
+ * @param vq
+ *	Reference to the virtqueue.
+ * @param cookie
+ *      A list of reference to the cookie that was submitted.
+ *      with the dequeued descriptor after successful exit of this
+ *      function.
+ * @param cnt
+ *	A reference to the count of the max buffer to be dequeued. On
+ *	function exit contains the number of buffers removed from the
+ *	queue.
+ * @param len
+ *	Reference to the length of the data packet.
+ * @return
+ *	>= 0 A buffer was dequeued from the ring and the count indicates
+ *	the number of used slots in the ring after dequeueing.
+ *	< 0 Failed to dequeue a buffer, the output parameters cookie and len
+ *      are unmodified.
+ */
+int virtqueue_buffer_dequeue_burst(struct virtqueue *vq, void **cookie,
+				   __u16 *cnt, __u32 *len);
+
+/**
  * Create a descriptor chain starting at index head,
  * using vq->bufs also starting at index head.
  * @param vq

--- a/plat/drivers/include/virtio/virtqueue.h
+++ b/plat/drivers/include/virtio/virtqueue.h
@@ -160,6 +160,34 @@ int virtqueue_buffer_enqueue(struct virtqueue *vq, void *cookie,
 			     __u16 write_bufs);
 
 /**
+ * Enqueue a burst of a chain of descriptor into the virtqueue.
+ * @param vq
+ *	Reference to the virtqueue
+ * @param cookies
+ *	Reference to a list of the cookies to reconstruct the buffer.
+ * @param sg
+ *	Reference to the scatter gather list
+ * @param cnt
+ *	Reference to the cnt of the descriptor to insert into the virtqueue.
+ * @param *read_bufs
+ *	Reference to the list of number of read descriptors
+ * @param *write_bufs
+ *	Reference to the list of number of write descriptors
+ * @return
+ *	> 0 The buffers were added into the ring and the count indicates
+ *	the number of available slots in the ring. The value of cnt should
+ *	remain the same as the number of input descriptor.
+ *	0  The buffers were added and there are no further descriptors
+ *	available. The value of cnt should remain the same as the number of
+ *	input descriptor.
+ *	< 0 Failed to enqueue all the descriptor into the ring . The cnt field
+ *	indicates the number of descriptors added.
+ */
+int virtqueue_buffer_enqueue_burst(struct virtqueue *vq, void **cookies,
+				   struct uk_sglist *sg, __u16 *cnt,
+				   __u16 *read_bufs, __u16 *write_bufs);
+
+/**
  * Allocate a virtqueue.
  * @param queue_id
  *	The virtqueue hw id.

--- a/plat/drivers/virtio/virtio_net.c
+++ b/plat/drivers/virtio/virtio_net.c
@@ -69,7 +69,8 @@
 	__containerof(ndev, struct virtio_net_device, netdev)
 
 #define VIRTIO_NET_DRV_FEATURES(features)           \
-	(VIRTIO_FEATURES_UPDATE(features, VIRTIO_NET_F_MAC))
+	(VIRTIO_FEATURES_UPDATE(features, VIRTIO_NET_F_MAC));  \
+	(VIRTIO_FEATURES_UPDATE(features, VIRTIO_F_ANY_LAYOUT))
 
 typedef enum {
 	VNET_RX,
@@ -88,6 +89,11 @@ struct virtio_net_hdr_padded {
 };
 
 /**
+ * Fit packet to a ring, based on the feature negotiated.
+ */
+typedef int (*ring_desc_prepare_t)(struct uk_netbuf *, struct uk_sglist *);
+
+/**
  * @internal structure to represent the transmit queue.
  */
 struct uk_netdev_tx_queue {
@@ -99,6 +105,8 @@ struct uk_netdev_tx_queue {
 	uint16_t lqueue_id;
 	/* The nr. of descriptor limit */
 	uint16_t max_nb_desc;
+	/* Function to map the tx packet to the ring descriptor */
+	ring_desc_prepare_t txq_prepare;
 	/* The nr. of descriptor user configured */
 	uint16_t nb_desc;
 	/* The flag to interrupt on the transmit queue */
@@ -127,6 +135,8 @@ struct uk_netdev_rx_queue {
 	uint16_t max_nb_desc;
 	/* The nr. of descriptor user configured */
 	uint16_t nb_desc;
+	/* Function to map the rx buffer to the ring descriptor */
+	ring_desc_prepare_t rxq_prepare;
 	/* The flag to interrupt on the transmit queue */
 	uint8_t intr_enabled;
 	/* User-provided receive buffer allocation function */
@@ -166,6 +176,8 @@ struct virtio_net_device {
 	struct uk_hwaddr hw_addr;
 	/*  Netdev state */
 	__u8 state;
+	/* Any Layout */
+	__u8 any_layout;
 	/* RX promiscuous mode. */
 	__u8 promisc : 1;
 };
@@ -200,6 +212,10 @@ static int virtio_net_rx_intr_disable(struct uk_netdev *n,
 static int virtio_net_rx_intr_enable(struct uk_netdev *n,
 				     struct uk_netdev_rx_queue *queue);
 static int virtio_netdev_xmit_free(struct uk_netdev_tx_queue *txq);
+static inline int _virtio_netdev_xmit_inorder(struct uk_netbuf *nb,
+					      struct uk_sglist *sg);
+static inline int _virtio_netdev_xmit_anylayout(struct uk_netbuf *nb,
+						struct uk_sglist *sg);
 static int virtio_netdev_xmit(struct uk_netdev *dev,
 			      struct uk_netdev_tx_queue *queue,
 			      struct uk_netbuf **pkt, __u16 *cnt);
@@ -214,12 +230,12 @@ static int virtio_netdev_rxq_info_get(struct uk_netdev *dev, __u16 queue_id,
 static int virtio_netdev_txq_info_get(struct uk_netdev *dev, __u16 queue_id,
 				      struct uk_netdev_queue_info *qinfo);
 static int virtio_netdev_rxq_dequeue(struct uk_netdev_rx_queue *rxq,
-				     struct uk_netbuf **netbuf, __u16 *cnt);
-static int virtio_netdev_rxq_init(struct uk_netdev_rx_queue *rxq,
-				     struct uk_netbuf *netbuf);
+				     struct uk_netbuf **netbuf, __u16 *cnt,
+				     int16_t header_sz, __u8 any_layout,
+				     int *status);
 static int virtio_netdev_recv_done(struct virtqueue *vq, void *priv);
 static int virtio_netdev_rx_fillup(struct uk_netdev_rx_queue *rxq,
-				   __u16 num, int notify);
+				   __u16 num, int notify, __u8 any_layout);
 
 /**
  * Static global constants
@@ -285,7 +301,7 @@ static int virtio_netdev_xmit_free(struct uk_netdev_tx_queue *txq)
 
 static int virtio_netdev_rx_fillup(struct uk_netdev_rx_queue *rxq,
 				   __u16 nb_desc,
-				   int notify)
+				   int notify, __u8 any_layout)
 {
 	struct uk_netbuf *netbuf[RX_FILLUP_BATCHLEN];
 	int rc = 0;
@@ -295,6 +311,7 @@ static int virtio_netdev_rx_fillup(struct uk_netdev_rx_queue *rxq,
 	__u16 cnt = 0;
 	__u16 filled = 0;
 	int count;
+	__u16 rqst_cnt;
 
 	/**
 	 * Fixed amount of memory is allocated to each received buffer. In
@@ -304,16 +321,16 @@ static int virtio_netdev_rx_fillup(struct uk_netdev_rx_queue *rxq,
 	 * Because we using 2 descriptor for a single netbuf, our effective
 	 * queue size is just the half.
 	 */
-	nb_desc = ALIGN_DOWN(nb_desc, 2);
-	while (filled < nb_desc) {
-		req = MIN(nb_desc / 2, RX_FILLUP_BATCHLEN / 2);
-		uk_pr_debug(DRIVER_NAME": Request %d descriptor from rx queue %d\n",
-			    req, rxq->lqueue_id);
+	rqst_cnt = (any_layout) ? nb_desc : (nb_desc >> 1);
+	while (filled < rqst_cnt) {
+		req = MIN(rqst_cnt, RX_FILLUP_BATCHLEN);
 		cnt = rxq->alloc_rxpkts(rxq->alloc_rxpkts_argp, netbuf, req);
+		uk_pr_debug(DRIVER_NAME": Request %d buffers, filling %d buffers from rx queue %d\n",
+			    req, cnt, rxq->lqueue_id);
 		uk_sglist_reset(&rxq->sg);
 		for (i = 0; i < cnt && rxq->sg.sg_nseg < cnt; i++) {
 			count = rxq->sg.sg_nseg;
-			rc = virtio_netdev_rxq_init(rxq, netbuf[i]);
+			rc = rxq->rxq_prepare(netbuf[i], &rxq->sg);
 			if (unlikely(rc < 0)) {
 				uk_pr_err("Failed to add a buffer to receive virtqueue %p: %d\n",
 					  rxq, rc);
@@ -332,19 +349,21 @@ static int virtio_netdev_rx_fillup(struct uk_netdev_rx_queue *rxq,
 						    &rxq->sg, &i,
 						    rxq->readbuf_cnt,
 						    rxq->writebuf_cnt);
-		filled += (i * 2);
+		filled += i;
 		if (unlikely(rc > 0 && cnt < req)) {
 			uk_pr_debug("Incomplete fill-up of netbufs on receive virtqueue %p: Out of memory",
 				    rxq);
 			status |= UK_NETDEV_STATUS_UNDERRUN;
 			goto out;
 		} else if (unlikely(rc == -ENOSPC)) {
+			uk_pr_debug(DRIVER_NAME": Requesting %d desc freeing up %d desc\n", nb_desc, cnt);
 			/*
 			 * Release netbufs that we are not going
 			 * to use anymore
 			 */
-			for (j = i; j < cnt; j++)
+			for (j = i; j < cnt; j++) {
 				uk_netbuf_free(netbuf[j]);
+			}
 			goto out;
 		}
 	}
@@ -362,27 +381,136 @@ out:
 	return status;
 }
 
+static inline int _virtio_netdev_xmit_inorder(struct uk_netbuf *nb,
+					      struct uk_sglist *sg)
+{
+	struct virtio_net_hdr_padded *padded_hdr;
+	int16_t header_sz = sizeof(*padded_hdr);
+	struct virtio_net_hdr *vhdr;
+	size_t total_len = 0;
+	int rc;
+	__u8  *buf_start;
+	size_t buf_len;
+
+	total_len = 0;
+	buf_start = nb->data;
+	buf_len = nb->len;
+	/**
+	 * Use the preallocated header space for the virtio header.
+	 */
+	rc = uk_netbuf_header(nb, header_sz);
+	if (unlikely(rc != 1)) {
+		uk_pr_err("Failed to prepend virtio header\n");
+		return rc;
+	}
+
+	vhdr = nb->data;
+
+	/**
+	 * Fill the virtio-net-header with the necessary information.
+	 * Zero explicitly set.
+	 */
+	memset(vhdr, 0, sizeof(*vhdr));
+	vhdr->gso_type = VIRTIO_NET_HDR_GSO_NONE;
+	/**
+	 * According the specification 5.1.6.6, we need to explicitly use
+	 * 2 descriptor for each transmit and receive network packet since we
+	 * do not negotiate for the VIRTIO_F_ANY_LAYOUT.
+	 *
+	 * 1 for the virtio header and the other for the actual network packet.
+	 */
+	/* Appending the data to the list. */
+	rc = uk_sglist_append(sg, vhdr, sizeof(*vhdr));
+	if (unlikely(rc != 0)) {
+		uk_pr_err("Failed to append to the sg list\n");
+		goto remove_vhdr;
+	}
+	total_len += sizeof(*vhdr);
+	rc = uk_sglist_append(sg, buf_start, buf_len);
+	if (unlikely(rc != 0)) {
+		uk_pr_err("Failed to append to the sg list\n");
+		goto remove_vhdr;
+	}
+	total_len += buf_len;
+	if (nb->next) {
+		rc = uk_sglist_append_netbuf(sg, nb->next);
+		if (unlikely(rc <= 0)) {
+			uk_pr_err("Failed to append to the sg list\n");
+			goto remove_vhdr;
+		}
+		total_len += rc;
+	}
+	if (unlikely(total_len > VIRTIO_PKT_BUFFER_LEN)) {
+		uk_pr_err("Packet size too big: %lu, max:%u\n",
+				total_len, VIRTIO_PKT_BUFFER_LEN);
+		rc = -ENOTSUP;
+		goto remove_vhdr;
+	}
+
+	return 0;
+
+remove_vhdr:
+	uk_netbuf_header(nb, -header_sz);
+	return rc;
+}
+
+static inline int _virtio_netdev_xmit_anylayout(struct uk_netbuf *nb,
+						struct uk_sglist *sg)
+{
+	struct virtio_net_hdr *vhdr;
+	uint16_t total_len;
+	uint16_t header_sz = sizeof(*vhdr);
+	int rc;
+
+	total_len = 0;
+
+	/**
+	 * Use the preallocated header space for the virtio header.
+	 */
+	rc = uk_netbuf_header(nb, header_sz);
+	if (unlikely(rc != 1)) {
+		uk_pr_err("Failed to prepend virtio header\n");
+		return rc;
+	}
+
+	rc = uk_sglist_append_netbuf(sg, nb);
+	if (unlikely(rc <= 0)) {
+		uk_pr_err("Failed to append to the sg list\n");
+		goto remove_vhdr;
+	}
+	total_len += rc;
+	if (unlikely(total_len > VIRTIO_PKT_BUFFER_LEN)) {
+		uk_pr_err("Packet size too big: %u, max:%u\n",
+				total_len, VIRTIO_PKT_BUFFER_LEN);
+		rc = -ENOTSUP;
+		goto remove_vhdr;
+	}
+	uk_pr_debug("Packet total length: %d\n", total_len);
+
+	return 0;
+
+remove_vhdr:
+	uk_netbuf_header(nb, -header_sz);
+	return rc;
+}
+
 static int virtio_netdev_xmit(struct uk_netdev *dev,
 			      struct uk_netdev_tx_queue *queue,
 			      struct uk_netbuf **pkt, __u16 *cnt)
 {
-	struct virtio_net_device *vndev __unused;
-	struct virtio_net_hdr *vhdr;
-	struct virtio_net_hdr_padded *padded_hdr;
-	int16_t header_sz = sizeof(*padded_hdr);
+	struct virtio_net_device *vndev;
 	int rc = 0;
 	int status = 0x0;
-	size_t total_len = 0;
-	__u8  *buf_start;
-	size_t buf_len;
-	int desc_cnt, count = 0, hdr_cnt = 0;
-	__u16 i;
-	int sg_count;
+	int16_t header_sz;
+	int desc_cnt;
+	__u16 i, count, hdr_cnt = 0;
 
 	UK_ASSERT(dev);
 	UK_ASSERT(pkt && queue && cnt);
 
 	vndev = to_virtionetdev(dev);
+	header_sz = vndev->any_layout ? sizeof(struct virtio_net_hdr) :
+					sizeof(struct virtio_net_hdr_padded);
 	/**
 	 * We are reclaiming the free descriptors from buffers. The function is
 	 * not protected by means of locks. We need to be careful if there are
@@ -399,71 +527,22 @@ static int virtio_netdev_xmit(struct uk_netdev *dev,
 
 
 	for (i = 0; i < *cnt && queue->sg.sg_nseg < desc_cnt; i++) {
-		total_len = 0;
-		buf_start = pkt[i]->data;
-		buf_len = pkt[i]->len;
+		count = queue->sg.sg_nseg;
 		/**
 		 * Prepare the sg list.
 		 */
-		rc = uk_netbuf_header(pkt[i], header_sz);
-		if (unlikely(rc != 1)) {
-			uk_pr_err("Failed to prepend virtio header\n");
+		rc = queue->txq_prepare(pkt[i], &queue->sg);
+		if (unlikely(rc < 0))
 			break;
-		}
+
 		hdr_cnt++;
-		vhdr = pkt[i]->data;
-
-		/**
-		 * Fill the virtio-net-header with the necessary information.
-		 * Zero explicitly set.
-		 */
-		memset(vhdr, 0, sizeof(*vhdr));
-		vhdr->gso_type = VIRTIO_NET_HDR_GSO_NONE;
-
-		/**
-		 * According the specification 5.1.6.6, we need to explicitly
-		 * use 2 descriptor for each transmit and receive network
-		 * packet since we do not negotiate for the
-		 * VIRTIO_F_ANY_LAYOUT.
-		 *
-		 * 1 for the virtio header and the other for the actual
-		 * network packet.
-		 */
-		/* Appending the data to the list. */
-		sg_count = queue->sg.sg_nseg;
-		rc = uk_sglist_append(&queue->sg, vhdr, sizeof(*vhdr));
-		if (unlikely(rc != 0)) {
-			uk_pr_err("Failed to append to the sg list\n");
-			break;
-		}
-		rc = uk_sglist_append(&queue->sg, buf_start, buf_len);
-		if (unlikely(rc != 0)) {
-			uk_pr_err("Failed to append to the sg list\n");
-			break;
-		}
-		total_len += buf_len;
-		if (pkt[i]->next) {
-			rc = uk_sglist_append_netbuf(&queue->sg, pkt[i]->next);
-			if (unlikely(rc < 0)) {
-				uk_pr_err("Failed to append to the sg list\n");
-				break;
-			}
-			total_len += rc;
-		}
-
-		if (unlikely(total_len > VIRTIO_PKT_BUFFER_LEN)) {
-			uk_pr_err("Packet size too big: %lu, max:%u\n",
-					total_len, VIRTIO_PKT_BUFFER_LEN);
-			rc = -ENOTSUP;
-			break;
-		}
-		queue->readbuf_cnt[i] = queue->sg.sg_nseg - sg_count;
+		queue->readbuf_cnt[i] = queue->sg.sg_nseg - count;
 		queue->writebuf_cnt[i] = 0;
 	}
 	if (i == 0) {
 		status = rc;
 		*cnt = 0;
-		goto err_remove_vhdr;
+		goto err_exit;
 	} else if (i < *cnt)  {
 		uk_pr_info(DRIVER_NAME": Expected to send %d packets but have slot for only %d packets\n",
 			   count, i);
@@ -515,55 +594,54 @@ static int virtio_netdev_xmit(struct uk_netdev *dev,
 		*cnt = i;
 		status = rc;
 	}
-err_remove_vhdr:
+
+	uk_pr_debug("free %d packets with virtio header from tx queue %d\n",
+		    hdr_cnt - i, queue->lqueue_id);
 	/**
 	 * Remove header before exiting because we could not send
 	 */
 	for ( ; i < hdr_cnt; i++)
 		uk_netbuf_header(pkt[i], -header_sz);
+err_exit:
 	return status;
 }
 
-static int virtio_netdev_rxq_init(struct uk_netdev_rx_queue *rxq,
-				     struct uk_netbuf *netbuf)
+static int _virtio_netdev_rxq_init_inorder(struct uk_netbuf *nb,
+					  struct uk_sglist *sg)
 {
-	int rc = 0;
-	struct virtio_net_hdr_padded *rxhdr;
-	int16_t header_sz = sizeof(*rxhdr);
 	__u8 *buf_start;
 	size_t buf_len = 0;
-	struct uk_sglist *sg;
+	struct virtio_net_hdr_padded *rxhdr;
+	int16_t header_sz = sizeof(*rxhdr);
+	int rc;
 
 	/**
 	 * Saving the buffer information before reserving the header space.
 	 */
-	buf_start = netbuf->data;
-	buf_len = netbuf->len;
+	buf_start = nb->data;
+	buf_len = nb->len;
 
 	/**
 	 * Retrieve the buffer header length.
 	 */
-	rc = uk_netbuf_header(netbuf, header_sz);
+	rc = uk_netbuf_header(nb, header_sz);
 	if (unlikely(rc != 1)) {
 		uk_pr_err("Failed to allocate space to prepend virtio header\n");
 		return -EINVAL;
 	}
-	rxhdr = netbuf->data;
-
-	sg = &rxq->sg;
 
 	/* Appending the header buffer to the sglist */
-	rc = uk_sglist_append(sg, rxhdr, sizeof(struct virtio_net_hdr));
+	rc = uk_sglist_append(sg, nb->data, sizeof(struct virtio_net_hdr));
 	if (rc < 0) {
 		uk_pr_err("Failed(%d) to append to virtio header on netbuf %p\n",
-			  rc, netbuf);
+			  rc, nb);
 		goto error_remove_hdr;
 	}
 
 	/* Appending the data buffer to the sglist */
 	rc = uk_sglist_append(sg, buf_start, buf_len);
 	if (rc < 0) {
-		uk_pr_err("Failed to append data\n");
+		uk_pr_err("Failed(%d) to append empty buffer to rxq\n", rc);
 		goto error_remove_sglist;
 	}
 
@@ -572,11 +650,39 @@ static int virtio_netdev_rxq_init(struct uk_netdev_rx_queue *rxq,
 error_remove_sglist:
 	sg->sg_nseg--;
 error_remove_hdr:
-	uk_netbuf_header(netbuf, -header_sz);
+	uk_netbuf_header(nb, -header_sz);
 	return rc;
 }
 
-static int _virtio_pkt_hdr_process(struct uk_netbuf *buf, __u32 len)
+static int _virtio_netdev_rxq_init_anylayout(struct uk_netbuf *nb,
+					     struct uk_sglist *sg)
+{
+	int rc;
+	struct virtio_net_hdr *hdr;
+	int16_t header_sz = sizeof(*hdr);
+
+	rc = uk_netbuf_header(nb, header_sz);
+	if (unlikely(rc != 1)) {
+		uk_pr_err("Failed to allocate space to prepend virtio header\n");
+		return -EINVAL;
+	}
+
+	rc = uk_sglist_append(sg, nb->data, nb->len);
+	if (rc < 0) {
+		uk_pr_err("Failed(%d) to append empty buffer to rxq\n", rc);
+		goto error_remove_sglist;
+	}
+
+	return 0;
+
+error_remove_sglist:
+	sg->sg_nseg--;
+	uk_netbuf_header(nb, -header_sz);
+	return rc;
+}
+
+static int _virtio_pkt_hdr_process(struct uk_netbuf *buf, __u32 len,
+				   int16_t header_sz, __u8 any_layout)
 {
 	int rc;
 
@@ -589,21 +695,25 @@ static int _virtio_pkt_hdr_process(struct uk_netbuf *buf, __u32 len)
 	}
 	uk_pr_debug("Received packet size: %"__PRIu32"\n", len);
 
-	/**
-	 * Removing the virtio header from the buffer and adjusting length.
-	 * We pad "VTNET_RX_HEADER_PAD" to the rx buffer while enqueuing for
-	 * alignment of the packet data. We compensate for this, by adding the
-	 *  padding to the length on dequeue.
-	 */
-	buf->len = len + VTNET_RX_HEADER_PAD;
-	rc = uk_netbuf_header(buf,
-			      -((int16_t)sizeof(struct virtio_net_hdr_padded)));
+	if (any_layout == 0)
+		/**
+		 * Removing the virtio header from the buffer and adjusting length.
+		 * We pad "VTNET_RX_HEADER_PAD" to the rx buffer while enqueuing for
+		 * alignment of the packet data. We compensate for this, by adding the
+		 *  padding to the length on dequeue.
+		 */
+		buf->len = len + VTNET_RX_HEADER_PAD;
+	else
+		buf->len = len;
+	rc = uk_netbuf_header(buf, -header_sz);
 	UK_ASSERT(rc == 1);
 	return 0;
 }
 
 static int virtio_netdev_rxq_dequeue(struct uk_netdev_rx_queue *rxq,
-				     struct uk_netbuf **netbuf, __u16 *cnt)
+				     struct uk_netbuf **netbuf, __u16 *cnt,
+				     int16_t header_sz, __u8 any_layout,
+				     int *status)
 {
 	int ret;
 	int rc = 0, i, j, bad_pkts = 0;
@@ -619,17 +729,18 @@ static int virtio_netdev_rxq_dequeue(struct uk_netdev_rx_queue *rxq,
 	}
 
 	for (i = 0, j = 0; i < *cnt; i++) {
-		rc = _virtio_pkt_hdr_process(netbuf[i], rxq->len[i]);
-		if (unlikely(rc < 0)) {
+		rc = _virtio_pkt_hdr_process(netbuf[i], rxq->len[i], header_sz,
+					     any_layout);
+		if (rc < 0) {
 			uk_pr_warn("Receive queue: %d, bad packet: %p\n",
 					rxq->lqueue_id, netbuf[i]);
+			*status |= UK_NETDEV_STATUS_PKT_ERR;
 			bad_pkts++;
 			continue;
 		}
 		netbuf[j] = netbuf[i];
 		j++;
 	}
-
 	*cnt = *cnt - bad_pkts;
 
 	return ret;
@@ -639,27 +750,34 @@ static int virtio_netdev_recv(struct uk_netdev *dev __maybe_unused,
 			      struct uk_netdev_rx_queue *queue,
 			      struct uk_netbuf **pkt, __u16 *cnt)
 {
+	struct virtio_net_device *vndev;
 	int status = 0x0;
 	int rc = 0;
 	__u16 buf_cnt;
+	int16_t header_sz;
 
 	UK_ASSERT(dev && queue);
 	UK_ASSERT(pkt && cnt);
 
 	buf_cnt = *cnt;
+	vndev = to_virtionetdev(dev);
+	header_sz = vndev->any_layout ? sizeof(struct virtio_net_hdr) :
+					sizeof(struct virtio_net_hdr_padded);
 
 	/* Queue interrupts have to be off when calling receive */
 	UK_ASSERT(!(queue->intr_enabled & VTNET_INTR_EN));
 
-	rc = virtio_netdev_rxq_dequeue(queue, pkt, &buf_cnt);
+	rc = virtio_netdev_rxq_dequeue(queue, pkt, &buf_cnt, header_sz,
+				       vndev->any_layout, &status);
 	if (unlikely(buf_cnt == 0)) {
-		uk_pr_debug("no packet available\n");
 		*cnt = buf_cnt;
 		return status;
 	}
 	status = UK_NETDEV_STATUS_SUCCESS;
 	status |= virtio_netdev_rx_fillup(queue, (queue->nb_desc - rc),
-					  1);
+					  1, vndev->any_layout);
+
+	uk_pr_debug("%s: received %d pkts\n", __func__, buf_cnt);
 
 	/* Enable interrupt only when user had previously enabled it */
 	if (queue->intr_enabled & VTNET_INTR_USR_EN_MASK) {
@@ -672,12 +790,16 @@ static int virtio_netdev_recv(struct uk_netdev *dev __maybe_unused,
 			 * enabling the interrupt
 			 */
 			rc = virtio_netdev_rxq_dequeue(queue, &pkt[buf_cnt],
-						       &tmp_cnt);
+						       &tmp_cnt, header_sz,
+						       vndev->any_layout,
+						       &status);
 			if (unlikely(rc < 0)) {
 				uk_pr_err("Failed to dequeue the packet: %d\n",
 					  rc);
 				goto err_exit;
 			}
+			uk_pr_debug(DRIVER_NAME": Receiving the %d packets on queue :%d\n",
+				    cnt, queue->lqueue_id);
 			status |= UK_NETDEV_STATUS_SUCCESS;
 			buf_cnt += tmp_cnt;
 
@@ -687,7 +809,7 @@ static int virtio_netdev_recv(struct uk_netdev *dev __maybe_unused,
 			 */
 			status |= virtio_netdev_rx_fillup(queue,
 							  (queue->nb_desc - rc),
-							  1);
+							  1, vndev->any_layout);
 
 			/* Need to enable the interrupt on the last packet */
 			rc = virtqueue_intr_enable(queue->vq);
@@ -698,6 +820,7 @@ static int virtio_netdev_recv(struct uk_netdev *dev __maybe_unused,
 			uk_pr_debug("Receive status: %d Interrupt enabling: %d\n",
 				    status, rc);
 		}
+		uk_pr_debug(DRIVER_NAME": Interrupt state: %d\n", rc);
 	} else if (buf_cnt > 0) {
 		/**
 		 * For polling case, we report always there are further
@@ -742,11 +865,14 @@ static struct uk_netdev_rx_queue *virtio_netdev_rx_queue_setup(
 		goto err_exit;
 	}
 	rxq  = &vndev->rxqs[rc];
+	rxq->rxq_prepare = (vndev->any_layout == 1) ?
+			    _virtio_netdev_rxq_init_anylayout :
+			    _virtio_netdev_rxq_init_inorder;
 	rxq->alloc_rxpkts = conf->alloc_rxpkts;
 	rxq->alloc_rxpkts_argp = conf->alloc_rxpkts_argp;
 
 	/* Allocate receive buffers for this queue */
-	virtio_netdev_rx_fillup(rxq, rxq->nb_desc, 0);
+	virtio_netdev_rx_fillup(rxq, rxq->nb_desc, 0, vndev->any_layout);
 
 exit:
 	return rxq;
@@ -858,6 +984,10 @@ static struct uk_netdev_tx_queue *virtio_netdev_tx_queue_setup(
 		goto err_exit;
 	}
 	txq = &vndev->txqs[rc];
+	txq->txq_prepare = (vndev->any_layout == 1) ?
+			    _virtio_netdev_xmit_anylayout
+			    : _virtio_netdev_xmit_inorder;
+
 exit:
 	return txq;
 
@@ -988,6 +1118,11 @@ static int virtio_netdev_feature_negotiate(struct virtio_net_device *vndev)
 		goto exit;
 	}
 	rc = 0;
+
+	if (virtio_has_features(host_features, VIRTIO_F_ANY_LAYOUT)) {
+		vndev->any_layout = 1;
+		printf("virtqueue are configure with any layout\n");
+	}
 
 	/**
 	 * Mask out features supported by both driver and device.

--- a/plat/drivers/virtio/virtio_net.c
+++ b/plat/drivers/virtio/virtio_net.c
@@ -532,7 +532,7 @@ static int virtio_netdev_rxq_dequeue(struct uk_netdev_rx_queue *rxq,
 	return ret;
 }
 
-static int virtio_netdev_recv(struct uk_netdev *dev,
+static int virtio_netdev_recv(struct uk_netdev *dev __maybe_unused,
 			      struct uk_netdev_rx_queue *queue,
 			      struct uk_netbuf **pkt)
 {


### PR DESCRIPTION
This patch series enables batching the send/receive operation on
a network packets on a netdev. The implementation extends the
virtio-net driver to support batch operation.

- plat/virtio: Remove warning in virtio_netdev_recv
- lib/uknetdev: Support burst tx
- lib/uknetdev: Support to check UK_NETDEV_UNDERRUN status
- lib/uknetdev: Support burst receive
- plat/virtio: Support ANY_LAYOUT on virtio_net
- lib/uknetdev: Release a burst of packet from ring
