### PR TITLE
arch/arm64: Do not pass -march with -mcpu

### DIFF
--- a/arch/arm/arm64/Config.uk
+++ b/arch/arm/arm64/Config.uk
@@ -23,6 +23,16 @@ choice
 		help
 			Compile for Generic Armv8 compatible CPUs.
 
+	config MCPU_ARM64_CORTEX_A34
+		bool "Cortex-A34"
+		help
+			Compile and optimize for Cortex-A34 CPUs.
+
+	config MCPU_ARM64_CORTEX_A35
+		bool "Cortex-A35"
+		help
+			Compile and optimize for Cortex-A35 CPUs.
+
 	config MCPU_ARM64_CORTEX_A53
 		bool "Cortex-A53"
 		help
@@ -38,20 +48,101 @@ choice
 		help
 			Compile and optimize for Cortex-A57 CPUs.
 
+	config MCPU_ARM64_CORTEX_A57_A53
+		bool "Cortex-A57 / Cortex-A53 big.LITTLE"
+		help
+			Compile and optimize for Cortex-A57 / Cortex-A53
+			big.LITTLE CPUs.
+
+	config MCPU_ARM64_CORTEX_A65
+		bool "Cortex-A65"
+		help
+			Compile and optimize for Cortex-A65 CPUs.
+
+	config MCPU_ARM64_CORTEX_A65AE
+		bool "Cortex-A65AE"
+		help
+			Compile and optimize for Cortex-A65AE CPUs.
+
 	config MCPU_ARM64_CORTEX_A72
 		bool "Cortex-A72"
 		help
 			Compile and optimize for Cortex-A72 CPUs.
+
+	config MCPU_ARM64_CORTEX_A72_A53
+		bool "Cortex-A72 / Cortex-A53 big.LITTLE"
+		help
+			Compile and optimize for Cortex-A72 / Cortex-A53
+			big.LITTLE CPUs.
 
 	config MCPU_ARM64_CORTEX_A73
 		bool "Cortex-A73"
 		help
 			Compile and optimize for Cortex-A73 CPUs.
 
+	config MCPU_ARM64_CORTEX_A73_A35
+		bool "Cortex-A73 / Cortex-A35 big.LITTLE"
+		help
+			Compile and optimize for Cortex-A73 / Cortex-A35
+			big.LITTLE CPUs.
+
+	config MCPU_ARM64_CORTEX_A73_A53
+		bool "Cortex-A73 / Cortex-A53 big.LITTLE"
+		help
+			Compile and optimize for Cortex-A73 / Cortex-A53
+			big.LITTLE CPUs.
+
 	config MCPU_ARM64_CORTEX_A75
 		bool "Cortex-A75"
 		help
 			Compile and optimize for Cortex-A75 CPUs.
+
+	config MCPU_ARM64_CORTEX_A76
+		bool "Cortex-A76"
+		help
+			Compile and optimize for Cortex-A76 CPUs.
+
+	config MCPU_ARM64_CORTEX_A76AE
+		bool "Cortex-A76AE"
+		help
+			Compile and optimize for Cortex-A76AE CPUs.
+
+	config MCPU_ARM64_CORTEX_A75_A55
+		bool "Cortex-A75 / Cortex-A55 DynamIQ"
+		help
+			Compile and optimize for Cortex-A75 / Cortex-A55 DynamIQ
+			big.LITTLE CPUs.
+
+	config MCPU_ARM64_CORTEX_A76_A55
+		bool "Cortex-A76 / Cortex-A55 DynamIQ"
+		help
+			Compile and optimize for Cortex-A76 / Cortex-A55 DynamIQ
+			big.LITTLE CPUs.
+
+	config MCPU_ARM64_CORTEX_A77
+		bool "Cortex-A77"
+		help
+			Compile and optimize for Cortex-A77 CPUs.
+
+	config MCPU_ARM64_NEOVERSE_E1
+		bool "Neoverse E1"
+		help
+			Compile and optimize for Neoverse E1 CPUs.
+
+	config MCPU_ARM64_NEOVERSE_N1
+		bool "Neoverse N1"
+		help
+			Compile and optimize for Neoverse N1 CPUs.
+
+	config MCPU_ARM64_NEOVERSE_N2
+		bool "Neoverse N2"
+		help
+			Compile and optimize for Neoverse N2 CPUs.
+
+	config MCPU_ARM64_NEOVERSE_V1
+		bool "Neoverse V1"
+		help
+			Compile and optimize for Neoverse V1 CPUs.
 endchoice
 
 config ARM64_ERRATUM_858921

