### PR TITLE
lib/all:  Clean up pre-rigorous use of checkpatch errors and warnings

### DIFF
--- a/lib/9pfs/9pfs_vnops.c
+++ b/lib/9pfs/9pfs_vnops.c
@@ -186,8 +186,7 @@ static int uk_9pfs_open(struct vfscore_file *file)
 
 	fd->fid = openedfid;
 	file->f_data = fd;
- 	UK_9PFS_ND(file->f_dentry->d_vnode)->nb_open_files++;
-
+	UK_9PFS_ND(file->f_dentry->d_vnode)->nb_open_files++;
 	return 0;
 
 out_err:

--- a/lib/fdt/fdt_ro.c
+++ b/lib/fdt/fdt_ro.c
@@ -177,7 +177,8 @@ int fdt_subnode_offset_namelen(const void *fdt, int offset,
 int fdt_subnode_offset(const void *fdt, int parentoffset,
 		       const char *name)
 {
-	return fdt_subnode_offset_namelen(fdt, parentoffset, name, strlen(name));
+	return fdt_subnode_offset_namelen(fdt, parentoffset, name,
+	strlen(name));
 }
 
 int fdt_path_offset_namelen(const void *fdt, const char *path, int namelen)
@@ -212,7 +213,7 @@ int fdt_path_offset_namelen(const void *fdt, const char *path, int namelen)
 				return offset;
 		}
 		q = memchr(p, '/', end - p);
-		if (! q)
+		if (!q)
 			q = end;
 
 		offset = fdt_subnode_offset_namelen(fdt, offset, p, q-p);
