### PR TITLE
uksp: Restrict availabiltiy of libuksp to supporting architectures

### DIFF
--- a/lib/uksp/Config.uk
+++ b/lib/uksp/Config.uk
@@ -1,6 +1,7 @@
 menuconfig LIBUKSP
 	bool "uksp: Stack protector"
 	select HAVE_STACKPROTECTOR
+	depends on (ARCH_ARM_64 || ARCH_X86_64)
 	default n
 
 if LIBUKSP


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm`]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

At the time of writing GCC does not support -mstack-protector-guard
on 32-bit ARM:

* https://gcc.gnu.org/onlinedocs/gcc-10.1.0/gcc/ARM-Options.html#ARM-Options
* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102352

Update Config.uk to restrict availability of libuksp to AArch64 and
x86_64.

Resolves #351
Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>