### PR TITLE
arm/rtc: enable pl031 for arm64

### DIFF
--- a/plat/drivers/include/rtc/pl031.h
+++ b/plat/drivers/include/rtc/pl031.h
@@ -1,0 +1,121 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Author: Razvan Deaconescu <razvan.deaconescu@cs.pub.ro>
+ *
+ * Copyright (c) 2022, University POLITEHNICA of Bucharest. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef __PLAT_DRV_RTC_PL031_H__
+#define __PLAT_DRV_RTC_PL031_H__
+
+#define PL031_STATUS_ENABLED	1
+#define PL031_STATUS_DISABLED	0
+
+#include <rtc/rtc.h>
+
+/**
+ * Read time from device and store in RTC structure.
+ *
+ * @param[out] rt Pointer to time structure storing result
+ */
+void pl031_read_time(struct rtc_time *rt);
+
+/**
+ * Write time from RTC structure to device.
+ *
+ * @param[in] rt Pointer to time structure storing time
+ */
+void pl031_write_time(struct rtc_time *rt);
+
+/**
+ * Set alarm timeout. Interrupt will be delivered at timeout expiry.
+ *
+ * @param[in] rt Pointer to time structure storing timeout
+ */
+void pl031_write_alarm(struct rtc_time *rt);
+
+/**
+ * Read alarm timeout.
+ *
+ * @param[out] rt Pointer to time structure storing result
+ */
+void pl031_read_alarm(struct rtc_time *rt);
+
+/**
+ * Enable PL031 device.
+ */
+void pl031_enable(void);
+
+/**
+ * Disable PL031 device.
+ */
+void pl031_disable(void);
+
+/**
+ * Get PL031 device status (enabled or disabled).
+ *
+ * @return PL031_STATUS_ENABLED or PL031_STATUS_DISABLED if device
+ *         is enabled or not
+ */
+int pl031_get_status(void);
+
+/**
+ * Enable interrupt for device.
+ */
+void pl031_enable_intr(void);
+
+/**
+ * Disable interrupt for device.
+ */
+void pl031_disable_intr(void);
+
+/**
+ * Clear interrupt for device.
+ */
+void pl031_clear_intr(void);
+
+/**
+ * Register alarm handler to be called when interrupt is delivered
+ * (at alarm expiry).
+ *
+ * @param[in] handler Alarm handler as function pointer
+ * @return <0 for error, 0 for success
+ */
+int pl031_register_alarm_handler(int (*handler)(void *));
+
+/**
+ * Initialize PL031 device. Parse device tree blob (DTB) to extract
+ * base address and IRQ.
+ *
+ * @param[in] dtb Pointer to DTB structure
+ * @return <0 for error, 0 for success
+ */
+int pl031_init_rtc(void *dtb);
+
+#endif /* __PLAT_DRV_RTC_PL031_H__ */

--- a/plat/drivers/include/rtc/rtc.h
+++ b/plat/drivers/include/rtc/rtc.h
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Authors: Wei Chen <Wei.Chen@arm.com>
+ *          Jianyong Wu <Jianyong.Wu@arm.com>
+ *
+ * Copyright (c) 2019, Arm Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef __PLAT_DRV_RTC_H__
+#define __PLAT_DRV_RTC_H__
+
+#include <uk/arch/types.h>
+
+/* Store time in structured format. */
+struct rtc_time {
+	int year;
+	int mon;
+	int day;
+	int hour;
+	int min;
+	int sec;
+};
+
+/**
+ * Convert raw RTC data (read from RTC register) to a time structure.
+ *
+ * @param raw Raw RTC value
+ * @param [inout] tm Pointer to time structure storing the result
+ */
+void rtc_raw_to_tm(__u32 raw, struct rtc_time *tm);
+
+/**
+ * Convert structured time to raw RTC data (to be written to RTC register).
+ *
+ * @param tm Pointer to time structure
+ *
+ * @return The raw RTC data
+ */
+__u32 rtc_tm_to_raw(struct rtc_time *tm);
+
+#endif //__PLAT_DRV_RTC_H__

