### PR TITLE
lib/syscall_shim: Ignore unnumbered system calls

### DIFF
--- a/lib/syscall_shim/gen_provided.awk
+++ b/lib/syscall_shim/gen_provided.awk
@@ -1,13 +1,18 @@
 BEGIN {
 	print "/* Automatically generated file; DO NOT EDIT */"
 	print "#ifndef __LIBSYSCALL_SHIM_PROVIDED_SYSCALLS_H__"
-	print "#define __LIBSYSCALL_SHIM_PROVIDED_SYSCALLS_H__\n"
+	print "#define __LIBSYSCALL_SHIM_PROVIDED_SYSCALLS_H__"
+	print "\n#include <uk/bits/syscall_nrs.h>"
 }
 
 /[a-zA-Z0-9]+-[0-9]+/{
-	printf "\n#define HAVE_uk_syscall_%s t\n", $1;
+	printf "\n#ifndef SYS_%s\n", $1;
+	printf "#warning Ignoring system call '%s': No system call number available\n", $1
+	printf "#else\n";
+	printf "#define HAVE_uk_syscall_%s t\n", $1;
 	printf "UK_SYSCALL_E_PROTO(%s, %s);\n", $2, $1;
 	printf "UK_SYSCALL_R_PROTO(%s, %s);\n", $2, $1;
+	printf "#endif /* !SYS_%s */\n", $1;
 }
 
 END {

--- a/lib/syscall_shim/gen_provided.awk
+++ b/lib/syscall_shim/gen_provided.awk
@@ -1,6 +1,15 @@
-BEGIN {print "/* Automatically generated file; DO NOT EDIT */"}
+BEGIN {
+	print "/* Automatically generated file; DO NOT EDIT */"
+	print "#ifndef __LIBSYSCALL_SHIM_PROVIDED_SYSCALLS_H__"
+	print "#define __LIBSYSCALL_SHIM_PROVIDED_SYSCALLS_H__\n"
+}
+
 /[a-zA-Z0-9]+-[0-9]+/{
 	printf "\n#define HAVE_uk_syscall_%s t\n", $1;
 	printf "UK_SYSCALL_E_PROTO(%s, %s);\n", $2, $1;
 	printf "UK_SYSCALL_R_PROTO(%s, %s);\n", $2, $1;
+}
+
+END {
+	print "\n#endif /* __LIBSYSCALL_SHIM_PROVIDED_SYSCALLS_H__ */"
 }

--- a/lib/syscall_shim/gen_syscall_nrs.awk
+++ b/lib/syscall_shim/gen_syscall_nrs.awk
@@ -1,4 +1,13 @@
-BEGIN {print "/* Automatically generated file; DO NOT EDIT */"}
+BEGIN {
+	print "/* Automatically generated file; DO NOT EDIT */"
+	print "#ifndef __LIBSYSCALL_SHIM_SYSCALL_NRS_H__"
+	print "#define __LIBSYSCALL_SHIM_SYSCALL_NRS_H__"
+}
+
 /#define __NR_/{
 	 printf "\n#define SYS_%s\t\t%s", substr($2,6),$3
+}
+
+END {
+	print "\n\n#endif /* __LIBSYSCALL_SHIM_SYSCALL_NRS_H__ */"
 }

--- a/lib/syscall_shim/gen_syscall_nrs2.awk
+++ b/lib/syscall_shim/gen_syscall_nrs2.awk
@@ -1,13 +1,13 @@
 BEGIN {
 	print "/* Automatically generated file; DO NOT EDIT */"
-	print "#ifndef __UK_SYSCALL_NRS_2_H__"
-	print "#define __UK_SYSCALL_NRS_2_H__"
+	print "#ifndef __LIBSYSCALL_SHIM_SYSCALLS_NRS2_H__"
+	print "#define __LIBSYSCALL_SHIM_SYSCALLS_NRS2_H__"
 }
 
 /#define __NR_/{
-	 printf "#define __NR_%s\t\t%s\n", substr($2,6),$3
+	 printf "\n#define __NR_%s\t\t%s", substr($2,6),$3
 }
 
 END {
-	print "#endif /* __UK_SYSCALL_NRS_2_H__ */"
+	print "\n\n#endif /* __LIBSYSCALL_SHIM_SYSCALLS_NRS2_H__ */"
 }

