### PR TITLE
plat/linuxu: Add dependency to `lib/ukalloc`

### DIFF
--- a/plat/linuxu/Config.uk
+++ b/plat/linuxu/Config.uk
@@ -3,6 +3,7 @@ menuconfig PLAT_LINUXU
        default n
        depends on ((ARCH_X86_64 && !HAVE_SYSCALL && !HAVE_SMP) || (ARCH_ARM_32 && !HAVE_SYSCALL && !HAVE_SMP))
        select LIBUKDEBUG
+       select LIBUKALLOC
        select LIBNOLIBC if !HAVE_LIBC
        help
                 Create a Unikraft image that runs as a Linux user space program


### PR DESCRIPTION
The linuxu platform library requires the `ukalloc` API to be available
(not necessarily an allocator) in order to succeed with compilation.

### Prerequisite checklist

 - [X] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `linuxu`
 - Application(s): N/A

### Additional configuration

Minimal configuration as possible for linuxu:

 - `CONFIG_ARCH_X86_64=y`
 - `CONFIG_PLAT_LINUXU=y`
 - `CONFIG_LIBUKBOOT=y`
 - `CONFIG_LIBUKBOOT_NOALLOC=y`