### PR TITLE
BugFix: uk_sched_set_default now updates the uk_sched_head

### DIFF
--- a/lib/uksched/sched.c
+++ b/lib/uksched/sched.c
@@ -107,6 +107,8 @@ int uk_sched_set_default(struct uk_sched *s)
 			prev->next = this->next;
 			this->next = head->next;
 			head = this;
+			// Update the default scheduler to head
+			uk_sched_head = head;
 			return 0;
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x]  Tested your changes against relevant architectures and platforms;
 - [x]  Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x]  Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes
A bug is fixed in `int uk_sched_set_default(struct uk_sched *s)` that was not  updating the `uk_sched_head` pointer after moving the default schedule pointer to top of the queue.
```
struct uk_sched *s = uk_sched_head->next;
uk_sched_set_default(s); //where, s is in the list
struct uk_sched *t = uk_sched_get_default();
assert(t == s); //Failed due to this bug
```
<!--
Please provide a detailed description of the changes made in this new PR.
-->
