### PR TITLE
lib/vfscore: Fix `pread64` and `pwrite64` syscall implementations

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -401,7 +401,7 @@ UK_LLSYSCALL_R_DEFINE(ssize_t, pread64, int, fd,
 	};
 	ssize_t bytes;
 
-	bytes = uk_syscall_r_preadv((long) fd, (long) &iov,
+	bytes = uk_syscall_r_pread64((long) fd, (long) &iov,
 				    1, (long) offset);
 	if (bytes < 0)
 		trace_vfs_pread_err(bytes);
@@ -598,7 +598,7 @@ UK_LLSYSCALL_R_DEFINE(ssize_t, pwrite64, int, fd,
 	};
 	ssize_t bytes;
 
-	bytes = uk_syscall_r_pwritev((long) fd, (long) &iov,
+	bytes = uk_syscall_r_pwrite64((long) fd, (long) &iov,
 				     1, (long) offset);
 	if (bytes < 0)
 		trace_vfs_pwrite_err(bytes);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): All
 - Platform(s): All
 - Application(s): All


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit fixes #322 where vfscore's syscall registration of `pread64` and `pwrite64` incorrectly called the implicit syscall methods of `preadv` and `pwritev`, respectively.

This was introduced when #174 was merged.