--- a/arch/arm/arm64/Config.uk
+++ b/arch/arm/arm64/Config.uk
@@ -1,50 +1,57 @@
 choice
-	prompt "Processor Optimization"
-	default MARCH_ARM64_GENERIC
+	prompt "Target Processor"
+	default MCPU_ARM64_NONE
 	help
-		Optimize the code for selected target processor
+		Compile and optimize the code for selected target processor.
+		This automatically enables/disables architecture extensions
+		and applies compiler optimizations for the target processor.
 
-config MARCH_ARM64_NATIVE
-	bool "Auto-detect host CPU"
-	help
-		Optimize compilation to host CPU. Please note that this
-		option will fail in case of cross-compilation
+	config MCPU_ARM64_NONE
+		bool "None"
+		help
+			Do not compile for a specific CPU. This allows choosing
+			individual architecture extensions or features.
 
-config MARCH_ARM64_GENERIC
-	bool "Generic Armv8 CPU"
-	help
-		Compile for Generic Armv8 compatible CPUs
+	config MCPU_ARM64_NATIVE
+		bool "Auto-detect host CPU"
+		help
+			Compile and optimize for the host CPU. Please note that this
+			option will fail in case of cross-compilation.
 
-config MARCH_ARM64_CORTEXA53
-	bool "Generic Armv8 Cortex A53"
-	help
-		Compile for Armv8 Cortex-A53 (and compatible) CPUs
+	config MCPU_ARM64_GENERIC
+		bool "Generic Armv8 CPU"
+		help
+			Compile for Generic Armv8 compatible CPUs.
 
-config MARCH_ARM64_CORTEXA57
-	bool "Generic Armv8 Cortex A57"
-	help
-		Compile for Armv8 Cortex-A57 (and compatible) CPUs
+	config MCPU_ARM64_CORTEX_A53
+		bool "Cortex-A53"
+		help
+			Compile and optimize for Cortex-A53 CPUs.
 
-config MARCH_ARM64_CORTEXA72
-	bool "Generic Armv8 Cortex A72"
-	help
-		Compile for Armv8 Cortex-A72 (and compatible) CPUs
+	config MCPU_ARM64_CORTEX_A55
+		bool "Cortex-A55"
+		help
+			Compile and optimize for Cortex-A55 CPUs.
 
-config MARCH_ARM64_CORTEXA73
-	bool "Generic Armv8 Cortex A73"
-	help
-		Compile for Armv8 Cortex-A73 (and compatible) CPUs
+	config MCPU_ARM64_CORTEX_A57
+		bool "Cortex-A57"
+		help
+			Compile and optimize for Cortex-A57 CPUs.
 
-config MARCH_ARM64_CORTEXA55
-	bool "Generic Armv8.2 Cortex A55"
-	help
-		Compile for Armv8.2 Cortex-A55 (and compatible) CPUs
+	config MCPU_ARM64_CORTEX_A72
+		bool "Cortex-A72"
+		help
+			Compile and optimize for Cortex-A72 CPUs.
 
-config MARCH_ARM64_CORTEXA75
-	bool "Generic Armv8.2 Cortex A75"
-	help
-		Compile for Armv8.2 Cortex-A75 (and compatible) CPUs
+	config MCPU_ARM64_CORTEX_A73
+		bool "Cortex-A73"
+		help
+			Compile and optimize for Cortex-A73 CPUs.
 
+	config MCPU_ARM64_CORTEX_A75
+		bool "Cortex-A75"
+		help
+			Compile and optimize for Cortex-A75 CPUs.
 endchoice
 
 config ARM64_ERRATUM_858921

--- a/arch/arm/arm64/Makefile.uk
+++ b/arch/arm/arm64/Makefile.uk
@@ -17,57 +17,57 @@ ASINCLUDES  += -I$(CONFIG_UK_BASE)/arch/arm/arm64/include
 CXXINCLUDES += -I$(CONFIG_UK_BASE)/arch/arm/arm64/include
 
 # GCC support -mcpu=native for arm64 from 6.0
-ifeq ($(CONFIG_MARCH_ARM64_NATIVE),y)
+ifeq ($(CONFIG_MCPU_ARM64_NATIVE),y)
 $(call error_if_gcc_version_lt,6,0)
 ARCHFLAGS-$(call gcc_version_ge,6,0)     += -mcpu=native
 ISR_ARCHFLAGS-$(call gcc_version_ge,6,0) += -mcpu=native
 endif
 
 # GCC support -mcpu=generic for arm64 from 4.8
