### PR TITLE
lib/vfscore: Solve redefining conflicts

### DIFF
--- a/lib/vfscore/mount.c
+++ b/lib/vfscore/mount.c
@@ -308,11 +308,13 @@ found:
 	return error;
 }
 
+#if UK_LIBC_SYSCALLS
 int
 umount(const char *path)
 {
 	return umount2(path, 0);
 }
+#endif /* UK_LIBC_SYSCALLS */
 
 #if 0
 int
@@ -386,7 +388,7 @@ void sync(void)
 {
 	uk_syscall_e_sync();
 }
-#endif
+#endif /* UK_LIBC_SYSCALLS */
 
 /*
  * Compare two path strings. Return matched length.

--- a/lib/vfscore/pipe.c
+++ b/lib/vfscore/pipe.c
@@ -707,6 +707,7 @@ UK_SYSCALL_R_DEFINE(int, pipe2, int*, pipefd, int, flags)
 	return 0;
 }
 
+#if UK_LIBC_SYSCALLS
 /* TODO maybe find a better place for this when it will be implemented */
 int mkfifo(const char *path __unused, mode_t mode __unused)
 {
@@ -714,3 +715,4 @@ int mkfifo(const char *path __unused, mode_t mode __unused)
 	errno = ENOTSUP;
 	return -1;
 }
+#endif /* UK_LIBC_SYSCALLS */

--- a/lib/vfscore/stdio.c
+++ b/lib/vfscore/stdio.c
@@ -217,8 +217,8 @@ void init_stdio(void)
 	fd = vfscore_alloc_fd();
 	UK_ASSERT(fd == 0);
 	vfscore_install_fd(0, &stdio_file);
-	if (dup2(0, 1) != 1)
+	if (uk_syscall_r_dup2(0, 1) != 1)
 		uk_pr_err("failed to dup to stdin\n");
-	if (dup2(0, 2) != 2)
+	if (uk_syscall_r_dup2(0, 2) != 2)
 		uk_pr_err("failed to dup to stderr\n");
 }


### PR DESCRIPTION
There are many functions that are defined in musl as well as in vfscore. When using
musl we want to use the musl functions. When we use musl the `LIBSYSCALL_SHIM_NOWRAPPER`
macro is set, which leads to the setting of `UK_LIBC_SYSCALLS` to 0. We can use this
to exclude the redefined functions from vfscore.

This PR is part of a series:
https://github.com/unikraft/unikraft/pull/454
https://github.com/unikraft/unikraft/pull/453
https://github.com/unikraft/unikraft/pull/442
https://github.com/unikraft/unikraft/pull/441

Signed-off-by: Dragos Iulian Argint <dragosargint21@gmail.com>

