### PR TITLE
plat/linuxu: Fix build errors introduced by #251

### DIFF
--- a/plat/linuxu/include/linuxu/syscall.h
+++ b/plat/linuxu/include/linuxu/syscall.h
@@ -49,14 +49,6 @@
 #error "Unsupported architecture"
 #endif
 
-static inline int sys_open(const char *pathname, int flags, k_mode_t mode)
-{
-	return (int)syscall3(__SC_OPEN,
-			    (long) (pathname),
-			    (long) (flags),
-			    (long) (mode));
-}
-
 static inline int sys_close(int fd)
 {
 	return (int)syscall1(__SC_CLOSE,
@@ -85,7 +77,7 @@ static inline int sys_fstat(int fd, struct k_stat *statbuf)
 	return (int)syscall2(__SC_FSTAT,
 			     (long)(fd),
 			     (long)(statbuf));
-
+}
 #ifndef O_RDONLY
 #define O_RDONLY                  00000000
 #endif /* O_RDONLY */
@@ -138,12 +130,6 @@ static inline int sys_open(const char *pathname, int flags, ...)
 			 (long)FD_CLOEXEC);
 
 	return fd;
-}
-
-static inline int sys_close(int fd)
-{
-	return (ssize_t) syscall1(__SC_CLOSE,
-				  (long) fd);
 }
 
 #ifndef SOCK_STREAM


### PR DESCRIPTION
Fix build errors introduced by https://github.com/unikraft/unikraft/pull/251. 
We add a missing bracket and remove duplicate definitions of sys_open and
sys_close.

Signed-off-by: Vlad-Andrei Badoiu <vlad_andrei.badoiu@upb.ro>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