-ifeq ($(CONFIG_MARCH_ARM64_GENERIC),y)
+ifeq ($(CONFIG_MCPU_ARM64_GENERIC),y)
 $(call error_if_gcc_version_lt,4,8)
-ARCHFLAGS-$(call gcc_version_ge,4,8)     += -march=armv8-a -mcpu=generic -mtune=generic
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,8) += -march=armv8-a -mcpu=generic -mtune=generic
+ARCHFLAGS-$(call gcc_version_ge,4,8)     += -mcpu=generic -mtune=generic
+ISR_ARCHFLAGS-$(call gcc_version_ge,4,8) += -mcpu=generic -mtune=generic
 endif
 
 # GCC support -mcpu=cortex-a53 for arm64 from 4.9
-ifeq ($(CONFIG_MARCH_ARM64_CORTEXA53),y)
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A53),y)
 $(call error_if_gcc_version_lt,4,9)
-ARCHFLAGS-$(call gcc_version_ge,4,9)     += -march=armv8-a -mcpu=cortex-a53 -mtune=cortex-a53
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -march=armv8-a -mcpu=cortex-a53 -mtune=cortex-a53
+ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mcpu=cortex-a53 -mtune=cortex-a53
+ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mcpu=cortex-a53 -mtune=cortex-a53
 endif
 
 # GCC support -mcpu=cortex-a57 for arm64 from 4.9
-ifeq ($(CONFIG_MARCH_ARM64_CORTEXA57),y)
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A57),y)
 $(call error_if_gcc_version_lt,4,9)
-ARCHFLAGS-$(call gcc_version_ge,4,9)     += -march=armv8-a -mcpu=cortex-a57 -mtune=cortex-a57
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -march=armv8-a -mcpu=cortex-a57 -mtune=cortex-a57
+ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mcpu=cortex-a57 -mtune=cortex-a57
+ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mcpu=cortex-a57 -mtune=cortex-a57
 endif
 
 # GCC support -mcpu=cortex-a72 for arm64 from 5.0
-ifeq ($(CONFIG_MARCH_ARM64_CORTEXA72),y)
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A72),y)
 $(call error_if_gcc_version_lt,5,0)
-ARCHFLAGS-$(call gcc_version_ge,5,0)     += -march=armv8-a -mcpu=cortex-a72 -mtune=cortex-a72
-ISR_ARCHFLAGS-$(call gcc_version_ge,5,0) += -march=armv8-a -mcpu=cortex-a72 -mtune=cortex-a72
+ARCHFLAGS-$(call gcc_version_ge,5,0)     += -mcpu=cortex-a72 -mtune=cortex-a72
+ISR_ARCHFLAGS-$(call gcc_version_ge,5,0) += -mcpu=cortex-a72 -mtune=cortex-a72
 endif
 
 # GCC support -mcpu=cortex-a73 for arm64 from 7.0
-ifeq ($(CONFIG_MARCH_ARM64_CORTEXA73),y)
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A73),y)
 $(call error_if_gcc_version_lt,7,0)
-ARCHFLAGS-$(call gcc_version_ge,7,0)     += -march=armv8-a -mcpu=cortex-a73 -mtune=cortex-a73
-ISR_ARCHFLAGS-$(call gcc_version_ge,7,0) += -march=armv8-a -mcpu=cortex-a73 -mtune=cortex-a73
+ARCHFLAGS-$(call gcc_version_ge,7,0)     += -mcpu=cortex-a73 -mtune=cortex-a73
+ISR_ARCHFLAGS-$(call gcc_version_ge,7,0) += -mcpu=cortex-a73 -mtune=cortex-a73
 endif
 
 # GCC support -mcpu=cortex-a55 for arm64 from 8.0
-ifeq ($(CONFIG_MARCH_ARM64_CORTEXA55),y)
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A55),y)
 $(call error_if_gcc_version_lt,8,0)
-ARCHFLAGS-$(call gcc_version_ge,8,0)     += -march=armv8.2-a -mcpu=cortex-a55 -mtune=cortex-a55
-ISR_ARCHFLAGS-$(call gcc_version_ge,8,0) += -march=armv8.2-a -mcpu=cortex-a55 -mtune=cortex-a55
+ARCHFLAGS-$(call gcc_version_ge,8,0)     += -mcpu=cortex-a55 -mtune=cortex-a55
+ISR_ARCHFLAGS-$(call gcc_version_ge,8,0) += -mcpu=cortex-a55 -mtune=cortex-a55
 endif
 
 # GCC support -mcpu=cortex-a75 for arm64 from 8.0
