### PR TITLE
doc: Update `COPYING.md` with generalized copyright copyright attribution

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -7,12 +7,13 @@ Unikraft Source Code
 Unikraft is organized into libraries where each might be individually licensed.
 In general, each source file should declare who is the copyright owner and under
 which terms and conditions the code is licensed. The main license of the project
-is the following BSD 3-clause license. It applies in particular to source code
-files that do not declare a license and where there is no license information
-file (e.g., `LICENSE`, `COPYING`) placed in the same or corresponding root
-folder.
+is the following BSD 3-clause license. It applies verbatim with copyright
+attributed to Unikraft UG (haftungsbeschränkt) to all source code files that do
+not declare a license with copyright attributed and where there is no license
+information file (e.g., `LICENSE`, `COPYING`) placed in the same or
+corresponding root folder.
 
-	Copyright (c) 2017, NEC Europe Ltd., NEC Corporation. All rights reserved.
+	Copyright (c) YYYY, Copyright holder. All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

-->

N/A

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR updates the `COPYING.md` licensing and copyright attribution file to:

 * Automatically indicate the attribution of copyright to Unikraft UG (haftungsbeschränkt) if no SPDX identifier comment preamble is provided within a source code file or if no `LICENSE` or `COPYING` files are found within the relevant source code sub-directory; and,
 * Generalizes the example BSD-3-Clause, removing the year and the "NEC Europe Ltd., NEC Corporation" association to indicate "Copyright holder".  This is because the example should serve as a template for new files where the author should update the year and associated copyright holder.
