### PR TITLE
uknetdev, plat/kvm: Support for partial checksumming / checksum offloading

### DIFF
--- a/lib/uknetdev/exportsyms.uk
+++ b/lib/uknetdev/exportsyms.uk
@@ -13,6 +13,7 @@ uk_netdev_get
 uk_netdev_id_get
 uk_netdev_drv_name_get
 uk_netdev_state_get
+uk_netdev_probe
 uk_netdev_info_get
 uk_netdev_einfo_get
 uk_netdev_rxq_info_get

--- a/lib/uknetdev/include/uk/netdev.h
+++ b/lib/uknetdev/include/uk/netdev.h
@@ -54,6 +54,7 @@
  * The functions exported by the Unikraft NET API to setup a device
  * must be invoked in the following order:
  *     - uk_netdev
+ *     - uk_netdev_probe()
  *     - uk_netdev_configure()
  *     - uk_netdev_txq_configure()
  *     - uk_netdev_rxq_configure()
@@ -62,7 +63,7 @@
  * device is not started.
  *
  * There are 4 states in which a network device can be found:
- *     - UK_NETDEV_UNREGISTERED
+ *     - UK_NETDEV_UNPROBED
  *     - UK_NETDEV_UNCONFIGURED
  *     - UK_NETDEV_CONFIGURED
  *     - UK_NETDEV_RUNNING
