### PR TITLE
arch/arm64: Add Branch Target Identification

### DIFF
--- a/arch/arm/arm64/Config.uk
+++ b/arch/arm/arm64/Config.uk
@@ -155,6 +155,12 @@ menu "Armv8-A Extensions"
 		provides protections against classes of attacks that
 		rely on memory corruption, such as stack smashing and
 		ROP.
+
+	config ARM64_FEAT_BTI
+	bool "Armv8.5 Branch Target Identification"
+	help
+		BTI protects against JOP-like attacks by placing and
+		verifying landing pads on branch targets.
 endmenu
 
 config ARM64_ERRATUM_858921

--- a/arch/arm/arm64/Makefile.uk
+++ b/arch/arm/arm64/Makefile.uk
@@ -29,6 +29,18 @@ ARCH_REV := armv8.3-a
 BRANCH_PROTECTION := pac-ret+leaf
 endif
 
+ifeq ($(CONFIG_ARM64_FEAT_BTI),y)
+# Min GCC >= 10, due to buggy GCC-9.
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94697
+$(call error_if_gcc_version_lt,10,0)
+ARCH_REV := armv8.5-a
+ifeq ($(BRANCH_PROTECTION),)
+	BRANCH_PROTECTION := bti
+else
+	BRANCH_PROTECTION := standard
+endif
+endif
+
 ifdef ARCH_REV
 ARCHFLAGS-y += -march=$(ARCH_REV)
 ISR_ARCHFLAGS-y += -march=$(ARCH_REV)

--- a/arch/arm/arm64/include/uk/asm/compiler.h
+++ b/arch/arm/arm64/include/uk/asm/compiler.h
@@ -33,8 +33,28 @@
 #endif
 
 #if CONFIG_ARM64_FEAT_PAUTH
+#if CONFIG_ARM64_FEAT_BTI
+#define __no_pauth __attribute__((target("branch-protection=bti")))
+#else
 #define __no_pauth __attribute__((target("branch-protection=none")))
+#endif /* CONFIG_ARM64_FEAT_BTI */
 #else
 #define __no_pauth
 #endif /* CONFIG_ARM64_FEAT_PAUTH */
+
+#if CONFIG_ARM64_FEAT_BTI
+#if CONFIG_ARM64_FEAT_PAUTH
+#define __no_bti __attribute__((target("branch-protection=pac-ret+leaf")))
+#else
+#define __no_bti __attribute__((target("branch-protection=none")))
+#endif /* CONFIG_ARM64_FEAT_PAUTH */
+#else
+#define __no_bti
+#endif /* CONFIG_ARM64_FEAT_BTI */
+
+#if defined(CONFIG_ARM64_FEAT_PAUTH) || defined(CONFIG_ARM64_FEAT_BTI)
+#define __no_branch_protection __attribute__((target("branch-protection=none")))
+#else
+#define __no_branch_protection
+#endif /* CONFIG_ARM64_FEAT_PAUTH || CONFIG_ARM64_FEAT_BTI */
 

--- a/plat/common/arm/smccc_invoke.S
+++ b/plat/common/arm/smccc_invoke.S
@@ -35,6 +35,14 @@
 #ifdef CONFIG_ARCH_ARM_64
 .macro smccc conduit
 
