### PR TITLE
lib/uksignal: Update struct sigset_t and macros to 1024bits and solve compilation errors

### DIFF
--- a/lib/uksignal/include/uk/bits/sigset.h
+++ b/lib/uksignal/include/uk/bits/sigset.h
@@ -43,16 +43,16 @@ extern "C" {
 
 /* TODO: do we have gnu statement expression?  */
 /* internal use */
-#define uk_sigemptyset(ptr)	(*(ptr) = 0)
-#define uk_sigfillset(ptr)  (*(ptr) = ~((__sigset_t) 0))
-#define uk_sigaddset(ptr, signo) (*(ptr) |= (1 << ((signo) - 1)))
-#define uk_sigdelset(ptr, signo) (*(ptr) &= ~(1 << ((signo) - 1)))
-#define uk_sigcopyset(ptr1, ptr2) (*(ptr1) = *(ptr2))
-#define uk_sigandset(ptr1, ptr2)  (*(ptr1) &= *(ptr2))
-#define uk_sigorset(ptr1, ptr2)	  (*(ptr1) |= *(ptr2))
-#define uk_sigreverseset(ptr)	  (*(ptr) = ~(*(ptr)))
-#define uk_sigismember(ptr, signo) (*(ptr) & (1 << ((signo) - 1)))
-#define uk_sigisempty(ptr) (*(ptr) == 0)
+#define uk_sigemptyset(ptr) (((ptr)->__bits[0]) = 0)
+#define uk_sigfillset(ptr) (((ptr)->__bits[0]) = ~(0))
+#define uk_sigaddset(ptr, signo) (((ptr)->__bits[0]) |= (1 << ((signo) - 1)))
+#define uk_sigdelset(ptr, signo) (((ptr)->__bits[0]) &= ~(1 << ((signo) - 1)))
+#define uk_sigcopyset(ptr1, ptr2) (((ptr1)->__bits[0]) = ((ptr2)->__bits[0]))
+#define uk_sigandset(ptr1, ptr2) (((ptr1)->__bits[0]) &= ((ptr2)->__bits[0]))
+#define uk_sigorset(ptr1, ptr2) (((ptr1)->__bits[0]) |= ((ptr2)->__bits[0]))
+#define uk_sigreverseset(ptr) (((ptr)->__bits[0]) = ~((ptr)->__bits[0]))
+#define uk_sigismember(ptr, signo) (((ptr)->__bits[0]) & (1 << ((signo) - 1)))
+#define uk_sigisempty(ptr) (((ptr)->__bits[0]) == 0)
 
 #ifdef __cplusplus
 }

--- a/lib/uksignal/include/uk/uk_signal.h
+++ b/lib/uksignal/include/uk/uk_signal.h
@@ -45,6 +45,16 @@
 extern "C" {
 #endif
 
+#ifndef is_sig_dfl
+#define is_sig_dfl(ptr) \
+	(!((ptr)->sa_flags & SA_SIGINFO) && (ptr)->sa_handler == SIG_DFL)
+#endif
+
+#ifndef is_sig_ign
+#define is_sig_ign(ptr) \
+	(!((ptr)->sa_flags & SA_SIGINFO) && (ptr)->sa_handler == SIG_IGN)
+#endif
+
 #define _UK_TH_SIG uk_crr_thread_sig_container()
 
 struct uk_thread;

--- a/lib/uksignal/signal.c
+++ b/lib/uksignal/signal.c
@@ -33,7 +33,7 @@
  *     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /* adapted from OSv */
-
+#define _GNU_SOURCE
 #include <errno.h>
 
 #include <uk/alloc.h>


### PR DESCRIPTION
Signed-off-by: Dragos Iulian Argint <dragosargint21@gmail.com>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [`kvm`]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->
Include `uksignal` from menuconfig.
### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
As newlib uses a 64bits mask for signals and musl uses 128bits mask we need a unified way for those to work
with the underlying signal processing. This is what this PR intends to do.

This PR is part of a group that aims to solve compiling errors for both musl and newlib:
* https://github.com/unikraft/lib-newlib/pull/15
* https://github.com/unikraft/lib-musl/pull/4
* https://github.com/unikraft/unikraft/pull/327
* https://github.com/unikraft/unikraft/pull/326