### PR TITLE
lib/syscall_shim: Filter provided syscalls based on architecture

### DIFF
--- a/lib/syscall_shim/Makefile.uk
+++ b/lib/syscall_shim/Makefile.uk
@@ -45,31 +45,36 @@ $(LIBSYSCALL_SHIM_INCLUDES_PATH)/syscall_map.h.new: $(LIBSYSCALL_SHIM_BASE)/gen_
 		$(AWK) -f  $(LIBSYSCALL_SHIM_BASE)/gen_syscall_map.awk \
 		$(LIBSYSCALL_SHIM_TEMPL) > $@)
 
-$(LIBSYSCALL_SHIM_INCLUDES_PATH)/provided_syscalls.h: $(LIBSYSCALL_SHIM_BASE)/gen_provided.awk $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls.h.in
+$(LIBSYSCALL_SHIM_BUILD)/provided_syscalls_arch.h.in: $(LIBSYSCALL_SHIM_BASE)/gen_available.awk $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls.h.in $(LIBSYSCALL_SHIM_TEMPL)
+	$(call build_cmd,GEN,libsyscall_shim,$(notdir $@), \
+		$(AWK) -F '[- \t]' -f $(LIBSYSCALL_SHIM_BASE)/gen_available.awk \
+		$(LIBSYSCALL_SHIM_BUILD)/provided_syscalls.h.in $(LIBSYSCALL_SHIM_TEMPL) > $@)
+
+$(LIBSYSCALL_SHIM_INCLUDES_PATH)/provided_syscalls.h: $(LIBSYSCALL_SHIM_BASE)/gen_provided.awk  $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls_arch.h.in
 	$(call build_cmd,GEN,libsyscall_shim,$(notdir $@), \
 		$(AWK) -F '-' -f  $(LIBSYSCALL_SHIM_BASE)/gen_provided.awk \
-		$(LIBSYSCALL_SHIM_BUILD)/provided_syscalls.h.in > $@)
+		$(LIBSYSCALL_SHIM_BUILD)/provided_syscalls_arch.h.in > $@)
 
-$(LIBSYSCALL_SHIM_BUILD)/uk_syscall6.c: $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls.h.in $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall6.awk
+$(LIBSYSCALL_SHIM_BUILD)/uk_syscall6.c: $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls_arch.h.in $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall6.awk
 	$(call build_cmd,GEN,libsyscall_shim,$(notdir $@), \
 		$(AWK) -F '-' -f $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall6.awk $< > $@)
 
-$(LIBSYSCALL_SHIM_BUILD)/uk_syscall.c: $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls.h.in $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall.awk $(LIBSYSCALL_SHIM_BASE)/uk_syscall.c.in_end
+$(LIBSYSCALL_SHIM_BUILD)/uk_syscall.c: $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls_arch.h.in $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall.awk $(LIBSYSCALL_SHIM_BASE)/uk_syscall.c.in_end
 	$(call build_cmd,GEN,libsyscall_shim,$(notdir $@), \
 		$(AWK) -F '-' -f $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall.awk $< > $@ && \
 		cat $(LIBSYSCALL_SHIM_BASE)/uk_syscall.c.in_end >> $@)
 
-$(LIBSYSCALL_SHIM_BUILD)/uk_syscall_r.c: $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls.h.in $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall_r.awk $(LIBSYSCALL_SHIM_BASE)/uk_syscall_r.c.in_end
+$(LIBSYSCALL_SHIM_BUILD)/uk_syscall_r.c: $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls_arch.h.in $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall_r.awk $(LIBSYSCALL_SHIM_BASE)/uk_syscall_r.c.in_end
 	$(call build_cmd,GEN,libsyscall_shim,$(notdir $@), \
 		$(AWK) -F '-' -f $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall_r.awk $< > $@ && \
 		cat $(LIBSYSCALL_SHIM_BASE)/uk_syscall_r.c.in_end >> $@)
 
-$(LIBSYSCALL_SHIM_BUILD)/uk_syscall6_r.c: $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls.h.in $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall6_r.awk $(LIBSYSCALL_SHIM_BASE)/uk_syscall6_r.c.in_end
+$(LIBSYSCALL_SHIM_BUILD)/uk_syscall6_r.c: $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls_arch.h.in $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall6_r.awk $(LIBSYSCALL_SHIM_BASE)/uk_syscall6_r.c.in_end
 	$(call build_cmd,GEN,libsyscall_shim,$(notdir $@), \
 		$(AWK) -F '-' -f $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall6_r.awk $< > $@ && \
 		cat $(LIBSYSCALL_SHIM_BASE)/uk_syscall6_r.c.in_end >> $@)
 
-$(LIBSYSCALL_SHIM_BUILD)/uk_syscall_r_fn.c: $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls.h.in $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall_r_fn.awk
+$(LIBSYSCALL_SHIM_BUILD)/uk_syscall_r_fn.c: $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls_arch.h.in $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall_r_fn.awk
 	$(call build_cmd,GEN,libsyscall_shim,$(notdir $@), \
 		$(AWK) -F '-' -f $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall_r_fn.awk $< > $@)
 
@@ -78,7 +83,7 @@ $(LIBSYSCALL_SHIM_BUILD)/uk_syscall_name.c: $(LIBSYSCALL_SHIM_BASE)/gen_uk_sysca
 		$(AWK) -f $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall_name.awk \
 		$(LIBSYSCALL_SHIM_TEMPL) > $@)
 
-$(LIBSYSCALL_SHIM_BUILD)/uk_syscall_name_p.c: $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls.h.in $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall_name_p.awk
+$(LIBSYSCALL_SHIM_BUILD)/uk_syscall_name_p.c: $(LIBSYSCALL_SHIM_BUILD)/provided_syscalls_arch.h.in $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall_name_p.awk
 	$(call build_cmd,GEN,libsyscall_shim,$(notdir $@), \
 		$(AWK) -F '-' -f $(LIBSYSCALL_SHIM_BASE)/gen_uk_syscall_name_p.awk $< > $@)
 

--- a/lib/syscall_shim/gen_available.awk
+++ b/lib/syscall_shim/gen_available.awk
@@ -1,0 +1,9 @@
+BEGIN {print "/* Automatically generated file; DO NOT EDIT */"}
+
+NR==FNR {
+    lines[$1]=$0; next
+}
+
+lines[substr($2,6)]!="" {
+    print lines[substr($2,6)]
+}


### PR DESCRIPTION
Currently, when we register a syscall to the syscall shim layer,
we don't check if it should be available on the target architecture.
Therefore, several build errors appear when some libraries are selected.
This commit adds an additional intermediary file in the build process,
which helps registering a syscall only if it is present in the
corresponding `syscall.h.in` architecture file.

Signed-off-by: Răzvan Vîrtan <virtanrazvan@gmail.com>
Signed-off-by: Răzvan Deaconescu <razvan.deaconescu@cs.pub.ro>