-ifeq ($(CONFIG_MARCH_ARM64_CORTEXA75),y)
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A75),y)
 $(call error_if_gcc_version_lt,8,0)
-ARCHFLAGS-$(call gcc_version_ge,8,0)     += -march=armv8.2-a -mcpu=cortex-a75 -mtune=cortex-a75
-ISR_ARCHFLAGS-$(call gcc_version_ge,8,0) += -march=armv8.2-a -mcpu=cortex-a75 -mtune=cortex-a75
+ARCHFLAGS-$(call gcc_version_ge,8,0)     += -mcpu=cortex-a75 -mtune=cortex-a75
+ISR_ARCHFLAGS-$(call gcc_version_ge,8,0) += -mcpu=cortex-a75 -mtune=cortex-a75
 endif

--- a/arch/arm/arm64/Makefile.uk
+++ b/arch/arm/arm64/Makefile.uk
@@ -44,6 +44,15 @@ ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mcpu=cortex-a57 -mtune=cortex-a57
 ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mcpu=cortex-a57 -mtune=cortex-a57
 endif
 
+# GCC support -mcpu=cortex-a57.cortex-a53 for arm64 from 4.9
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A57_A53),y)
+$(call error_if_gcc_version_lt,4,9)
+ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mcpu=cortex-a57.cortex-a53
+ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mtune=cortex-a57.cortex-a53
+ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mcpu=cortex-a57.cortex-a53
+ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mtune=cortex-a57.cortex-a53
+endif
+
 # GCC support -mcpu=cortex-a72 for arm64 from 5.0
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A72),y)
 $(call error_if_gcc_version_lt,5,0)
@@ -51,11 +60,45 @@ ARCHFLAGS-$(call gcc_version_ge,5,0)     += -mcpu=cortex-a72 -mtune=cortex-a72
 ISR_ARCHFLAGS-$(call gcc_version_ge,5,0) += -mcpu=cortex-a72 -mtune=cortex-a72
 endif
 
+# GCC support -mcpu=cortex-a72.cortex-a53 for arm64 from 5.0
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A72_A53),y)
+$(call error_if_gcc_version_lt,5,0)
+ARCHFLAGS-$(call gcc_version_ge,5,0)     += -mcpu=cortex-a72.cortex-a53
+ARCHFLAGS-$(call gcc_version_ge,5,0)     += -mtune=cortex-a72.cortex-a53
+ISR_ARCHFLAGS-$(call gcc_version_ge,5,0) += -mcpu=cortex-a72.cortex-a53
+ISR_ARCHFLAGS-$(call gcc_version_ge,5,0) += -mtune=cortex-a72.cortex-a53
+endif
+
+# GCC support -mcpu=cortex-a35 for arm64 from 6.0
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A35),y)
+$(call error_if_gcc_version_lt,6,0)
+ARCHFLAGS-$(call gcc_version_ge,6,0)     += -mcpu=cortex-a35 -mtune=cortex-a35
+ISR_ARCHFLAGS-$(call gcc_version_ge,6,0) += -mcpu=cortex-a35 -mtune=cortex-a35
+endif
+
 # GCC support -mcpu=cortex-a73 for arm64 from 7.0
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A73),y)
 $(call error_if_gcc_version_lt,7,0)
 ARCHFLAGS-$(call gcc_version_ge,7,0)     += -mcpu=cortex-a73 -mtune=cortex-a73
 ISR_ARCHFLAGS-$(call gcc_version_ge,7,0) += -mcpu=cortex-a73 -mtune=cortex-a73
