### PR TITLE
Introduce ukarch_random and add implementation for arm64 (FEAT_RNG)

### DIFF
--- a/arch/Config.uk
+++ b/arch/Config.uk
@@ -33,3 +33,8 @@ config STACK_SIZE_PAGE_ORDER
 		Indirectly configures the stack size by changing the stack size page
 		order. Stack size is equal with 2^order * page size (e.g. 4KB).
 		Only change this if you know what you're doing.
+
+config HAVE_RANDOM
+	bool
+	help
+		Processor-generated randomness support.

--- a/arch/arm/arm64/Config.uk
+++ b/arch/arm/arm64/Config.uk
@@ -161,6 +161,15 @@ menu "Armv8-A Extensions"
 	help
 		BTI protects against JOP-like attacks by placing and
 		verifying landing pads on branch targets.
+
+config ARM64_FEAT_RNG
+	bool "Armv8.5 Random Number Generator"
+	select HAVE_RANDOM
+	help
+	  This enables the hardware RNG functionality provided by the
+	  processor. The architecture specifies that this is implemented
+	  by a Deterministic Random Bit Generator (DRBG) that is seeded
+	  from a TRNG.
 endmenu
 
 config ARM64_ERRATUM_858921

--- a/arch/arm/arm64/Makefile.uk
+++ b/arch/arm/arm64/Makefile.uk
@@ -41,9 +41,16 @@ else
 endif
 endif
 
+ifeq ($(CONFIG_ARM64_FEAT_RNG),y)
+# FEAT_RNG support introduced in GCC-9
+$(call error_if_gcc_version_lt,9,0)
+ARCH_REV := armv8.5-a
+ARCH_OPT += +rng
+endif
+
 ifdef ARCH_REV
-ARCHFLAGS-y += -march=$(ARCH_REV)
-ISR_ARCHFLAGS-y += -march=$(ARCH_REV)
+ARCHFLAGS-y += -march=$(ARCH_REV)$(ARCH_OPT)
+ISR_ARCHFLAGS-y += -march=$(ARCH_REV)$(ARCH_OPT)
 endif
 
 ifdef BRANCH_PROTECTION

--- a/arch/arm/arm64/include/uk/asm/arch.h
+++ b/arch/arm/arm64/include/uk/asm/arch.h
@@ -143,6 +143,10 @@
 #define ESR_ISS_ABRT_FSC_LOCKDOWN		0x34
 #define ESR_ISS_ABRT_FSC_UNSUP_EXCL		0x35
 
+/* ID_AA64ISAR0_EL1: AArch64 Instruction Set Attributes Register 0 */
+#define ID_AA64ISAR0_EL1_RNDR_SHIFT		_AC(60, ULL)
+#define ID_AA64ISAR0_EL1_RNDR_MASK		_AC(0xf, UL)
+
 /* ID_AA64ISAR1_EL1: AArch64 Instruction Set Attributes Register 1 */
 #define ID_AA64ISAR1_EL1_GPI_SHIFT		28
 #define ID_AA64ISAR1_EL1_GPI_MASK		0xf

--- a/arch/arm/arm64/include/uk/asm/random.h
+++ b/arch/arm/arm64/include/uk/asm/random.h
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2022, Michalis Pappas <mpappas@fastmail.fm>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __UKARCH_RANDOM_H__
+#error Do not include this header directly
+#endif
+
+#ifdef CONFIG_ARM64_FEAT_RNG
+
+static inline int ukarch_random_init(void)
+{
+	__u64 reg;
+
+	__asm__ __volatile__("mrs %x0, ID_AA64ISAR0_EL1\n" : "=r"(reg));
+
+	return !((reg >> ID_AA64ISAR0_EL1_RNDR_SHIFT) &
+		 ID_AA64ISAR0_EL1_RNDR_MASK);
+}
+
+static inline int ukarch_random_u64(__u64 *val)
+{
+	__u64 res;
+
+	__asm__ __volatile__("	mrs	%x0, RNDR\n" /* Get rand */
+			     "	mrs	%x1, NZCV\n" /* Get result */
+			     : "=r"(*val), "=r"(res));
+	return res;
+}
+
+static inline int ukarch_random_u32(__u32 *val)
+{
+	__u32 res;
+	__u64 val64;
+
+	res = ukarch_random_u64(&val64);
+
+	*val = (__u32)val64;
+
+	return res;
+}
+
+static inline int ukarch_random_seed_u64(__u64 *val)
+{
+	__u64 res;
+
+	__asm__ __volatile__("	mrs	%x0, RNDRRS\n" /* Get rand */
+			     "	mrs	%x1, NZCV\n"   /* Get result */
+			     : "=r"(*val), "=r"(res));
+	return res;
+}
+
+static inline int ukarch_random_seed_u32(__u32 *val)
+{
+	__u32 res;
+	__u64 val64;
+
+	res = ukarch_random_seed_u64(&val64);
+
+	*val = (__u32)val64;
+
+	return res;
+}
+
+#endif /* CONFIG_ARM64_FEAT_RNG */