--- a/plat/drivers/rtc/pl031.c
+++ b/plat/drivers/rtc/pl031.c
@@ -1,0 +1,211 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Authors: Wei Chen <Wei.Chen@arm.com>
+ *          Jianyong Wu <Jianyong.Wu@arm.com>
+ *
+ * Copyright (c) 2018, Arm Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <string.h>
+#include <uk/essentials.h>
+#include <libfdt.h>
+#include <ofw/fdt.h>
+#include <gic/gic-v2.h>
+#include <ofw/gic_fdt.h>
+#include <uk/print.h>
+#include <arm/cpu.h>
+#include <rtc/rtc.h>
+#include <rtc/pl031.h>
+#include <uk/plat/common/irq.h>
+
+static __u64 pl031_base_addr;
+static int pl031_irq;
+
+/* FDT compatible property for PL031 device */
+#define PL031_COMPATIBLE	"arm,pl031"
+
+/* status mask to check if device is enabled */
+#define PL031_RTC_CR_STATUS_MASK	1
+
+/* offsets of PL031 registers */
+#define RTC_DR		0x00	/* Data read */
+#define RTC_MR		0x04	/* Match register */
+#define RTC_LR		0x08	/* Load register */
+#define RTC_CR		0x0c	/* Control register */
+#define RTC_IMSC	0x10	/* Interrupt mask and set register */
+#define RTC_RIS		0x14	/* Raw interrupt status */
+#define RTC_MIS		0x18	/* Masked interrupt status */
+#define RTC_ICR		0x1c	/* Interrupt clear register */
+
+#define PL031_REG(r)	(void *)(pl031_base_addr + (r))
+
+static __u32 pl031_read_raw(void)
+{
+	return ioreg_read32(PL031_REG(RTC_DR));
+}
+
+void pl031_read_time(struct rtc_time *rt)
+{
+	__u32 raw;
+
+	raw = pl031_read_raw();
+	rtc_raw_to_tm(raw, rt);
+}
+
+static void pl031_write_raw(__u32 val)
+{
+	ioreg_write32(PL031_REG(RTC_LR), val);
+}
+
+void pl031_write_time(struct rtc_time *rt)
+{
+	__u32 raw;
+
+	raw = rtc_tm_to_raw(rt);
+	pl031_write_raw(raw);
+}
+
+static void pl031_write_alarm_raw(__u32 alarm)
+{
+	ioreg_write32(PL031_REG(RTC_MR), alarm);
+}
+
+void pl031_write_alarm(struct rtc_time *rt)
+{
+	__u32 raw;
+
+	raw = rtc_tm_to_raw(rt);
+	pl031_write_alarm_raw(raw);
+}
+
+static __u32 pl031_read_alarm_raw(void)
+{
+	return ioreg_read32(PL031_REG(RTC_MR));
+}
+
+void pl031_read_alarm(struct rtc_time *rt)
+{
+	rtc_raw_to_tm(pl031_read_alarm_raw(), rt);
+}
+
+void pl031_enable(void)
+{
+	ioreg_write32(PL031_REG(RTC_CR), 1);
+}
+
+void pl031_disable(void)
+{
+	ioreg_write32(PL031_REG(RTC_CR), 0);
+}
+
+int pl031_get_status(void)
+{
+	int val;
+
+	val = ioreg_read32(PL031_REG(RTC_CR));
+	val &= PL031_RTC_CR_STATUS_MASK;
+	return val;
+}
+
+void pl031_enable_intr(void)
+{
+	ioreg_write32(PL031_REG(RTC_IMSC), 1);
+}
+
+void pl031_disable_intr(void)
+{
+	ioreg_write32(PL031_REG(RTC_IMSC), 0);
+}
+
+static __u32 pl031_get_raw_intr_state(void)
+{
+	return ioreg_read32(PL031_REG(RTC_RIS));
+}
+
+void pl031_clear_intr(void)
+{
+	while (pl031_get_raw_intr_state())
+		ioreg_write32(PL031_REG(RTC_ICR), 1);
+}
+
+int pl031_register_alarm_handler(int (*handler)(void *))
+{
+	return ukplat_irq_register(pl031_irq, handler, NULL);
+}
+
+int pl031_init_rtc(void *dtb)
+{
+	__u64 size;
+	__u32 irq_type, hwirq, trigger_type;
+	int fdt_rtc, rc;
+
+	uk_pr_info("Probing RTC...\n");
+
+	/* Search for RTC device by compatible property name. */
+	fdt_rtc = fdt_node_offset_by_compatible(dtb, -1, PL031_COMPATIBLE);
+	if (unlikely(fdt_rtc < 0)) {
+		uk_pr_err("Could not find RTC device, fdt_rtc is %d\n",
+			  fdt_rtc);
+		return -EINVAL;
+	}
+
+	rc = fdt_get_address(dtb, fdt_rtc, 0, &pl031_base_addr, &size);
+	if (unlikely(rc < 0)) {
+		uk_pr_err("Could not get RTC address\n");
+		return -EINVAL;
+	}
+	uk_pr_info("Found RTC at: 0x%lx\n", pl031_base_addr);
+
+	rc = gic_get_irq_from_dtb(dtb, fdt_rtc, 0, &irq_type, &hwirq,
+				  &trigger_type);
+	if (unlikely(rc < 0)) {
+		uk_pr_err("Failed to find RTC IRQ from DTB\n");
+		return -EINVAL;
+	}
+
+	pl031_irq = gic_irq_translate(irq_type, hwirq);
+	if (unlikely(pl031_irq < 0 || pl031_irq >= __MAX_IRQ)) {
+		uk_pr_err("Failed to translate RTC IRQ\n");
+		return -EINVAL;
+	}
+	uk_pr_info("RTC IRQ is: %d\n", pl031_irq);
+
+	if (pl031_get_status() == PL031_STATUS_DISABLED)
+		pl031_enable();
+
+	if (unlikely(pl031_get_status() != PL031_STATUS_ENABLED)) {
+		uk_pr_err("Fail to enable RTC\n");
+		return -EINVAL;
+	}
+	uk_pr_info("RTC enabled\n");
+
+	/* Enable RTC alarm IRQ at its reset. */
+	pl031_enable_intr();
+
+	return 0;
+}