+endif
+
+# GCC support -mcpu=cortex-a73.cortex-a35 for arm64 from 7.0
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A73_A35),y)
+$(call error_if_gcc_version_lt,7,0)
+ARCHFLAGS-$(call gcc_version_ge,7,0)     += -mcpu=cortex-a73.cortex-a35
+ARCHFLAGS-$(call gcc_version_ge,7,0)     += -mtune=cortex-a73.cortex-a35
+ISR_ARCHFLAGS-$(call gcc_version_ge,7,0) += -mcpu=cortex-a73.cortex-a35
+ISR_ARCHFLAGS-$(call gcc_version_ge,7,0) += -mtune=cortex-a73.cortex-a35
+endif
+
+# GCC support -mcpu=cortex-a73.cortex-a53 for arm64 from 7.0
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A73_A53),y)
+$(call error_if_gcc_version_lt,7,0)
+ARCHFLAGS-$(call gcc_version_ge,7,0)     += -mcpu=cortex-a73.cortex-a53
+ARCHFLAGS-$(call gcc_version_ge,7,0)     += -mtune=cortex-a73.cortex-a53
+ISR_ARCHFLAGS-$(call gcc_version_ge,7,0) += -mcpu=cortex-a73.cortex-a53
+ISR_ARCHFLAGS-$(call gcc_version_ge,7,0) += -mtune=cortex-a73.cortex-a53
 endif
 
 # GCC support -mcpu=cortex-a55 for arm64 from 8.0
@@ -70,4 +113,92 @@ ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A75),y)
 $(call error_if_gcc_version_lt,8,0)
 ARCHFLAGS-$(call gcc_version_ge,8,0)     += -mcpu=cortex-a75 -mtune=cortex-a75
 ISR_ARCHFLAGS-$(call gcc_version_ge,8,0) += -mcpu=cortex-a75 -mtune=cortex-a75
+endif
+
+# GCC support -mcpu=cortex-a75.cortex-a55 for arm64 from 8.0
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A75_A55),y)
+$(call error_if_gcc_version_lt,8,0)
+ARCHFLAGS-$(call gcc_version_ge,8,0)     += -mcpu=cortex-a75.cortex-a55
+ARCHFLAGS-$(call gcc_version_ge,8,0)     += -mtune=cortex-a75.cortex-a55
+ISR_ARCHFLAGS-$(call gcc_version_ge,8,0) += -mcpu=cortex-a75.cortex-a55
+ISR_ARCHFLAGS-$(call gcc_version_ge,8,0) += -mtune=cortex-a75.cortex-a55
+endif
+
+# GCC support -mcpu=cortex-a76 for arm64 from 9.1
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A76),y)
+$(call error_if_gcc_version_lt,9,1)
+ARCHFLAGS-$(call gcc_version_ge,9,1)     += -mcpu=cortex-a76 -mtune=cortex-a76
+ISR_ARCHFLAGS-$(call gcc_version_ge,9,1) += -mcpu=cortex-a76 -mtune=cortex-a76
+endif
+
+# GCC support -mcpu=cortex-a76.cortex-a55 for arm64 from 9.1
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A76_A55),y)
+$(call error_if_gcc_version_lt,9,1)
+ARCHFLAGS-$(call gcc_version_ge,9,1)     += -mcpu=cortex-a76.cortex-a55
+ARCHFLAGS-$(call gcc_version_ge,9,1)     += -mtune=cortex-a76.cortex-a55
+ISR_ARCHFLAGS-$(call gcc_version_ge,9,1) += -mcpu=cortex-a76.cortex-a55
+ISR_ARCHFLAGS-$(call gcc_version_ge,9,1) += -mtune=cortex-a76.cortex-a55
+endif
+
+# GCC support -mcpu=neoverse-n1 for arm64 from 9.1
+ifeq ($(CONFIG_MCPU_ARM64_NEOVERSE_N1),y)
+$(call error_if_gcc_version_lt,9,1)
+ARCHFLAGS-$(call gcc_version_ge,9,1)     += -mcpu=neoverse-n1 -mtune=neoverse-n1
+ISR_ARCHFLAGS-$(call gcc_version_ge,9,1) += -mcpu=neoverse-n1 -mtune=neoverse-n1
+endif
+
+# GCC support -mcpu=neoverse-e1 for arm64 from 9.1
+ifeq ($(CONFIG_MCPU_ARM64_NEOVERSE_E1),y)
+$(call error_if_gcc_version_lt,9,1)
+ARCHFLAGS-$(call gcc_version_ge,9,1)     += -mcpu=neoverse-e1 -mtune=neoverse-e1
+ISR_ARCHFLAGS-$(call gcc_version_ge,9,1) += -mcpu=neoverse-e1 -mtune=neoverse-e1
+endif
+
+# GCC support -mcpu=cortex-a34 for arm64 from 10.1
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A34),y)
+$(call error_if_gcc_version_lt,10,1)
+ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=cortex-a34 -mtune=cortex-a34
+ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=cortex-a34 -mtune=cortex-a34
+endif
+
+# GCC support -mcpu=cortex-a65 for arm64 from 10.1
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A65),y)
+$(call error_if_gcc_version_lt,10,1)
+ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=cortex-a65 -mtune=cortex-a65
+ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=cortex-a65 -mtune=cortex-a65
+endif
+
+# GCC support -mcpu=cortex-a65ae for arm64 from 10.1
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A65AE),y)
+$(call error_if_gcc_version_lt,10,1)
+ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=cortex-a65ae -mtune=cortex-a65ae
+ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=cortex-a65ae -mtune=cortex-a65ae
+endif
+
+# GCC support -mcpu=cortex-a76ae for arm64 from 10.1
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A76AE),y)
+$(call error_if_gcc_version_lt,10,1)
+ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=cortex-a76ae -mtune=cortex-a76ae
+ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=cortex-a76ae -mtune=cortex-a76ae
+endif
+
+# GCC support -mcpu=cortex-a77 for arm64 from 10.1
+ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A77),y)
+$(call error_if_gcc_version_lt,10,1)
+ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=cortex-a77 -mtune=cortex-a77
+ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=cortex-a77 -mtune=cortex-a77
+endif
+
+# GCC support -mcpu=neoverse-n2 for arm64 from 10.1
+ifeq ($(CONFIG_MCPU_ARM64_NEOVERSE_N2),y)
+$(call error_if_gcc_version_lt,10,1)
+ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=neoverse-n2 -mtune=neoverse-n2
+ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=neoverse-n2 -mtune=neoverse-n2
+endif
+
+# GCC support -mcpu=neoverse-v1 for arm64 from 10.1
+ifeq ($(CONFIG_MCPU_ARM64_NEOVERSE_V1),y)
+$(call error_if_gcc_version_lt,10,1)
+ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=neoverse-v1 -mtune=neoverse-v1
+ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=neoverse-v1 -mtune=neoverse-v1
 endif


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): arm/arm64
 - Platform(s): kvm
 - Application(s): N/A

