### PR TITLE
lib/uksched: Fix race condition in wait_event

### DIFF
--- a/lib/uksched/include/uk/wait.h
+++ b/lib/uksched/include/uk/wait.h
@@ -105,6 +105,10 @@ do { \
 		for (;;) { \
 			/* protect the list */ \
 			flags = ukplat_lcpu_save_irqf(); \
+			if (condition) { \
+				ukplat_lcpu_restore_irqf(flags); \
+				break; \
+			} \
 			uk_waitq_add(wq, &__wait); \
 			__current->wakeup_time = deadline; \
 			clear_runnable(__current); \


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [X] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [X] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

`__wq_wait_event_deadline()` waits until a certain condition is met or a deadline is reached. The current code does a preliminary condition check to avoid disabling interrupts just to find that the condition evaluates to true. However, if the condition is actually false, it is not checked again after disabling interrupts. If the condition changes in an interrupt handler this can lead to a signal loss. The thread then goes to sleep although it should continue to run.

The commit adds the additional check and bails out if the condition is met before blocking the thread.

The problem could be observed in the network stack where in the interrupt handler a `uk_semaphore_up()` is done to inform the uknetdev dispatch thread of incoming data. Once the dispatch thread has finished processing all data it goes to sleep using a `uk_semaphore_down()`.

As can be seen, the condition `s->count > 0` is supplied and eventually checked in `uk_waitq_wait_event()` without interrupts being disabled; thereby making the operation susceptible to signal loss.
```C
static inline void uk_semaphore_down(struct uk_semaphore *s)
{
	unsigned long irqf;

	for (;;) {
		uk_waitq_wait_event(&s->wait, s->count > 0);
		irqf = ukplat_lcpu_save_irqf();
	...
```

The problem manifests if `s->count` changes (i.e., an interrupt occurs) between the two marked code locations: 
```C
#define __wq_wait_event_deadline(wq, condition, deadline, deadline_condition, \
				 lock_fn, unlock_fn, lock) \
({ \
	struct uk_thread *__current; \
	unsigned long flags; \
	int timedout = 0; \
	DEFINE_WAIT(__wait); \
	if (!(condition)) { \                                      <------   
		__current = uk_thread_current(); \
		for (;;) { \
			/* protect the list */ \
			flags = ukplat_lcpu_save_irqf(); \         <------ 
			uk_waitq_add(wq, &__wait); \
			__current->wakeup_time = deadline; \
			clear_runnable(__current); \
			....
```