### PR TITLE
lib/uksglist: Replace EDOOFUS macro

### DIFF
--- a/lib/uksglist/sglist.c
+++ b/lib/uksglist/sglist.c
@@ -379,7 +379,7 @@ int uk_sglist_split(struct uk_sglist *original, struct uk_sglist **head,
 	int count, i;
 
 	if (uk_refcount_read(&original->sg_refs) > 1)
-		return -EDOOFUS;
+		return -EINVAL;
 
 	/* Figure out how big of a sglist '*head' has to hold. */
 	count = 0;


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Changed the macro EDOOFUS which is undeclared, to EINVAL.
The EDOOFUS macro exists only in unikraft/lib/nolibc which is deactivated when newlib is used. 

### Log output
```
/home/maniatro111/test2/unikraft/lib/uksglist/sglist.c:382:11: error: ‘EDOOFUS’ undeclared (first use in this function);
```

