### PR TITLE
plat/xen: Remove __i386__ code

### DIFF
--- a/plat/xen/include/xen-x86/mm.h
+++ b/plat/xen/include/xen-x86/mm.h
@@ -28,10 +28,7 @@
 #include <uk/plat/common/sections.h>
 #ifndef __ASSEMBLY__
 #include <xen/xen.h>
-#if defined(__i386__)
-#include <xen/arch-x86_32.h>
-#define __CONST(x) x ## ULL
-#elif defined(__x86_64__)
+#if defined(__x86_64__)
 #include <xen/arch-x86_64.h>
 #define __CONST(x) x ## UL
 #else
@@ -74,39 +71,7 @@
 
 #define L1_PAGETABLE_SHIFT      12
 
-#if defined(__i386__)
-
-#define L2_PAGETABLE_SHIFT      21
-#define L3_PAGETABLE_SHIFT      30
-
-#define L1_PAGETABLE_ENTRIES    512
-#define L2_PAGETABLE_ENTRIES    512
-#define L3_PAGETABLE_ENTRIES    4
-
-#define PAGETABLE_LEVELS        3
-
-#define PADDR_BITS              44
-#define PADDR_MASK              ((1ULL << PADDR_BITS)-1)
-
-#define L2_MASK  ((1UL << L3_PAGETABLE_SHIFT) - 1)
-
-#define PRIpte "016llx"
-#ifndef __ASSEMBLY__
-typedef uint64_t pgentry_t;
-#else
-#define PTE(val) .long val; .long 0
-#endif
-
-#define MAX_MEM_SIZE            CONST(0x3f000000)
-#define VIRT_KERNEL_AREA        CONST(0x3f000000)
-#define VIRT_DEMAND_AREA        CONST(0x40000000)
-#define VIRT_HEAP_AREA          CONST(0xb0000000)
-
-#define DEMAND_MAP_PAGES        CONST(0x6ffff)
-#define HEAP_PAGES_MAX          ((HYPERVISOR_VIRT_START - VIRT_HEAP_AREA) / \
-                                 PAGE_SIZE - 1)
-
-#elif defined(__x86_64__)
+#if defined(__x86_64__)
 
 #define L2_PAGETABLE_SHIFT      21
 #define L3_PAGETABLE_SHIFT      30
@@ -176,18 +141,13 @@ typedef unsigned long pgentry_t;
 #define _PAGE_PSE      CONST(0x080)
 #define _PAGE_GLOBAL   CONST(0x100)
 
-#if defined(__i386__)
-#define L1_PROT (_PAGE_PRESENT|_PAGE_RW|_PAGE_ACCESSED)
-#define L1_PROT_RO (_PAGE_PRESENT|_PAGE_ACCESSED)
-#define L2_PROT (_PAGE_PRESENT|_PAGE_RW|_PAGE_ACCESSED|_PAGE_DIRTY |_PAGE_USER)
-#define L3_PROT (_PAGE_PRESENT)
-#elif defined(__x86_64__)
+#if defined(__x86_64__)
 #define L1_PROT (_PAGE_PRESENT|_PAGE_RW|_PAGE_ACCESSED|_PAGE_USER)
 #define L1_PROT_RO (_PAGE_PRESENT|_PAGE_ACCESSED|_PAGE_USER)
 #define L2_PROT (_PAGE_PRESENT|_PAGE_RW|_PAGE_ACCESSED|_PAGE_DIRTY|_PAGE_USER)
 #define L3_PROT (_PAGE_PRESENT|_PAGE_RW|_PAGE_ACCESSED|_PAGE_DIRTY|_PAGE_USER)
 #define L4_PROT (_PAGE_PRESENT|_PAGE_RW|_PAGE_ACCESSED|_PAGE_DIRTY|_PAGE_USER)
-#endif /* __i386__ || __x86_64__ */
+#endif /* __x86_64__ */
 
 /* flags for ioremap */
 #define IO_PROT (L1_PROT)
@@ -208,13 +168,8 @@ typedef unsigned long pgentry_t;
 
 #ifndef __ASSEMBLY__
 /* Definitions for machine and pseudophysical addresses. */
-#ifdef __i386__
-typedef unsigned long long paddr_t;
-typedef unsigned long long maddr_t;
-#else
 typedef unsigned long paddr_t;
 typedef unsigned long maddr_t;
-#endif
 
 extern pgentry_t *pt_base;
 #ifdef CONFIG_PARAVIRT

--- a/plat/xen/x86/arch_time.c
+++ b/plat/xen/x86/arch_time.c
@@ -99,33 +99,16 @@ static inline int wc_values_up_to_date(void)
 static inline uint64_t scale_delta(uint64_t delta, uint32_t mul_frac, int shift)
 {
 	uint64_t product;
-#ifdef __i386__
-	uint32_t tmp1, tmp2;
-#endif
 
 	if (shift < 0)
 		delta >>= -shift;
 	else
 		delta <<= shift;
 
-#ifdef __i386__
-	__asm__(
-		"mul  %5       ; "
-		"mov  %4,%%eax ; "
-		"mov  %%edx,%4 ; "
-		"mul  %5       ; "
-		"add  %4,%%eax ; "
-		"xor  %5,%5    ; "
-		"adc  %5,%%edx ; "
-		: "=A" (product), "=r" (tmp1), "=r" (tmp2)
-		: "a" ((uint32_t)delta), "1" ((uint32_t)(delta >> 32)), "2" (mul_frac)
-	);
-#else
 	__asm__(
 		"mul %%rdx ; shrd $32,%%rdx,%%rax"
 		: "=a" (product) : "0" (delta), "d" ((uint64_t)mul_frac)
 	);
-#endif
 
 	return product;
 }

--- a/plat/xen/x86/mm.c
+++ b/plat/xen/x86/mm.c
@@ -530,9 +530,6 @@ int unmap_frames(unsigned long va, unsigned long num_frames)
 			call[i].op = __HYPERVISOR_update_va_mapping;
 			call[i].args[arg++] = va;
 			call[i].args[arg++] = 0;
-#ifdef __i386__
-			call[i].args[arg++] = 0;
-#endif
 			call[i].args[arg++] = UVMF_INVLPG;
 
 			va += PAGE_SIZE;

--- a/plat/xen/x86/traps.c
+++ b/plat/xen/x86/traps.c
@@ -70,14 +70,8 @@ void traps_init(void)
 {
 	HYPERVISOR_set_trap_table(trap_table);
 
-#ifdef __i386__
-	HYPERVISOR_set_callbacks(__KERNEL_CS,
-				 (unsigned long) asm_trap_hypervisor_callback,
-				 __KERNEL_CS, (unsigned long) asm_failsafe_callback);
-#else
 	HYPERVISOR_set_callbacks((unsigned long) asm_trap_hypervisor_callback,
 				 (unsigned long) asm_failsafe_callback, 0);
-#endif
 }
 
 void traps_fini(void)


### PR DESCRIPTION
The unikraft is never going to support the 32-bit on x86, hence this
commit removes the redundant code introduced due to "#if defined(\_\_i386__) and
Closes #26

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): x86_64
 - Platform(s):  xen 
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes
As mentioned in issue #26 Unikraft is never going to support the i386 architecture, hence the commit removes the redundant code introduced by #if defined(\_\_i386__).


<!--
Please provide a detailed description of the changes made in this new PR.
-->
