### PR TITLE
lib/ukallocpool: Make it compile again

### DIFF
--- a/lib/ukallocpool/include/uk/allocpool.h
+++ b/lib/ukallocpool/include/uk/allocpool.h
@@ -43,8 +43,6 @@
 extern "C" {
 #endif
 
-typedef void (*uk_allocpool_obj_init_t)(void *obj, __sz len, void *cookie);
-
 struct uk_allocpool;
 
 /**

--- a/lib/ukallocpool/include/uk/allocpool.h
+++ b/lib/ukallocpool/include/uk/allocpool.h
@@ -43,7 +43,7 @@
 extern "C" {
 #endif
 
-typedef void (*uk_allocpool_obj_init_t)(void *obj, size_t len, void *cookie);
+typedef void (*uk_allocpool_obj_init_t)(void *obj, __sz len, void *cookie);
 
 struct uk_allocpool;
 
@@ -59,8 +59,8 @@ struct uk_allocpool;
  * @return
  *  Number of bytes needed for pool allocation.
  */
-size_t uk_allocpool_reqmem(unsigned int obj_count, size_t obj_len,
-			   size_t obj_align);
+__sz uk_allocpool_reqmem(unsigned int obj_count, __sz obj_len,
+			 __sz obj_align);
 
 /**
  * Allocates a memory pool on a parent allocator.
@@ -79,7 +79,7 @@ size_t uk_allocpool_reqmem(unsigned int obj_count, size_t obj_len,
  */
 struct uk_allocpool *uk_allocpool_alloc(struct uk_alloc *parent,
 					unsigned int obj_count,
-					size_t obj_len, size_t obj_align);
+					__sz obj_len, __sz obj_align);
 
 /**
  * Frees a memory pool that was allocated with
@@ -109,8 +109,8 @@ void uk_allocpool_free(struct uk_allocpool *p);
  *  - (NULL): Not enough memory for pool.
  *  - pointer to initializes pool.
  */
-struct uk_allocpool *uk_allocpool_init(void *base, size_t len,
-				       size_t obj_len, size_t obj_align);
+struct uk_allocpool *uk_allocpool_init(void *base, __sz len,
+				       __sz obj_len, __sz obj_align);
 
 /**
  * Return uk_alloc compatible interface for allocpool.
@@ -142,7 +142,7 @@ unsigned int uk_allocpool_availcount(struct uk_allocpool *p);
  * @return
  *  Size of an object.
  */
-size_t uk_allocpool_objlen(struct uk_allocpool *p);
+__sz uk_allocpool_objlen(struct uk_allocpool *p);
 
 /**
  * Get one object from a pool.


### PR DESCRIPTION
Commit ed1ef9a caused `lib/ukallocpool` not to compile anymore because `<stddef.h>` is included too late. However, the purpose of commit ed1ef9a was to avoid libc datatypes for allocators. `lib/ukallocpool` got forgotten to adopt. This series fixes the issue for `lib/ukallocpool` by using the Unikraft internal datatypes.