@@ -234,7 +235,6 @@ const char *fdt_get_name(const void *fdt, int nodeoffset, int *len)
 {
 	const struct fdt_node_header *nh = _fdt_offset_ptr(fdt, nodeoffset);
 	int err;
-
 	if (((err = fdt_check_header(fdt)) != 0)
 	    || ((err = _fdt_check_node_offset(fdt, nodeoffset)) < 0))
 			goto fail;
@@ -422,7 +422,6 @@ int fdt_get_path(const void *fdt, int nodeoffset, char *buf, int buflen)
 		if (offset == nodeoffset) {
 			if (pdepth < (depth + 1))
 				return -FDT_ERR_NOSPACE;
-
 			if (p > 1) /* special case so that root path is "/", not "" */
 				p--;
 			buf[p] = '\0';

--- a/lib/fdt/fdt_sw.c
+++ b/lib/fdt/fdt_sw.c
@@ -175,7 +175,7 @@ int fdt_begin_node(void *fdt, const char *name)
 	FDT_SW_CHECK_HEADER(fdt);
 
 	nh = _fdt_grab_space(fdt, sizeof(*nh) + FDT_TAGALIGN(namelen));
-	if (! nh)
+	if (!nh)
 		return -FDT_ERR_NOSPACE;
 
 	nh->tag = cpu_to_fdt32(FDT_BEGIN_NODE);
@@ -190,7 +190,7 @@ int fdt_end_node(void *fdt)
 	FDT_SW_CHECK_HEADER(fdt);
 
 	en = _fdt_grab_space(fdt, FDT_TAGSIZE);
-	if (! en)
+	if (!en)
 		return -FDT_ERR_NOSPACE;
 
 	*en = cpu_to_fdt32(FDT_END_NODE);
@@ -232,7 +232,7 @@ int fdt_property_placeholder(void *fdt, const char *name, int len, void **valp)
 		return -FDT_ERR_NOSPACE;
 
 	prop = _fdt_grab_space(fdt, sizeof(*prop) + FDT_TAGALIGN(len));
-	if (! prop)
+	if (!prop)
 		return -FDT_ERR_NOSPACE;
 
 	prop->tag = cpu_to_fdt32(FDT_PROP);
@@ -266,7 +266,7 @@ int fdt_finish(void *fdt)
 
 	/* Add terminator */
 	end = _fdt_grab_space(fdt, sizeof(*end));
-	if (! end)
+	if (!end)
 		return -FDT_ERR_NOSPACE;
 	*end = cpu_to_fdt32(FDT_END);
 

--- a/lib/nolibc/include/stdlib.h
+++ b/lib/nolibc/include/stdlib.h
@@ -117,7 +117,7 @@ static inline void *memalign(size_t align, size_t size)
 void abort(void) __noreturn;
 
 void qsort(void *base, size_t nmemb, size_t size,
-           int (*compar)(const void *, const void *));
+		int (*compar)(const void *, const void *));
 
 #if CONFIG_LIBPOSIX_PROCESS
 int system(const char *command);

--- a/lib/nolibc/include/sys/statvfs.h
+++ b/lib/nolibc/include/sys/statvfs.h
@@ -15,17 +15,17 @@ struct statvfs {
 	fsfilcnt_t f_files, f_ffree, f_favail;
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 	unsigned long f_fsid;
-	unsigned :8*(2*sizeof(int)-sizeof(long));
+	unsigned:8*(2*sizeof(int)-sizeof(long));
 #else
-	unsigned :8*(2*sizeof(int)-sizeof(long));
+	unsigned:8*(2*sizeof(int)-sizeof(long));
 	unsigned long f_fsid;
 #endif
 	unsigned long f_flag, f_namemax;
 	int __reserved[6];
 };
 
-int statvfs (const char *__restrict, struct statvfs *__restrict);
-int fstatvfs (int, struct statvfs *);
+int statvfs(const char *__restrict, struct statvfs *__restrict);
+int fstatvfs(int, struct statvfs *);
 
 #define ST_RDONLY 1
 #define ST_NOSUID 2

--- a/lib/nolibc/musl-imported/arch/generic/bits/ioctl.h
+++ b/lib/nolibc/musl-imported/arch/generic/bits/ioctl.h
@@ -1,12 +1,12 @@
-#define _IOC(a,b,c,d) ( ((a)<<30) | ((b)<<8) | (c) | ((d)<<16) )
+#define _IOC(a, b, c, d) (((a)<<30) | ((b)<<8) | (c) | ((d)<<16))
 #define _IOC_NONE  0U
 #define _IOC_WRITE 1U
 #define _IOC_READ  2U
 
-#define _IO(a,b) _IOC(_IOC_NONE,(a),(b),0)
-#define _IOW(a,b,c) _IOC(_IOC_WRITE,(a),(b),sizeof(c))
-#define _IOR(a,b,c) _IOC(_IOC_READ,(a),(b),sizeof(c))
-#define _IOWR(a,b,c) _IOC(_IOC_READ|_IOC_WRITE,(a),(b),sizeof(c))
+#define _IO(a, b) _IOC(_IOC_NONE, (a), (b), 0)
+#define _IOW(a, b, c) _IOC(_IOC_WRITE, (a), (b), sizeof(c))
+#define _IOR(a, b, c) _IOC(_IOC_READ, (a), (b), sizeof(c))
+#define _IOWR(a, b, c) _IOC(_IOC_READ|_IOC_WRITE, (a), (b), sizeof(c))
 
 #define TCGETS		0x5401
 #define TCSETS		0x5402

--- a/lib/nolibc/musl-imported/include/sys/ioctl.h
+++ b/lib/nolibc/musl-imported/include/sys/ioctl.h
@@ -116,7 +116,7 @@ struct winsize {
 #define SIOCDEVPRIVATE     0x89F0
 #define SIOCPROTOPRIVATE   0x89E0
 
-int ioctl (int, int, ...);
+int ioctl(int, int, ...);
 
 #ifdef __cplusplus
 }

--- a/lib/nolibc/musl-imported/include/sys/mman.h
+++ b/lib/nolibc/musl-imported/include/sys/mman.h
@@ -105,33 +105,33 @@ extern "C" {
 #define MFD_HUGETLB 0x0004U
 #endif
 
-void *mmap (void *, size_t, int, int, int, off_t);
-int munmap (void *, size_t);
+void *mmap(void *, size_t, int, int, int, off_t);
+int munmap(void *, size_t);
 
-int mprotect (void *, size_t, int);
-int msync (void *, size_t, int);
+int mprotect(void *, size_t, int);
+int msync(void *, size_t, int);
 
-int posix_madvise (void *, size_t, int);
+int posix_madvise(void *, size_t, int);
 
-int mlock (const void *, size_t);
-int munlock (const void *, size_t);
-int mlockall (int);
-int munlockall (void);
+int mlock(const void *, size_t);
+int munlock(const void *, size_t);
+int mlockall(int);
+int munlockall(void);
 
 #ifdef _GNU_SOURCE
-void *mremap (void *, size_t, size_t, int, ...);
-int remap_file_pages (void *, size_t, int, size_t, int);
-int memfd_create (const char *, unsigned);
-int mlock2 (const void *, size_t, unsigned);
+void *mremap(void *, size_t, size_t, int, ...);
+int remap_file_pages(void *, size_t, int, size_t, int);
+int memfd_create(const char *, unsigned);
+int mlock2(const void *, size_t, unsigned);
 #endif
 
 #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
-int madvise (void *, size_t, int);
-int mincore (void *, size_t, unsigned char *);
+int madvise(void *, size_t, int);
+int mincore(void *, size_t, unsigned char *);
 #endif
 
-int shm_open (const char *, int, mode_t);
-int shm_unlink (const char *);
+int shm_open(const char *, int, mode_t);
+int shm_unlink(const char *);
 
 #if defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)
 #define mmap64 mmap

--- a/lib/nolibc/musl-imported/src/signal/psignal.c
+++ b/lib/nolibc/musl-imported/src/signal/psignal.c
@@ -15,6 +15,6 @@ void psignal(int sig, const char *msg)
 	 * error since fprintf might change it even on success but psignal is
 	 * not permitted to do so. */
 
-	if (fprintf(f, "%s%s%s\n", msg?msg:"", msg?": ":"", s)>=0)
+	if (fprintf(f, "%s%s%s\n", msg?msg:"", msg?": ":"", s) >= 0)
 		errno = old_errno;
 }

--- a/lib/posix-process/musl-imported/include/sys/resource.h
+++ b/lib/posix-process/musl-imported/include/sys/resource.h
@@ -45,12 +45,12 @@ struct rusage {
 	long    __reserved[16];
 };
 
-int getrlimit (int, struct rlimit *);
-int setrlimit (int, const struct rlimit *);
-int getrusage (int, struct rusage *);
+int getrlimit(int, struct rlimit *);
+int setrlimit(int, const struct rlimit *);
+int getrusage(int, struct rusage *);
 
-int getpriority (int, id_t);
-int setpriority (int, id_t, int);
+int getpriority(int, id_t);
+int setpriority(int, id_t, int);
 
 #ifdef _GNU_SOURCE
 int prlimit(pid_t, int, const struct rlimit *, struct rlimit *);

--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -336,7 +336,7 @@ UK_SYSCALL_R_DEFINE(int, setpriority, int, which, id_t, who, int, prio)
 			rc = -ESRCH;
 		}
 		break;
