### PR TITLE
lib/vfscore: Fix `pread64` and `pwrite64` syscall implementations

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -782,7 +782,7 @@ int ioctl(int fd, unsigned long int request, ...)
 	arg = va_arg(ap, void*);
 	va_end(ap);
 
-	return uk_syscall_e_ioctl(fd, request, arg);
+	return uk_syscall_e_ioctl((long) fd, (long) request, (long) arg);
 }
 #endif
 

--- a/lib/vfscore/mount.c
+++ b/lib/vfscore/mount.c
@@ -377,12 +377,14 @@ UK_LLSYSCALL_R_DEFINE(int, sync)
 	bio_sync();
 #endif
 	uk_mutex_unlock(&mount_lock);
+
+	return 0;
 }
 
 #if UK_LIBC_SYSCALLS
 void sync(void)
 {
-   uk_syscall_e_sync();
+	uk_syscall_e_sync();
 }
 #endif
 


### PR DESCRIPTION
### Description of changes

PR #174 caused a compilation error for vfscore because of undefined symbols `uk_syscall_r_pwritev` and `uk_syscall_r_preadv`. This PR fixes this issues and closes two other compiler warnings caused by `lib/vfscore`.