### PR TITLE
.github: Updates `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,9 +24,13 @@
 # These owners oversee the ARM architecture.
 /lib/fdt/		@unikraft/maintainers-arch-arm @unikraft/reviewers-arch-arm
 /arch/arm/		@unikraft/maintainers-arch-arm @unikraft/reviewers-arch-arm
+/plat/*/arm/		@unikraft/maintainers-arch-arm @unikraft/reviewers-arch-arm
+/plat/*/include/*-arm/	@unikraft/maintainers-arch-arm @unikraft/reviewers-arch-arm
 
 # These owners oversee the x86 architecture.
 /arch/x86/		@unikraft/maintainers-arch-x86 @unikraft/reviewers-arch-x86
+/plat/*/x86/		@unikraft/maintainers-arch-x86 @unikraft/reviewers-arch-x86
+/plat/*/include/*-x86/	@unikraft/maintainers-arch-x86 @unikraft/reviewers-arch-x86
 
 # These owners oversee the KVM platform.
 /plat/kvm/		@unikraft/maintainers-plat-kvm @unikraft/reviewers-plat-kvm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,6 +75,8 @@
 # These owners oversee the build system.
 /Makefile		@unikraft/maintainers-build @unikraft/reviewers-build
 /Makefile.uk		@unikraft/maintainers-build @unikraft/reviewers-build
+/lib/Config.uk		@unikraft/maintainers-build @unikraft/reviewers-build
+/lib/Makefile.uk	@unikraft/maintainers-build @unikraft/reviewers-build
 /support/		@unikraft/maintainers-build @unikraft/reviewers-build
 
 # These owners oversee the debugging support.


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A


### Description of changes

This PR adds has updates to the `CODEOWNERS` file, including:

 * two new patterns to the `CODEOWNERS` file such that it matches directories listed in the platform (`plat/`) directory which are relevant to the Special Interest Groups (SIGs) who work on the ARM and x86 architectures;
 * adding the SIG on build system to the registration files for all internal Unikraft libraries at `lib/Makefile.uk` and `lib/Config.uk`.