### PR TITLE
lib/uksglist: Fix conditional definition of functions

### DIFF
--- a/lib/uksglist/sglist.c
+++ b/lib/uksglist/sglist.c
@@ -294,7 +294,7 @@ int uk_sglist_join(struct uk_sglist *first, struct uk_sglist *second)
 	return 0;
 }
 
-#ifdef CONFIG_UKALLOC
+#ifdef CONFIG_LIBUKALLOC
 struct uk_sglist *uk_sglist_alloc(struct uk_alloc *a, int nsegs)
 {
 	struct uk_sglist *sg;
@@ -530,7 +530,7 @@ int uk_sglist_slice(struct uk_sglist *original, struct uk_sglist **slice,
 	}
 	return 0;
 }
-#endif /* CONFIG_UKALLOC */
+#endif /* CONFIG_LIBUKALLOC */
 
 #ifdef CONFIG_LIBUKNETDEV
 int uk_sglist_append_netbuf(struct uk_sglist *sg, struct uk_netbuf *netbuf)


### PR DESCRIPTION
Signed-off-by: George Hopkins <george-hopkins@null.net>

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

 - `CONFIG_LIBUKALLOC=y`

### Description of changes

The functions which depend on ukalloc were not defined due to a typo in the macro.
