### PR TITLE
support/scripts: Use more portable bash shebang

### DIFF
--- a/support/scripts/configupdate
+++ b/support/scripts/configupdate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 UK_CONFIG="${1:-${UK_BASE}/.config}"
 UK_CONFIG_OLD="${2:-${UK_BASE}/.config.old}"
 

--- a/support/scripts/mkcpio
+++ b/support/scripts/mkcpio
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 CPIOTOOL="$( which bsdcpio )"
 
 usage()

--- a/support/scripts/uk-gdb.py
+++ b/support/scripts/uk-gdb.py
@@ -1,4 +1,4 @@
-#!/user/bin/env python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: BSD-3-Clause */
 #
 # Authors: Yuri Volchkov <yuri.volchkov@neclab.eu>

--- a/support/scripts/uk_build_configure.sh
+++ b/support/scripts/uk_build_configure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OPT_BASENAME=`basename $0`
 OPT_STRING="a:e:ho:p:"


### PR DESCRIPTION
/bin/bash is not guaranteed to exist, and does not exist, for instance
on NixOS. In contrast, /usr/bin/env is part of the POSIX spec, and
should exist on all systems.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project; (I read an [archived copy](https://web.archive.org/web/20211204234937/https://docs.unikraft.org/contribute.html), since the main site appears to be down — `curl` reports: `curl: (7) Failed to connect to docs.unikraft.org port 443 after 305 ms: Connection refused`)
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR; (I was unable to figure out how to run checkpatch on a patch that's destined for a GitHub PR rather than an email. Perhaps I'm not supposed to use GitHub at all? But it seems like many people do...)
 - [x] Updated relevant documentation. (no documentation updates needed)


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

None

### Description of changes

Use `#!/usr/bin/env bash` instead of `#!/bin/bash`, since it's more portable and allows building on NixOS.