### PR TITLE
arch/arm/arm64: Add errata for Cortex A53

### DIFF
--- a/arch/arm/arm64/Config.uk
+++ b/arch/arm/arm64/Config.uk
@@ -54,3 +54,19 @@ config ARM64_ERRATUM_858921
 	  This option enables a workaround for Cortex-A73 (r0p0 - r0p2),
 	  whose counter may return a wrong value when the counter crosses
 	  a 32-bit boundary. The newer Cortex-A73 are not affected.
+
+config ARM64_ERRATUM_835769
+	bool "Workaround for Cortex-A53 erratum 835769"
+	default y
+	help
+	  This option enables a workaround for Cortex-A53. This erratum
+	  workaraound is made at compile time by passing the corresponding
+	  flag to GCC.
+
+config ARM64_ERRATUM_843419
+	bool "Workaround for Cortex-A53 erratum 843419"
+	default y
+	help
+	  This option enables a workaround for Cortex-A53. This erratum
+	  workaround is made at link time by passing the corresponding
+	  flag to GCC.

--- a/arch/arm/arm64/Makefile.uk
+++ b/arch/arm/arm64/Makefile.uk
@@ -37,6 +37,20 @@ ARCHFLAGS-$(call gcc_version_ge,4,9)     += -march=armv8-a -mcpu=cortex-a53 -mtu
 ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -march=armv8-a -mcpu=cortex-a53 -mtune=cortex-a53
 endif
 
+# For erratum 835769
+ifeq ($(CONFIG_ARM64_ERRATUM_835769),y)
+$(call error_if_gcc_version_lt,4,9)
+ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mfix-cortex-a53-835769
+ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mfix-cortex-a53-835769
+endif
+
+# For erratum 843419
+ifeq ($(CONFIG_ARM64_ERRATUM_843419),y)
+$(call error_if_gcc_version_lt,4,9)
+ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mfix-cortex-a53-843419
+ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mfix-cortex-a53-843419
+endif
+
 # GCC support -mcpu=cortex-a57 for arm64 from 4.9
 ifeq ($(CONFIG_MARCH_ARM64_CORTEXA57),y)
 $(call error_if_gcc_version_lt,4,9)


### PR DESCRIPTION
Add two errata for Cortex-A53:

1. Workaround for Cortex-A53 erratum 835769
1. Workaround for Cortex-A53 erratum 843419
    
 Also add temporary workaround to have atomic operations working on ARM64 baremetal.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`
 - Platform(s): N/A
 - Application(s): N/A

### Additional configuration

No additional configuration is required. The configuration options for the errata are enabled by default for ARM64 builds.

### Description of changes

Add `ARM64_ERRATUM_835769` and `ARM64_ERRATUM_843419` configuration options for `arm64`. They are enabled by default. Each configuration option adds a specific compiler option.
