### PR TITLE
Add optional locking to waitq wait event to prevent signal loss

### DIFF
--- a/lib/uklock/include/uk/mutex.h
+++ b/lib/uklock/include/uk/mutex.h
@@ -124,6 +124,15 @@ static inline void uk_mutex_unlock(struct uk_mutex *m)
 	ukplat_lcpu_restore_irqf(irqf);
 }
 
+#define uk_waitq_wait_event_mutex(wq, condition, mutex) \
+	uk_waitq_wait_event_locked(wq, condition, uk_mutex_lock, \
+				   uk_mutex_unlock, mutex)
+
+#define uk_waitq_wait_event_deadline_mutex(wq, condition, deadline, mutex) \
+	uk_waitq_wait_event_deadline_locked(wq, condition, deadline, \
+					    uk_mutex_lock, uk_mutex_unlock, \
+					    mutex)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Description of changes

The commit series solves a signal loss problem in the following scenario, where thread1 remains blocked although the list is not empty.

```C
struct uk_mutex mutex;
struct uk_list_head list; /* protected by mutex */
struct uk_waitq wq;

void thread1(void) {
  uk_mutex_lock(&mutex);
  for (;;) {
    /* process events in list */
    uk_mutex_unlock(&mutex);

    uk_waitq_wait_event(&wq, uk_list_empty(&list));   /* <<-- potential signal loss here  */

    uk_mutex_lock(&mutex);
  }
}

void called_from_thread2(/* some entry */) {
  uk_mutex_lock(&mutex);
  uk_list_add_tail( /* some entry */, &list);
  uk_waitq_wake_up(&wq);
  uk_mutex_unlock(&mutex);
}
```

* Unlock mutex in `thread1()`
* Go into `uk_waitq_wait_event()`
* Check condition (`uk_list_empty(&list)`) _without holding mutex_ (might be dangerous anyways). List is empty.
* Switch to thread2
* Add element to list under lock
* Wake up any waiters (none in wq) <<-- signal lost
* Switch to thread1
* Add thread to wait queue and block.

The patch performs the unlock *after* adding the thread to the wait queue and immediately locks the mutex again when the thread is scheduled again. The condition is thus always checked under the lock and thread2 has to wait until thread1 is actually blocked so that the wake up is not lost.

This is relevant with preemptive schedulers and SMP-enabled builds. Changes are compatible with existing code. No additional overhead if no lock is supplied.

The code changes to:
```C
void thread1(void) {
  uk_mutex_lock(&mutex);
  for (;;) {
    /* process events in list */

    uk_waitq_wait_event_mutex(&wq, uk_list_empty(&list), &mutex); 
  }
}
```