### PR TITLE
plat/kvm/x86: Unify boot information storage

### DIFF
--- a/plat/kvm/include/kvm-x86/bootinfo.h
+++ b/plat/kvm/include/kvm-x86/bootinfo.h
@@ -1,0 +1,22 @@
+#ifndef __BOOTINFO_H__
+#define __BOOTINFO_H__
+
+#include <uk/arch/types.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct uk_bootinfo {
+	/* Command line information */
+	__u64 u64_cmdline;
+
+	/* Memmory mapping information */
+	size_t max_addr;
+
+	/* Initrd information */
+	__u8 has_initrd;
+	uintptr_t initrd_start;
+	uintptr_t initrd_end;
+	size_t initrd_length;
+};
+
+#endif /* __BOOTINFO_H__ */


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): N/A

### Additional configuration

None

### Description of changes

This PR adds Unikraft's own structure to store boot information. This is needed to have a cleaner integration of other bootloaders than Multiboot, that use different structures (see Multiboot v2).
