### PR TITLE
plat/linuxu: Reorder macros in the linuxu system call header files

### DIFF
--- a/plat/linuxu/include/linuxu/syscall-arm_32.h
+++ b/plat/linuxu/include/linuxu/syscall-arm_32.h
@@ -36,27 +36,27 @@
 
 #include <stdint.h>
 
-#define __SC_READ       3
-#define __SC_WRITE      4
-#define __SC_OPENAT     322
-#define __SC_CLOSE      6
-#define __SC_MMAP     192 /* use mmap2() since mmap() is obsolete */
-#define __SC_MUNMAP    91
-#define __SC_EXIT       1
-#define __SC_IOCTL     54
-#define __SC_FSTAT    108
-#define __SC_FCNTL     55
-#define __SC_RT_SIGPROCMASK   126
-#define __SC_ARCH_PRCTL       172
-#define __SC_RT_SIGACTION     174
-#define __SC_TIMER_CREATE     257
-#define __SC_TIMER_SETTIME    258
-#define __SC_TIMER_GETTIME    259
-#define __SC_TIMER_GETOVERRUN 260
-#define __SC_TIMER_DELETE     261
-#define __SC_CLOCK_GETTIME    263
-#define __SC_SOCKET           281
-#define __SC_PSELECT6 335
+#define __SC_EXIT	1
+#define __SC_READ	3
+#define __SC_WRITE	4
+#define __SC_CLOSE	6
+#define __SC_IOCTL	54
+#define __SC_FCNTL	55
+#define __SC_MUNMAP	91
+#define __SC_FSTAT	108
+#define __SC_RT_SIGPROCMASK	126
+#define __SC_ARCH_PRCTL	172
+#define __SC_RT_SIGACTION	174
+#define __SC_MMAP	192 /* use mmap2() since mmap() is obsolete */
+#define __SC_TIMER_CREATE	257
+#define __SC_TIMER_SETTIME	258
+#define __SC_TIMER_GETTIME	259
+#define __SC_TIMER_GETOVERRUN	260
+#define __SC_TIMER_DELETE	261
+#define __SC_CLOCK_GETTIME	263
+#define __SC_SOCKET	281
+#define __SC_OPENAT	322
+#define __SC_PSELECT6	335
 
 #ifndef O_TMPFILE
 #define O_TMPFILE 020040000

--- a/plat/linuxu/include/linuxu/syscall-arm_64.h
+++ b/plat/linuxu/include/linuxu/syscall-arm_64.h
@@ -38,27 +38,29 @@
 
 #include <stdint.h>
 
-#define __SC_READ       63
-#define __SC_WRITE      64
-#define __SC_OPENAT     56 /* changed to openat because open is not on arm64 */
-#define __SC_CLOSE      57
-#define __SC_MMAP      222 /* use mmap2() since mmap() is obsolete */
-#define __SC_MUNMAP    215
-#define __SC_EXIT       93
-#define __SC_IOCTL		29
-#define __SC_FSTAT		80
-#define __SC_FCNTL		25
-#define __SC_RT_SIGPROCMASK   135
-#define __SC_ARCH_PRCTL       167
-#define __SC_RT_SIGACTION     134
-#define __SC_TIMER_CREATE     107
-#define __SC_TIMER_SETTIME    110
-#define __SC_TIMER_GETTIME    108
-#define __SC_TIMER_GETOVERRUN 109
-#define __SC_TIMER_DELETE     111
-#define __SC_CLOCK_GETTIME    113
-#define __SC_SOCKET           198
-#define __SC_PSELECT6         72
+#define __SC_FCNTL	25
+#define __SC_IOCTL	29
+#define __SC_OPENAT	56 /* use openat because open is not on arm64 */
+#define __SC_CLOSE	57
+#define __SC_READ	63
+#define __SC_WRITE	64
+#define __SC_PSELECT6	72
+#define __SC_FSTAT	80
+#define __SC_EXIT	93
+#define __SC_TIMER_CREATE	107
+#define __SC_TIMER_GETTIME	108
+#define __SC_TIMER_GETOVERRUN	109
+#define __SC_TIMER_SETTIME	110
+#define __SC_TIMER_DELETE	111
+#define __SC_CLOCK_GETTIME	113
+#define __SC_RT_SIGACTION	134
+#define __SC_RT_SIGPROCMASK	135
+#define __SC_ARCH_PRCTL	167
+#define __SC_SOCKET	198
+#define __SC_MUNMAP	215
+#define __SC_MMAP	222 /* use mmap2() since mmap() is obsolete */
+
+
 
 #ifndef O_TMPFILE
 #define O_TMPFILE 020040000

--- a/plat/linuxu/include/linuxu/syscall-x86_64.h
+++ b/plat/linuxu/include/linuxu/syscall-x86_64.h
@@ -36,27 +36,27 @@
 
 #include <stdint.h>
 
-#define __SC_READ    0
-#define __SC_WRITE   1
-#define __SC_OPENAT  257
-#define __SC_CLOSE   3
-#define __SC_FSTAT   5
-#define __SC_MMAP    9
-#define __SC_MUNMAP 11
-#define __SC_RT_SIGACTION   13
-#define __SC_RT_SIGPROCMASK 14
-#define __SC_IOCTL  16
-#define __SC_SOCKET 41
-#define __SC_EXIT   60
-#define __SC_FCNTL  72
-#define __SC_ARCH_PRCTL       158
-#define __SC_TIMER_CREATE     222
-#define __SC_TIMER_SETTIME    223
-#define __SC_TIMER_GETTIME    224
-#define __SC_TIMER_GETOVERRUN 225
-#define __SC_TIMER_DELETE     226
-#define __SC_CLOCK_GETTIME    228
-#define __SC_PSELECT6 270
+#define __SC_READ	0
+#define __SC_WRITE	1
+#define __SC_CLOSE	3
+#define __SC_FSTAT	5
+#define __SC_MMAP	9
+#define __SC_MUNMAP	11
+#define __SC_RT_SIGACTION	13
+#define __SC_RT_SIGPROCMASK	14
+#define __SC_IOCTL	16
+#define __SC_SOCKET	41
+#define __SC_EXIT	60
+#define __SC_FCNTL	72
+#define __SC_ARCH_PRCTL	158
+#define __SC_TIMER_CREATE	222
+#define __SC_TIMER_SETTIME	223
+#define __SC_TIMER_GETTIME	224
+#define __SC_TIMER_GETOVERRUN	225
+#define __SC_TIMER_DELETE	226
+#define __SC_CLOCK_GETTIME	228
+#define __SC_OPENAT	257
+#define __SC_PSELECT6	270
 
 
 #ifndef O_TMPFILE


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): linuxu
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit reorders all system call macros in the
/plat/linuxu/include/linuxu header files after their system call numbers.
