### PR TITLE
lib/nolibc: Use types from shareddefs.h

### DIFF
--- a/lib/nolibc/include/nolibc-internal/shareddefs.h
+++ b/lib/nolibc/include/nolibc-internal/shareddefs.h
@@ -142,3 +142,15 @@ typedef unsigned long long fsblkcnt_t;
 typedef unsigned long long fsfilcnt_t;
 #define __DEFINED_fsfilcnt_t
 #endif
+
+#if defined(__NEED_sigset_t) && !defined(__DEFINED_sigset_t)
+typedef unsigned long __sigset_t;
+typedef __sigset_t sigset_t;
+#define __DEFINED_sigset_t
+#endif
+
+#if defined(__NEED_sig_atomic_t) && !defined(__DEFINED_sig_atomic_t)
+typedef int __sig_atomic_t;
+typedef __sig_atomic_t sig_atomic_t;
+#define __DEFINED_sig_atomic_t
+#endif

--- a/lib/nolibc/musl-imported/include/signal.h
+++ b/lib/nolibc/musl-imported/include/signal.h
@@ -58,10 +58,10 @@ extern "C" {
 #define SA_RESETHAND  0x80000000
 #define SA_RESTORER   0x04000000
 
-typedef int pid_t;
-typedef int sig_atomic_t;
-typedef unsigned long __sigset_t;
-typedef __sigset_t sigset_t;
+#define __NEED_pid_t
+#define __NEED_sig_atomic_t
+#define __NEED_sigset_t
+#include <nolibc-internal/shareddefs.h>
 
 #define NSIG _NSIG
 


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [X] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The current `signal.h` redefines `pid_t` from `shareddefs.h` and makes own defines for `sig_atomic_t` and `sigset_t`. This commit moves the declarations to the `shareddefs.h` header to prevent conflicts due to (incompatible) redefinitions.