### PR TITLE
lib/*: Fix gcc-11 warnings/errors regarding time structures

### DIFF
--- a/lib/uktime/musl-imported/include/sys/time.h
+++ b/lib/uktime/musl-imported/include/sys/time.h
@@ -29,16 +29,16 @@ struct itimerval {
 
 int getitimer (int, struct itimerval *);
 int setitimer (int, const struct itimerval *__restrict, struct itimerval *__restrict);
-int utimes (const char *, const struct timeval [2]);
+int utimes (const char *, const struct timeval *);
 
 #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
 struct timezone {
 	int tz_minuteswest;
 	int tz_dsttime;
 };
-int futimes(int, const struct timeval [2]);
-int futimesat(int, const char *, const struct timeval [2]);
-int lutimes(const char *, const struct timeval [2]);
+int futimes(int, const struct timeval *);
+int futimesat(int, const char *, const struct timeval *);
+int lutimes(const char *, const struct timeval *);
 int settimeofday(const struct timeval *, const struct timezone *);
 int adjtime (const struct timeval *, struct timeval *);
 #define timerisset(t) ((t)->tv_sec || (t)->tv_usec)

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -2064,7 +2064,7 @@ UK_TRACEPOINT(trace_vfs_utimes, "\"%s\"", const char*);
 UK_TRACEPOINT(trace_vfs_utimes_ret, "");
 UK_TRACEPOINT(trace_vfs_utimes_err, "%d", int);
 
-int futimes(int fd, const struct timeval times[2])
+int futimes(int fd, const struct timeval *times)
 {
     return futimesat(fd, NULL, times);
 }
@@ -2153,7 +2153,7 @@ UK_TRACEPOINT(trace_vfs_futimens, "%d", int);
 UK_TRACEPOINT(trace_vfs_futimens_ret, "");
 UK_TRACEPOINT(trace_vfs_futimens_err, "%d", int);
 
-int futimens(int fd, const struct timespec times[2])
+int futimens(int fd, const struct timespec *times)
 {
 	trace_vfs_futimens(fd);
 
@@ -2168,7 +2168,7 @@ int futimens(int fd, const struct timespec times[2])
 	return 0;
 }
 
-static int do_utimes(const char *pathname, const struct timeval times[2], int flags)
+static int do_utimes(const char *pathname, const struct timeval *times, int flags)
 {
 	struct task *t = main_task;
 	char path[PATH_MAX];
@@ -2200,7 +2200,7 @@ UK_SYSCALL_R_DEFINE(int, utimes, const char*, pathname,
 	return do_utimes(pathname, times, 0);
 }
 
-int lutimes(const char *pathname, const struct timeval times[2])
+int lutimes(const char *pathname, const struct timeval *times)
 {
 	return do_utimes(pathname, times, AT_SYMLINK_NOFOLLOW);
 }

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1285,7 +1285,7 @@ static void convert_timeval(struct timespec *to, const struct timeval *from)
 }
 
 int
-sys_utimes(char *path, const struct timeval times[2], int flags)
+sys_utimes(char *path, const struct timeval *times, int flags)
 {
 	int error;
 	struct dentry *dp;

--- a/lib/vfscore/vfs.h
+++ b/lib/vfscore/vfs.h
@@ -104,7 +104,7 @@ int	 sys_lstat(char *path, struct stat *st);
 int	 sys_statfs(char *path, struct statfs *buf);
 int	 sys_truncate(char *path, off_t length);
 int	 sys_readlink(char *path, char *buf, size_t bufsize, ssize_t *size);
-int  sys_utimes(char *path, const struct timeval times[2], int flags);
+int  sys_utimes(char *path, const struct timeval *times, int flags);
 int  sys_utimensat(int dirfd, const char *pathname,
 				   const struct timespec times[2], int flags);
 int  sys_futimens(int fd, const struct timespec times[2]);


### PR DESCRIPTION
In gcc-11 mismatches between pointer formats are treated as warnings.
This is generated by the `timeval` structure:
`const struct timeval times[2]` vs. `const struct timeval *times`

In the case of Unikraft these warnings are treated as errors and the
build fails.

This commit fixes all the new mismatches by switching to the second
version. This should not change behaviour.

This PR fixes the Issue described here: #313

Signed-off-by: Cezar Craciunoiu <cezar.craciunoiu@gmail.com>