### PR TITLE
Provide spinlock implementation for arm64 and x86_64

### DIFF
--- a/arch/arm/arm64/include/uk/asm/spinlock.h
+++ b/arch/arm/arm64/include/uk/asm/spinlock.h
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2013-2019, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021 OpenSynergy GmbH. All rights reserved.
+ * Copyright (c) 2021 Karlsruhe Institute of Technology (KIT).
+ *               All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __UKARCH_SPINLOCK_H__
+#error Do not include this header directly
+#endif
+
+#include <uk/arch/atomic.h>
+
+struct __spinlock {
+	volatile int lock;
+};
+
+/* Initialize a spinlock to unlocked state */
+#define UKARCH_SPINLOCK_INITIALIZER() { 0 }
+
+static inline void ukarch_spin_init(struct __spinlock *lock)
+{
+	lock->lock = 0;
+}
+
+static inline void ukarch_spin_lock(struct __spinlock *lock)
+{
+	register int r, locked = 1;
+
+	__asm__ __volatile__(
+		"	sevl\n"			/* set event locally */
+		"1:	wfe\n"			/* wait for event */
+		"2:	ldaxr	%w0, [%1]\n"	/* exclusive load lock value */
+		"	cbnz	%w0, 1b\n"	/* check if already locked */
+		"	stxr	%w0, %2, [%1]\n"/* try to lock it */
+		"	cbnz	%w0, 2b\n"	/* jump to l2 if we failed */
+		: "=&r" (r)
+		: "r" (&lock->lock), "r" (locked));
+}
+
+static inline void ukarch_spin_unlock(struct __spinlock *lock)
+{
+	__asm__ __volatile__(
+		"stlr	wzr, [%0]\n"		/* unlock lock */
+		"sev\n"				/* wake up any waiters */
+		:
+		: "r" (&lock->lock));
+}
+
+static inline int ukarch_spin_trylock(struct __spinlock *lock)
+{
+	register int r, locked = 1;
+
+	__asm__ __volatile__(
+		"	ldaxr	%w0, [%1]\n"	/* exclusive load lock value */
+		"	cbnz	%w0, 1f\n"	/* bail out if locked */
+		"	stxr	%w0, %2, [%1]\n"/* try to lock it */
+		"1:\n"
+		: "=&r" (r)
+		: "r" (&lock->lock), "r" (locked));
+
+	return !r;
+}
+
+static inline int ukarch_spin_is_locked(struct __spinlock *lock)
+{
+	return UK_READ_ONCE(lock->lock);
+}

--- a/arch/x86/x86_64/include/uk/asm/spinlock.h
+++ b/arch/x86/x86_64/include/uk/asm/spinlock.h
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2021 Karlsruhe Institute of Technology (KIT).
+ *               All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __UKARCH_SPINLOCK_H__
+#error Do not include this header directly
+#endif
+
+#include <uk/arch/atomic.h>
+
+struct __spinlock {
+	volatile int lock;
+};
+
+/* Initialize a spinlock to unlocked state */
+#define UKARCH_SPINLOCK_INITIALIZER() { 0 }
+
+static inline void ukarch_spin_init(struct __spinlock *lock)
+{
+	lock->lock = 0;
+}
+
+static inline void ukarch_spin_lock(struct __spinlock *lock)
+{
+	register int locked = 1;
+
+	__asm__ __volatile__(
+		"1:	mov	(%0), %%eax\n"	/* read current value */
+		"	test	%%eax, %%eax\n"	/* check if locked */
+		"	jz	3f\n"		/* if not locked, try get it */
+		"2:	pause\n"		/* is locked, hint spinning */
+		"	jmp	1b\n"		/* retry */
+		"3:	lock; cmpxchg %1, (%0)\n" /* try to acquire spinlock */
+		"	jnz	2b\n"		/* if unsuccessful, retry */
+		:
+		: "r" (&lock->lock), "r" (locked)
+		: "eax");
+}
+
+static inline void ukarch_spin_unlock(struct __spinlock *lock)
+{
+	UK_WRITE_ONCE(lock->lock, 0);
+}
+
+static inline int ukarch_spin_trylock(struct __spinlock *lock)
+{
+	register int r = 0, locked = 1;
+
+	__asm__ __volatile__(
+		"	mov	(%1), %%eax\n"	/* read current value */
+		"	test	%%eax, %%eax\n"	/* bail out if locked */
+		"	jnz	1f\n"
+		"	lock; cmpxchg %2, (%1)\n" /* try to acquire spinlock */
+		"	cmove	%2, %0\n"	/* store if successful */
+		"1:\n"
+		: "+&r" (r)
+		: "r" (&lock->lock), "r" (locked)
+		: "eax");
+
+	return r;
+}
+
+static inline int ukarch_spin_is_locked(struct __spinlock *lock)
+{
+	return UK_READ_ONCE(lock->lock);
+}

