### PR TITLE
lib/nolibc: Fix off-by-one error in memmove

### DIFF
--- a/lib/nolibc/string.c
+++ b/lib/nolibc/string.c
@@ -113,8 +113,8 @@ void *memmove(void *dst, const void *src, size_t len)
 		for (; len > 0; --len)
 			*(d++) = *(s++);
 	} else {
-		s += len;
-		d += len;
+		s += len - 1;
+		d += len - 1;
 
 		for (; len > 0; --len)
 			*(d--) = *(s--);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The last byte of a buffer is at `buf + len - 1` and `buf + len` is
already past the end. This caused memmove to copy too much at the end
and not enough data at the start of the specified memory areas.
