### PR TITLE
include/uk/list.h: Add uk_list_last_entry_or_null

### DIFF
--- a/include/uk/list.h
+++ b/include/uk/list.h
@@ -137,6 +137,9 @@ uk_list_del_init(struct uk_list_head *entry)
 #define	uk_list_first_entry_or_null(ptr, type, member) \
 	(!uk_list_empty(ptr) ? uk_list_first_entry(ptr, type, member) : NULL)
 
+#define	uk_list_last_entry_or_null(ptr, type, member)			\
+	(!uk_list_empty(ptr) ? uk_list_last_entry(ptr, type, member) : NULL)
+
 #define	uk_list_next_entry(ptr, member)					\
 	uk_list_entry(((ptr)->member.next), typeof(*(ptr)), member)
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [X] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [X] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

This commit adds an equivalent version to `uk_list_first_entry_or_null` for the last element in the list.
