### PR TITLE
lib/ukcpio: Fail boot on initrd extraction errors

### DIFF
--- a/lib/ukcpio/cpio.c
+++ b/lib/ukcpio/cpio.c
@@ -306,7 +306,7 @@ ukcpio_extract(const char *dest, void *buf, size_t buflen)
 	if (dest == NULL)
 		return -UKCPIO_NODEST;
 
-	while (!error && header) {
+	while ((error == UKCPIO_SUCCESS) && header) {
 		error = read_section(header_ptr, dest, end + buflen);
 		header = *header_ptr;
 	}

--- a/lib/vfscore/rootfs.c
+++ b/lib/vfscore/rootfs.c
@@ -107,7 +107,7 @@ static int vfscore_rootfs(void)
 			   initrd.base, initrd.len);
 
 		error = ukcpio_extract("/", initrd.base, initrd.len);
-		if (error < 0) {
+		if (error != UKCPIO_SUCCESS) {
 			uk_pr_crit("Failed to extract cpio archive to /: %d\n",
 				   error);
 			return -1;


### PR DESCRIPTION
This PR makes it easier to identify issues when extracting CPIO images during boot:
* Verbosity is increased so that files causing errors can be easily identified
* Fixes an issue that did not stop the boot procedure when the archive extraction failed during boot 