-default:
+	default:
 		rc = -EINVAL;
 		break;
 	}

--- a/lib/posix-sysinfo/include/sys/sysinfo.h
+++ b/lib/posix-sysinfo/include/sys/sysinfo.h
@@ -49,11 +49,11 @@ struct sysinfo {
 	char __reserved[256];
 };
 
-int sysinfo (struct sysinfo *);
-int get_nprocs_conf (void);
-int get_nprocs (void);
-long get_phys_pages (void);
-long get_avphys_pages (void);
+int sysinfo(struct sysinfo *);
+int get_nprocs_conf(void);
+int get_nprocs(void);
+long get_phys_pages(void);
+long get_avphys_pages(void);
 
 #ifdef __cplusplus
 }

--- a/lib/syscall_shim/include/uk/syscall.h
+++ b/lib/syscall_shim/include/uk/syscall.h
@@ -69,24 +69,24 @@ typedef long uk_syscall_arg_t;
 	UK_CONCAT(uk_syscall_r_fn_, syscall_nr) (__VA_ARGS__)
 
 #define __uk_syscall0(n) __uk_syscall_fn(n)
-#define __uk_syscall1(n,a) __uk_syscall_fn(n,__uk_scc(a))
-#define __uk_syscall2(n,a,b) __uk_syscall_fn(n,__uk_scc(a),__uk_scc(b))
-#define __uk_syscall3(n,a,b,c) __uk_syscall_fn(n,__uk_scc(a),__uk_scc(b),__uk_scc(c))
-#define __uk_syscall4(n,a,b,c,d) __uk_syscall_fn(n,__uk_scc(a),__uk_scc(b),__uk_scc(c),__uk_scc(d))
-#define __uk_syscall5(n,a,b,c,d,e) __uk_syscall_fn(n,__uk_scc(a),__uk_scc(b),__uk_scc(c),__uk_scc(d),__uk_scc(e))
-#define __uk_syscall6(n,a,b,c,d,e,f) __uk_syscall_fn(n,__uk_scc(a),__uk_scc(b),__uk_scc(c),__uk_scc(d),__uk_scc(e),__uk_scc(f))
-#define __uk_syscall7(n,a,b,c,d,e,f,g) __uk_syscall_fn(n,__uk_scc(a),__uk_scc(b),__uk_scc(c),__uk_scc(d),__uk_scc(e),__uk_scc(f),__uk_scc(g))
+#define __uk_syscall1(n, a) __uk_syscall_fn(n, __uk_scc(a))
+#define __uk_syscall2(n, a, b) __uk_syscall_fn(n, __uk_scc(a), __uk_scc(b))
+#define __uk_syscall3(n, a, b, c) __uk_syscall_fn(n,__uk_scc(a), __uk_scc(b), __uk_scc(c))
+#define __uk_syscall4(n, a, b, c, d) __uk_syscall_fn(n, __uk_scc(a), __uk_scc(b), __uk_scc(c), __uk_scc(d))
+#define __uk_syscall5(n, a, b, c, d, e) __uk_syscall_fn(n, __uk_scc(a), __uk_scc(b), __uk_scc(c), __uk_scc(d), __uk_scc(e))
+#define __uk_syscall6(n, a, b, c, d, e, f) __uk_syscall_fn(n, __uk_scc(a), __uk_scc(b), __uk_scc(c), __uk_scc(d), __uk_scc(e), __uk_scc(f))
+#define __uk_syscall7(n, a, b, c, d, e, f, g) __uk_syscall_fn(n, __uk_scc(a), __uk_scc(b), __uk_scc(c), __uk_scc(d), __uk_scc(e), __uk_scc(f), __uk_scc(g))
 
 #define __uk_syscall0_r(n) __uk_syscall_r_fn(n)
