### PR TITLE
lib/ukargparse: Use mutable strings in tests

### DIFF
--- a/lib/ukargparse/tests/test_ukargparse_parse.c
+++ b/lib/ukargparse/tests/test_ukargparse_parse.c
@@ -42,7 +42,7 @@
 
 UK_TESTCASE(ukargparse, parse_space_separated)
 {
-	char *arg_str = {"some/path/file -test 1 --test-this"};
+	char arg_str[] = "some/path/file -test 1 --test-this";
 	static const char * const arg_ex[] = {"some/path/file",
 		"-test", "1", "--test-this"};
 
@@ -71,7 +71,7 @@ UK_TESTCASE(ukargparse, parse_null)
 
 UK_TESTCASE(ukargparse, parse_extra_whitespaces)
 {
-	char *arg_str = {"some\t\t\n\t\tseparated\n\t\t  \n  string"};
+	char arg_str[] = "some\t\t\n\t\tseparated\n\t\t  \n  string";
 	static const char * const arg_ex[] = {"some", "separated", "string"};
 
 	// null-terminated array of parsed arguments
@@ -88,7 +88,7 @@ UK_TESTCASE(ukargparse, parse_extra_whitespaces)
 
 UK_TESTCASE(ukargparse, parse_quotes)
 {
-	char *arg_str = {"\"\targ_a\" ' arg_b' \"arg'c\" arg_d'' arg\"_\"e\"'\""};
+	char arg_str[] = "\"\targ_a\" ' arg_b' \"arg'c\" arg_d'' arg\"_\"e\"'\"";
 	static const char * const arg_ex[] = {"\targ_a", " arg_b", "arg'c", "arg_d", "arg_e'"};
 
 	// null-terminated array of parsed arguments


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

None.

### Description of changes

Tests in libukarparse pass `ukargnparse()` with string literals. As string literals are stored in `.rodata`, and `ukargnparse()` performs in-place modification of parsed strings, this causes a data abort in KVM / Arm64. The only reason it works on x86 is because segments attributes are not properly set and `.text` and `.rodata` are not read-only (#414) 😛 This commit adds a macro to convert string literals into string buffers.