### PR TITLE
lib/ukmmap: Fix some bugs and add mprotect

### DIFF
--- a/lib/ukmmap/Makefile.uk
+++ b/lib/ukmmap/Makefile.uk
@@ -3,4 +3,4 @@ $(eval $(call addlib_s,libukmmap,$(CONFIG_LIBUKMMAP)))
 LIBUKMMAP_SRCS-y += $(LIBUKMMAP_BASE)/mmap.c
 
 UK_PROVIDED_SYSCALLS-$(CONFIG_LIBUKMMAP) += mmap-6 munmap-2 madvise-3
-UK_PROVIDED_SYSCALLS-$(CONFIG_LIBUKMMAP) += mremap-5
+UK_PROVIDED_SYSCALLS-$(CONFIG_LIBUKMMAP) += mremap-5 mprotect-3

--- a/lib/ukmmap/exportsyms.uk
+++ b/lib/ukmmap/exportsyms.uk
@@ -4,9 +4,12 @@ uk_syscall_r_mmap
 munmap
 uk_syscall_e_munmap
 uk_syscall_r_munmap
-mremap
 madvise
 uk_syscall_e_madvise
 uk_syscall_r_madvise
+mremap
 uk_syscall_e_mremap
 uk_syscall_r_mremap
+mprotect
+uk_syscall_e_mprotect
+uk_syscall_r_mprotect

--- a/lib/ukmmap/mmap.c
+++ b/lib/ukmmap/mmap.c
@@ -189,3 +189,9 @@ UK_SYSCALL_R_DEFINE(int, madvise, void*, addr, size_t, length, int, advice)
 	WARN_STUBBED();
 	return 0;
 }
+
+UK_SYSCALL_R_DEFINE(int, mprotect, void*, addr, size_t, len, int, prot)
+{
+	WARN_STUBBED();
+	return 0;
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [X] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [X] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

`CONFIG_LIBUKMMAP=y`

### Description of changes

This PR fixes two bugs:
* Callers of `mmap` expect anonymous memory to be zeroed. The patch adds a `memset` to do so.
* The `munmap` call tries to remap remaining memory to a smaller area. However, the caller won't have a chance to be informed about the changing base address of the area. Changing the base address also violates POSIX. As we are not able to free parts of the memory area, we have to keep it unchanged and silently fail. We only free it, if the caller unmaps the whole area.

In addition, the PR introduces a stub for `mprotect`.