-#define __uk_syscall1_r(n,a) __uk_syscall_r_fn(n,__uk_scc(a))
-#define __uk_syscall2_r(n,a,b) __uk_syscall_r_fn(n,__uk_scc(a),__uk_scc(b))
-#define __uk_syscall3_r(n,a,b,c) __uk_syscall_r_fn(n,__uk_scc(a),__uk_scc(b),__uk_scc(c))
-#define __uk_syscall4_r(n,a,b,c,d) __uk_syscall_r_fn(n,__uk_scc(a),__uk_scc(b),__uk_scc(c),__uk_scc(d))
-#define __uk_syscall5_r(n,a,b,c,d,e) __uk_syscall_r_fn(n,__uk_scc(a),__uk_scc(b),__uk_scc(c),__uk_scc(d),__uk_scc(e))
-#define __uk_syscall6_r(n,a,b,c,d,e,f) __uk_syscall_r_fn(n,__uk_scc(a),__uk_scc(b),__uk_scc(c),__uk_scc(d),__uk_scc(e),__uk_scc(f))
-#define __uk_syscall7_r(n,a,b,c,d,e,f,g) __uk_syscall_r_fn(n,__uk_scc(a),__uk_scc(b),__uk_scc(c),__uk_scc(d),__uk_scc(e),__uk_scc(f),__uk_scc(g))
+#define __uk_syscall1_r(n, a) __uk_syscall_r_fn(n, __uk_scc(a))
+#define __uk_syscall2_r(n, a, b) __uk_syscall_r_fn(n, __uk_scc(a), __uk_scc(b))
+#define __uk_syscall3_r(n, a, b, c) __uk_syscall_r_fn(n, __uk_scc(a), __uk_scc(b), __uk_scc(c))
+#define __uk_syscall4_r(n, a, b, c, d) __uk_syscall_r_fn(n, __uk_scc(a), __uk_scc(b), __uk_scc(c), __uk_scc(d))
+#define __uk_syscall5_r(n, a, b, c, d, e) __uk_syscall_r_fn(n, __uk_scc(a), __uk_scc(b), __uk_scc(c), __uk_scc(d), __uk_scc(e))
+#define __uk_syscall6_r(n, a, b, c, d, e, f) __uk_syscall_r_fn(n, __uk_scc(a), __uk_scc(b), __uk_scc(c), __uk_scc(d), __uk_scc(e), __uk_scc(f))
+#define __uk_syscall7_r(n, a, b, c, d, e, f, g) __uk_syscall_r_fn(n, __uk_scc(a), __uk_scc(b), __uk_scc(c), __uk_scc(d), __uk_scc(e), __uk_scc(f), __uk_scc(g))
 
-#define __UK_SYSCALL_NARGS_X(a,b,c,d,e,f,g,h,n,...) n
+#define __UK_SYSCALL_NARGS_X(a, b, c, d, e, f, g, h, n, ...) n
 #define __UK_SYSCALL_NARGS(...) __UK_SYSCALL_NARGS_X(__VA_ARGS__,7,6,5,4,3,2,1,0,)
 
 #define __UK_SYSCALL_DEF_NARGS_X(z, a1,a2, b1,b2, c1,c2, d1,d2, e1,e2, f1,f2, g1,g2, nr, ...) nr

--- a/lib/ukargparse/argparse.c
+++ b/lib/ukargparse/argparse.c
@@ -35,9 +35,9 @@
 #include <uk/assert.h>
 
 
-static void left_shift(char *buf, __sz index, __sz maxlen) 
+static void left_shift(char *buf, __sz index, __sz maxlen)
 {
-	while(buf[index] != '\0' && index < maxlen) {
+	while (buf[index] != '\0' && index < maxlen) {
 		buf[index] = buf[index + 1];
 		index++;
 	}
@@ -87,7 +87,6 @@ int uk_argnparse(char *argb, __sz maxlen, char *argv[], int maxcount)
 				--i;
 				break;
 			}
-			
 			/* Fall through */
 		default:
 			/* any character */

--- a/lib/uklibparam/param.c
+++ b/lib/uklibparam/param.c
@@ -617,7 +617,7 @@ int uk_libparam_parse(const char *progname, int argc, char **argv)
 			uk_pr_err("Failed to fetch arg between index %d and %d\n",
 				  cnt, (cnt + args_read));
 			uk_pr_err("Skipping Args:");
-			for ( i = cnt; i < cnt + args_read; i++)
+			for (i = cnt; i < cnt + args_read; i++)
 				uk_pr_err(" %s", argv[i]);
 			uk_pr_err("\n");
 			cnt += args_read;

--- a/lib/uknetdev/netbuf.c
+++ b/lib/uknetdev/netbuf.c
@@ -158,7 +158,7 @@ struct uk_netbuf *uk_netbuf_prepare_buf(void *mem, size_t size,
 			     mem,
 			     (size_t) ((__uptr) m - (__uptr) mem),
 			     headroom,
-			     privlen > 0 ? (void *) ((__uptr) m+ sizeof(*m))
+			     privlen > 0 ? (void *) ((__uptr) m + sizeof(*m))
 					 : NULL,
 			     dtor);
 	return m;

--- a/lib/ukring/include/uk/ring.h
+++ b/lib/ukring/include/uk/ring.h
@@ -111,7 +111,7 @@ uk_ring_enqueue(struct uk_ring *br, void *buf)
 	/*
 	 * If there are other enqueues in progress
 	 * that preceded us, we need to wait for them
-	 * to complete 
+	 * to complete
 	 */
 	while (br->br_prod_tail != prod_head)
 		ukarch_spinwait();
@@ -121,7 +121,7 @@ uk_ring_enqueue(struct uk_ring *br, void *buf)
 }
 
 /*
- * multi-consumer safe dequeue 
+ * multi-consumer safe dequeue
  *
  */
 static __inline void *
@@ -161,7 +161,7 @@ uk_ring_dequeue_mc(struct uk_ring *br)
 }
 
 /*
- * single-consumer dequeue 
+ * single-consumer dequeue
  * use where dequeue is protected by a lock
  * e.g. a network driver's tx queue lock
  */
