### PR TITLE
lib/vfscore, lib/*fs: Use non-prototyped no-ops

### DIFF
--- a/lib/9pfs/Makefile.uk
+++ b/lib/9pfs/Makefile.uk
@@ -1,6 +1,4 @@
 $(eval $(call addlib_s,lib9pfs,$(CONFIG_LIB9PFS)))
 
-LIB9PFS_CFLAGS-$(call gcc_version_ge,8,0) += -Wno-cast-function-type
-
 LIB9PFS_SRCS-y += $(LIB9PFS_BASE)/9pfs_vfsops.c
 LIB9PFS_SRCS-y += $(LIB9PFS_BASE)/9pfs_vnops.c

--- a/lib/devfs/Makefile.uk
+++ b/lib/devfs/Makefile.uk
@@ -2,8 +2,6 @@ $(eval $(call addlib_s,libdevfs,$(CONFIG_LIBDEVFS)))
 
 CINCLUDES-y += -I$(LIBDEVFS_BASE)/include
 
-LIBDEVFS_CFLAGS-$(call gcc_version_ge,8,0) += -Wno-cast-function-type
-
 LIBDEVFS_SRCS-y += $(LIBDEVFS_BASE)/device.c
 LIBDEVFS_SRCS-y += $(LIBDEVFS_BASE)/devfs_vnops.c
 LIBDEVFS_SRCS-$(CONFIG_LIBDEVFS_DEV_NULL_ZERO) += $(LIBDEVFS_BASE)/null.c

--- a/lib/devfs/devfs_vnops.c
+++ b/lib/devfs/devfs_vnops.c
@@ -230,18 +230,6 @@ devfs_getattr(struct vnode *vnode, struct vattr *attr)
 	return 0;
 }
 
-int
-vop_einval(void)
-{
-	return EINVAL;
-}
-
-int
-vop_eperm(void)
-{
-	return EPERM;
-}
-
 #define devfs_mount	((vfsop_mount_t)vfscore_nullop)
 #define devfs_sync	((vfsop_sync_t)vfscore_nullop)
 #define devfs_vget	((vfsop_vget_t)vfscore_nullop)
@@ -249,15 +237,15 @@ vop_eperm(void)
 
 #define devfs_seek	((vnop_seek_t)vfscore_vop_nullop)
 #define devfs_fsync	((vnop_fsync_t)vfscore_vop_nullop)
-#define devfs_create	((vnop_create_t)vop_einval)
-#define devfs_remove	((vnop_remove_t)vop_einval)
-#define devfs_rename	((vnop_rename_t)vop_einval)
-#define devfs_mkdir	((vnop_mkdir_t)vop_einval)
-#define devfs_rmdir	((vnop_rmdir_t)vop_einval)
-#define devfs_setattr	((vnop_setattr_t)vop_eperm)
+#define devfs_create	((vnop_create_t)vfscore_vop_einval)
+#define devfs_remove	((vnop_remove_t)vfscore_vop_einval)
+#define devfs_rename	((vnop_rename_t)vfscore_vop_einval)
+#define devfs_mkdir	((vnop_mkdir_t)vfscore_vop_einval)
+#define devfs_rmdir	((vnop_rmdir_t)vfscore_vop_einval)
+#define devfs_setattr	((vnop_setattr_t)vfscore_vop_eperm)
 #define devfs_inactive	((vnop_inactive_t)vfscore_vop_nullop)
 #define devfs_truncate	((vnop_truncate_t)vfscore_vop_nullop)
-#define devfs_link	((vnop_link_t)vop_eperm)
+#define devfs_link	((vnop_link_t)vfscore_vop_eperm)
 #define devfs_fallocate ((vnop_fallocate_t)vfscore_vop_nullop)
 #define devfs_readlink	((vnop_readlink_t)vfscore_vop_nullop)
 #define devfs_symlink	((vnop_symlink_t)vfscore_vop_nullop)

--- a/lib/ramfs/Makefile.uk
+++ b/lib/ramfs/Makefile.uk
@@ -1,6 +1,4 @@
 $(eval $(call addlib_s,libramfs,$(CONFIG_LIBRAMFS)))
 
-LIBRAMFS_CFLAGS-$(call gcc_version_ge,8,0) += -Wno-cast-function-type
-
 LIBRAMFS_SRCS-y += $(LIBRAMFS_BASE)/ramfs_vfsops.c
 LIBRAMFS_SRCS-y += $(LIBRAMFS_BASE)/ramfs_vnops.c

--- a/lib/vfscore/Makefile.uk
+++ b/lib/vfscore/Makefile.uk
@@ -5,8 +5,6 @@ $(eval $(call addlib_paramprefix,libvfscore,vfs))
 
 CINCLUDES-y += -I$(LIBVFSCORE_BASE)/include
 
-LIBVFSCORE_CFLAGS-$(call gcc_version_ge,8,0) += -Wno-cast-function-type
-
 LIBVFSCORE_SRCS-y += $(LIBVFSCORE_BASE)/fd.c
 LIBVFSCORE_SRCS-y += $(LIBVFSCORE_BASE)/file.c
 LIBVFSCORE_SRCS-y += $(LIBVFSCORE_BASE)/stdio.c

--- a/lib/vfscore/include/vfscore/mount.h
+++ b/lib/vfscore/include/vfscore/mount.h
@@ -171,8 +171,8 @@ typedef int (*vfsop_statfs_t)(struct mount *, struct statfs *);
 
 #define VFS_NULL		    ((void *)vfs_null)
 
-int	vfscore_nullop(void);
-int	vfs_einval(void);
+int vfscore_nullop();
+int vfscore_einval();
 
 void	 vfs_busy(struct mount *mp);
 void	 vfs_unbusy(struct mount *mp);

--- a/lib/vfscore/include/vfscore/vnode.h
+++ b/lib/vfscore/include/vfscore/vnode.h
@@ -229,10 +229,10 @@ struct vnops {
 #define VOP_READLINK(VP, U)        ((VP)->v_op->vop_readlink)(VP, U)
 #define VOP_SYMLINK(DVP, OP, NP)   ((DVP)->v_op->vop_symlink)(DVP, OP, NP)
 
-int	 vfscore_vop_nullop(void);
-int	 vfscore_vop_einval(void);
-int	 vfscore_vop_eperm(void);
-int	 vfscore_vop_erofs(void);
+int vfscore_vop_nullop();
+int vfscore_vop_einval();
+int vfscore_vop_eperm();
+int vfscore_vop_erofs();
 struct vnode *vn_lookup(struct mount *, uint64_t);
 void	 vn_lock(struct vnode *);
 void	 vn_unlock(struct vnode *);

--- a/lib/vfscore/mount.c
+++ b/lib/vfscore/mount.c
@@ -476,13 +476,14 @@ vfs_unbusy(struct mount *mp)
 	ukarch_dec(&mp->m_count);
 }
 
-int vfscore_nullop(void)
+int
+vfscore_nullop()
 {
 	return 0;
 }
 
 int
-vfs_einval(void)
+vfscore_einval()
 {
 	return EINVAL;
 }

--- a/lib/vfscore/vnode.c
+++ b/lib/vfscore/vnode.c
@@ -477,25 +477,25 @@ vnode_dump(void)
 #endif
 
 int
-vfscore_vop_nullop(void)
+vfscore_vop_nullop()
 {
 	return 0;
 }
 
 int
-vfscore_vop_einval(void)
+vfscore_vop_einval()
 {
 	return EINVAL;
 }
 
 int
-vfscore_vop_eperm(void)
+vfscore_vop_eperm()
 {
 	return EPERM;
 }
 
 int
-vfscore_vop_erofs(void)
+vfscore_vop_erofs()
 {
 	return EROFS;
 }
@@ -528,4 +528,3 @@ void vn_del_name(struct vnode *vp __unused, struct dentry *dp)
 	/* UK_ASSERT(uk_mutex_is_locked(&vp->v_lock)); */
 	uk_list_del(&dp->d_names_link);
 }
-


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

For example:
- `CONFIG_LIBVFSCORE=y`
- `CONFIG_LIBRAMFS=y`

### Description of changes

VFS operations are implemented with function calls. In order to stub some of the operations a no-op function is assigned to those function pointers. As the function signature between the generic no-op function and the respective VOP does not match, the compiler displays a warning. We currently suppress this warning with a compile flag. However, this also suppresses legitimate warnings and may hide bugs. This commit changes the no-op functions to be non-prototypical so that any function signature is treated as valid. The compile flags can thus be removed.