### PR TITLE
support/scripts: Allow `mkcpio` to quietly gzip compress CPIO images

### DIFF
--- a/support/scripts/mkcpio
+++ b/support/scripts/mkcpio
@@ -3,10 +3,37 @@ CPIOTOOL="$( which bsdcpio )"
 
 usage()
 {
-	echo "$0 [output.cpio] [CPIO root path]" 1>&2
+	echo "$0 [options] [output.cpio] [CPIO root path]" 1>&2
+	echo "-h	display this help screen" 1>&2
+	echo "-q	suppress non-critical output" 1>&2
 	exit 1
 }
 
+# Process extra options
+CPIOFLAGS=()
+while getopts ":hq" option; do
+	case $option in
+		h)
+			usage
+			;;
+		q)
+			OPT_QUIET=true
+			;;
+		?)
+			usage
+			;;
+	esac
+done
+
+if [ "$OPT_QUIET" = true ]; then
+	CPIOFLAGS+=("--quiet")
+else
+	CPIOFLAGS+=("-v")
+fi
+
+shift $((OPTIND - 1))
+
+# Process primary arguments
 [ -z "$1" -o -z "$2" ] && usage
 if [ -e "$1" -a ! -f "$1" ]; then
 	echo "Output '$1' does already exist and is not a file" 1>&2
@@ -29,8 +56,9 @@ if [ -z "${CPIOTOOL}" ]; then
 	exit 1
 fi
 
+# Generate CPIO file
 cd "$2"
 find . -depth \( ! -iname ".gitkeep" \) -print \
 	| tac \
-	| "${CPIOTOOL}" -v -o --format newc > "${OUT_BASE}/${OUT_FILE}"
+	| "${CPIOTOOL}" "${CPIOFLAGS[@]}" -o --format newc > "${OUT_BASE}/${OUT_FILE}"
 exit $?


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Users may sometimes require compressed CPIO images. With the current
`mkcpio` script, the only way to do this is to create a regular CPIO
image and then gzip it separately. This is inefficient and unnecessary,
as `bsdcpio` natively allows for gzip compression. Furthermore, some
users may wish to suppress the output generated by the `mkcpio` script.
This commit offers new command line arguments that allow the user to
satisfy both of these requirements. 