### PR TITLE
plat/kvm: Re-introduce `kvm/console.h`

### DIFF
--- a/plat/kvm/include/kvm/console.h
+++ b/plat/kvm/include/kvm/console.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: ISC */
+/* Copyright (c) 2015, IBM
+ *           (c) 2017, NEC Europe Ltd.
+ * Author(s): Dan Williams <djwillia@us.ibm.com>
+ *            Simon Kuenzer <simon.kuenzer@neclab.eu>
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef __KVM_CONSOLE_H__
+#define __KVM_CONSOLE_H__
+
+void _libkvmplat_init_console(void);
+
+#endif /* __KVM_CONSOLE_H__ */


### PR DESCRIPTION
The commit that removed kvm dependencies from pl011 driver (https://github.com/unikraft/unikraft/commit/d76893e123ad2a8cec8b62af3d638e78f5dd6626) also removed `kvm/console.h` (it is not necessary anymore on arm).
However, the `kvm/console.h` header is still necessary on x86_64.
This commit re-introduces `kvm/console.h`.

Signed-off-by: Răzvan Vîrtan <virtanrazvan@gmail.com>