### PR TITLE
lib/uktest: Fixes layout of assert table on ARM64

### DIFF
--- a/lib/uktest/include/uk/test.h
+++ b/lib/uktest/include/uk/test.h
@@ -320,8 +320,8 @@ struct uk_testsuite {
 #define _UK_TEST_ASSERTTAB_ENTRY(status)				\
 	_UK_TEST_SECTION_DATA(						\
 		".uk_asserttab",					\
-		".word " STRINGIFY(status) "\n"				\
-		".word " STRINGIFY(__LINE__)				\
+		".hword " STRINGIFY(status) "\n"			\
+		".hword " STRINGIFY(__LINE__)				\
 	)
 
 /**

--- a/lib/uktest/tests.ld
+++ b/lib/uktest/tests.ld
@@ -9,4 +9,4 @@ SECTIONS
 		uk_asserttab_end = .;
 	}
 }
-INSERT AFTER .text;
+INSERT AFTER .rodata;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [X] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [X] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

- `CONFIG_LIBUKTEST=y`
- `CONFIG_LIBUKTEST_ALL=y`

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes the broken layout of the assertion table on ARM64 which causes the test code to not find the corresponding entry in the assertion table. The PR also fixes the page protections set on the table by the platform initialization code on ARM64 by moving it to a writeable memory area.

Closes #393 