### PR TITLE
lib/uk9p: Remove unguarded include of uk/wait.h (fix #320)

### DIFF
--- a/lib/uk9p/9pdev.c
+++ b/lib/uk9p/9pdev.c
@@ -39,7 +39,6 @@
 #include <uk/errptr.h>
 #include <uk/bitmap.h>
 #include <uk/refcount.h>
-#include <uk/wait.h>
 #include <uk/9p.h>
 #include <uk/9pdev.h>
 #include <uk/9pdev_trans.h>


### PR DESCRIPTION
The `9pdev.c` file includes `uk/wait.h` twice. The second include is properly guarded by `#if CONFIG_LIBUKSCHED`. But the first include (duplicate) is not guarded (and shouldn't actually be part of the code).

Fix #320 .

This depends on the #277 pull request.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): `app-helloworld`

### Additional configuration

 - `CONFIG_LIBUK9P=y`
 - `# CONFIG_LIBUKSCHED is not set`

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Remove the first unguarded 
<!--
Please provide a detailed description of the changes made in this new PR.
-->

This removes the first (unguarded) include of `uk/wait.h` in `9pdev.c`.