### PR TITLE
lib/vfscore: Move alloc out of critical section in sys_open

### DIFF
--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -158,9 +158,8 @@ sys_open(char *path, int flags, mode_t mode, struct vfscore_file **fpp)
 		/* Open */
 		if (flags & O_NOFOLLOW) {
 			error = open_no_follow_chk(path);
-			if (error != 0) {
-				return (error);
-			}
+			if (error != 0)
+				return error;
 		}
 		error = namei(path, &dp);
 		if (error)
@@ -178,10 +177,10 @@ sys_open(char *path, int flags, mode_t mode, struct vfscore_file **fpp)
 				goto out_drele;
 		}
 		if (flags & O_DIRECTORY) {
-		    if (vp->v_type != VDIR) {
-		        error = ENOTDIR;
-		        goto out_drele;
-		    }
+			if (vp->v_type != VDIR) {
+				error = ENOTDIR;
+				goto out_drele;
+			}
 		}
 	}
 
@@ -227,9 +226,8 @@ out_fp_free_unlock:
 	free(fp);
 	vn_unlock(vp);
 out_drele:
-	if (dp) {
+	if (dp)
 		drele(dp);
-	}
 	return error;
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [X] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

- `CONFIG_LIBVFSCORE=y`

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The open function locks the vnode that is opened and then performs an allocation to create a vfs_file descriptor. This PR moves the allocation out of the critical section to reduce lock holder time. The PR also fixes style issues in the open syscall.