--- a/include/uk/arch/random.h
+++ b/include/uk/arch/random.h
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2022, Michalis Pappas <mpappas@fastmail.fm>.
+ *                     All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __UKARCH_RANDOM_H__
+#define __UKARCH_RANDOM_H__
+
+#include <uk/arch/types.h>
+#include <uk/essentials.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if CONFIG_HAVE_RANDOM
+
+#include <uk/asm/random.h>
+
+/**
+ * Initialize the RNG
+ *
+ * @return 0 on success, negative value on failure
+ */
+int ukarch_random_init(void);
+
+/**
+ * Get a 64-bit random integer
+ *
+ * @param [out] val Pointer to store the generated value
+ * @return 0 on success, negative value on failure
+ */
+int __check_result ukarch_random_u32(__u32 *val);
+
+/**
+ * Get a 32-bit random integer
+ *
+ * @param [out] val Pointer to store the generated value
+ * @return 0 on success, negative value on failure
+ */
+int __check_result ukarch_random_u64(__u64 *val);
+
+/**
+ * Reseed the RNG and get a 64-bit random integer
+ *
+ * @param [out] val Pointer to store the generated value
+ * @return 0 on success, negative value on failure
+ */
+int __check_result ukarch_random_seed_u32(__u32 *val);
+
+/**
+ * Reseed the RNG and get a 32-bit random integer
+ *
+ * @param [out] val Pointer to store the generated value
+ * @return 0 on success, negative value on failure
+ */
+int __check_result ukarch_random_seed_u64(__u64 *val);
+
+#else /* CONFIG_HAVE_RANDOM */
+
+static inline int __check_result ukarch_random_init(void)
+{
+	return -1;
+}
+
+static inline int __check_result ukarch_random_u32(__u32 *val __unused)
+{
+	return -1;
+}
+
+static inline int __check_result ukarch_random_u64(__u64 *val __unused)
+{
+	return -1;
+}
+
+static inline int __check_result ukarch_random_seed_u32(__u32 *val __unused)
+{
+	return -1;
+}
+
+static inline int __check_result ukarch_random_seed_u64(__u64 *val __unused)
+{
+	return -1;
+}
+
+#endif /* CONFIG_HAVE_RANDOM */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __UKARCH_RANDOM_H__ */

--- a/include/uk/essentials.h
+++ b/include/uk/essentials.h
@@ -96,6 +96,9 @@ extern "C" {
 #ifndef __noinline
 #define __noinline             __attribute__((noinline))
 #endif
+#ifndef __check_result
+#define __check_result         __attribute__((warn_unused_result))
+#endif
 
 #ifndef __alias
 #define __alias(old, new) \


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`, `x86_64`]
 - Platform(s): [N/A]
 - Application(s): [N/A]

### Additional configuration

The ukarch_random API is unconditionally present. Each architecture's support is conditional and can be checked via the `ukararch_random_avail()`.

In arm64, availability is controlled by a newly introduced parameter `CONFIG_ARM_64_FEAT_RNG`.

### Description of changes

#### The ukarch_random API

Processor-supported random number generation can be useful for different purposes on the platform and library level. Some examples include key / seed generation for hardware-based security protections, such as PAuth, MTE in Armv8, or seed generation for the ChaCha20-based PRNG in the ukswrand library.

This PR introduces a minimal API for processor-supported randomness, namely `ukarch_random`. The API consists of merely three functions, that map closely to the functionality provided by the relevant mechanisms in Armv8 and x86_64: `ukarch_random_avail()` checks whether the feature is implemented by the processor, `ukarch_random_get_long()` returns a random long integer, and `ukarch_random_long_reseed()` returns a random long integer after reseeding the RNG.

Given that the trustworthiness of processor-provided randomness is a controversial topic, higher layers shall ideally use `ukarch_random` optionally and when possible provide the user with additional options for other sources of randomness, such as drivers to TRNGs or Crypto Engines external to the processor.

#### Implementation in Armv8

Processor-supported randomness (FEAT_RNG) is introduced as an OPTIONAL extension in Armv8.5-a. The architecture defines the RNG as the output of a Deterministic Random Bit Generator (DRBG) that produces random numbers from a cryptographically secure algorithm, and is seeded by a True Random Number Generator (TRNG). The architecture requires that the DRBG and TRNG conform to a set of standards. Specifically the DRBG should conform to NIST SP800-90A Rev1, while TRNG should conform to NIST SP800-90B, NIST SP800-22, FIPS 140-2, BSI AIS-31.

The RNG is exposed to the user through the RNDR and RNDRSS registers. The RNDR outputs random numbers, and is re-seeded at an IMPLEMENTATION DEFINED rate. RNDRSS re-seeds the DRBG immediately before generating a new random number.

This PR provides an implementation of the `ukarch_random` API via the RNDR / RNDRSS registers, along with a new option `CONFIG_ARM_64_FEAT_RNG`, to enable the feature. As no Armv8 IP provided by Arm implements Armv8.5-A, this can be only tested in QEMU with `-machine virt -cpu max` or third-party SoCs that implement `FEAT_RNG`.

***Notice:*** Since the rate at which TRNGs can generate random bits is limited, RNDR and RNDRSS try to return a random number at a "reasonable period of time". When that fails, the PSTATE.NZCV bits are set to 0b0100, and a zero value is returned. Callers must therefore always check the result of the operation, and act as required on failure.