### PR TITLE
build: print-vars: Value only for simply expanded variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ noconfig_targets	:= ukconfig menuconfig nconfig gconfig xconfig config \
 			   silentoldconfig \
 			   release olddefconfig properclean distclean \
 			   scriptconfig iscriptconfig kmenuconfig guiconfig \
-			   dumpvarsconfig $(null_targets)
+			   dumpvarsconfig print-version help
 
 # we want bash as shell
 SHELL := $(shell if [ -x "$$BASH" ]; then echo $$BASH; \
@@ -925,9 +925,10 @@ $(KCONFIG_AUTOHEADER): $(UK_CONFIG) $(KCONFIG_DIR)/conf
 print-vars:
 	@$(foreach V, \
 		$(sort $(if $(VARS),$(filter $(VARS),$(.VARIABLES)),$(.VARIABLES))), \
-		$(if $(filter-out environment% default automatic, \
-				$(origin $V)), \
-		$(info $V=$($V) ($(value $V)))))
+		$(if $(filter-out environment% default automatic,$(origin $V)), \
+		$(if $(filter simple,$(flavor $V)), \
+			$(info [$(origin $V)] $V := $(value $V)), \
+			$(info [$(origin $V)] $V = <$(flavor $V)>))))
 
 print-version:
 	@echo $(UK_FULLVERSION)


### PR DESCRIPTION
### Description of changes

This PR makes `make print-vars` work again by only showing the value of variables that are simply expanded (`:=` or `::=`). Printing the value of recursive variables caused errors for some variables that we use as function to generate build recipes.
This PR adopts the  output format: For each variable, the variable origin is printed before the variable name. Afterwards the value is shown for simply expanded variables. Otherwise the flavor is shown.

Example:
```
[file] SIMPLE_VAR := Hello World!
[file] RECURSIVE_VAR = <recursive>
```