### PR TITLE
arch/x86_64: Fix TLS alignment issue

### DIFF
--- a/arch/x86/x86_64/Makefile.uk
+++ b/arch/x86/x86_64/Makefile.uk
@@ -45,3 +45,6 @@ ARCHFLAGS-$(CONFIG_MARCH_X86_64_BTVER1)         += -march=btver1
 ISR_ARCHFLAGS-$(CONFIG_MARCH_X86_64_BTVER1)     += -march=btver1
 ARCHFLAGS-$(CONFIG_MARCH_X86_64_BTVER2)         += -march=btver2
 ISR_ARCHFLAGS-$(CONFIG_MARCH_X86_64_BTVER2)     += -march=btver2
+
+$(eval $(call addlib,libx86_64arch))
+LIBX86_64ARCH_SRCS-y += $(CONFIG_UK_BASE)/arch/x86/x86_64/tls.c

--- a/arch/x86/x86_64/include/uk/asm/tls.h
+++ b/arch/x86/x86_64/include/uk/asm/tls.h
@@ -50,7 +50,10 @@ static inline __sz ukarch_tls_area_size(void)
 
 static inline __sz ukarch_tls_area_align(void)
 {
-	return 8;
+	/* The minimal required TLS area alignment should ideally come from the
+	 * ELF header, but 32 should be fine for all use X86_64 instructions.
+	 */
+	return 32;
 }
 
 static inline void ukarch_tls_area_copy(void *tls_area)

--- a/arch/x86/x86_64/tls.c
+++ b/arch/x86/x86_64/tls.c
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Authors: Cyril Soldani <cyril.soldani@uliege.be>
+ *
+ * Copyright (c) 2021, University of Liège. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Dummy thread-local variable to force a non-empty .tbss section. Padding is
+ * automatically added to the .tbss section by the linker script to align the
+ * thread pointer which directly follows the TLS area. However, ld's generated
+ * offsets for TLS variables are wrong when the .tbss section only contains
+ * padding and no actual variables. This definition ensures there will be at
+ * least one.
+ */
+__thread int _uk_dummy_tls;

--- a/plat/common/include/uk/plat/common/common.lds.h
+++ b/plat/common/include/uk/plat/common/common.lds.h
@@ -103,7 +103,7 @@
 	uk_inittab_end = .;
 
 #define TLS_SECTIONS							\
-	. = ALIGN(0x8);							\
+	. = ALIGN(0x20);						\
 	_tls_start = .;							\
 	.tdata :							\
 	{								\
@@ -117,7 +117,7 @@
 		*(.tbss)						\
 		*(.tbss.*)						\
 		*(.gnu.linkonce.tb.*)					\
-		. = ALIGN(0x8);						\
+		. = ALIGN(0x20);					\
 	}								\
 	_tls_end = . + SIZEOF(.tbss);
 


### PR DESCRIPTION
According to the x86_64 ELF ABI, the thread pointer in FS register should be aligned according to the alignment of the TLS program header in the ELF file. As this pointer should be just after the TLS area, the TLS area itself has to be properly aligned and padded.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): x86_64
 - Platform(s): N/A
 - Application(s): N/A

### Description of changes

Change the TLS area setup so that the thread pointer always has sufficient (i.e. 32-byte) alignment. This amounts to increase alignment and padding of the TLS area. Additionally, we ensure there is always at least one variable in `.tbss` section, to work around a ld limitation (ld ignores the `.tbss` section if it contains only padding).