--- a/lib/syscall_shim/gen_uk_syscall.awk
+++ b/lib/syscall_shim/gen_uk_syscall.awk
@@ -20,6 +20,7 @@ BEGIN {
 	name = $1
 	sys_name = "SYS_" name
 	args_nr = $2 + 0
+	printf "#ifdef HAVE_uk_syscall_%s\n", name;
 	printf "\tcase %s:\n", sys_name;
 	for (i = 1; i <= args_nr; i++)
 		printf "\t\ta%s = va_arg(arg, long);\n", i;
@@ -29,6 +30,7 @@ BEGIN {
 	if (args_nr > 0)
 		printf "a%d", args_nr;
 	printf(");\n")
+	printf "#endif /* HAVE_uk_syscall_%s */\n\n", name;
 }
 
 END {

--- a/lib/syscall_shim/gen_uk_syscall6.awk
+++ b/lib/syscall_shim/gen_uk_syscall6.awk
@@ -21,6 +21,7 @@ BEGIN {
 	name = $1
 	sys_name = "SYS_" name
 	args_nr = $2 + 0
+	printf "#ifdef HAVE_uk_syscall_%s\n", name;
 	printf "\tcase %s:\n", sys_name;
 	printf "\t\treturn uk_syscall_e_%s(", name;
 	for (i = 1; i < args_nr; i++)
@@ -28,6 +29,7 @@ BEGIN {
 	if (args_nr > 0)
 		printf("arg%d", args_nr)
 	printf(");\n")
+	printf "#endif /* HAVE_uk_syscall_%s */\n\n", name;
 }
 
 END {

--- a/lib/syscall_shim/gen_uk_syscall6_r.awk
+++ b/lib/syscall_shim/gen_uk_syscall6_r.awk
@@ -22,6 +22,7 @@ BEGIN {
 	sys_name = "SYS_" name
 	uk_syscall_r = "uk_syscall_r_" name
 	args_nr = $2 + 0
+	printf "#ifdef HAVE_uk_syscall_%s\n", name;
 	printf "\tcase %s:\n", sys_name;
 	printf "\t\treturn %s(", uk_syscall_r;
 	for (i = 1; i < args_nr; i++)
@@ -29,6 +30,7 @@ BEGIN {
 	if (args_nr > 0)
 		printf("arg%d", args_nr)
 	printf(");\n")
+	printf "#endif /* HAVE_uk_syscall_%s */\n\n", name;
 }
 
 END {

--- a/lib/syscall_shim/gen_uk_syscall_name_p.awk
+++ b/lib/syscall_shim/gen_uk_syscall_name_p.awk
@@ -9,8 +9,10 @@ BEGIN {
 }
 
 /[a-zA-Z0-9]+-[0-9]+/{
+	printf "#ifdef HAVE_uk_syscall_%s\n", name;
 	printf "\tcase SYS_%s:\n", $1
 	printf "\t\treturn \"%s\";\n", $1
+	printf "#endif /* HAVE_uk_syscall_%s */\n\n", name;
 }
 
 END {

--- a/lib/syscall_shim/gen_uk_syscall_r.awk
+++ b/lib/syscall_shim/gen_uk_syscall_r.awk
@@ -16,6 +16,7 @@ BEGIN {
 	sys_name = "SYS_" name
 	uk_syscall_r = "uk_syscall_r_" name
 	args_nr = $2 + 0
+	printf "#ifdef HAVE_uk_syscall_%s\n", name;
 	printf "\tcase %s:\n", sys_name;
 	printf "\t\treturn %s(", uk_syscall_r;
 	for (i = 1; i < args_nr; i++)
@@ -23,6 +24,7 @@ BEGIN {
 	if (args_nr > 0)
 		printf("va_arg(arg, long)")
 	printf(");\n")
+	printf "#endif /* HAVE_uk_syscall_%s */\n\n", name;
 }
 
 END {

--- a/lib/syscall_shim/gen_uk_syscall_r_fn.awk
+++ b/lib/syscall_shim/gen_uk_syscall_r_fn.awk
@@ -13,8 +13,10 @@ BEGIN {
 	name = $1
 	sys_name = "SYS_" name
 	uk_syscall_r = "uk_syscall_r_" name
+	printf "#ifdef HAVE_uk_syscall_%s\n", name;
 	printf "\tcase %s:\n", sys_name;
 	printf "\t\treturn (long (*)(void)) %s;\n", uk_syscall_r;
+	printf "#endif /* HAVE_uk_syscall_%s */\n\n", name;
 }
 
 END {


### PR DESCRIPTION
### Base target

 - Architecture(s): all
 - Platform(s): all
 - Application(s): all

### Additional configuration

 - `CONFIG_LIBSYSCALL_SHIM=y`

### Description of changes

This PR adds a warning issued by the pre-processor for system calls that do not have a system call number defined. This can happen when a system call has been registered to `UK_PROVIDED_SYSCALLS-y`, but no system call number is assigned in the architecture-dependent `syscall.h.in`. `lib/syscall_shim` will not be linked with such ignored system calls.

This PR is the first step in making the `syscall_shim` compilable on Arm. It is intended to replace PR #422 and PR #336. In a later step, it is currently planned to distinguish between 1) actual system call implementations, 2) legacy system call interfaces and 3) architecture-dependent system calls. The idea is that legacy interfaces can be treated as optional because they are less powerful system call interfaces of a system call that is only available on Linux architectures that have been supported longer, such as `open` as a legacy interface to `openat`. Architecture-dependent system calls are system calls that exist only for a particular architecture, such as `arch_prctl` on x86. The `syscall_shim` will treat actual system calls and architecture-dependent system calls as mandatory; legacy system calls will be treated as optional, and the `syscall_shim` will silently ignores legacy definitions if no number mapping exists. Since this requires more code adoptions, we plan to complete the work with the 0.10 release.