### PR TITLE
Fix interprocessor interrupts in gic-v2

### DIFF
--- a/plat/drivers/gic/gic-v2.c
+++ b/plat/drivers/gic/gic-v2.c
@@ -163,7 +163,7 @@ static void gic_sgi_gen(uint32_t sgintid, enum sgi_filter targetfilter,
 	/* Set SGI INITID field */
 	val |= sgintid;
 
-	/* Generate SGI */
+	/* Generate SGI - spin lock here is needed when smp is supported */
 	dist_lock(gicv2_drv);
 	write_gicd32(GICD_SGIR, val);
 	dist_unlock(gicv2_drv);
@@ -172,35 +172,27 @@ static void gic_sgi_gen(uint32_t sgintid, enum sgi_filter targetfilter,
 /*
  * Forward the SGI to the CPU interfaces specified in the
  * targetlist. Targetlist is a 8-bit bitmap for 0~7 CPU.
- * TODO: this will not work until SMP is supported
  */
 void gic_sgi_gen_to_list(uint32_t sgintid, uint8_t targetlist)
 {
 	unsigned long irqf;
 
-	/* spin lock here is needed when smp is supported */
-	dist_lock(gicv2_drv);
 	irqf = ukplat_lcpu_save_irqf();
 	gic_sgi_gen(sgintid, GICD_SGI_FILTER_TO_LIST, targetlist);
 	ukplat_lcpu_restore_irqf(irqf);
-	dist_unlock(gicv2_drv);
 }
 
 /*
  * Forward the SGI to all CPU interfaces except that of the
  * processor that requested the interrupt.
- * TODO: this will not work until SMP is supported
  */
 void gic_sgi_gen_to_others(uint32_t sgintid)
 {
 	unsigned long irqf;
 
-	/* spin lock here is needed when smp is supported */
-	dist_lock(gicv2_drv);
 	irqf = ukplat_lcpu_save_irqf();
 	gic_sgi_gen(sgintid, GICD_SGI_FILTER_TO_OTHERS, 0);
 	ukplat_lcpu_restore_irqf(irqf);
-	dist_unlock(gicv2_drv);
 }
 
 /*

--- a/plat/drivers/gic/gic-v2.c
+++ b/plat/drivers/gic/gic-v2.c
@@ -183,6 +183,14 @@ void gic_sgi_gen_to_list(uint32_t sgintid, uint8_t targetlist)
 }
 
 /*
+ * Forward the SGI to the CPU specified by cpuid.
+ */
+static void gic_sgi_gen_to_cpu(uint8_t sgintid, uint32_t cpuid)
+{
+	gic_sgi_gen_to_list((uint32_t) sgintid, (uint8_t) (1 << (cpuid % 8)));
+}
+
+/*
  * Forward the SGI to all CPU interfaces except that of the
  * processor that requested the interrupt.
  */
@@ -465,6 +473,7 @@ static int gicv2_do_probe(const void *fdt)
 		.set_irq_affinity  = gic_set_irq_target,
 		.irq_translate     = gic_irq_translate,
 		.handle_irq        = gic_handle_irq,
+		.gic_sgi_gen = gic_sgi_gen_to_cpu,
 	};
 
 	/* Set driver functions */

--- a/plat/drivers/include/gic/gic.h
+++ b/plat/drivers/include/gic/gic.h
@@ -95,6 +95,8 @@ struct _gic_operations {
 	uint32_t (*irq_translate)(uint32_t type, uint32_t irq);
 	/** Handle IRQ */
 	void (*handle_irq)(void);
+	/** Send a SGI to the specifiec core */
+	void (*gic_sgi_gen)(uint8_t sgintid, uint32_t cpuid);
 };
 
 /** GIC controller structure */

--- a/plat/kvm/arm/intctrl.c
+++ b/plat/kvm/arm/intctrl.c
@@ -62,7 +62,7 @@ EXIT_ERR:
 
 void intctrl_ack_irq(unsigned int irq __unused)
 {
-	//NOP
+	gic->ops.ack_irq();
 }
 
 void intctrl_mask_irq(unsigned int irq)
@@ -73,4 +73,9 @@ void intctrl_mask_irq(unsigned int irq)
 void intctrl_clear_irq(unsigned int irq)
 {
 	gic->ops.enable_irq(irq);
+}
+
+void intctrl_send_ipi(uint8_t sgintid, uint32_t cpuid)
+{
+	gic->ops.gic_sgi_gen(sgintid, cpuid);
 }

--- a/plat/kvm/include/kvm/intctrl.h
+++ b/plat/kvm/include/kvm/intctrl.h
@@ -34,3 +34,4 @@ void intctrl_init(void);
 void intctrl_clear_irq(unsigned int irq);
 void intctrl_mask_irq(unsigned int irq);
 void intctrl_ack_irq(unsigned int irq);
+void intctrl_send_ipi(uint8_t sgintid, uint32_t cpuid);


### PR DESCRIPTION
This PR fixes the SGI generation and interrupts ack functionalities on gic-v2.
A deadlock in the SGI implementation is fixed in the already existing implementation. Also, SGIs are added to our GIC generic interface.

Signed-off-by: Răzvan Vîrtan <virtanrazvan@gmail.com>
