### PR TITLE
plat/arm: Fix unknown type issue when including irq.h

### DIFF
--- a/plat/common/include/arm/arm64/irq.h
+++ b/plat/common/include/arm/arm64/irq.h
@@ -32,6 +32,8 @@
 #ifndef __PLAT_CMN_ARM64_IRQ_H__
 #define __PLAT_CMN_ARM64_IRQ_H__
 
+#include <uk/arch/types.h>
+
 /*
  * SPSR_EL1, Saved Program Status Register
  * When the exception is taken in AArch64:
@@ -89,7 +91,7 @@
 
 static inline int irqs_disabled(void)
 {
-	uint64_t flags;
+	__u64 flags;
 	__save_flags(flags);
 	return (flags & PSR_I);
 }


### PR DESCRIPTION
This fixes #375: "Including uk/plat/common/irq.h on ARM64 results in an unknown type error. The actual included file is plat/common/include/arm/arm64/irq.h."

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`
 - Platform(s): `kvm`
 - Application(s): N/A

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The fix is including `uk/arch/types.h` in `plat/common/include/arm/arm64/irq.h`.