### PR TITLE
plat/xen: Netfront improvements

### DIFF
--- a/plat/xen/drivers/net/netfront.c
+++ b/plat/xen/drivers/net/netfront.c
@@ -137,6 +137,8 @@ static int netfront_xmit(struct uk_netdev *n,
 	UK_ASSERT(txq != NULL);
 	UK_ASSERT(pkt != NULL);
 	UK_ASSERT(pkt->len < PAGE_SIZE);
+	UK_ASSERT(!pkt->next); /* TODO: Support for netbuf chains missing */
+	UK_ASSERT(((unsigned long) pkt->buf & ~PAGE_MASK) == 0);
 
 	nfdev = to_netfront_dev(n);
 
@@ -164,7 +166,7 @@ static int netfront_xmit(struct uk_netdev *n,
 	UK_ASSERT(tx_req->gref != GRANT_INVALID_REF);
 	txq->netbuf[id] = pkt;
 
-	tx_req->offset = 0;
+	tx_req->offset = (uint16_t) uk_netbuf_headroom(pkt);
 	tx_req->size = (uint16_t) pkt->len;
 	tx_req->flags = 0;
 	tx_req->id = id;

--- a/plat/xen/drivers/net/netfront.c
+++ b/plat/xen/drivers/net/netfront.c
@@ -105,7 +105,7 @@ static int network_tx_buf_gc(struct uk_netdev_tx_queue *txq)
 
 			gnttab_end_access(txq->gref[id]);
 			txq->gref[id] = GRANT_INVALID_REF;
-			uk_netbuf_free_single(txq->netbuf[id]);
+			uk_netbuf_free_single(txq->nbuf[id]);
 
 			add_id_to_freelist(id, txq->freelist);
 			uk_semaphore_up(&txq->sem);
@@ -164,7 +164,9 @@ static int netfront_xmit(struct uk_netdev *n,
 		gnttab_grant_access(nfdev->xendev->otherend_id,
 			virt_to_mfn(pkt->buf), 1);
 	UK_ASSERT(tx_req->gref != GRANT_INVALID_REF);
-	txq->netbuf[id] = pkt;
+
+	/* remember netbuf reference for free'ing it later */
+	txq->nbuf[id] = pkt;
 
 	tx_req->offset = (uint16_t) uk_netbuf_headroom(pkt);
 	tx_req->size = (uint16_t) pkt->len;

--- a/plat/xen/drivers/net/netfront.c
+++ b/plat/xen/drivers/net/netfront.c
@@ -152,7 +152,6 @@ static int netfront_xmit(struct uk_netdev *n,
 
 	/* get request id */
 	id = get_id_from_freelist(txq->freelist);
-	local_irq_restore(flags);
 
 	/* get request */
 	req_prod = txq->ring.req_prod_pvt;
@@ -189,17 +188,15 @@ static int netfront_xmit(struct uk_netdev *n,
 	if (notify)
 		notify_remote_via_evtchn(txq->evtchn);
 
-	status |= UK_NETDEV_STATUS_SUCCESS;
 
 	/* some cleanup */
-	local_irq_save(flags);
 	do {
 		network_tx_buf_gc(txq);
 		RING_FINAL_CHECK_FOR_RESPONSES(&txq->ring, more_to_do);
 	} while (more_to_do);
-	local_irq_restore(flags);
 
 	status |= (RING_FULL(&txq->ring)) ? 0x0 : UK_NETDEV_STATUS_MORE;
+	local_irq_restore(flags);
 
 	return status;
 }

--- a/plat/xen/drivers/net/netfront.c
+++ b/plat/xen/drivers/net/netfront.c
@@ -357,7 +357,7 @@ static int netfront_rxq_intr_enable(struct uk_netdev_rx_queue *rxq)
 	return (more > 0);
 }
 
-static int netfront_recv(struct uk_netdev *n,
+static int netfront_recv(struct uk_netdev *n __unused,
 		struct uk_netdev_rx_queue *rxq,
 		struct uk_netbuf **pkt)
 {
@@ -611,7 +611,7 @@ err_free_txrx:
 	return rc;
 }
 
-static int netfront_rx_intr_enable(struct uk_netdev *n,
+static int netfront_rx_intr_enable(struct uk_netdev *n __unused,
 		struct uk_netdev_rx_queue *rxq)
 {
 	int rc;
@@ -637,7 +637,7 @@ static int netfront_rx_intr_enable(struct uk_netdev *n,
 	return rc;
 }
 
-static int netfront_rx_intr_disable(struct uk_netdev *n,
+static int netfront_rx_intr_disable(struct uk_netdev *n __unused,
 		struct uk_netdev_rx_queue *rxq)
 {
 	UK_ASSERT(n != NULL);

--- a/plat/xen/drivers/net/netfront.c
+++ b/plat/xen/drivers/net/netfront.c
@@ -180,6 +180,7 @@ static int netfront_xmit(struct uk_netdev *n,
 	tx_req->size = (uint16_t) pkt->len;
 	tx_req->flags = 0;
 	tx_req->id = id;
+	status = UK_NETDEV_STATUS_SUCCESS;
 
 	txq->ring.req_prod_pvt = req_prod + 1;
 	wmb(); /* Ensure backend sees requests */

--- a/plat/xen/drivers/net/netfront.c
+++ b/plat/xen/drivers/net/netfront.c
@@ -479,7 +479,7 @@ static struct uk_netdev_tx_queue *netfront_txq_setup(struct uk_netdev *n,
 	return txq;
 }
 
-static void netfront_handler(evtchn_port_t port __unused,
+static void netfront_rxq_handler(evtchn_port_t port __unused,
 		struct __regs *regs __unused, void *arg)
 {
 	struct uk_netdev_rx_queue *rxq = arg;
@@ -531,7 +531,7 @@ static struct uk_netdev_rx_queue *netfront_rxq_setup(struct uk_netdev *n,
 	/* Setup event channel */
 	if (nfdev->split_evtchn || !nfdev->txqs[queue_id].initialized) {
 		rc = evtchn_alloc_unbound(nfdev->xendev->otherend_id,
-				netfront_handler, rxq,
+				netfront_rxq_handler, rxq,
 				&rxq->evtchn);
 		if (rc) {
 			uk_pr_err("Error creating event channel: %d\n", rc);
@@ -542,7 +542,7 @@ static struct uk_netdev_rx_queue *netfront_rxq_setup(struct uk_netdev *n,
 	} else {
 		rxq->evtchn = nfdev->txqs[queue_id].evtchn;
 		/* overwriting event handler */
-		bind_evtchn(rxq->evtchn, netfront_handler, rxq);
+		bind_evtchn(rxq->evtchn, netfront_rxq_handler, rxq);
 	}
 	/*
 	 * By default, events are disabled and it is up to the user or

--- a/plat/xen/drivers/net/netfront.c
+++ b/plat/xen/drivers/net/netfront.c
@@ -362,6 +362,7 @@ static int netfront_recv(struct uk_netdev *n __unused,
 		struct uk_netbuf **pkt)
 {
 	int rc, status = 0;
+	int more;
 
 	UK_ASSERT(n != NULL);
 	UK_ASSERT(rxq != NULL);
@@ -407,7 +408,8 @@ static int netfront_recv(struct uk_netdev *n __unused,
 		 * For polling case, we report always there are further
 		 * packets unless the queue is empty.
 		 */
-		status |= UK_NETDEV_STATUS_MORE;
+		RING_FINAL_CHECK_FOR_RESPONSES(&rxq->ring, more);
+		status |= (more) ? UK_NETDEV_STATUS_MORE : 0x0;
 	}
 
 	return status;

--- a/plat/xen/drivers/net/netfront.c
+++ b/plat/xen/drivers/net/netfront.c
@@ -535,7 +535,7 @@ static struct uk_netdev_rx_queue *netfront_rxq_setup(struct uk_netdev *n,
 static int netfront_rxtx_alloc(struct netfront_dev *nfdev,
 		const struct uk_netdev_conf *conf)
 {
-	int rc = 0;
+	int rc = 0, i;
 
 	if (conf->nb_tx_queues != conf->nb_rx_queues) {
 		uk_pr_err("Different number of queues not supported\n");
@@ -553,6 +553,8 @@ static int netfront_rxtx_alloc(struct netfront_dev *nfdev,
 		rc = -ENOMEM;
 		goto err_free_txrx;
 	}
+	for (i = 0; i < nfdev->max_queue_pairs; i++)
+		nfdev->txqs[i].ring_size = NET_TX_RING_SIZE;
 
 	nfdev->rxqs = uk_calloc(drv_allocator,
 		nfdev->max_queue_pairs, sizeof(*nfdev->rxqs));
@@ -561,6 +563,8 @@ static int netfront_rxtx_alloc(struct netfront_dev *nfdev,
 		rc = -ENOMEM;
 		goto err_free_txrx;
 	}
+	for (i = 0; i < nfdev->max_queue_pairs; i++)
+		nfdev->rxqs[i].ring_size = NET_RX_RING_SIZE;
 
 	return rc;
 

--- a/plat/xen/drivers/net/netfront.h
+++ b/plat/xen/drivers/net/netfront.h
@@ -35,6 +35,7 @@
 #define __NETFRONT_H__
 
 #include <uk/netdev.h>
+#include <uk/netbuf.h>
 #include <uk/semaphore.h>
 #include <xen/io/netif.h>
 #include <common/gnttab.h>
@@ -68,6 +69,8 @@ struct uk_netdev_tx_queue {
 	struct uk_semaphore sem;
 	/* Free list of transmitting request IDs */
 	uint16_t freelist[NET_TX_RING_SIZE + 1];
+	/* Ring of inflight netbufs */
+	struct uk_netbuf *nbuf[NET_TX_RING_SIZE];
 	/* Grants for transmit buffers */
 	grant_ref_t gref[NET_TX_RING_SIZE];
 	/* Transmit packets addresses */

--- a/plat/xen/drivers/net/netfront.h
+++ b/plat/xen/drivers/net/netfront.h
@@ -65,8 +65,6 @@ struct uk_netdev_tx_queue {
 	/* Queue event channel */
 	evtchn_port_t evtchn;
 
-	/* Free list protecting semaphore */
-	struct uk_semaphore sem;
 	/* Free list of transmitting request IDs */
 	uint16_t freelist[NET_TX_RING_SIZE + 1];
 	/* Ring of inflight netbufs */


### PR DESCRIPTION
### Base target

 - Architecture(s): any
 - Platform(s): `xen`

### Description of changes

This PR contains a number of improvements, adoption and bugfixes to our netfront driver. Besides adopting the driver to comply with the recent `uknetdev` API, this PR contains a number of improvements that we used for the [Linux.com article](https://www.linux.com/news/cut-your-cloud-computing-costs-by-half-with-unikraft/).

Please note that this PR is not implementing checksum offloading for netfront yet, there will be a separate PR to be opened.