### PR TITLE
arch/arm/arm64: Introduce Pointer Authentication support

### DIFF
--- a/arch/arm/arm/include/uk/asm/compiler.h
+++ b/arch/arm/arm/include/uk/asm/compiler.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) YYYY, Copyright Holder. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __UK_ESSENTIALS_H__
+#error Do not include this header directly
+#endif
+
+/* Architecture-specific compiler definitions */
+

--- a/arch/arm/arm64/Config.uk
+++ b/arch/arm/arm64/Config.uk
@@ -145,6 +145,18 @@ choice
 			Compile and optimize for Neoverse V1 CPUs.
 endchoice
 
+menu "Armv8-A Extensions"
+	depends on MCPU_ARM64_NONE
+
+	config ARM64_FEAT_PAUTH
+	bool "Armv8.3 Pointer Authentication"
+	help
+		Enable signing and authentication of pointers. This
+		provides protections against classes of attacks that
+		rely on memory corruption, such as stack smashing and
+		ROP.
+endmenu
+
 config ARM64_ERRATUM_858921
 	bool "Workaround for Cortex-A73 erratum 858921"
 	default y

--- a/arch/arm/arm64/Makefile.uk
+++ b/arch/arm/arm64/Makefile.uk
@@ -16,6 +16,29 @@ CINCLUDES   += -I$(CONFIG_UK_BASE)/arch/arm/arm64/include
 ASINCLUDES  += -I$(CONFIG_UK_BASE)/arch/arm/arm64/include
 CXXINCLUDES += -I$(CONFIG_UK_BASE)/arch/arm/arm64/include
 
+# Architecture Extensions
+#
+# Define these in the order of arch revision, to allow march
+# to be overwritten to the highest version required by the
+# selected extensions.
+ifeq ($(CONFIG_ARM64_FEAT_PAUTH),y)
+# Min GCC >= 9 to avoid dealing with deprecated
+# msign-return-address here and in macros
+$(call error_if_gcc_version_lt,9,0)
+ARCH_REV := armv8.3-a
+BRANCH_PROTECTION := pac-ret+leaf
+endif
+
+ifdef ARCH_REV
+ARCHFLAGS-y += -march=$(ARCH_REV)
+ISR_ARCHFLAGS-y += -march=$(ARCH_REV)
+endif
+
+ifdef BRANCH_PROTECTION
+ARCHFLAGS-y += -mbranch-protection=$(BRANCH_PROTECTION)
+ISR_ARCHFLAGS-y += -mbranch-protection=$(BRANCH_PROTECTION)
+endif
+
 # GCC support -mcpu=native for arm64 from 6.0
 ifeq ($(CONFIG_MCPU_ARM64_NATIVE),y)
 $(call error_if_gcc_version_lt,6,0)

--- a/arch/arm/arm64/include/uk/asm/compiler.h
+++ b/arch/arm/arm64/include/uk/asm/compiler.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) YYYY, Copyright Holder. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __UK_ESSENTIALS_H__
+#error Do not include this header directly
+#endif
+
+/* Architecture-specific compiler definitions */
+

--- a/arch/arm/arm64/include/uk/asm/lcpu.h
+++ b/arch/arm/arm64/include/uk/asm/lcpu.h
@@ -30,6 +30,8 @@
 #error Do not include this header directly
 #endif
 
+#include <uk/asm.h>
+
 #define CACHE_LINE_SIZE	64
 
 #ifdef __ASSEMBLY__
@@ -152,5 +154,49 @@ static inline void ukarch_spinwait(void)
 {
 	/* Intelligent busy wait not supported on arm64. */
 }
