### PR TITLE
plat/*: Fix build warning for halt definition

### DIFF
--- a/plat/linuxu/irq.c
+++ b/plat/linuxu/irq.c
@@ -37,6 +37,13 @@
 #include <uk/assert.h>
 #include <linuxu/syscall.h>
 #include <linuxu/signal.h>
+#if defined(__X86_32__) || defined(__x86_64__)
+#include <x86/cpu.h>
+#elif (defined __ARM_32__) || (defined __ARM_64__)
+#include <arm/cpu.h>
+#else
+#error "Unsupported architecture"
+#endif
 
 #define IRQS_NUM    16
 

--- a/plat/xen/lcpu.c
+++ b/plat/xen/lcpu.c
@@ -33,8 +33,10 @@
 #include <stdint.h>
 #if defined(__X86_32__) || defined(__x86_64__)
 #include <xen-x86/irq.h>
+#include <x86/cpu.h>
 #elif (defined __ARM_32__) || (defined __ARM_64__)
 #include <xen-arm/os.h>
+#include <arm/cpu.h>
 #else
 #error "Unsupported architecture"
 #endif


### PR DESCRIPTION
Fix build warning for implicit declaration of function halt.

Signed-off-by: Gabriel Mocanu <gabi.mocanu98@gmail.com>

### Base target

 - Architecture(s): [N/A]
 - Platform(s): [`xen`, `linuxu`]
 - Application(s): [N/A]