### PR TITLE
Solved some compilation warnings

### DIFF
--- a/lib/nolibc/stdio.c
+++ b/lib/nolibc/stdio.c
@@ -486,7 +486,7 @@ int fflush(FILE *fp __unused)
 
 int fputc(int _c, FILE *fp)
 {
-	int ret;
+	int ret = 0;
 	unsigned char c = _c;
 
 	if (fp == stdout)

--- a/lib/uksignal/signal.c
+++ b/lib/uksignal/signal.c
@@ -360,7 +360,7 @@ int killpg(int pgrp, int sig)
 		return -1;
 	}
 
-	return kill(getpid(), sig);
+	return kill(uk_syscall_r_getpid(), sig);
 }
 
 int raise(int sig)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64` 
 - Platform(s): `kvm`
 - Application(s): N/A


### Description of changes

Fixed 4 compilation warnings for core libraries:

- returning uninitialized value in `fputc()`
- missing return statement in `sync()`
- added cast to `unsigned long` for address in `ioctl()`
- replaced implicit declaration of `getpid()` when libc-style stubs are not generated