### PR TITLE
lib/nolibc: Update sigset_t from nolibc to 1024 bits

### DIFF
--- a/lib/nolibc/musl-imported/include/signal.h
+++ b/lib/nolibc/musl-imported/include/signal.h
@@ -60,7 +60,7 @@ extern "C" {
 
 typedef int pid_t;
 typedef int sig_atomic_t;
-typedef unsigned long __sigset_t;
+typedef struct { unsigned long __bits[128/sizeof(long)]; } __sigset_t;
 typedef __sigset_t sigset_t;
 
 #define NSIG _NSIG


### PR DESCRIPTION
Signed-off-by: Dragos Iulian Argint <dragosargint21@gmail.com>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [`kvm`]


### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
This PR modifies the sigset_t structure to 128 bits for nolibc. The 128bits signal mask is musl imported.

This PR is part of a group that aims to solve compiling errors for both musl and newlib:
* https://github.com/unikraft/lib-newlib/pull/15
* https://github.com/unikraft/lib-musl/pull/4
* https://github.com/unikraft/unikraft/pull/327
* https://github.com/unikraft/unikraft/pull/326