+
+/******************************************************************
+ * System Register Definitions
+ ******************************************************************/
+
+/* SCTLR_EL1: System Control Register */
+#define SCTLR_EL1_M_BIT             (_AC(1, ULL) << 0)
+#define SCTLR_EL1_A_BIT             (_AC(1, ULL) << 1)
+#define SCTLR_EL1_C_BIT             (_AC(1, ULL) << 2)
+#define SCTLR_EL1_SA_BIT            (_AC(1, ULL) << 3)
+#define SCTLR_EL1_SA0_BIT           (_AC(1, ULL) << 4)
+#define SCTLR_EL1_CP15BEN_BIT       (_AC(1, ULL) << 5)
+#define SCTLR_EL1_ITD_BIT           (_AC(1, ULL) << 7)
+#define SCTLR_EL1_SED_BIT           (_AC(1, ULL) << 8)
+#define SCTLR_EL1_UMA_BIT           (_AC(1, ULL) << 9)
+#define SCTLR_EL1_I_BIT             (_AC(1, ULL) << 12)
+#define SCTLR_EL1_EnDB_BIT          (_AC(1, ULL) << 13)
+#define SCTLR_EL1_DZE_BIT           (_AC(1, ULL) << 14)
+#define SCTLR_EL1_UCT_BIT           (_AC(1, ULL) << 15)
+#define SCTLR_EL1_NTWI_BIT          (_AC(1, ULL) << 16)
+#define SCTLR_EL1_NTWE_BIT          (_AC(1, ULL) << 18)
+#define SCTLR_EL1_WXN_BIT           (_AC(1, ULL) << 19)
+#define SCTLR_EL1_UWXN_BIT          (_AC(1, ULL) << 20)
+#define SCTLR_EL1_IESB_BIT          (_AC(1, ULL) << 21)
+#define SCTLR_EL1_E0E_BIT           (_AC(1, ULL) << 24)
+#define SCTLR_EL1_EE_BIT            (_AC(1, ULL) << 25)
+#define SCTLR_EL1_UCI_BIT           (_AC(1, ULL) << 26)
+#define SCTLR_EL1_EnDA_BIT          (_AC(1, ULL) << 27)
+#define SCTLR_EL1_EnIB_BIT          (_AC(1, ULL) << 30)
+#define SCTLR_EL1_EnIA_BIT          (_AC(1, ULL) << 31)
+#define SCTLR_EL1_BT0_BIT           (_AC(1, ULL) << 35)
+#define SCTLR_EL1_BT1_BIT           (_AC(1, ULL) << 36)
+#define SCTLR_EL1_BT_BIT            (_AC(1, ULL) << 36)
+#define SCTLR_EL1_DSSBS_BIT         (_AC(1, ULL) << 44)
+
+/* ID_AA64_ISAR_EL1: AArch64 Instruction Set Attributes Register 1 */
+#define ID_AA64ISAR1_EL1_GPI_SHIFT  28
+#define ID_AA64ISAR1_EL1_GPI_MASK   0xf
+#define ID_AA64ISAR1_EL1_GPA_SHIFT  24
+#define ID_AA64ISAR1_EL1_GPA_MASK   0xf
+#define ID_AA64ISAR1_EL1_API_SHIFT  8
+#define ID_AA64ISAR1_EL1_API_MASK   0xf
+#define ID_AA64ISAR1_EL1_APA_SHIFT  4
+#define ID_AA64ISAR1_EL1_APA_MASK   0xf
 
 #endif /* __ASSEMBLY__ */

--- a/arch/x86/x86_64/include/uk/asm/compiler.h
+++ b/arch/x86/x86_64/include/uk/asm/compiler.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) YYYY, Copyright Holder. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __UK_ESSENTIALS_H__
+#error Do not include this header directly
+#endif
+
+/* Architecture-specific compiler definitions */
+

--- a/include/uk/essentials.h
+++ b/include/uk/essentials.h
@@ -54,6 +54,8 @@
 extern "C" {
 #endif
 
+#include <uk/asm/compiler.h>
+
 #ifdef __GNUC__
 #ifndef __packed
 #define __packed               __attribute__((packed))

--- a/plat/common/include/arm/arm64/pauth.h
+++ b/plat/common/include/arm/arm64/pauth.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * Copyright (c) 2022, Michalis Pappas <mpappas@fastmail.fm>.
+ * Copyright (c) 2021, Michalis Pappas <mpappas@fastmail.fm>.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,13 +28,32 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __UK_ESSENTIALS_H__
-#error Do not include this header directly
-#endif
+#ifndef __PLAT_COMMON_ARM64_PAUTH_H__
+#define __PLAT_COMMON_ARM64_PAUTH_H__
 
-#if CONFIG_ARM64_FEAT_PAUTH
-#define __no_pauth __attribute__((target("branch-protection=none")))
-#else
-#define __no_pauth
-#endif /* CONFIG_ARM64_FEAT_PAUTH */
+/* Generate a PAuth key
+ *
+ * Generate an 128-bit key for PAC generation and verification. This
+ * function should be implemented by the platform. Failure to generate
+ * a key must be handled internally to this function in a platform-specific
+ * way.
+ *
+ * NOTICE: Definition of this function must use the __no_pauth attribute.
+ *         See arch/arm/arm64/compiler.h
+ *
+ * @param [in/out] key_hi upper 64 key bits
+ * @param [in/out] key_lo lower 64 key bits
+ */
+void ukplat_pauth_gen_key(__u64 *key_hi, __u64 *key_lo);
 
+/* Initialize and enable Pointer Authentication
+ *
+ * Initializes and enables Pointer Authentication. This function
+ * generates keys by calling ukplat_pauth_gen_key(), programs keys,
+ * and enables pointer authentication.
+ *
+ * @return 0 on success, -1 if FEAT_PAUTH is not implemented.
+ */
+int ukplat_pauth_init(void);
+
+#endif /* __PLAT_COMMON_ARM64_PAUTH_H__ */


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s): arm64
 - Platform(s): common
 - Application(s): N/A

