### PR TITLE
lib/vfscore: Fixing various bugs

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1541,8 +1541,7 @@ int __xstat(int ver __unused, const char *pathname, struct stat *st)
 
 	out_errno:
 	trace_vfs_stat_err(error);
-	errno = error;
-	return -1;
+	return -error;
 }
 
 #ifdef __xstat64

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1204,7 +1204,8 @@ sys_fchdir(struct vfscore_file *fp, char *cwd)
 		vn_unlock(dvp);
 		return EBADF;
 	}
-	strlcpy(cwd, fp->f_dentry->d_path, PATH_MAX);
+	strlcpy(cwd, fp->f_dentry->d_mount->m_path, PATH_MAX);
+	strlcat(cwd, fp->f_dentry->d_path, PATH_MAX);
 	vn_unlock(dvp);
 	return 0;
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [X] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

- `CONFIG_LIBVFSCORE=y`

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes a couple of bugs in `lib/vfscore` where:
+ `sys_fchdir` sets the wrong current working directory if the FS is not mounted at `/` (root)
+ the `read`/`write`/`stat` syscalls return values according to the C lib but not the raw syscall implementation
