### PR TITLE
lib/ukrust: Do not invoke rustc if ukrust is not enabled

### DIFF
--- a/lib/ukrust/Makefile.uk
+++ b/lib/ukrust/Makefile.uk
@@ -7,8 +7,13 @@ RUSTCFLAGS-$(CONFIG_LIBUKRUST) += --extern ukrust_sys -L $(LIBUKRUST_BUILD)/ --e
 		-Zallow-features=allocator_api,bench_black_box,concat_idents,global_asm,try_reserve
 
 export LIBUKRUST_BINDINGS_FILE=$(LIBUKRUST_BUILD)/bindings_generated.rs
-RUSTC_SYSROOT = $(shell $(RUSTC)  --print sysroot)
+
+ifeq ($(CONFIG_LIBRUST),y)
+# Do not perform these if CONFIG_RUST is not set, as it is not
+# guaranteed that rustc will be available in the system.
+RUSTC_SYSROOT := $(shell $(RUSTC)  --print sysroot)
 RUST_LIB_SRC ?= $(RUSTC_SYSROOT)/lib/rustlib/src/rust/library
+endif
 
 # Common flags
 LIBUKRUST_COMMON_FLAGS = --target=$(LIBUKRUST_BASE)/target.json --emit=dep-info,obj,metadata --edition=2018 \


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64`]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Invoking rustc to determine the sysroot causes a warning when rustc
is not installed:
```
/bin/bash: rustc: command not found
/bin/bash: rustc: command not found
```
Update the makefile to invoke rustc conditionally
to CONFIG_UKRUST.