### PR TITLE
lib/syscall_shim: Solve UK_SYSCALL_R_DEFINE macro

### DIFF
--- a/lib/syscall_shim/include/uk/syscall.h
+++ b/lib/syscall_shim/include/uk/syscall.h
@@ -286,6 +286,7 @@ typedef long uk_syscall_arg_t;
 #else
 #define UK_SYSCALL_R_DEFINE(rtype, name, ...)				\
 	_UK_LLSYSCALL_R_DEFINE(__UK_SYSCALL_DEF_NARGS(__VA_ARGS__),	\
+			       rtype,					\
 			       name,					\
 			       __UK_NAME2SCALLE_FN(name),		\
 			       __UK_NAME2SCALLR_FN(name),		\


### PR DESCRIPTION
When musl is used we set the option
`LIBSYSCALL_SHIM_NOWRAPPER`. This causes
the low level version of the macro to
be used (i.e.  _UK_LLSYSCALL_R_DEFINE).
In the current version the compilation
fails due to omitting the `rtype` field.
This commit will solve this issue.

Signed-off-by: Dragos Iulian Argint <dragosargint21@gmail.com>