### PR TITLE
plat/kvm/arm: Zero out the .bss on runtime setup

### DIFF
--- a/plat/kvm/arm/entry64.S
+++ b/plat/kvm/arm/entry64.S
@@ -121,6 +121,14 @@ ENTRY(_libkvmplat_entry)
 
 	mov sp, x27
 
+	/* Zero-out the BSS */
+	ldr x26, =__bss_start
+	ldr x27, =_end
+2:
+	str	xzr, [x26], #8
+	cmp	x26, x27
+	b.lo	2b
+
 	/* Set the context id */
 	msr contextidr_el1, xzr
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]

### Additional configuration

None

### Description of changes

The bootcode in kvm/arm does not zero-out the bss. This causes the
retention of values after a system reset. Update entry64.S to zero-out
the bss when setting up the runtime.

Resolves #360