--- a/include/uk/arch/spinlock.h
+++ b/include/uk/arch/spinlock.h
@@ -21,7 +21,6 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-/* Taken from Mini-OS */
 
 #ifndef __UKARCH_SPINLOCK_H__
 #define __UKARCH_SPINLOCK_H__
@@ -30,22 +29,81 @@
 extern "C" {
 #endif
 
-typedef struct {} spinlock_t;
+#include <uk/arch/lcpu.h>
 
-#ifdef CONFIG_SMP
-#error "Define your spinlock operations!"
-#else
+#ifdef CONFIG_HAVE_SMP
+#include <uk/asm/spinlock.h>
 
-#define ukarch_spin_lock_init(lock)      (void)(lock)
-#define ukarch_spin_is_locked(lock)      (void)(lock)
-#define ukarch_spin_lock(lock)           (void)(lock)
-#define ukarch_spin_trylock(lock)        (void)(lock)
-#define ukarch_spin_unlock(lock)         (void)(lock)
+/* Unless you know what you are doing, use struct uk_spinlock instead. */
+typedef struct __spinlock __spinlock;
 
-/* Defines a preinitialized spin_lock in unlocked state */
-#define DEFINE_SPINLOCK(lock)            spinlock_t lock = {}
+/**
+ * UKARCH_SPINLOCK_INITIALIZER() macro
+ *
+ * Statically initialize a spinlock to unlocked stated.
+ */
 
-#endif
+/**
+ * Initialize a spinlock to unlocked state.
+ *
+ * @param [in/out] lock Pointer to spinlock.
+ */
+void ukarch_spin_init(__spinlock *lock);
+
+/**
+ * Acquire spinlock. It is guaranteed that the spinlock will be held
+ * exclusively.
+ *
+ * @param [in/out] lock Pointer to spinlock.
+ */
+void ukarch_spin_lock(__spinlock *lock);
+
+/**
+ * Release previously acquired spinlock.
+ *
+ * @param [in/out] lock Pointer to spinlock.
+ */
+void ukarch_spin_unlock(__spinlock *lock);
+
+/**
+ * Try to acquire spinlock. If the lock is already acquired (busy), this
+ * function returns instead of spinning.
+ *
+ * @param [in/out] lock Pointer to spinlock.
+ *
+ * @return A non-zero value if spinlock was acquired, 0 otherwise.
+ */
+int ukarch_spin_trylock(__spinlock *lock);
+
+/**
+ * Read spinlock state. No lock/unlock operations are performed on the lock.
+ *
+ * @param [in/out] lock Pointer to spinlock.
+ *
+ * @return A non-zero value if spinlock is acquired, 0 otherwise.
+ */
+int ukarch_spin_is_locked(__spinlock *lock);
+
+#else /* CONFIG_HAVE_SMP */
+/* N.B.: For single-core systems we remove spinlocks by mapping functions to
+ * void operations. No state is saved for the spinlock but we assume that the
+ * CPU is always able to get the lock. Trying to acquire a spinlock thus always
+ * succeeds and asserting that a lock is held returns false.
+ */
+typedef struct __spinlock {
+	/* empty */
+} __spinlock;
+
+#define UKARCH_SPINLOCK_INITIALIZER()	{}
+#define ukarch_spin_init(lock)		(void)(lock)
+#define ukarch_spin_lock(lock)		\
+	do { barrier(); (void)(lock); } while (0)
+#define ukarch_spin_unlock(lock)	\
+	do { barrier(); (void)(lock); } while (0)
+#define ukarch_spin_trylock(lock)	({ barrier(); (void)(lock); 1; })
+#define ukarch_spin_is_locked(lock)	({ barrier(); (void)(lock); 0; })
+
+#endif /* CONFIG_HAVE_SMP */
 
 #ifdef __cplusplus
 }

