### PR TITLE
lib/syscall_shim: Fix build warning for _uk_printd definition

### DIFF
--- a/lib/syscall_shim/Config.uk
+++ b/lib/syscall_shim/Config.uk
@@ -38,4 +38,5 @@ if LIBSYSCALL_SHIM
 	config LIBSYSCALL_SHIM_DEBUG
 		bool "Enable debug messages"
 		default n
+		select LIBUKDEBUG_PRINTD
 endif


### PR DESCRIPTION
Fix build warning for implicit declaration of _uk_printd

Signed-off-by: Gabriel Mocanu <gabi.mocanu98@gmail.com>

### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

In order to reproduce this warning you can build a hello-world application and select:
`syscall-shim -> Enable debug messages`.

### Description of changes

I added a dependency of LIBUKDEBUG_PRINTD for shim layer debug to avoid that implicit declaration.