### PR TITLE
plat/kvm/arm: Add alignament attribute to spinlock struct

### DIFF
--- a/arch/arm/arm64/include/uk/asm/spinlock.h
+++ b/arch/arm/arm64/include/uk/asm/spinlock.h
@@ -36,7 +36,7 @@
 
 #include <uk/arch/atomic.h>
 
-struct __spinlock {
+struct __align(8) __spinlock {
 	volatile int lock;
 };
 


### PR DESCRIPTION
The arm64 spinlocks need to be 8 bytes aligned, otherwise they will
cause problems when using them with a `ldaxr` instruction.
This PR adds an alignament attribute that solves this problem.

For reference, also check this issue: https://github.com/unikraft/unikraft/issues/372

Signed-off-by: Răzvan Vîrtan <virtanrazvan@gmail.com>