--- a/lib/uk9p/9pdev.c
+++ b/lib/uk9p/9pdev.c
@@ -51,7 +51,7 @@
 
 static void _fid_mgmt_init(struct uk_9pdev_fid_mgmt *fid_mgmt)
 {
-	ukarch_spin_lock_init(&fid_mgmt->spinlock);
+	ukarch_spin_init(&fid_mgmt->spinlock);
 	fid_mgmt->next_fid = 0;
 	UK_INIT_LIST_HEAD(&fid_mgmt->fid_free_list);
 	UK_INIT_LIST_HEAD(&fid_mgmt->fid_active_list);
@@ -126,7 +126,7 @@ static void _fid_mgmt_cleanup(struct uk_9pdev_fid_mgmt *fid_mgmt)
 
 static void _req_mgmt_init(struct uk_9pdev_req_mgmt *req_mgmt)
 {
-	ukarch_spin_lock_init(&req_mgmt->spinlock);
+	ukarch_spin_init(&req_mgmt->spinlock);
 	uk_bitmap_zero(req_mgmt->tag_bm, UK_9P_NUMTAGS);
 	UK_INIT_LIST_HEAD(&req_mgmt->req_list);
 	UK_INIT_LIST_HEAD(&req_mgmt->req_free_list);

--- a/lib/uk9p/include/uk/9pdev_core.h
+++ b/lib/uk9p/include/uk/9pdev_core.h
@@ -113,7 +113,7 @@ struct uk_9pdev_trans_ops {
  */
 struct uk_9pdev_req_mgmt {
 	/* Spinlock protecting this data. */
-	spinlock_t                      spinlock;
+	__spinlock                      spinlock;
 	/* Bitmap of available tags. */
 	unsigned long                   tag_bm[UK_BITS_TO_LONGS(UK_9P_NUMTAGS)];
 	/* List of requests allocated and not yet removed. */
@@ -128,7 +128,7 @@ struct uk_9pdev_req_mgmt {
  */
 struct uk_9pdev_fid_mgmt {
 	/* Spinlock protecting fids. */
-	spinlock_t			spinlock;
+	__spinlock			spinlock;
 	/* Next available fid. */
 	uint32_t			next_fid;
 	/* Free-list of fids that can be reused. */

--- a/lib/uklock/include/uk/spinlock.h
+++ b/lib/uklock/include/uk/spinlock.h
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2021 OpenSynergy GmbH. All rights reserved.
+ * Copyright (c) 2021 Karlsruhe Institute of Technology (KIT).
+ *               All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __UK_SPINLOCK_H__
+#define __UK_SPINLOCK_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* See uk/arch/spinlock.h for the interface documentation */
+
+#ifndef uk_spinlock
+#include <uk/arch/spinlock.h>
+
+#define uk_spinlock __spinlock
+
+#define UK_SPINLOCK_INITIALIZER()  UKARCH_SPINLOCK_INITIALIZER()
+#define uk_spin_init(lock)         ukarch_spin_init(lock)
+#define uk_spin_lock(lock)         ukarch_spin_lock(lock)
+#define uk_spin_unlock(lock)       ukarch_spin_unlock(lock)
+#define uk_spin_trylock(lock)      ukarch_spin_trylock(lock)
+#define uk_spin_is_locked(lock)    ukarch_spin_is_locked(lock)
+#endif /* uk_spinlock */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __UK_SPINLOCK_H__ */

--- a/plat/drivers/virtio/virtio_9p.c
+++ b/plat/drivers/virtio/virtio_9p.c
@@ -31,6 +31,7 @@
  */
 
 #include <inttypes.h>
+#include <unistd.h>
 #include <uk/alloc.h>
 #include <uk/essentials.h>
 #include <uk/sglist.h>
@@ -47,7 +48,7 @@ static struct uk_alloc *a;
 
 /* List of initialized virtio 9p devices. */
 static UK_LIST_HEAD(virtio_9p_device_list);
-static DEFINE_SPINLOCK(virtio_9p_device_list_lock);
+static __spinlock virtio_9p_device_list_lock;
 
 struct virtio_9p_device {
 	/* Virtio device. */
@@ -66,7 +67,7 @@ struct virtio_9p_device {
 	struct uk_sglist sg;
 	struct uk_sglist_seg sgsegs[NUM_SEGMENTS];
 	/* Spinlock protecting the sg list and the vq. */
-	spinlock_t spinlock;
+	__spinlock spinlock;
 };
 
 static int virtio_9p_connect(struct uk_9pdev *p9dev,
@@ -431,7 +432,7 @@ static int virtio_9p_add_dev(struct virtio_dev *vdev)
 		rc = -ENOMEM;
 		goto out;
 	}
-	ukarch_spin_lock_init(&d->spinlock);
+	ukarch_spin_init(&d->spinlock);
 	d->vdev = vdev;
 	virtio_9p_feature_set(d);
 	rc = virtio_9p_configure(d);

--- a/plat/xen/drivers/9p/9pfront.c
+++ b/plat/xen/drivers/9p/9pfront.c
@@ -56,7 +56,7 @@
 
 static struct uk_alloc *a;
 static UK_LIST_HEAD(p9front_device_list);
-static DEFINE_SPINLOCK(p9front_device_list_lock);
+static __spinlock p9front_device_list_lock;
 
 struct p9front_header {
 	uint32_t size;
@@ -221,7 +221,7 @@ static int p9front_allocate_dev_ring(struct p9front_dev *p9fdev, int idx)
 	ring = &p9fdev->rings[idx];
 	UK_ASSERT(!ring->initialized);
 
-	ukarch_spin_lock_init(&ring->spinlock);
+	ukarch_spin_init(&ring->spinlock);
 	ring->dev = p9fdev;
 
 	/* Allocate ring intf page. */

--- a/plat/xen/drivers/9p/9pfront.h
+++ b/plat/xen/drivers/9p/9pfront.h
@@ -57,7 +57,7 @@ struct p9front_dev_ring {
 	/* Grant reference for the interface. */
 	grant_ref_t ref;
 	/* Per-ring spinlock. */
-	spinlock_t spinlock;
+	__spinlock spinlock;
 	/* Tracks if this ring was initialized. */
 	bool initialized;
 #if CONFIG_LIBUKSCHED

--- a/plat/xen/include/xenbus/xenbus.h
+++ b/plat/xen/include/xenbus/xenbus.h
@@ -103,7 +103,7 @@ struct xenbus_watch {
 	/**< in use internally */
 	UK_TAILQ_ENTRY(struct xenbus_watch) watch_list;
 	/**< Lock */
-	spinlock_t lock;
+	__spinlock lock;
 	/**< Number of pending events */
 	int pending_events;
 	/**< Watch waiting queue */

--- a/plat/xen/xenbus/xs_comms.c
+++ b/plat/xen/xenbus/xs_comms.c
@@ -105,7 +105,7 @@ struct xs_request_pool {
 	/**< Last probed request index */
 	__u32 last_probed;
 	/**< Lock */
-	spinlock_t lock;
+	__spinlock lock;
 	/**< Waiting queue for 'not-full' notifications */
 	struct uk_waitq waitq;
 	/**< Queue for requests to be sent */
@@ -129,7 +129,7 @@ static void xs_request_pool_init(struct xs_request_pool *pool)
 
 	pool->num_live = 0;
 	pool->last_probed = -1;
-	ukarch_spin_lock_init(&pool->lock);
+	ukarch_spin_init(&pool->lock);
 	uk_waitq_init(&pool->waitq);
 	UK_TAILQ_INIT(&pool->queued);
 	uk_bitmap_zero(pool->entries_bm, XS_REQ_POOL_SIZE);

--- a/plat/xen/xenbus/xs_watch.c
+++ b/plat/xen/xenbus/xs_watch.c
@@ -62,7 +62,7 @@ struct xs_watch *xs_watch_create(const char *path)
 	if (!xsw)
 		return ERR2PTR(-ENOMEM);
 
-	ukarch_spin_lock_init(&xsw->base.lock);
+	ukarch_spin_init(&xsw->base.lock);
 	xsw->base.pending_events = 0;
 	uk_waitq_init(&xsw->base.wq);
 


### PR DESCRIPTION
## Prerequisite checklist

 - [X] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [X] Updated relevant documentation.

### Base target

 - Architecture(s): arm64
 - Platform(s): kvm
 - Application(s): N/A

### Additional configuration

CONFIG_UKPLAT_LCPU_MULTICORE will need to be set when SMP become available.

### Description of changes

This pull request provide a patch series that provide spinlock implementation for ARM64. The following functions are implemented:

void ukarch_spin_lock_init(spinlock_t *spinlock);
void ukarch_spin_lock(spinlock_t *lock);
void ukarch_spin_unlock(spinlock_t *lock);
int ukarch_spin_trylock(spinlock_t *lock);
int ukarch_spin_is_locked(spinlock_t *lock);

FYI: @razvand @skuenzer @marcrittinghaus 