### PR TITLE
Order dependencies for prepare and preprocess targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -697,10 +697,10 @@ $(UK_CONFIG_OUT): $(UK_CONFIG)
 		$(UK_CONFIG) \
 		$(UK_CONFIG_OUT))
 
-prepare: $(KCONFIG_AUTOHEADER) $(UK_CONFIG_OUT) $(UK_PREPARE) $(UK_PREPARE-y)
-prepare: $(UK_FIXDEP) | fetch
+prepare: $(KCONFIG_AUTOHEADER) $(UK_CONFIG_OUT) $(UK_PREPARE) fetch $(UK_PREPARE-y)
+prepare: $(UK_FIXDEP)
 
-preprocess: $(UK_PREPROCESS) $(UK_PREPROCESS-y) | prepare
+preprocess: $(UK_PREPROCESS) prepare $(UK_PREPROCESS-y)
 
 objs: $(UK_OBJS) $(UK_OBJS-y)
 


### PR DESCRIPTION
The `prepare` target in the Makefile depends on the `fetch` target. The dependency is marked as an order-only dependency (`| fetch`), that is run after all other dependencies.

This causes an issue when the `$(UK_PREPARE-y)` prerequisite depends on the `fetch` target. This is the case with the `app-micropython` application, where the `prepare` target for `lib-micropython` relies on the `lib-newlib` library being fetched beforehand.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): `app-micropython`

### Description of changes

This commit solves this by adding the `fetch` target as a prerequisite for `prepare` **before** the `$(UK_PREPARE-y)` prerequisite.

For consistency, the `prepare` target is added as a prerequisite for`preprocess` **before** the `$(UK_PREPROCESS-y)` prerequisite.