### PR TITLE
lib/ukargparse: Fix quoted whitespaces handling

### DIFF
--- a/lib/ukargparse/argparse.c
+++ b/lib/ukargparse/argparse.c
@@ -35,7 +35,7 @@
 #include <uk/assert.h>
 
 
-static void left_shift(char *buf, __sz index, __sz maxlen) 
+static void left_shift(char *buf, __sz index, __sz maxlen)
 {
 	while(buf[index] != '\0' && index < maxlen) {
 		buf[index] = buf[index + 1];
@@ -69,8 +69,9 @@ int uk_argnparse(char *argb, __sz maxlen, char *argv[], int maxcount)
 			if (!in_quote) {
 				argb[i] = '\0';
 				prev_wspace = 1;
+				break;
 			}
-			break;
+			goto regularchar;
 
 		/* quotes */
 		case '\'':
@@ -87,9 +88,10 @@ int uk_argnparse(char *argb, __sz maxlen, char *argv[], int maxcount)
 				--i;
 				break;
 			}
-			
-			/* Fall through */
+			goto regularchar;
+
 		default:
+		regularchar:
 			/* any character */
 			if (prev_wspace) {
 				argv[argc++] = &argb[i];


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A
 
### Description of changes

Previously, the whitespaces were not handled when placed inside a quoted text and at the beginning of a new word (i.e when `prev_wspace` == 1 and `in_quote` != 0).
This led to arguments like `"\targ"` be parsed to `arg` instead of `\targ`.

This commit treats the whitespaces when inside a quoted text the same as all the other characters in the `default` branch of the switch statement, so when `prev_wspace` is set to 1 a new entry is created in `argv` and `prev_wspace` is set to 0.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>
