### PR TITLE
Remove PKU support

### DIFF
--- a/arch/x86/x86_64/Makefile.uk
+++ b/arch/x86/x86_64/Makefile.uk
@@ -9,6 +9,9 @@ CINCLUDES   += -I$(CONFIG_UK_BASE)/arch/x86/x86_64/include
 ASINCLUDES  += -I$(CONFIG_UK_BASE)/arch/x86/x86_64/include
 CXXINCLUDES += -I$(CONFIG_UK_BASE)/arch/x86/x86_64/include
 
+# compiler flags to prevent the use of PKU, for gcc versions < 9.1
+ARCHFLAGS += -mno-pku
+
 # compiler flags to prevent use of extended (FP, SSE, AVX) registers.
 # This is for files that contain trap/exception/interrupt handlers
 ISR_ARCHFLAGS += -mno-80387 -mno-mmx -mno-sse -mno-avx

--- a/plat/kvm/x86/entry64.S
+++ b/plat/kvm/x86/entry64.S
@@ -196,7 +196,7 @@ ENTRY(_libkvmplat_start64)
 	movq %rdi, %cr4
 	ldmxcsr (mxcsr_ptr)
 #endif /* __SSE__ */
-#if (__AVX__ || CONFIG_HAVE_X86PKU)
+#if (__AVX__)
 	/* Check capabilities subject to availability as indicated by cpuid.
 	 * First, start off with "standard features" */
 	movl $0x1, %eax
@@ -208,7 +208,7 @@ ENTRY(_libkvmplat_start64)
 	jz noxsave
 	orl $(X86_CR4_OSXSAVE), %edi
 	movq %rdi, %cr4
-#if __AVX__
+
 	/* now enable AVX. This needs to be last checking cpuid features from
 	 * the eax=1 cpuid call, because it clobbers ecx */
 	testl $(X86_CPUID1_ECX_AVX), %ecx
@@ -218,10 +218,9 @@ ENTRY(_libkvmplat_start64)
 	orl $(X86_XCR0_SSE | X86_XCR0_AVX), %eax
 	xsetbv
 noavx:
-#endif /* __AVX__ */
 /* Do not enable AVX without XSAVE, otherwise we'll get #UD */
 noxsave:
-#endif /* __AVX__ || CONFIG_HAVE_X86PKU */
+#endif /* __AVX__ */
 	/* Now, check for extended features. */
 	movl $0x7, %eax
 	movl $0x0, %ecx
@@ -233,23 +232,6 @@ noxsave:
 	orl $(X86_CR4_FSGSBASE), %edi
 	movq %rdi, %cr4
 nofsgsbase:
-#if CONFIG_HAVE_X86PKU
-	/* check for Memory Protection Keys (PKU) */
-	testl $(X86_CPUID7_ECX_PKU), %ecx
-	jz nopku
-	/* only enable PKU if we support XSAVE */
-	testl $(X86_CR4_OSXSAVE), %edi
-	jz nopku
-	/* PKU is supported, enable it via CR4 */
-	orl $(X86_CR4_PKE), %edi
-	movq %rdi, %cr4
-	/* also enable XSAVE for the PKRU */
-	xorl %ecx, %ecx
-	xgetbv
-	orl $(X86_XCR0_PKRU), %eax
-	xsetbv
-nopku:
-#endif /* CONFIG_HAVE_X86PKU */
 	/* done setting up CPU capabilities */
 
 	/* read multiboot info pointer */

--- a/plat/xen/x86/entry64.S
+++ b/plat/xen/x86/entry64.S
@@ -81,7 +81,7 @@ _libxenplat_start:
 	movq %rdi, %cr4
 	ldmxcsr (mxcsr_ptr)
 #endif /* __SSE__ */
-#if (__AVX__ || CONFIG_HAVE_X86PKU)
+#if (__AVX__)
 	/* Check capabilities subject to availability as indicated by cpuid.
 	 * First, start off with "standard features" */
 	movl $0x1, %eax
@@ -93,7 +93,7 @@ _libxenplat_start:
 	jz noxsave
 	orl $(X86_CR4_OSXSAVE), %edi
 	movq %rdi, %cr4
-#if __AVX__
+
 	/* now enable AVX. This needs to be last checking cpuid features from
 	 * the eax=1 cpuid call, because it clobbers ecx */
 	testl $(X86_CPUID1_ECX_AVX), %ecx
@@ -103,10 +103,9 @@ _libxenplat_start:
 	orl $(X86_XCR0_SSE | X86_XCR0_AVX), %eax
 	xsetbv
 noavx:
-#endif /* __AVX__ */
 /* Do not enable AVX without XSAVE, otherwise we'll get #UD */
 noxsave:
-#endif /* __AVX__ || CONFIG_HAVE_X86PKU */
+#endif /* __AVX__ */
 	/* Now, check for extended features. */
 	movl $0x7, %eax
 	movl $0x0, %ecx
@@ -118,23 +117,6 @@ noxsave:
 	orl $(X86_CR4_FSGSBASE), %edi
 	movq %rdi, %cr4
 nofsgsbase:
-#if CONFIG_HAVE_X86PKU
-	/* check for Memory Protection Keys (PKU) */
-	testl $(X86_CPUID7_ECX_PKU), %ecx
-	jz nopku
-	/* only enable PKU if we support XSAVE */
-	testl $(X86_CR4_OSXSAVE), %edi
-	jz nopku
-	/* PKU is supported, enable it via CR4 */
-	orl $(X86_CR4_PKE), %edi
-	movq %rdi, %cr4
-	/* also enable XSAVE for the PKRU */
-	xorl %ecx, %ecx
-	xgetbv
-	orl $(X86_XCR0_PKRU), %eax
-	xsetbv
-nopku:
-#endif /* CONFIG_HAVE_X86PKU */
 	/* Done setting up CPU capabilities, hand over to C entry point. */
 	movq %r8, %rdi /* pass pointer to start_info page to C entry */
 	call _libxenplat_x86entry


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture: `x86_64`
 - Platforms: `kvm`, `xen`


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

None

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR removes the support for PKU, also known as Memory Protection Keys. Support for PKU was removed in GCC 9.1, due to its security and performance issues. 
