### PR TITLE
lib/uksignal: use getpid() instead of uk_syscall_r_getpid()

### DIFF
--- a/lib/uksignal/signal.c
+++ b/lib/uksignal/signal.c
@@ -360,7 +360,7 @@ int killpg(int pgrp, int sig)
 		return -1;
 	}
 
-	return kill(uk_syscall_r_getpid(), sig);
+	return kill(getpid(), sig);
 }
 
 int raise(int sig)


### PR DESCRIPTION
This commit reverts ec8882b and replaces uk_syscall_r_getpid() by
getpid().

Signed-off-by: Matias Ezequiel Vara Larsen <matiasevara@torokernel.io>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
