### PR TITLE
Enforce W^X to counter code inject attacks

### DIFF
--- a/include/uk/plat/memory.h
+++ b/include/uk/plat/memory.h
@@ -45,11 +45,12 @@ extern "C" {
 /* Memory region flags */
 #define UKPLAT_MEMRF_FREE	(0x1)	/* Region with uninitialized memory */
 #define UKPLAT_MEMRF_RESERVED	(0x2)	/* Region is in use by platform */
-#define UKPLAT_MEMRF_EXTRADATA	(0x4)	/* Contains additional loaded data
-					 * (e.g., initramdisk)
+#define UKPLAT_MEMRF_EXTRADATA	(0x4)	/* Contains additional loaded data \
+					 * (e.g., initramdisk) \
 					 */
 #define UKPLAT_MEMRF_READABLE	(0x10)	/* Region is readable */
 #define UKPLAT_MEMRF_WRITABLE	(0x20)	/* Region is writable */
+#define UKPLAT_MEMRF_EXECUTABLE	(0x40)	/* Region is executable */
 
 #define UKPLAT_MEMRF_ALLOCATABLE (UKPLAT_MEMRF_FREE \
 				  | UKPLAT_MEMRF_READABLE \

--- a/lib/ukboot/Config.uk
+++ b/lib/ukboot/Config.uk
@@ -117,4 +117,13 @@ if LIBUKBOOT
 		bool "None"
 
 	endchoice
+
+	config LIBUKBOOT_ENFORCE_W_XOR_X
+		bool "Enforce W^X"
+		default n
+		depends on PAGING
+		help
+			During boot the protection settings of all memory
+			ranges are updated to enforce write XOR execute (W^X)
+			and mitigate code injection attacks.
 endif

--- a/plat/kvm/memory.c
+++ b/plat/kvm/memory.c
@@ -43,7 +43,8 @@ int ukplat_memregion_get(int i, struct ukplat_memregion_desc *m)
 		m->base  = (void *) __TEXT;
 		m->len   = (size_t) __ETEXT - (size_t) __TEXT;
 		m->flags = (UKPLAT_MEMRF_RESERVED
-			    | UKPLAT_MEMRF_READABLE);
+			    | UKPLAT_MEMRF_READABLE
+			    | UKPLAT_MEMRF_EXECUTABLE);
 #if CONFIG_UKPLAT_MEMRNAME
 		m->name  = "text";
 #endif

--- a/plat/xen/memory.c
+++ b/plat/xen/memory.c
@@ -62,7 +62,8 @@ int ukplat_memregion_get(int i, struct ukplat_memregion_desc *m)
 		m->base  = (void *) __TEXT;
 		m->len   = (size_t) __ETEXT - (size_t) __TEXT;
 		m->flags = (UKPLAT_MEMRF_RESERVED
-			    | UKPLAT_MEMRF_READABLE);
+			    | UKPLAT_MEMRF_READABLE
+			    | UKPLAT_MEMRF_EXECUTABLE);
 #if CONFIG_UKPLAT_MEMRNAME
 		m->name  = "text";
 #endif


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [`kvm`, `xen`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

- `CONFIG_LIBUKBOOT_ENFORCE_W_XOR_X=y`

### Description of changes

When all memory regions use default memory protections (RWX) it is easy to inject shellcode. For example, an attack could use a stack buffer overflow to overwrite the return address and hijack execution to run the injected code. Another example would be to use a write primitive to modify the .text segment so that during regular program execution, attacked-controller code is
run.

The standard method to mitigate these simple attacks is to enforce write XOR execute (W^X) permissions - meaning that a memory region can either be writeable or executable but not both. This way, all memory that is executable cannot be changed at runtime and every memory that is writeable is not executable.

The PR at hand implements W^X using the paging API by enforcing the respective page permissions during boot in `ukboot`. Doing it in `ukboot` has the advantage that the solution is agnostic to the platform. A disadvantage is that it causes additional boot time overhead. It should therefore also be investigated, how to build the static page tables with the proper protections already in. This would also enable the feature for unikernels without the paging API.

Issue #414 