### PR TITLE
plat/drivers/virtio-net: Suppress compilation warnings

### DIFF
--- a/plat/drivers/virtio/virtio_net.c
+++ b/plat/drivers/virtio/virtio_net.c
@@ -499,7 +499,7 @@ static int virtio_netdev_rxq_dequeue(struct uk_netdev_rx_queue *rxq,
 				     struct uk_netbuf **netbuf)
 {
 	int ret;
-	int rc = 0;
+	int rc __maybe_unused = 0;
 	struct uk_netbuf *buf = NULL;
 	__u32 len;
 
@@ -532,7 +532,7 @@ static int virtio_netdev_rxq_dequeue(struct uk_netdev_rx_queue *rxq,
 	return ret;
 }
 
-static int virtio_netdev_recv(struct uk_netdev *dev,
+static int virtio_netdev_recv(struct uk_netdev *dev __unused,
 			      struct uk_netdev_rx_queue *queue,
 			      struct uk_netbuf **pkt)
 {


### PR DESCRIPTION
Suppress compilation warnings when assertions are switched off in `lib/ukdebug`.