--- a/plat/drivers/rtc/rtc.c
+++ b/plat/drivers/rtc/rtc.c
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Authors: Wei Chen <Wei.Chen@arm.com>
+ *          Jianyong Wu <Jianyong.Wu@arm.com>
+ *
+ * Copyright (c) 2018, Arm Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <uk/essentials.h>
+#include <rtc/rtc.h>
+
+static const unsigned int days_per_mon[12] = {
+	31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+static int is_leap_year(unsigned int year)
+{
+	return ((!(year % 4) && (year % 100)) || !(year % 400));
+}
+
+void rtc_raw_to_tm(__u32 raw, struct rtc_time *rt)
+{
+	unsigned int hours, days, years;
+	unsigned int normal_days, day_in_year;
+	unsigned int leap, i, sum = 0;
+
+	/*
+	 * Total days for every consecutive 4 years, assuming there is a leap
+	 * year every 4 years
+	 */
+	const unsigned int dy4   = 365 * 3 + 366;
+	/* Total days for every consecutive 100 years */
+	const unsigned int dy100 = 25 * dy4 - 1;
+	/* Total days for every consecutive 400 years */
+	const unsigned int dy400 = dy100 * 4 + 1;
+
+	rt->sec = raw % 60;
+	rt->min = (raw % 3600) / 60;
+	hours = (raw / 60) / 60;
+	days = hours / 24;
+	rt->hour = hours % 24;
+
+	/* Normalize days by getting rid of the additional day in leap year */
+	normal_days = days - days / dy4 + days / dy100 + days / dy400;
+	years = normal_days / 365;
+	rt->year = 1970 + years;
+
+	leap = is_leap_year(rt->year);
+	day_in_year = normal_days - years * 365;
+
+	/*
+	 * If the remaining number of days is larger than the sum of the first
+	 * two months we should consider 29 days for February.
+	 */
+	sum += leap * (day_in_year >= (days_per_mon[0] + days_per_mon[1]));
+	for (i = 0; i < 12; i++) {
+		sum += days_per_mon[i];
+		if (day_in_year < sum) {
+			rt->mon = i + 1;
+			rt->day = day_in_year - (sum - days_per_mon[i]) + 1;
+			break;
+		}
+	}
+}
+
+__u32 rtc_tm_to_raw(struct rtc_time *rt)
+{
+	unsigned int leaps, leap, years, days, sec;
+	int i;
+
+	years = rt->year - 1970;
+	leaps = years / 4 - years / 100 + years / 400;
+	leap = is_leap_year(rt->year);
+
+	days = years * 365 + leaps;
+	if (rt->mon == 1) {
+		days += days_per_mon[0];
+	} else {
+		for (i = 0; i < rt->mon - 1; i++)
+			days += days_per_mon[i];
+	}
+
+	days += rt->day + (rt->mon > 2) * leap - 1;
+	sec = days * 3600 * 24 + rt->hour * 3600 + rt->min * 60 + rt->sec;
+
+	return sec;
+}

--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -152,6 +152,11 @@ config VIRTIO_9P
               Virtio 9P driver.
 endmenu
 
+config RTC_PL031
+       bool "Arm platform RTC (PL031) driver"
+       default y if ARCH_ARM_64
+       depends on ARCH_ARM_64
+
 config LIBOFW
        bool "Open Firmware library support"
        default n

--- a/plat/kvm/Makefile.uk
+++ b/plat/kvm/Makefile.uk
@@ -15,6 +15,7 @@ $(eval $(call addplatlib_s,kvm,libkvmvirtioblk,$(CONFIG_VIRTIO_BLK)))
 $(eval $(call addplatlib_s,kvm,libkvmvirtio9p,$(CONFIG_VIRTIO_9P)))
 $(eval $(call addplatlib_s,kvm,libkvmofw,$(CONFIG_LIBOFW)))
 $(eval $(call addplatlib_s,kvm,libkvmgic,$(CONFIG_LIBGIC)))
+$(eval $(call addplatlib_s,kvm,libkvmpl031,$(CONFIG_RTC_PL031)))
 
 ##
 ## Platform library definitions
@@ -219,3 +220,13 @@ ifeq ($(findstring y,$(CONFIG_LIBGICV3)),y)
 LIBKVMGIC_SRCS-y += $(UK_PLAT_DRIVERS_BASE)/gic/gic-v3.c
 endif
 endif
+
+##
+## RTC-PL031 library definitions
+##
+LIBKVMPL031_CINCLUDES-y		+= -I$(LIBKVMPLAT_BASE)/include
+LIBKVMPL031_CINCLUDES-y		+= -I$(UK_PLAT_COMMON_BASE)/include
+LIBKVMPL031_CINCLUDES-y		+= -I$(UK_PLAT_DRIVERS_BASE)/include
+
+LIBKVMPL031_SRCS-y		+= $(UK_PLAT_DRIVERS_BASE)/rtc/pl031.c
+LIBKVMPL031_SRCS-y		+= $(UK_PLAT_DRIVERS_BASE)/rtc/rtc.c

--- a/plat/kvm/arm/setup.c
+++ b/plat/kvm/arm/setup.c
@@ -22,6 +22,9 @@
 #include <libfdt.h>
 #include <uk/plat/common/sections.h>
 #include <uart/pl011.h>
+#ifdef CONFIG_RTC_PL031
+#include <rtc/pl031.h>
+#endif /* CONFIG_RTC_PL031 */
 #include <kvm/config.h>
 #include <uk/assert.h>
 #include <kvm-arm/mm.h>
@@ -220,6 +223,11 @@ void __no_pauth _libkvmplat_start(void *dtb_pointer)
 
 	/* Initialize memory from DTB */
 	_init_dtb_mem();
+
+#ifdef CONFIG_RTC_PL031
+	/* Initialize RTC */
+	pl031_init_rtc(dtb_pointer);
+#endif /* CONFIG_RTC_PL031 */
 
 	/* Initialize interrupt controller */
 	intctrl_init();


### PR DESCRIPTION
Currently, rtc is not enabled in arm, so wall time can't
be provided currectly.
pl031 is chosen as the rtc device for arm in this patch, but
we have interface extension of capable of plugging other rtc device.

Signed-off-by: Wei Chen <wei.chen@arm.com>
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>
Reviewed-by: Sharan Santhanam <sharan.santhanam@neclab.eu>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