@@ -193,7 +193,7 @@ uk_ring_dequeue_sc(struct uk_ring *br)
 	 * br->br_ring[prod_head] = buf;
 	 * atomic_store_rel_32(&br->br_prod_tail, ...);
 	 *                                                                                prod_tail = br->br_prod_tail;
-	 *                                                                                if (cons_head == prod_tail) 
+	 *                                                                                if (cons_head == prod_tail)
 	 *                                                                                        return (NULL);
 	 *                                                                                <condition is false and code uses invalid(old) buf>`
 	 *

--- a/lib/uktime/musl-imported/include/sys/time.h
+++ b/lib/uktime/musl-imported/include/sys/time.h
@@ -43,14 +43,14 @@ int settimeofday(const struct timeval *, const struct timezone *);
 int adjtime (const struct timeval *, struct timeval *);
 #define timerisset(t) ((t)->tv_sec || (t)->tv_usec)
 #define timerclear(t) ((t)->tv_sec = (t)->tv_usec = 0)
-#define timercmp(s,t,op) ((s)->tv_sec == (t)->tv_sec ? \
+#define timercmp(s, t, op) ((s)->tv_sec == (t)->tv_sec ? \
 	(s)->tv_usec op (t)->tv_usec : (s)->tv_sec op (t)->tv_sec)
-#define timeradd(s,t,a) (void) ( (a)->tv_sec = (s)->tv_sec + (t)->tv_sec, \
+#define timeradd(s, t, a) (void) ((a)->tv_sec = (s)->tv_sec + (t)->tv_sec, \
 	((a)->tv_usec = (s)->tv_usec + (t)->tv_usec) >= 1000000 && \
-	((a)->tv_usec -= 1000000, (a)->tv_sec++) )
-#define timersub(s,t,a) (void) ( (a)->tv_sec = (s)->tv_sec - (t)->tv_sec, \
+	((a)->tv_usec -= 1000000, (a)->tv_sec++))
+#define timersub(s, t, a) (void) ((a)->tv_sec = (s)->tv_sec - (t)->tv_sec, \
 	((a)->tv_usec = (s)->tv_usec - (t)->tv_usec) < 0 && \
-	((a)->tv_usec += 1000000, (a)->tv_sec--) )
+	((a)->tv_usec += 1000000, (a)->tv_sec--))
 #endif
 
 #if defined(_GNU_SOURCE)
@@ -61,7 +61,7 @@ int adjtime (const struct timeval *, struct timeval *);
 #define TIMESPEC_TO_TIMEVAL(tv, ts) ( \
 	(tv)->tv_sec = (ts)->tv_sec, \
 	(tv)->tv_usec = (ts)->tv_nsec / 1000, \
-	(void)0 )
+	(void)0)
 #endif
 
 #ifdef __cplusplus

--- a/lib/uktime/musl-imported/include/time.h
+++ b/lib/uktime/musl-imported/include/time.h
@@ -42,29 +42,29 @@ struct tm {
 	const char *__tm_zone;
 };
 
-clock_t clock (void);
-time_t time (time_t *);
-double difftime (time_t, time_t);
-time_t mktime (struct tm *);
-size_t strftime (char *__restrict, size_t, const char *__restrict, const struct tm *__restrict);
-struct tm *gmtime (const time_t *);
-struct tm *localtime (const time_t *);
-char *asctime (const struct tm *);
-char *ctime (const time_t *);
+clock_t clock(void);
+time_t time(time_t *);
+double difftime(time_t, time_t);
+time_t mktime(struct tm *);
+size_t strftime(char *__restrict, size_t, const char *__restrict, const struct tm *__restrict);
+struct tm *gmtime(const time_t *);
+struct tm *localtime(const time_t *);
+char *asctime(const struct tm *);
+char *ctime(const time_t *);
 int timespec_get(struct timespec *, int);
 
 #define CLOCKS_PER_SEC 1000000L
 
 #define TIME_UTC 1
 
-size_t strftime_l (char *  __restrict, size_t, const char *  __restrict, const struct tm *  __restrict, locale_t);
+size_t strftime_l(char *__restrict, size_t, const char *__restrict, const struct tm *__restrict, locale_t);
 
-struct tm *gmtime_r (const time_t *__restrict, struct tm *__restrict);
-struct tm *localtime_r (const time_t *__restrict, struct tm *__restrict);
-char *asctime_r (const struct tm *__restrict, char *__restrict);
-char *ctime_r (const time_t *, char *);
+struct tm *gmtime_r(const time_t *__restrict, struct tm *__restrict);
+struct tm *localtime_r(const time_t *__restrict, struct tm *__restrict);
+char *asctime_r(const struct tm *__restrict, char *__restrict);
+char *ctime_r(const time_t *, char *);
 
-void tzset (void);
+void tzset(void);
 
 struct itimerspec {
 	struct timespec it_interval;
@@ -86,19 +86,19 @@ struct itimerspec {
 
 #define TIMER_ABSTIME 1
 
-int nanosleep (const struct timespec *, struct timespec *);
-int clock_getres (clockid_t, struct timespec *);
-int clock_gettime (clockid_t, struct timespec *);
-int clock_settime (clockid_t, const struct timespec *);
-int clock_nanosleep (clockid_t, int, const struct timespec *, struct timespec *);
-int clock_getcpuclockid (pid_t, clockid_t *);
+int nanosleep(const struct timespec *, struct timespec *);
+int clock_getres(clockid_t, struct timespec *);
+int clock_gettime(clockid_t, struct timespec *);
+int clock_settime(clockid_t, const struct timespec *);
+int clock_nanosleep(clockid_t, int, const struct timespec *, struct timespec *);
+int clock_getcpuclockid(pid_t, clockid_t *);
 
 struct sigevent;
-int timer_create (clockid_t, struct sigevent *__restrict, timer_t *__restrict);
-int timer_delete (timer_t);
-int timer_settime (timer_t, int, const struct itimerspec *__restrict, struct itimerspec *__restrict);
-int timer_gettime (timer_t, struct itimerspec *);
-int timer_getoverrun (timer_t);
+int timer_create(clockid_t, struct sigevent *__restrict, timer_t *__restrict);
+int timer_delete(timer_t);
+int timer_settime(timer_t, int, const struct itimerspec *__restrict, struct itimerspec *__restrict);
+int timer_gettime(timer_t, struct itimerspec *);
+int timer_getoverrun(timer_t);
 
 extern char *tzname[2];
 
@@ -107,7 +107,7 @@ char *strptime (const char *__restrict, const char *__restrict, struct tm *__res
 extern int daylight;
 extern long timezone;
 extern int getdate_err;
-struct tm *getdate (const char *);
+struct tm *getdate(const char *);
 #endif
 
 

--- a/lib/uktime/musl-imported/src/__secs_to_tm.c
+++ b/lib/uktime/musl-imported/src/__secs_to_tm.c
@@ -30,7 +30,8 @@ int __secs_to_tm(long long t, struct tm *tm)
 	}
 
 	wday = (3+days)%7;
-	if (wday < 0) wday += 7;
+	if (wday < 0)
+		wday += 7;
 
 	qc_cycles = days / DAYS_PER_400Y;
 	remdays = days % DAYS_PER_400Y;

--- a/lib/vfscore/dentry.c
+++ b/lib/vfscore/dentry.c
@@ -69,7 +69,7 @@ struct dentry *
 dentry_alloc(struct dentry *parent_dp, struct vnode *vp, const char *path)
 {
 	struct mount *mp = vp->v_mount;
-	struct dentry *dp = (struct dentry*)calloc(sizeof(*dp), 1);
+	struct dentry *dp = (struct dentry *)calloc(sizeof(*dp), 1);
 
 	if (!dp) {
 		return NULL;

--- a/lib/vfscore/include/vfscore/file.h
+++ b/lib/vfscore/include/vfscore/file.h
@@ -73,8 +73,8 @@ void vfscore_put_file(struct vfscore_file *file);
 /*
  * File descriptors reference count
  */
-void fhold(struct vfscore_file* fp);
-int fdrop(struct vfscore_file* fp);
+void fhold(struct vfscore_file *fp);
+int fdrop(struct vfscore_file *fp);
 
 #define FOF_OFFSET  0x0800    /* Use the offset in uio argument */
 

--- a/lib/vfscore/lookup.c
+++ b/lib/vfscore/lookup.c
@@ -55,11 +55,11 @@ read_link(struct vnode *vp, char *buf, size_t bufsz, ssize_t *sz)
 	vn_unlock(vp);
 
 	if (rc != 0) {
-		return (rc);
+		return rc;
 	}
 
 	*sz = bufsz - uio.uio_resid;
-	return (0);
+	return 0;
 }
 
 int
@@ -74,7 +74,7 @@ namei_follow_link(struct dentry *dp, char *node, char *name, char *fp, size_t mo
 
 	error = read_link(dp->d_vnode, link, PATH_MAX, &sz);
 	if (error != 0) {
-		return (error);
+		return error;
 	}
 	link[sz] = 0;
 
@@ -93,7 +93,7 @@ namei_follow_link(struct dentry *dp, char *node, char *name, char *fp, size_t mo
 	}
 	node[0] = 0;
 	name[0] = 0;
-	return (0);
+	return 0;
 }
 /*
  * Convert a pathname into a pointer to a dentry
@@ -205,7 +205,7 @@ namei(const char *path, struct dentry **dpp)
 				error = namei_follow_link(dp, node, name, fp, mountpoint_len);
 				if (error) {
 					drele(dp);
-					return (error);
+					return error;
 				}
 
 				drele(dp);
@@ -219,7 +219,7 @@ namei(const char *path, struct dentry **dpp)
 				node[0] = 0;
 
 				if (++links_followed >= MAXSYMLINKS) {
-					return (ELOOP);
+					return ELOOP;
 				}
 				need_continue = 1;
 				break;
@@ -258,18 +258,18 @@ namei_last_nofollow(char *path, struct dentry *ddp, struct dentry **dpp)
 	dvp  = NULL;
 
 	if (path[0] != '/') {
-		return (ENOTDIR);
+		return ENOTDIR;
 	}
 
 	name = strrchr(path, '/');
 	if (name == NULL) {
-		return (ENOENT);
+		return ENOENT;
 	}
 	name++;
 
 	error = vfs_findroot(path, &mp, &p);
 	if (error != 0) {
-		return (ENOTDIR);
+		return ENOTDIR;
 	}
 
 	strlcpy(node, "/", PATH_MAX);

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -960,8 +960,7 @@ UK_TRACEPOINT(trace_vfs_readdir, "%d %p", int, struct dirent*);
 UK_TRACEPOINT(trace_vfs_readdir_ret, "");
 UK_TRACEPOINT(trace_vfs_readdir_err, "%d", int);
 
-struct __dirstream
-{
+struct __dirstream {
 	int fd;
 };
 
@@ -1039,14 +1038,14 @@ int scandir(const char *path, struct dirent ***res,
 	int (*cmp)(const struct dirent **, const struct dirent **))
 {
 	DIR *d = opendir(path);
-	struct dirent *de, **names=0, **tmp;
-	size_t cnt=0, len=0;
+	struct dirent *de, **names = 0, **tmp;
+	size_t cnt = 0, len = 0;
 	int old_errno = errno;
 
 	if (!d)
 		return -1;
 
-	while ((errno=0), (de = readdir(d))) {
+	while ((errno = 0), (de = readdir(d))) {
 		if (sel && !sel(de))
 			continue;
 		if (cnt >= len) {
@@ -1068,7 +1067,7 @@ int scandir(const char *path, struct dirent ***res,
 
 	if (errno) {
 		if (names)
-			while (cnt-->0)
+			while (cnt-- > 0)
 				free(names[cnt]);
 		free(names);
 		return -1;
@@ -1757,7 +1756,7 @@ UK_SYSCALL_R_DEFINE(char*, getcwd, char*, path, size_t, size)
 	if (!path) {
 		if (!size)
 			size = len;
-		path = (char*)malloc(size);
+		path = (char *)malloc(size);
 		if (!path) {
 			error = ENOMEM;
 			goto out_error;
@@ -1867,7 +1866,7 @@ UK_SYSCALL_R_DEFINE(int, dup3, int, oldfd, int, newfd, int, flags)
 
 	out_error:
 	trace_vfs_dup3_err(error);
-	if(error > 0)
+	if (error > 0)
 		return -error;
 	return error;
 }
@@ -2070,7 +2069,7 @@ int euidaccess(const char *pathname, int mode)
 	return access(pathname, mode);
 }
 
-__weak_alias(euidaccess,eaccess);
+__weak_alias(euidaccess, eaccess);
 
 #if 0
 /*
@@ -2260,7 +2259,7 @@ UK_SYSCALL_DEFINE(int, futimesat, int, dirfd, const char*, pathname, const struc
 			goto out_errno;
 		}
 
-		if (!S_ISDIR(st.st_mode)){
+		if (!S_ISDIR(st.st_mode)) {
 			error = ENOTDIR;
 			goto out_errno;
 		}
@@ -2271,7 +2270,7 @@ UK_SYSCALL_DEFINE(int, futimesat, int, dirfd, const char*, pathname, const struc
 		goto out_errno;
 
 	/* build absolute path */
-	absolute_path = (char*)malloc(PATH_MAX);
+	absolute_path = (char *)malloc(PATH_MAX);
 	if (!absolute_path) {
 		fdrop(fp);
 		error = EFAULT;
@@ -2527,7 +2526,7 @@ ssize_t sendfile(int out_fd, int in_fd, off_t *_offset, size_t count)
 
 	if (ret < 0) {
 		return libc_error(errno);
-	} else if(_offset == nullptr) {
+	} else if (_offset == nullptr) {
 		lseek(in_fd, ret, SEEK_CUR);
 	} else {
 		*_offset += ret;

--- a/lib/vfscore/mount.c
+++ b/lib/vfscore/mount.c
@@ -322,7 +322,7 @@ sys_pivot_root(const char *new_root, const char *put_old)
 	int error;
 
 	WITH_LOCK(mount_lock) {
-		for (auto&& mp : mount_list) {
+		for (auto && mp : mount_list) {
 			if (!strcmp(mp->m_path, new_root)) {
 				newmp = mp;
 			}
@@ -333,7 +333,7 @@ sys_pivot_root(const char *new_root, const char *put_old)
 		if (!newmp || !oldmp || newmp == oldmp) {
 			return EINVAL;
 		}
-		for (auto&& mp : mount_list) {
+		for (auto && mp : mount_list) {
 			if (mp == newmp || mp == oldmp) {
 				continue;
 			}

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -71,7 +71,7 @@ open_no_follow_chk(char *path)
 
 	error = lookup(path, &ddp, &name);
 	if (error) {
-		return (error);
+		return error;
 	}
 
 	error = namei_last_nofollow(path, ddp, &dp);
@@ -159,7 +159,7 @@ sys_open(char *path, int flags, mode_t mode, struct vfscore_file **fpp)
 		if (flags & O_NOFOLLOW) {
 			error = open_no_follow_chk(path);
 			if (error != 0) {
-				return (error);
+				return error;
 			}
 		}
 		error = namei(path, &dp);
@@ -179,8 +179,8 @@ sys_open(char *path, int flags, mode_t mode, struct vfscore_file **fpp)
 		}
 		if (flags & O_DIRECTORY) {
 		    if (vp->v_type != VDIR) {
-		        error = ENOTDIR;
-		        goto out_drele;
+				error = ENOTDIR;
+				goto out_drele;
 		    }
 		}
 	}
@@ -729,13 +729,13 @@ sys_rename(char *src, char *dest)
 
 	error = lookup(src, &ddp1, &sname);
 	if (error != 0) {
-		return (error);
+		return error;
 	}
 
 	error = namei_last_nofollow(src, ddp1, &dp1);
 	if (error != 0) {
 		drele(ddp1);
-		return (error);
+		return error;
 	}
 
 	vp1 = dp1->d_vnode;
@@ -871,7 +871,7 @@ sys_symlink(const char *oldpath, const char *newpath)
 	char		*name;
 
 	if (oldpath == NULL || newpath == NULL) {
-		return (EFAULT);
+		return EFAULT;
 	}
 
 	DPRINTF(VFSDB_SYSCALL, ("sys_link: oldpath=%s newpath=%s\n",
@@ -882,7 +882,7 @@ sys_symlink(const char *oldpath, const char *newpath)
 
 	error = task_conv(t, newpath, VWRITE, np);
 	if (error != 0) {
-		return (error);
+		return error;
 	}
 
 	/* parent directory for new path must exist */
@@ -1000,7 +1000,7 @@ sys_unlink(char *path)
 
 	error = lookup(path, &ddp, &name);
 	if (error != 0) {
-		return (error);
+		return error;
 	}
 
 	error = namei_last_nofollow(path, ddp, &dp);
@@ -1103,7 +1103,7 @@ int sys_lstat(char *path, struct stat *st)
 
 	error = lookup(path, &ddp, &name);
 	if (error) {
-		return (error);
+		return error;
 	}
 
 	error = namei_last_nofollow(path, ddp, &dp);
@@ -1223,19 +1223,19 @@ sys_readlink(char *path, char *buf, size_t bufsize, ssize_t *size)
 	*size = 0;
 	error = lookup(path, &ddp, &name);
 	if (error) {
-		return (error);
+		return error;
 	}
 
 	error = namei_last_nofollow(path, ddp, &dp);
 	if (error) {
 		drele(ddp);
-		return (error);
+		return error;
 	}
 
 	if (dp->d_vnode->v_type != VLNK) {
 		drele(dp);
 		drele(ddp);
-		return (EINVAL);
+		return EINVAL;
 	}
 	vec.iov_base	= buf;
 	vec.iov_len	= bufsize;
@@ -1255,11 +1255,11 @@ sys_readlink(char *path, char *buf, size_t bufsize, ssize_t *size)
 	drele(ddp);
 
 	if (error) {
-		return (error);
+		return error;
 	}
 
 	*size = bufsize - uio.uio_resid;
-	return (0);
+	return 0;
 }
 
 /*
@@ -1362,7 +1362,7 @@ sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], i
 	struct dentry *dp;
 
 	/* utimensat should return ENOENT when pathname is empty */
-	if(pathname && pathname[0] == 0)
+	if (pathname && pathname[0] == 0)
 		return ENOENT;
 
 	if (flags && !(flags & AT_SYMLINK_NOFOLLOW))

--- a/lib/vfscore/task.c
+++ b/lib/vfscore/task.c
@@ -119,7 +119,7 @@ path_conv(char *wd, const char *cpath, char *full)
 	}
 	*tgt = '\0';
 
-	return (0);
+	return 0;
 }
 
 /*
@@ -136,7 +136,7 @@ task_conv(struct task *t, const char *cpath, int acc __unused, char *full)
 
 	rc = path_conv(t->t_cwd, cpath, full);
 	if (rc != 0) {
-		return (rc);
+		return rc;
 	}
 
 	/* Check if the client task has required permission */

--- a/lib/vfscore/vfs.h
+++ b/lib/vfscore/vfs.h
@@ -58,7 +58,7 @@ extern int vfs_debug;
 
 #define VFSDB_FLAGS	0x00000013
 
-#define	DPRINTF(_m,X)	if (vfs_debug & (_m)) uk_pr_debug X
+#define	DPRINTF(_m, X)	if (vfs_debug & (_m)) uk_pr_debug X
 #else
 #define	DPRINTF(_m, X)
 #endif
@@ -78,7 +78,7 @@ int	 sys_read(struct vfscore_file *fp, const struct iovec *iov, size_t niov,
 		off_t offset, size_t *count);
 int	 sys_write(struct vfscore_file *fp, const struct iovec *iov, size_t niov,
 		off_t offset, size_t *count);
-int	 sys_lseek(struct vfscore_file *fp, off_t off, int type, off_t * cur_off);
+int	 sys_lseek(struct vfscore_file *fp, off_t off, int type, off_t *cur_off);
 int	 sys_ioctl(struct vfscore_file *fp, unsigned long request, void *buf);
 int	 sys_fstat(struct vfscore_file *fp, struct stat *st);
 int	 sys_fstatfs(struct vfscore_file *fp, struct statfs *buf);

--- a/lib/vfscore/vnode.c
+++ b/lib/vfscore/vnode.c
@@ -134,10 +134,10 @@ vn_path(struct vnode *vp)
 	struct dentry *dp;
 
 	if (uk_list_empty(&vp->v_names) == 1) {
-		return (" ");
+		return " ";
 	}
 	dp = uk_list_first_entry(&vp->v_names, struct dentry, d_names_link);
-	return (dp->d_path);
+	return dp->d_path;
 }
 #endif
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This resolves issue #199, Clean up pre-rigorous use of checkpatch errors and warnings, implemented mainly through syntax changes