+#if CONFIG_ARM64_FEAT_PAUTH
+	/* Also covers the case when both PAuth and BTI
+	 * are enalbled (ARM DDI 0487H.a Sect. D5.4.4)
+	 */
+	paciasp
+#elif CONFIG_ARM64_FEAT_BTI
+	bti jc
+#endif
 	str x19, [sp, #-16]!
 
 	mov x19, x0

--- a/plat/common/include/arm/arm64/cpu_defs.h
+++ b/plat/common/include/arm/arm64/cpu_defs.h
@@ -252,6 +252,7 @@
 #define ATTR_XN		(ATTR_PXN | ATTR_UXN)
 #define ATTR_CONTIGUOUS	(_AC(1, UL) << 52)
 #define ATTR_DBM	(_AC(1, UL) << 51)
+#define ATTR_GP		(_AC(1, UL) << 50)
 #define ATTR_nG		(1 << 11)
 #define ATTR_AF		(1 << 10)
 #define ATTR_SH(x)	((x) << 8)
@@ -278,18 +279,30 @@
  */
 #define SECT_ATTR_DEFAULT	\
 		(Ln_BLOCK | ATTR_DEFAULT)
+
 #define SECT_ATTR_NORMAL	\
 		(SECT_ATTR_DEFAULT | ATTR_XN | \
 		ATTR_IDX(NORMAL_WB))
+
 #define SECT_ATTR_NORMAL_RO	\
 		(SECT_ATTR_DEFAULT | ATTR_XN | \
 		ATTR_AP_RW_BIT | ATTR_IDX(NORMAL_WB))
+
+#ifdef CONFIG_ARM64_FEAT_BTI
+#define SECT_ATTR_NORMAL_EXEC	\
+		(SECT_ATTR_DEFAULT | ATTR_UXN | \
+		ATTR_GP |                       \
+		ATTR_AP_RW_BIT | ATTR_IDX(NORMAL_WB))
+#else
 #define SECT_ATTR_NORMAL_EXEC	\
 		(SECT_ATTR_DEFAULT | ATTR_UXN | \
 		ATTR_AP_RW_BIT | ATTR_IDX(NORMAL_WB))
+#endif /* CONFIG_ARM64_FEAT_BTI */
+
 #define SECT_ATTR_DEVICE_nGnRE	\
 		(SECT_ATTR_DEFAULT | ATTR_XN | \
 		ATTR_IDX(DEVICE_nGnRE))
+
 #define SECT_ATTR_DEVICE_nGnRnE	\
 		(SECT_ATTR_DEFAULT | ATTR_XN | \
 		ATTR_IDX(DEVICE_nGnRnE))

--- a/plat/kvm/arm/entry64.S
+++ b/plat/kvm/arm/entry64.S
@@ -143,13 +143,3 @@ ENTRY(_libkvmplat_entry)
 	b _libkvmplat_start
 END(_libkvmplat_entry)
 
-ENTRY(_libkvmplat_newstack)
-	/* Setup new stack */
-	mov sp, x0
-
-	/* Setup parameter for _libkvmplat_entry2 */
-	mov x0, x2
-
-	/* Branch to _libkvmplat_entry2 */
-	br x1
-END(_libkvmplat_newstack)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `arm64`]
 - Platform(s): [common]
 - Application(s): [N/A]

### Additional configuration

This PR introduces a new Kconfig option, CONFIG_ARM64_FEAT_BTI. For details, see below.

### Description of changes

FEAT_BTI is a hardware protection against JOP-like attacks.
To do that, it introduces:

* The BTI instruction.    
* The GP field in Stage 1 PTEs.    
* The PSTATE.BTYPE field.    

BTI instructions, aka landing pads, are placed by the compiler at branch targets. On runtime, branches that do not land on a BTI instruction trigger an Branch Target Exception.

The GP field indicates whether a page is guarded with BTI. This is allows backwards compatibilty, by disabling BTI on pages that contain non-BTI guarded code. Notice that BTI instructions on unguarded pages execute as NOP.

PSTATE.BTYPE encodes the type of an indirect jump, ie the branch instruction, the registers used to carry parameters, and whether the target page is guarded or or not. When an indirect branch is taken, the processor checks whether PSATE.BTYPE matches the type of the branch target, and on negative match it generates an Branch Target Exception. The purpose of this is to further limit the scope of possible gadgets among BTI protected branches. Notice that there are exceptions to this. For details see D5.4.4 in [2].

## Architecture Support

Armv8.5-a introduces FEAT_BTI as a mandatory feature. This feature is only available in AArch64.

## GCC Support

GCC-9 introduces support for Armv8.5-A. BTI is supported through the `-mbranch-protection` parameter.
    
The parameters passed to -mbranch-protection are interpreted as:

* none: Disables all branch protections.
* pac-ret: Enables PAuth for function returns on non-leaf functions. The `+leaf` modifier enables protection for leaf functions.    
* bti: Enables BTI.
* standard: Enables all branch protections.

GCC-9 comes with an [issue where under certain conditions incorrect BTI instructions are generated](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94697). Due of that issue, for BTI support in Unikraft we mandate GCC => 10.

## Backwards Compatibility

BTI is implemented as hint instructions. Processors based on older architecture revisions will execute these as NOP.

## Changes introduced in this PR

This PR adds BTI support on arm64-based platforms through a new Kconfig option CONFIG_ARM64_FEAT_BTI. Enabling this option instructs GCC to instrument branch targets with landing pads. The default PTE attributes of executable pages and blocks are updated to set the GP attribute when BTI is enabled.

## Platform Requirements

As GCC only generates BTI instructions for C code, platforms need to make sure that assembly functions that are called through indirect branching are updated with landing pads before BTI support is enabled.

## References

1. [Learn the architecture: Providing protection for complex software](https://developer.arm.com/documentation/102433/latest/)
2. [The Arm Architecture Reference Manual Armv8, for Armv8-A architecture profile](https://developer.arm.com/documentation/ddi0487/ga)