### PR TITLE
lib/uklock: adding mutex metrics

### DIFF
--- a/lib/uklock/Config.uk
+++ b/lib/uklock/Config.uk
@@ -17,4 +17,13 @@ if LIBUKLOCK
 		default y
 		help
 			Enable mutex based synchornization
+
+	config LIBUKLOCK_MUTEX_METRICS
+		bool "Metrics for mutex objects"
+		default n
+		depends on LIBUKLOCK_MUTEX
+		help
+			Metrics related to mutex objects: current amount of (un)locked
+			objects, as well as number of successful/failed locking attempts
+			since startup.
 endif

--- a/lib/uklock/exportsyms.uk
+++ b/lib/uklock/exportsyms.uk
@@ -1,4 +1,5 @@
 uk_semaphore_init
 uk_mutex_init
+uk_mutex_get_metrics
 _uk_mutex_metrics
 _uk_mutex_metrics_lock

--- a/lib/uklock/exportsyms.uk
+++ b/lib/uklock/exportsyms.uk
@@ -1,2 +1,4 @@
 uk_semaphore_init
 uk_mutex_init
+_uk_mutex_metrics
+_uk_mutex_metrics_lock

--- a/lib/uklock/include/uk/mutex.h
+++ b/lib/uklock/include/uk/mutex.h
@@ -93,6 +93,7 @@ extern __spinlock              _uk_mutex_metrics_lock;
 	{ 0, NULL, __WAIT_QUEUE_INITIALIZER((name).wait) }
 
 void uk_mutex_init(struct uk_mutex *m);
+void uk_mutex_get_metrics(struct uk_mutex_metrics *dst);
 
 static inline void uk_mutex_lock(struct uk_mutex *m)
 {

--- a/lib/uklock/mutex.c
+++ b/lib/uklock/mutex.c
@@ -1,8 +1,39 @@
 #include <uk/mutex.h>
 
+#ifdef CONFIG_LIBUKLOCK_MUTEX_METRICS
+#include <uk/init.h>
+
+struct uk_mutex_metrics _uk_mutex_metrics;
+__spinlock              _uk_mutex_metrics_lock;
+#endif /* CONFIG_LIBUKLOCK_MUTEX_METRICS */
+
 void uk_mutex_init(struct uk_mutex *m)
 {
 	m->lock_count = 0;
 	m->owner = NULL;
 	uk_waitq_init(&m->wait);
+
+#ifdef CONFIG_LIBUKLOCK_MUTEX_METRICS
+	ukarch_spin_lock(&_uk_mutex_metrics_lock);
+	_uk_mutex_metrics.active_unlocked++;
+	ukarch_spin_unlock(&_uk_mutex_metrics_lock);
+#endif /* CONFIG_LIBUKLOCK_MUTEX_METRICS */
 }
+
+#ifdef CONFIG_LIBUKLOCK_MUTEX_METRICS
+/**
+ * Initializes the mutex metric counters and its spinlock.
+ * @return 0 on success.
+ *
+ * NOTE: this function is registered as a CTOR for this library.
+ */
+static int mutex_metrics_ctor(void)
+{
+	memset(&_uk_mutex_metrics, 0, sizeof(_uk_mutex_metrics));
+	ukarch_spin_init(&_uk_mutex_metrics_lock);
+
+	return 0;
+}
+uk_lib_initcall_prio(mutex_metrics_ctor, 1);
+#endif /* CONFIG_LIBUKLOCK_MUTEX_METRICS */
+

--- a/lib/uklock/mutex.c
+++ b/lib/uklock/mutex.c
@@ -2,8 +2,9 @@
 
 #ifdef CONFIG_LIBUKLOCK_MUTEX_METRICS
 #include <uk/init.h>
+#include <uk/assert.h>
 
-struct uk_mutex_metrics _uk_mutex_metrics;
+struct uk_mutex_metrics _uk_mutex_metrics = { 0 };
 __spinlock              _uk_mutex_metrics_lock;
 #endif /* CONFIG_LIBUKLOCK_MUTEX_METRICS */
 
@@ -29,11 +30,23 @@ void uk_mutex_init(struct uk_mutex *m)
  */
 static int mutex_metrics_ctor(void)
 {
-	memset(&_uk_mutex_metrics, 0, sizeof(_uk_mutex_metrics));
 	ukarch_spin_init(&_uk_mutex_metrics_lock);
 
 	return 0;
 }
 uk_lib_initcall_prio(mutex_metrics_ctor, 1);
+
+/**
+ * Makes a copy of mutex metrics to avoid direct user access.
+ * @dst : destination buffer (must have been already allocated)
+ */
+void uk_mutex_get_metrics(struct uk_mutex_metrics *dst)
+{
+	UK_ASSERT(dst);
+
+	ukarch_spin_lock(&_uk_mutex_metrics_lock);
+	memcpy(dst, &_uk_mutex_metrics, sizeof(*dst));
+	ukarch_spin_unlock(&_uk_mutex_metrics_lock);
+}
 #endif /* CONFIG_LIBUKLOCK_MUTEX_METRICS */
 


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): N/A

### Description of changes

Added metric collection for `uklock/mutex`. These include active (un)locked mutex objects and total (un)successful (un)locks since startup.

Based on Cezar's branch: [ukstore_fixed_tree](https://github.com/craciunoiuc/unikraft/tree/ukstore_fixed_tree).
