### PR TITLE
lib/uksignal: Add sigaltstack stub to uksignal

### DIFF
--- a/lib/nolibc/musl-imported/include/signal.h
+++ b/lib/nolibc/musl-imported/include/signal.h
@@ -138,6 +138,8 @@ typedef struct sigaltstack {
 	size_t ss_size;
 } stack_t;
 
+int sigaltstack(const stack_t *ss, stack_t *old_ss);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/uksignal/exportsyms.uk
+++ b/lib/uksignal/exportsyms.uk
@@ -24,6 +24,7 @@ sigfillset
 sigaddset
 sigdelset
 sigismember
+sigaltstack
 
 # unistd.h
 alarm

--- a/lib/uksignal/signal.c
+++ b/lib/uksignal/signal.c
@@ -386,3 +386,10 @@ UK_SYSCALL_R_DEFINE(int, pause)
 {
 	return 0;
 }
+
+int sigaltstack(const stack_t *ss __unused, stack_t *old_ss __unused)
+{
+	UK_WARN_STUBBED();
+	errno = ENOTSUP;
+	return -1;
+}


### PR DESCRIPTION
`sigaltstack()` is required to compile an application with libgo.
newlib is now compatible to uksignal, so we need to add here the
sigaltstack stub.

Signed-off-by: Răzvan Vîrtan <virtanrazvan@gmail.com>
