### PR TITLE
build/grub: Allow building GRUB based ISO images.

### DIFF
--- a/support/scripts/mkgrubimg
+++ b/support/scripts/mkgrubimg
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# help menu
+usage()
+{
+	echo "Usage: $0 [options] [output file]"
+	echo "Creates bootable GRUB images from Unikraft kernel images."
+	echo ""
+	echo "  -h                         Display help and exit"
+	echo "  -f                         Output format (supported: iso)"
+	echo "  -k                         Path to the Unikraft kernel image"
+	echo "  -a                         Kernel command-line parameters (optional)"
+	echo "  -i                         Path to initrd cpio file (optional)"
+	exit 1
+}
+
+# default options
+OPTFORMAT="iso"
+OPTCMDLINE=""
+
+# cleanup
+BUILDDIR=
+sighandler_exit()
+{
+	if [ ! -z "${BUILDDIR}" -a -d "${BUILDDIR}" ]; then
+		rm -rf "${BUILDDIR}"
+	fi
+}
+
+# process options
+while getopts "hk:i:f:a:" OPT; do
+	case "${OPT}" in
+		h)
+			usage
+			;;
+		f)
+			OPTFORMAT="${OPTARG}"
+			;;
+		k)
+			OPTKERNELIMG="${OPTARG}"
+			;;
+		a)
+			OPTCMDLINE="${OPTARG}"
+			;;
+		i)
+			OPTINITRD="${OPTARG}"
+			;;
+		*)
+			usage
+			;;
+	esac
+done
+shift $((OPTIND-1))
+
+# validate arguments
+if [[ -z "${OPTKERNELIMG}" ]]; then
+	echo "Missing path to kernel image ('-k')" 1>&2
+	usage
+fi
+if [[ -z "${1}" ]]; then
+	echo "Missing path to output image" 1>&2
+	usage
+fi
+if [ ! -f "${OPTKERNELIMG}" ]; then
+	echo "${OPTKERNELIMG} does not exist or is not a file" 1>&2
+	exit 1
+fi
+if [ ! -z "${OPTINITRD}" -a ! -f "${OPTINITRD}" ]; then
+	echo "${OPTINITRD} does not exist or is not a file" 1>&2
+	exit 1
+fi
+
+# Register exit handler and create BUILDDIR
+trap sighandler_exit exit
+BUILDDIR="$( mktemp -d )"
+if [ $? -ne 0 -o -z "${BUILDDIR}" -o ! -d "${BUILDDIR}" ]; then
+	echo "Failed to create temporary directory" 1>&2
+	exit 1
+fi
+
+OPTKERNELNAME="${OPTKERNELIMG##*/}"
+OPTINITRDNAME="${OPTINITRD##*/}"
+
+case "${OPTFORMAT}" in
+	# generate grub iso image
+	iso)
+		# configure grub
+		mkdir -p "${BUILDDIR}/boot/grub"
+
+		if [ ! -z "${OPTINITRD}" ]; then
+			GRUB_CFG_INITRD="module /boot/${OPTINITRDNAME}"
+			cp "${OPTINITRD}" "${BUILDDIR}/boot/${OPTINITRDNAME}" || exit 1
+		fi
+		cp "${OPTKERNELIMG}" "${BUILDDIR}/boot/" || exit 1
+
+		cat >"${BUILDDIR}/boot/grub/grub.cfg" <<EOF
+set default=0
+set timeout=0
+
+menuentry "${OPTKERNELNAME}" {
+	multiboot /boot/${OPTKERNELNAME} /${OPTKERNELNAME} ${OPTCMDLINE}
+	${GRUB_CFG_INITRD}
+	boot
+}
+EOF
+
+		# build grub image
+		GRUB_INSTALL_MSGS=$( grub-mkrescue -o "$1" --install-modules="multiboot" --fonts="" --themes="" --locales="" "${BUILDDIR}/" 2>&1 )
+		if [ $? != 0 ]; then
+			printf '%s\n' "$GRUB_INSTALL_MSGS" 1>&2
+			exit 1
+		fi
+		;;
+	*)
+		echo -e "\"${OPTFORMAT}\" not a supported format." 1>&2
+		usage
+		;;
+esac


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation. --> Not sure if there is any documentation I need to update.


### Base target

 - Architecture(s): x86_64
 - Platform(s): KVM
 - Application(s): N/A


### Additional configuration
- `CONFIG_KVM_GRUB=y`

Building an iso image requires grub-mkrescue, which can be installed with `apt-get install grub-common` on Ubuntu and Debian Linux.
<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->


### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The traditional KVM images built by Unikraft are intended to be run with
`qemu` using the `-kernel` option. This is because they are not
formatted in a way that most external bootloaders can load. This PR
will allow users to select a GRUB option in menuconfig under KVM
platform specific options. Upon selection, Unikraft will build an ISO
image in addition to the regular KVM image such that any multiboot
complient bootloader (including GRUB) can load and run the image. This
commit is intended to close #265.