### PR TITLE
build: Declare archive dependency for extracted files (alias "towards parallel builds")

### DIFF
--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -384,6 +384,11 @@ $(error $(2): missing extraction rule for archive type)\
 UK_FETCH-y += $(BUILD_DIR)/$(1)/.origin \
 $(eval $(call vprefix_lib,$(1),ORIGIN) = $(BUILD_DIR)/$(1)/origin)
 $(call mk_sub_build_dir,$(1)/origin)
+
+.PRECIOUS: $(BUILD_DIR)/$(1)/origin
+
+$(BUILD_DIR)/$(1)/origin/%: $(BUILD_DIR)/$(1)/.origin
+	@:
 endef
 
 # Internal helper to compute and compare a checksum of a downloaded file


### PR DESCRIPTION
Introduces a no-op rule in order to force dependency for files that will be extracted from an archive. Before Make executes build commands, it builds a dependency tree based on the loaded rules available files in the file system. Without this rule, Make has no connection of source files that are created by an archive extraction. This may lead to `No rule to make target` errors, especially with parallel builds where Make executes independent rule chains earlier in parallel.

With this rule, make is finally also able to resolve our pre-requisites properly in parallel builds. Thanks to this, we do not need another no-op rule for the `patch` command because we closed the dependency gap. Patching is added to the `fetch` target that is a pre-requisite for all compile rules.