### Additional configuration

Support for several new CPUs added for arm/arm64:
* CONFIG_MCPU_ARM64_CORTEX_A34
* CONFIG_MCPU_ARM64_CORTEX_A35
* CONFIG_MCPU_ARM64_CORTEX_A53
* CONFIG_MCPU_ARM64_CORTEX_A57_A53
* CONFIG_MCPU_ARM64_CORTEX_A65
* CONFIG_MCPU_ARM64_CORTEX_A65AE
* CONFIG_MCPU_ARM64_CORTEX_A72
* CONFIG_MCPU_ARM64_CORTEX_A72_A53
* CONFIG_MCPU_ARM64_CORTEX_A73
* CONFIG_MCPU_ARM64_CORTEX_A73_A35
* CONFIG_MCPU_ARM64_CORTEX_A73_A53
* CONFIG_MCPU_ARM64_CORTEX_A75
* CONFIG_MCPU_ARM64_CORTEX_A76
* CONFIG_MCPU_ARM64_CORTEX_A76AE
* CONFIG_MCPU_ARM64_CORTEX_A75_A55
* CONFIG_MCPU_ARM64_CORTEX_A76_A55
* CONFIG_MCPU_ARM64_CORTEX_A77
* CONFIG_MCPU_ARM64_NEOVERSE_E1
* CONFIG_MCPU_ARM64_NEOVERSE_N1
* CONFIG_MCPU_ARM64_NEOVERSE_N2
* CONFIG_MCPU_ARM64_NEOVERSE_V1

### Description of changes

Currently declarations of ARCHFLAGS tie architecture revisions to CPU models. That is `-march` and `-mcpu` are declard together, based on the processor type selected by the user:
```    
    ifeq ($(CONFIG_MCPU_ARM64_CORTEXA55),y)
    ...
    ARCHFLAGS-$(call gcc_version_ge,8,0) += -march=armv8.2-a -mcpu=cortex-a55 -mtune=cortex-a55
    endif
```   
This is redundant, as `-mcpu` implicitly selects the archtectural features of the given processor. More importantly, it prevents selecting an architecture revision, or individual architectural feartures, for processors that are not directly supported by GCC.
    
This PR renames CPU config options from `CONFIG_MARCH_ARM64_` to `CONFIG_MCPU_ARM64_` and removes the `-march` parameter when setting `ARCHFLAGS` / `ISR_ARCHFLAGS` for a specific CPU. It also orders CPU selection options in Config.uk in alphabetical order.

An additional commit updates the list of supported CPUs with all designs by Arm supported by GCC up to version 10, inclusive.