### PR TITLE
arm/entry: set x0 before cache maintenance.

### DIFF
--- a/plat/kvm/arm/entry64.S
+++ b/plat/kvm/arm/entry64.S
@@ -90,6 +90,11 @@ ENTRY(_libkvmplat_entry)
 	add x27, x26, x17
 	add x27, x27, #__STACK_SIZE
 	sub x1, x27, x25
+
+	/*
+	 * set x0 as the start of ram address.
+	 */
+	ldr x0, = _start_ram_addr;
 	bl clean_and_invalidate_dcache_range
 
 	/* Disable the MMU and D-Cache. */

--- a/plat/kvm/arm/link64.lds.S
+++ b/plat/kvm/arm/link64.lds.S
@@ -54,6 +54,7 @@ SECTIONS {
 
 	/* Place DTB binary at the beginning of the RAM */
 	_dtb = .;
+	_start_ram_addr = .;
 	. = . + DTB_RESERVED_SIZE;
 
 	/* Code */


### PR DESCRIPTION
There is a long standing issue in entry code of arm that x0 is not
set before using it in clean_and_invalidate_dcache_range. This error
can be caught by kvm and result in core dump.
Here, x0 is set to the location where stores dtb before cache maintain.

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