@@ -125,12 +126,27 @@ const char *uk_netdev_drv_name_get(struct uk_netdev *dev);
 enum uk_netdev_state uk_netdev_state_get(struct uk_netdev *dev);
 
 /**
+ * Probes an unprobed Unikraft network device and turns it
+ * into unconfigured state. After successful probing, the
+ * driver collected information about the backend device.
+ * `uk_netdev_info_get()` and `uk_netdev_einfo_get()` can
+ * be called afterwards.
+ *
+ * @param dev
+ *   The Unikraft Network Device in unprobed state.
+ * @return
+ *   - (0): Success, device is in unconfigured state.
+ *   - (<0): Error code returned by the driver.
+ */
+int uk_netdev_probe(struct uk_netdev *dev);
+
+/**
  * Query device capabilities.
  * Information that is useful for device initialization (e.g.,
  * maximum number of supported RX/TX queues).
  *
  * @param dev
- *   The Unikraft Network Device.
+ *   The Unikraft Network Device in unconfigured state.
  * @param dev_info
  *   A pointer to a structure of type *uk_netdev_info* to be filled with
  *   the contextual information of the network device.

--- a/lib/uknetdev/include/uk/netdev_core.h
+++ b/lib/uknetdev/include/uk/netdev_core.h
@@ -190,6 +190,7 @@ struct uk_netdev_rx_queue;
  */
 enum uk_netdev_state {
 	UK_NETDEV_INVALID = 0,
+	UK_NETDEV_UNPROBED,
 	UK_NETDEV_UNCONFIGURED,
 	UK_NETDEV_CONFIGURED,
 	UK_NETDEV_RUNNING,
@@ -286,6 +287,10 @@ struct uk_netdev_rxqueue_conf {
 struct uk_netdev_txqueue_conf {
 	struct uk_alloc *a;               /* Allocator for descriptors. */
 };
+
+/** Driver callback type to probe device capabilities and features (optional)
+ */
+typedef int (*uk_netdev_probe_t)(struct uk_netdev *dev);
 
 /** Driver callback type to read device/driver capabilities,
  *  used for configuring the device
@@ -405,6 +410,7 @@ struct uk_netdev_ops {
 	uk_netdev_einfo_get_t           einfo_get;        /* optional */
 
 	/** Device life cycle. */
+	uk_netdev_probe_t               probe;            /* recommended */
 	uk_netdev_configure_t           configure;
 	uk_netdev_txq_configure_t       txq_configure;
 	uk_netdev_rxq_configure_t       rxq_configure;

--- a/lib/uknetdev/include/uk/netdev_core.h
+++ b/lib/uknetdev/include/uk/netdev_core.h
@@ -127,13 +127,15 @@ struct uk_hwaddr {
 /**
  * The netdevice support rx/tx interrupt.
  */
-#define UK_FEATURE_RXQ_INTR_BIT		    0
-#define UK_FEATURE_RXQ_INTR_AVAILABLE  (1UL << UK_FEATURE_RXQ_INTR_BIT)
-#define UK_FEATURE_TXQ_INTR_BIT		    1
-#define UK_FEATURE_TXQ_INTR_AVAILABLE  (1UL << UK_FEATURE_TXQ_INTR_BIT)
+#define UK_NETDEV_F_RXQ_INTR_BIT	0
+#define UK_NETDEV_F_RXQ_INTR		(1UL << UK_NETDEV_F_RXQ_INTR_BIT)
+#define UK_NETDEV_F_TXQ_INTR_BIT	1
+#define UK_NETDEV_F_TXQ_INTR		(1UL << UK_NETDEV_F_TXQ_INTR_BIT)
 
 #define uk_netdev_rxintr_supported(feature)	\
-	(feature & (UK_FEATURE_RXQ_INTR_AVAILABLE))
+	(feature & (UK_NETDEV_F_RXQ_INTR))
+#define uk_netdev_txintr_supported(feature)	\
+	(feature & (UK_NETDEV_F_TXQ_INTR))
 
 /**
  * A structure used to describe network device capabilities.

--- a/lib/uknetdev/include/uk/netdev_core.h
+++ b/lib/uknetdev/include/uk/netdev_core.h
@@ -132,10 +132,18 @@ struct uk_hwaddr {
 #define UK_NETDEV_F_TXQ_INTR_BIT	1
 #define UK_NETDEV_F_TXQ_INTR		(1UL << UK_NETDEV_F_TXQ_INTR_BIT)
 
+/* Indicates that UK_NETBUF_F_PARTIAL_CSUM and UK_NETBUF_F_DATA_VALID is
+ * supported by the device
+ */
+#define UK_NETDEV_F_PARTIAL_CSUM_BIT	2
+#define UK_NETDEV_F_PARTIAL_CSUM	(1UL << UK_NETDEV_F_PARTIAL_CSUM_BIT)
+
 #define uk_netdev_rxintr_supported(feature)	\
 	(feature & (UK_NETDEV_F_RXQ_INTR))
 #define uk_netdev_txintr_supported(feature)	\
 	(feature & (UK_NETDEV_F_TXQ_INTR))
+#define uk_netdev_partial_csum_supported(feature)	\
+	(feature & (UK_NETDEV_F_PARTIAL_CSUM))
 
 /**
  * A structure used to describe network device capabilities.

--- a/lib/uknetdev/netbuf.c
+++ b/lib/uknetdev/netbuf.c
@@ -48,19 +48,16 @@ void uk_netbuf_init_indir(struct uk_netbuf *m,
 	UK_ASSERT(buf || (buf == NULL && buflen == 0));
 	UK_ASSERT(headroom <= buflen);
 
-	m->buf    = buf;
-	m->buflen = buflen;
-	m->data   = (void *) ((uintptr_t) buf + headroom);
-	m->len    = 0;
-	m->prev   = NULL;
-	m->next   = NULL;
+	/* Reset pbuf, non-listed fields are automatically set to 0 */
+	*m = (struct uk_netbuf) {
+		.buf    = buf,
+		.buflen = buflen,
+		.data   = (void *) ((uintptr_t) buf + headroom),
+		.priv   = priv,
+		.dtor   = dtor
+	};
 
 	uk_refcount_init(&m->refcount, 1);
-
-	m->priv   = priv;
-	m->dtor   = dtor;
-	m->_a     = NULL;
-	m->_b     = NULL;
 }
 
 struct uk_netbuf *uk_netbuf_alloc_indir(struct uk_alloc *a,

--- a/plat/drivers/include/virtio/virtio_bus.h
+++ b/plat/drivers/include/virtio/virtio_bus.h
@@ -48,8 +48,18 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#define VIRTIO_FEATURES_UPDATE(features, bpos)	\
-	(features |= (1ULL << bpos))
+#define VIRTIO_FEATURE_SET(features, bitpos)				\
+	do {								\
+		(features) |=  (((typeof (features)) 1) << (bitpos));	\
+	} while (0)
+
+#define VIRTIO_FEATURE_CLEAR(features, bitpos) \
+	do {								\
+		(features) &= ~(((typeof (features)) 1) << (bitpos));	\
+	} while (0)
+
+#define VIRTIO_FEATURE_HAS(features, bitpos)				\
+	(!(!(features & (((typeof (features)) 1) << (bitpos)))))
 
 struct virtio_dev;
 typedef int (*virtio_driver_init_func_t)(struct uk_alloc *);
@@ -333,16 +343,6 @@ static inline void virtio_vqueue_release(struct virtio_dev *vdev,
 	UK_ASSERT(a);
 	if (likely(vdev->cops->vq_release))
 		vdev->cops->vq_release(vdev, vq, a);
-}
-
-static inline int virtio_has_features(__u64 features, __u8 bpos)
-{
-	__u64 tmp_feature = 0;
-
-	VIRTIO_FEATURES_UPDATE(tmp_feature, bpos);
-	tmp_feature &= features;
-
-	return tmp_feature ? 1 : 0;
 }
 
 static inline void virtio_dev_drv_up(struct virtio_dev *vdev)

--- a/plat/drivers/virtio/virtio_9p.c
+++ b/plat/drivers/virtio/virtio_9p.c
@@ -336,7 +336,7 @@ static int virtio_9p_feature_negotiate(struct virtio_9p_device *d)
 	int rc = 0;
 
 	host_features = virtio_feature_get(d->vdev);
-	if (!virtio_has_features(host_features, VIRTIO_9P_F_MOUNT_TAG)) {
+	if (!VIRTIO_FEATURE_HAS(host_features, VIRTIO_9P_F_MOUNT_TAG)) {
 		uk_pr_err(DRIVER_NAME": Host system does not offer MOUNT_TAG feature\n");
 		rc = -EINVAL;
 		goto out;
@@ -380,7 +380,7 @@ out:
 static inline void virtio_9p_feature_set(struct virtio_9p_device *d)
 {
 	d->vdev->features = 0;
-	VIRTIO_FEATURES_UPDATE(d->vdev->features, VIRTIO_9P_F_MOUNT_TAG);
+	VIRTIO_FEATURE_SET(d->vdev->features, VIRTIO_9P_F_MOUNT_TAG);
 }
 
 static int virtio_9p_configure(struct virtio_9p_device *d)

--- a/plat/drivers/virtio/virtio_net.c
+++ b/plat/drivers/virtio/virtio_net.c
@@ -1054,7 +1054,7 @@ static void virtio_net_info_get(struct uk_netdev *dev,
 	dev_info->nb_encap_tx = sizeof(struct virtio_net_hdr_padded);
 	dev_info->nb_encap_rx = sizeof(struct virtio_net_hdr_padded);
 	dev_info->ioalign = sizeof(void *); /* word size alignment */
-	dev_info->features = UK_FEATURE_RXQ_INTR_AVAILABLE;
+	dev_info->features = UK_NETDEV_F_RXQ_INTR;
 }
 
 static int virtio_net_start(struct uk_netdev *n)

--- a/plat/drivers/virtio/virtio_net.c
+++ b/plat/drivers/virtio/virtio_net.c
@@ -68,8 +68,8 @@
 #define to_virtionetdev(ndev) \
 	__containerof(ndev, struct virtio_net_device, netdev)
 
-#define VIRTIO_NET_DRV_FEATURES(features)           \
-	(VIRTIO_FEATURES_UPDATE(features, VIRTIO_NET_F_MAC))
+#define VIRTIO_NET_DRV_FEATURES(features)			\
+	VIRTIO_FEATURES_SET((features), VIRTIO_NET_F_MAC)
 
 typedef enum {
 	VNET_RX,
@@ -843,7 +843,7 @@ static int virtio_netdev_feature_negotiate(struct virtio_net_device *vndev)
 	 * accepting it.
 	 */
 	host_features = virtio_feature_get(vndev->vdev);
-	if (!virtio_has_features(host_features, VIRTIO_NET_F_MAC)) {
+	if (!VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_MAC)) {
 		/**
 		 * The feature that aren't supported are usually masked out and
 		 * provided with default value. In this case we need to

--- a/plat/drivers/virtio/virtio_net.c
+++ b/plat/drivers/virtio/virtio_net.c
@@ -68,9 +68,6 @@
 #define to_virtionetdev(ndev) \
 	__containerof(ndev, struct virtio_net_device, netdev)
 
-#define VIRTIO_NET_DRV_FEATURES(features)			\
-	VIRTIO_FEATURES_SET((features), VIRTIO_NET_F_MAC)
-
 typedef enum {
 	VNET_RX,
 	VNET_TX,
@@ -170,12 +167,11 @@ static int virtio_net_drv_init(struct uk_alloc *drv_allocator);
 static int virtio_net_add_dev(struct virtio_dev *vdev);
 static void virtio_net_info_get(struct uk_netdev *dev,
 				struct uk_netdev_info *dev_info);
-static inline void virtio_netdev_feature_set(struct virtio_net_device *vndev);
 static int virtio_netdev_configure(struct uk_netdev *n,
 				   const struct uk_netdev_conf *conf);
 static int virtio_netdev_rxtx_alloc(struct virtio_net_device *vndev,
 				    const struct uk_netdev_conf *conf);
-static int virtio_netdev_feature_negotiate(struct virtio_net_device *vndev);
+static int virtio_netdev_feature_negotiate(struct uk_netdev *n);
 static struct uk_netdev_tx_queue *virtio_netdev_tx_queue_setup(
 					struct uk_netdev *n, uint16_t queue_id,
 					uint16_t nb_desc,
@@ -372,8 +368,23 @@ static int virtio_netdev_xmit(struct uk_netdev *dev,
 	/**
 	 * Fill the virtio-net-header with the necessary information.
 	 * Zero explicitly set.
+	 * NOTE: We do not set VIRTIO_NET_HDR_F_DATA_VALID and
+	 *       VIRTIO_NET_HDR_F_RSC_INFO because we aren't allowed
+	 *       according to virtio specification during sending.
+	 * TODO: We assume that the PARTIAL_CSUM flag is only set with
+	 *       the first netbuf of a queue. If this is not the case,
+	 *       (e.g., due to encapsulation of protocol headers with
+	 *        prepending netbufs) we need to replace the call
+	 *       to `uk_sglist_append_netbuf()`. However, a netbuf
+	 *       chain can only once have set the PARTIAL_CSUM flag.
 	 */
 	memset(vhdr, 0, sizeof(*vhdr));
+	if (pkt->flags & UK_NETBUF_F_PARTIAL_CSUM) {
+		vhdr->flags       |= VIRTIO_NET_HDR_F_NEEDS_CSUM;
+		/* `csum_start` is without header size */
+		vhdr->csum_start   = pkt->csum_start - header_sz;
+		vhdr->csum_offset  = pkt->csum_offset;
+	}
 	vhdr->gso_type = VIRTIO_NET_HDR_GSO_NONE;
 
 	/**
@@ -501,6 +512,7 @@ static int virtio_netdev_rxq_dequeue(struct uk_netdev_rx_queue *rxq,
 	int ret;
 	int rc __maybe_unused = 0;
 	struct uk_netbuf *buf = NULL;
+	struct virtio_net_hdr *vhdr;
 	__u32 len;
 
 	UK_ASSERT(netbuf);
@@ -515,6 +527,22 @@ static int virtio_netdev_rxq_dequeue(struct uk_netdev_rx_queue *rxq,
 		     || (len > VIRTIO_PKT_BUFFER_LEN))) {
 		uk_pr_err("Received invalid packet size: %"__PRIu32"\n", len);
 		return -EINVAL;
+	}
+
+	/**
+	 * Copy virtio header flags to netbuf
+	 */
+	vhdr = (struct virtio_net_hdr *) buf->data;
+	buf->flags  = ((vhdr->flags & VIRTIO_NET_HDR_F_DATA_VALID)
+		       ? UK_NETBUF_F_DATA_VALID   : 0x0);
+	if (vhdr->flags & VIRTIO_NET_HDR_F_NEEDS_CSUM) {
+		buf->flags |= UK_NETBUF_F_PARTIAL_CSUM;
+		buf->csum_offset = vhdr->csum_offset;
+		/* NOTE: csum_start is without virtio header
+		 *       (uk_netbuf_header() will remove it again)
+		 */
+		buf->csum_start  = vhdr->csum_start
+			+ ((uint16_t)sizeof(struct virtio_net_hdr_padded));
 	}
 
 	/**
@@ -830,10 +858,15 @@ static __u16 virtio_net_mtu_get(struct uk_netdev *n)
 	return d->mtu;
 }
 
-static int virtio_netdev_feature_negotiate(struct virtio_net_device *vndev)
+static int virtio_netdev_feature_negotiate(struct uk_netdev *n)
 {
 	__u64 host_features = 0;
+	__u64 drv_features  = 0;
 	int rc = 0;
+	struct virtio_net_device *vndev;
+
+	UK_ASSERT(n);
+	vndev = to_virtionetdev(n);
 
 	/**
 	 * Read device feature bits, and write the subset of feature bits
@@ -843,6 +876,12 @@ static int virtio_netdev_feature_negotiate(struct virtio_net_device *vndev)
 	 * accepting it.
 	 */
 	host_features = virtio_feature_get(vndev->vdev);
+
+	/**
+	 * Hardware address
+	 * NOTE: For now, we require a provided hw address. In principle,
+	 *       we could generate one if none was given.
+	 */
 	if (!VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_MAC)) {
 		/**
 		 * The feature that aren't supported are usually masked out and
@@ -850,10 +889,46 @@ static int virtio_netdev_feature_negotiate(struct virtio_net_device *vndev)
 		 * report an error as we don't support  generation of random
 		 * MAC Address.
 		 */
-		uk_pr_err("Host system does not offer MAC feature\n");
+		uk_pr_err("%p: Host system does not offer MAC feature\n", n);
 		rc = -EINVAL;
-		goto exit;
+		goto err_negotiate_feature;
 	}
+	VIRTIO_FEATURE_SET(drv_features, VIRTIO_NET_F_MAC);
+
+	/**
+	 * MTU information (needed)
+	 */
+	if (!VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_STATUS)) {
+		uk_pr_err("%p: Host system does not offer MTU feature\n", n);
+		rc = -EINVAL;
+		goto err_negotiate_feature;
+	}
+	VIRTIO_FEATURE_SET(drv_features, VIRTIO_NET_F_STATUS);
+
+	/**
+	 * Gratuitous ARP
+	 * NOTE: We tell that we will do gratuitous ARPs ourselves.
+	 */
+	VIRTIO_FEATURE_SET(drv_features, VIRTIO_NET_F_GUEST_ANNOUNCE);
+
+	/**
+	 * Partial checksumming
+	 * NOTE: This enables sending and receiving of packets marked with
+	 *       VIRTIO_NET_HDR_F_DATA_VALID and VIRTIO_NET_HDR_F_NEEDS_CSUM
+	 */
+	if (!VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_CSUM)) {
+		uk_pr_debug("%p: Host does not offer partial checksumming feature: Checksum offloading disabled.\n",
+			    n);
+	} else {
+		VIRTIO_FEATURE_SET(drv_features, VIRTIO_NET_F_CSUM);
+		VIRTIO_FEATURE_SET(drv_features, VIRTIO_NET_F_GUEST_CSUM);
+	}
+
+	/**
+	 * Announce our enabled driver features back to the backend device
+	 */
+	vndev->vdev->features = drv_features;
+	virtio_feature_set(vndev->vdev, vndev->vdev->features);
 
 	/**
 	 * According to Virtio specification, section 2.3.1. Config fields
@@ -866,14 +941,11 @@ static int virtio_netdev_feature_negotiate(struct virtio_net_device *vndev)
 				   __offsetof(struct virtio_net_config, mac),
 				   &vndev->hw_addr.addr_bytes[0],
 				   UK_NETDEV_HWADDR_LEN, 1);
-	rc = 0;
 
-	/**
-	 * Mask out features supported by both driver and device.
-	 */
-	vndev->vdev->features &= host_features;
-	virtio_feature_set(vndev->vdev, vndev->vdev->features);
-exit:
+	return 0;
+
+err_negotiate_feature:
+	virtio_dev_status_update(vndev->vdev, VIRTIO_CONFIG_STATUS_FAIL);
 	return rc;
 }
 
@@ -969,30 +1041,17 @@ static int virtio_netdev_configure(struct uk_netdev *n,
 	UK_ASSERT(conf);
 	vndev = to_virtionetdev(n);
 
-	rc = virtio_netdev_feature_negotiate(vndev);
-	if (rc != 0) {
-		uk_pr_err("Failed to negotiate the device feature %d\n", rc);
-		goto err_negotiate_feature;
-	}
-
 	rc = virtio_netdev_rxtx_alloc(vndev, conf);
-	if (rc != 0) {
-		uk_pr_err("Failed to probe the rx and tx rings %d\n", rc);
-		goto err_negotiate_feature;
+	if (rc < 0) {
+		uk_pr_err("%p: Failed to initialize rx and tx rings: %d\n",
+			  n, rc);
 	}
 
 	/* Initialize the count of the virtio-net device */
 	vndev->rx_vqueue_cnt = 0;
 	vndev->tx_vqueue_cnt = 0;
 
-	uk_pr_info("Configured: features=0x%lx max_virtqueue_pairs=%"__PRIu16"\n",
-		   vndev->vdev->features, vndev->max_vqueue_pairs);
-exit:
 	return rc;
-
-err_negotiate_feature:
-	virtio_dev_status_update(vndev->vdev, VIRTIO_CONFIG_STATUS_FAIL);
-	goto exit;
 }
 
 static int virtio_net_rx_intr_enable(struct uk_netdev *n,
@@ -1046,7 +1105,9 @@ static void virtio_net_info_get(struct uk_netdev *dev,
 	dev_info->nb_encap_tx = sizeof(struct virtio_net_hdr_padded);
 	dev_info->nb_encap_rx = sizeof(struct virtio_net_hdr_padded);
 	dev_info->ioalign = sizeof(void *); /* word size alignment */
-	dev_info->features = UK_NETDEV_F_RXQ_INTR;
+	dev_info->features = UK_NETDEV_F_RXQ_INTR
+		| (VIRTIO_FEATURE_HAS(vndev->vdev->features, VIRTIO_NET_F_CSUM)
+		   ? UK_NETDEV_F_PARTIAL_CSUM : 0);
 }
 
 static int virtio_net_start(struct uk_netdev *n)
@@ -1081,19 +1142,8 @@ static int virtio_net_start(struct uk_netdev *n)
 	return 0;
 }
 
-static inline void virtio_netdev_feature_set(struct virtio_net_device *vndev)
-{
-	vndev->vdev->features = 0;
-	/* Setting the feature the driver support */
-	VIRTIO_NET_DRV_FEATURES(vndev->vdev->features);
-	/**
-	 * TODO:
-	 * Adding multiqueue support for the virtio net driver.
-	 */
-	vndev->max_vqueue_pairs = 1;
-}
-
 static const struct uk_netdev_ops virtio_netdev_ops = {
+	.probe = virtio_netdev_feature_negotiate,
 	.configure = virtio_netdev_configure,
 	.rxq_configure = virtio_netdev_rx_queue_setup,
 	.txq_configure = virtio_netdev_tx_queue_setup,
@@ -1136,8 +1186,13 @@ static int virtio_net_add_dev(struct virtio_dev *vdev)
 	vndev->max_mtu = UK_ETH_PAYLOAD_MAXLEN;
 	vndev->mtu = vndev->max_mtu;
 	vndev->promisc = 0;
-	virtio_netdev_feature_set(vndev);
-	uk_pr_info("virtio-net device registered with libuknet\n");
+
+	/**
+	 * TODO:
+	 * Adding multiqueue support for the virtio net driver.
+	 */
+	vndev->max_vqueue_pairs = 1;
+	uk_pr_debug("virtio-net device registered with libuknet\n");
 
 exit:
 	return rc;

--- a/plat/drivers/virtio/virtio_net.c
+++ b/plat/drivers/virtio/virtio_net.c
@@ -867,14 +867,6 @@ static int virtio_netdev_feature_negotiate(struct virtio_net_device *vndev)
 				   &vndev->hw_addr.addr_bytes[0],
 				   UK_NETDEV_HWADDR_LEN, 1);
 	rc = 0;
-	uk_pr_info("vndev->hw_addr.addr_bytes=[%x %x %x %x %x %x]\n",
-		vndev->hw_addr.addr_bytes[0],
-		vndev->hw_addr.addr_bytes[1],
-		vndev->hw_addr.addr_bytes[2],
-		vndev->hw_addr.addr_bytes[3],
-		vndev->hw_addr.addr_bytes[4],
-		vndev->hw_addr.addr_bytes[5]);
-
 
 	/**
 	 * Mask out features supported by both driver and device.

--- a/plat/xen/drivers/net/netfront.c
+++ b/plat/xen/drivers/net/netfront.c
@@ -177,7 +177,10 @@ static int netfront_xmit(struct uk_netdev *n,
 	tx_req->gref = txq->gref[id];
 	tx_req->offset = (uint16_t) uk_netbuf_headroom(pkt);
 	tx_req->size = (uint16_t) pkt->len;
-	tx_req->flags = 0;
+	tx_req->flags  = (pkt->flags & UK_NETBUF_F_PARTIAL_CSUM)
+			 ? NETTXF_csum_blank : 0x0;
+	tx_req->flags |= (pkt->flags & UK_NETBUF_F_DATA_VALID)
+			 ? NETTXF_data_validated : 0x0;
 	tx_req->id = id;
 	status = UK_NETDEV_STATUS_SUCCESS;
 
@@ -294,6 +297,15 @@ static int netfront_rxq_dequeue(struct uk_netdev_rx_queue *rxq,
 		buf->data = (void *)((__uptr) buf->buf + rx_rsp->offset);
 		buf->len = len;
 		UK_ASSERT(IN_RANGE(buf->data, buf->buf, buf->buflen));
+
+		buf->flags |= (rx_rsp->flags & NETTXF_csum_blank)
+			      ? UK_NETBUF_F_PARTIAL_CSUM : 0x0;
+		buf->flags |= (rx_rsp->flags & NETTXF_data_validated)
+			      ? UK_NETBUF_F_DATA_VALID : 0x0;
+
+		/* netfront does not tell us where the checksum is located */
+		buf->csum_start  = 0;
+		buf->csum_offset = 0;
 	}
 
 	*netbuf = buf;
@@ -756,7 +768,7 @@ static void netfront_info_get(struct uk_netdev *n,
 	dev_info->nb_encap_tx = 0;
 	dev_info->nb_encap_rx = 0;
 	dev_info->ioalign = PAGE_SIZE;
-	dev_info->features = UK_NETDEV_F_RXQ_INTR;
+	dev_info->features = UK_NETDEV_F_RXQ_INTR | UK_NETDEV_F_PARTIAL_CSUM;
 }
 
 static const void *netfront_einfo_get(struct uk_netdev *n,

--- a/plat/xen/drivers/net/netfront.c
+++ b/plat/xen/drivers/net/netfront.c
@@ -756,7 +756,7 @@ static void netfront_info_get(struct uk_netdev *n,
 	dev_info->nb_encap_tx = 0;
 	dev_info->nb_encap_rx = 0;
 	dev_info->ioalign = PAGE_SIZE;
-	dev_info->features = UK_FEATURE_RXQ_INTR_AVAILABLE;
+	dev_info->features = UK_NETDEV_F_RXQ_INTR;
 }
 
 static const void *netfront_einfo_get(struct uk_netdev *n,

--- a/plat/xen/drivers/net/netfront_xs.c
+++ b/plat/xen/drivers/net/netfront_xs.c
@@ -173,9 +173,9 @@ int netfront_xb_init(struct netfront_dev *nfdev, struct uk_alloc *a)
 	} else {
 		uk_pr_debug("\tIP via XenStore: %s\n", ip_str);
 		rc = xs_econf_init(&nfdev->econf, ip_str, a);
+		free(ip_str);
 		if (rc)
 			goto no_conf;
-		free(ip_str);
 	}
 
 	/* maximum queues number */


### PR DESCRIPTION
For checksum offloading for TCP and UDP flows, typically, a partial checksum needs to be computed. This checksum covers only the pseudo header of the protocols. By specifying a start pointer and another pointer to the checksum field, a hardware network device is able to complete the computation of the checksum.
This PR introduces support for `lib/uknetdev` for such a feature. Two new flags and two fields for pbufs are introduced to specify information needed by the driver to offload the computation for a packet. Additionally, a new `uknetdev` driver state is introduced: `UK_NETDEV_UNPROBED`. This state indicates that network devices features weren't negotiated with the device yet. During device initialization, a call to `uk_netdev_probe()` is becoming mandatory to turn the device into `UK_NETDEV_UNCOFNIGURED` state. For some devices (like virtio-net) this is required to figure out if the backend supports partial checksumming.
This PR also implements partial checksumming for `virtio-net`.