### Additional configuration

This PR introduces `CONFIG_ARM64_FEAT_PAUTH` to enable Pointer Authentication support.

### Description of changes

Pointer Authentication (PAuth) allows signing and authenticating pointers to harden the system against classes of attacks that rely on the manipulation of pointers, such as ROP. Pointer Authentication Codes (PACs) are created by signing a pointer and a 64-bit modifier with an 128-bit key. The modifier is a value that is normally used to restrict the PAC to a specific context (eg the SP). Keys are stored in registerers.

The PAC is stored in the unused upper bits of the memory address, and can be later verified to ensure that the pointer has not been tampered.

The reference algorithm is [the QARMA block cipher](https://eprint.iacr.org/2016/444.pdf), but it is possible for architectures to use an IMPLEMENTATION DEFINED algorithm instead.
 
**Basic Instructions:**
* PAC*: Sign address
* AUT*: Authenticate address
* XPA*: Strip PAC from address (useful for things like unwinding)

**Combined Instructions:**
* RETA*:  Auth and return
* BRA*:   Auth and branch
* BLRA*:  Auth and branch-link
* ERETA*: Auth and return from exception
* LDRA*:  Auth and load

**Keys:**
* APIA_Key: Key A for signing instructions
* APIB_Key: Key B for signing instructions
* APDA_Key: Key A for signing data
* APDB_Key: Key B for signing data
* APGA_Key: Key A for generic use

For more background see:
* [The Arm Architecture Reference Manual Armv8, for Armv8-A architecture profile](https://developer.arm.com/documentation/ddi0487/ga)
* [Learn the architecture: Providing protection for complex software](https://developer.arm.com/documentation/102433/latest/)
* [Pointer Authentication on ARMv8.3](https://www.qualcomm.com/media/documents/files/whitepaper-pointer-authentication-on-armv8-3.pdf)

## Architecture support

**Armv8.3:**
* Introduce FEAT_PAuth as a mandatory feature.
* Introduce FEAT_PAuth2 as an optional feature in Armv8.3 and mandatory in
  Armv8.6. FEAT_PAuth2 changes the way the PAC is applied to the address
  (XOR vs replace).
* Introduce FEAT_FPAC, which allows to control the faulting behavior when authentication
  fails. FEAT_FPAC is an optional feature and depends on FEAT_PAuth2.

## GCC support

**GCC 7:**
* Introduce support for armv8.3-a
* Introduce `--msign-return-address=[none|non-leaf|all]`

The parameters passed to `--msign-return-address` are interpreted as:
* `none`: Do not sign return addresses
* `non-leaf`: Sign/auth the return address of non-leaf functions.
* `all`: Sign/auth the return address of non-leaf and leaf functions.

GCC implements the Basic Set of PAuth instructions using the HINT instruction, in the so-called NOP space. This allows executing protected binaries on older platforms that do not implement Armv8.3-a. In these platforms PAuth instructions
execute as NOP.

When `sign-return-address` is enabled without setting `-march=armv8.3-a`, GCC generates PACIASP / AUTIASP sequences that sign and authenticate the LR upon function entry and exit. In the following snippet notice the opcode of the
HINT instruction (0xd5032300) that GCC generates for PACIASP and AUTIASP.
```
0000000000400564 <main>:
  400564:       d503233f        paciasp
  400568:       a9bf7bfd        stp     x29, x30, [sp, #-16]!
  40056c:       910003fd        mov     x29, sp
  400570:       90000000        adrp    x0, 400000 <_init-0x3e8>
  400574:       9118c000        add     x0, x0, #0x630
  400578:       97ffffb6        bl      400450 <puts@plt>
  40057c:       52800000        mov     w0, #0x0
  400580:       a8c17bfd        ldp     x29, x30, [sp], #16
  400584:       d50323bf        autiasp
  400588:       d65f03c0        ret
```

When `-msign-return-address` is used along with `-march=armv8.3-a`, GCC
generates PACIASP / RETAA sequences instead. In the snippet below notice the
opcode of RETAA (0xd65f0bff) which is in the fused space (instructions in the
Combined Set do not have HINT implementations). Clearly, this code cannot be
executed in architectures earlier than Armv8.3-a.
```
0000000000400564 <main>:
  400564:       d503233f        paciasp
  400568:       a9bf7bfd        stp     x29, x30, [sp, #-16]!
  40056c:       910003fd        mov     x29, sp
  400570:       90000000        adrp    x0, 400000 <_init-0x3e8>
  400574:       9118a000        add     x0, x0, #0x628
  400578:       97ffffb6        bl      400450 <puts@plt>
  40057c:       52800000        mov     w0, #0x0
  400580:       a8c17bfd        ldp     x29, x30, [sp], #16
  400584:       d65f0bff        retaa
```

**GCC 9:**
* Introduce support for armv8.5-a
* Deprecate `-msign-return-address`
* Introduce `-mbranch-protection=[none|pac-ret{+leaf}|bti|standard]`
* Introduce `--enable-standard-branch-protection` as a short to `mbranch-protection=standard`

The parameters passed to `-mbranch-protection` are interpreted as:
* `none`: Disables all protections
* `pac-ret`: Enables PAuth for function returns on non-leaf functions. The
           `+leaf` modifier enables protection for leaf functions.
* `bti`: Enables Branch Target Identification
* `standard`: Enables all protections

**GCC 10:**
* Introduce the b-key addendum to pac-ret in `--mbranch-protection`.
  This allows using the APIB_Key instead of the APIA_Key when signing
  return pointers.

## Changes introduced in this series

This PR provides platforms with an API to initialize PAuth keys, and enable PAuth.

A platform can initialize PAuth as:
```
#ifdef CONFIG_ARM64_FEAT_PAUTH
	if (ukplat_pauth_enable())
		UK_CRASH("Pointer Authentication is not available");
#endif
```

To generate PAyth keys, it is required that platforms provide an implementation of the key generation function that uses an adequate source of randomness.
```
void ukplat_pauth_gen_key(__u64 *key_hi, __u64 *key_lo);
```

Platforms that support Armv8.5 can use the random number generation instructions introduced into the architecture (`RNDR`/`RNDRSS`). Others can initialize drivers of an HWRNG/TRNG, or request randomness from the TEE.

Since the above functions are used for the initialization of PAuth, it is required that GCC excludes them when generating PACIASP/RETAA sequences. Otherwise, once PAuth is enabled, authentication will fail upon return. A macro is provided to help overriding the global gcc settings per function:
```
#define __no_pauth __attribute__((target("branch-protection=none")))
```

This macro is used by `pauth_enable()`, and should be used by all functions generated by GCC in the boot chain, up to - and including - the caller of `pauth_init()`.

Additionally to the above, the following choices are made:

**Do not enable backwards compatibility mode.**
If `-march=armv8.3-a` is not set, it is not possible to initialize the keys.
GCC exits with the following error:
```
bash$ ~/toolchains/gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf/bin/aarch64-none-elf-gcc -mbranch-protection=standard /tmp/test.c
/tmp/ccx7K1nD.s: Assembler messages:
/tmp/ccx7K1nD.s:17: Error: selected processor does not support system register name 'apiakeyhi_el1'
```
I believe that Arm's intention behind compatibility mode was mostly to provide backwards compatibility on userspace libraries. Clearly on Unikraft this feature cannot be utilized, except from the case of linking with prebuilt libraries.
Because of that this PR sets `-march=armv8.3-a` when enabling `CONFIG_ARM64_FEAT_PAUTH`.

**Enable leaf protection by default**

Although it's not strictly required as leaf functions do not save the LR, it doesn't hurt to be there as an additional protection.

**Initialize only the PACIA_Key**

The motivation for that is minimizing the impact on boot time. Additional keys can be enabled later, if needed.

**Do not introduce additional APIs for sign / auth / strip**

The intention of this PR is to provide initial PAuth support. As such, its scope is limited to the signing and verification of the function return address. Nevertheless, Pointer Authentication provides the possibility to harden the system further by signing more pointers. Additional functionality can be introduced into the Unkraft API later, on demand.
