### PR TITLE
plat/common: Architecture-independent parts of SMP API

### DIFF
--- a/include/uk/plat/lcpu.h
+++ b/include/uk/plat/lcpu.h
@@ -109,9 +109,9 @@ struct ukplat_lcpu_func {
 	 * Function to execute.
 	 *
 	 * @param regs pointer to a snapshot of the current CPU state. Changes
-	 *   to the state are applied after the function returns
+	 *   to the state are applied after the RUN IRQ handler returns
 	 * @param fn pointer to this structure. The structure is not touched
-	 *   after function invocation and can be freed if necessary during
+	 *   after function invocation and must be freed if necessary during
 	 *   function execution
 	 */
 	void (*fn)(struct __regs *regs, struct ukplat_lcpu_func *fn);
@@ -126,16 +126,18 @@ struct ukplat_lcpu_func {
 __lcpuid ukplat_lcpu_id(void);
 
 /**
- * Returns the number of logical CPUs present on the system
+ * Returns the number of logical CPUs present in the system
  */
 __lcpuid ukplat_lcpu_count(void);
 
 /**
  * Starts multiple logical CPUs and assigns them the given stacks. The logical
  * CPUs execute the entry functions if supplied or enter a low-power wait state
- * otherwise.
+ * otherwise. CPUs that have already been started are ignored.
  *
- * @param lcpuid array with the IDs of the logical CPUs that are to be started
+ * @param lcpuid array with the IDs of the logical CPUs that are to be started.
+ *   Can be NULL to include all logical CPUs except the one executing the
+ *   function.
  * @param sp array of stack pointers, one for each specified logical CPU
  * @param entry optional array of entry function pointers, one for each
  *   specified logical CPU. Provided functions must not return. If the
@@ -174,7 +176,7 @@ int ukplat_lcpu_wait(__lcpuid lcpuid[], unsigned int num, __nsec timeout);
  * @param num number of logical CPU IDs given
  * @param fn the function to be executed
  * @param flags (architecture-dependent) flags that specify how the function
- *   should be executed (see UKPLAT_LCPU_RFLG_* flags)
+ *   should be executed (see UKPLAT_LCPU_RFLG_* flags if available)
  *
  * @return 0 on success, an errno-type error value otherwise
  */
@@ -183,6 +185,11 @@ int ukplat_lcpu_run(__lcpuid lcpuid[], unsigned int num,
 
 /**
  * Wakes up the specified logical CPUs from a halt or low-power sleep state.
+ *
+ * @param lcpuid array with the IDs of the logical CPUs that should be waked up.
+ *   Can be NULL to execute the function on all logical CPUs except the current
+ *   one.
+ * @param num number of logical CPU IDs given
  *
  * @return 0 on success, an errno-type error value otherwise
  */

--- a/include/uk/plat/lcpu.h
+++ b/include/uk/plat/lcpu.h
@@ -149,8 +149,11 @@ __u32 ukplat_lcpu_count(void);
  *   sequential order of lcpuidx. If the call succeeds, input and output values
  *   are equal. Must be NULL if lcpuidx is NULL
  * @param sp array of stack pointers, one for each logical CPU to start. If
- *   lcpuidx is NULL, must be ukplat_lcpu_count() - 1 stacks
- * @param entry array of entry function pointers, one for logical CPU to start.
+ *   lcpuidx is NULL, must be ukplat_lcpu_count() - 1 stack pointers. The
+ *   stacks may be specifically prepared to contain arguments for the entry
+ *   function (e.g., cdecl calling convention). The platform may use the
+ *   following stack space to execute initialization routines
+ * @param entry array of entry functions, one for each logical CPU to start.
  *   Can be NULL, otherwise if lcpuidx is NULL, must contain
  *   ukplat_lcpu_count() - 1 function pointers. Provided functions must not
  *   return. If the parameter or individual function pointers are NULL the

--- a/include/uk/plat/lcpu.h
+++ b/include/uk/plat/lcpu.h
@@ -138,17 +138,17 @@ __lcpuid ukplat_lcpu_count(void);
  * @param lcpuid array with the IDs of the logical CPUs that are to be started.
  *   Can be NULL to include all logical CPUs except the one executing the
  *   function.
+ * @param num number of logical CPU IDs given
  * @param sp array of stack pointers, one for each specified logical CPU
  * @param entry optional array of entry function pointers, one for each
  *   specified logical CPU. Provided functions must not return. If the
  *   parameter or individual elements are NULL the respective logical CPUs
  *   enter a low-power wait state after startup
- * @param num number of logical CPU IDs given
  *
  * @return 0 on success, an errno-type error value otherwise
  */
-int ukplat_lcpu_start(__lcpuid lcpuid[], void *sp[],
-		      ukplat_lcpu_entry_t entry[], unsigned int num);
+int ukplat_lcpu_start(__lcpuid lcpuid[], unsigned int num, void *sp[],
+		      ukplat_lcpu_entry_t entry[]);
 
 /**
  * Waits for the specified logical CPUs to enter idle state, or until the

--- a/include/uk/plat/lcpu.h
+++ b/include/uk/plat/lcpu.h
@@ -80,7 +80,7 @@ void ukplat_lcpu_irqs_handle_pending(void);
 /**
  * Halts the current logical CPU execution
  */
-void ukplat_lcpu_halt(void);
+void __noreturn ukplat_lcpu_halt(void);
 
 /**
  * Halts the current logical CPU. Execution is resumed when an interrupt/signal

--- a/include/uk/plat/lcpu.h
+++ b/include/uk/plat/lcpu.h
@@ -144,11 +144,13 @@ __lcpuid ukplat_lcpu_count(void);
  *   specified logical CPU. Provided functions must not return. If the
  *   parameter or individual elements are NULL the respective logical CPUs
  *   enter a low-power wait state after startup
+ * @param flags (architecture-dependent) flags that specify how to start the
+ *   CPUs (see UKPLAT_LCPU_SFLG_* flags if available)
  *
  * @return 0 on success, an errno-type error value otherwise
  */
 int ukplat_lcpu_start(__lcpuid lcpuid[], unsigned int num, void *sp[],
-		      ukplat_lcpu_entry_t entry[]);
+		      ukplat_lcpu_entry_t entry[], unsigned long flags);
 
 /**
  * Waits for the specified logical CPUs to enter idle state, or until the
@@ -181,7 +183,7 @@ int ukplat_lcpu_wait(__lcpuid lcpuid[], unsigned int num, __nsec timeout);
  * @return 0 on success, an errno-type error value otherwise
  */
 int ukplat_lcpu_run(__lcpuid lcpuid[], unsigned int num,
-		    struct ukplat_lcpu_func *fn, int flags);
+		    struct ukplat_lcpu_func *fn, unsigned long flags);
 
 /**
  * Wakes up the specified logical CPUs from a halt or low-power sleep state.

--- a/include/uk/plat/lcpu.h
+++ b/include/uk/plat/lcpu.h
@@ -128,7 +128,7 @@ __lcpuid ukplat_lcpu_id(void);
 /**
  * Returns the number of logical CPUs present in the system
  */
-__lcpuid ukplat_lcpu_count(void);
+__u32 ukplat_lcpu_count(void);
 
 /**
  * Starts multiple logical CPUs and assigns them the given stacks. The logical

--- a/include/uk/plat/lcpu.h
+++ b/include/uk/plat/lcpu.h
@@ -108,23 +108,20 @@ typedef __u64 __lcpuid;		/* Physical ID of logical CPU */
 __lcpuid ukplat_lcpu_id(void);
 
 #ifdef CONFIG_HAVE_SMP
-#include <uk/list.h>
 
 struct ukplat_lcpu_func {
-	struct uk_list_head lentry;
-
 	/**
 	 * Function to execute.
 	 *
-	 * @param regs pointer to a snapshot of the current CPU state. Changes
-	 *   to the state are applied after the RUN IRQ handler returns
-	 * @param fn pointer to this structure. The structure is not touched
-	 *   after function invocation and must be freed if necessary during
-	 *   function execution
+	 * @param regs pointer to a snapshot of the current CPU register state.
+	 *    Changes to the registers are applied after the RUN IRQ handler
+	 *    returns. The parameter might be NULL if the platform does not
+	 *    support supplying a register snapshot.
+	 * @param arg user-supplied argument
 	 */
-	void (*fn)(struct __regs *regs, const struct ukplat_lcpu_func *fn);
+	void (*fn)(struct __regs *regs, void *arg);
 
-	/* Optional user-supplied pointer. */
+	/* Optional user-supplied argument. */
 	void *user;
 };
 

--- a/plat/Config.uk
+++ b/plat/Config.uk
@@ -6,14 +6,28 @@ config UKPLAT_MEMRNAME
 		Enable name field in memory region descriptors
 
 config UKPLAT_LCPU_MAXCOUNT
-        int "Maximum number of supported logical CPUs"
-        range 1 256
-        default 1
+	int "Maximum number of supported logical CPUs"
+	range 1 256
+	default 1
 
 config HAVE_SMP
-        bool
-        default y if UKPLAT_LCPU_MAXCOUNT > 1
-        default n
+	bool
+	default y if UKPLAT_LCPU_MAXCOUNT > 1
+	default n
+
+menu "Multiprocessor Configuration"
+	depends on HAVE_SMP
+
+config UKPLAT_LCPU_IDISIDX
+	bool "Assume sequential CPU IDs"
+	default n
+	help
+		The hardware assigns each CPU an ID, which typically encodes
+		the CPUs position in the processor topology. Many VMMs, however,
+		just use sequential numbers so internally mapping IDs to
+		indices in Unikraft is not necessary.
+
+endmenu
 
 menuconfig PAGING
 	bool "Virtual memory API"

--- a/plat/common/include/uk/plat/common/lcpu.h
+++ b/plat/common/include/uk/plat/common/lcpu.h
@@ -1,0 +1,419 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Authors: Marc Rittinghaus <marc.rittinghaus@kit.edu>
+ *          Răzvan Vîrtan <virtanrazvan@gmail.com>
+ *          Cristian Vijelie <cristianvijelie@gmail.com>
+ *
+ * Copyright (c) 2022, Karlsruhe Institute of Technology (KIT)
+ *                     All rights reserved.
+ * Copyright (c) 2022, University Politehnica of Bucharest.
+ *                     All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __PLAT_CMN_LCPU_H__
+#define __PLAT_CMN_LCPU_H__
+
+#include <uk/config.h>
+#include <uk/essentials.h>
+#ifndef __ASSEMBLY__
+#include <uk/arch/types.h>
+#include <uk/plat/lcpu.h>
+#include <uk/plat/spinlock.h>
+#include <uk/list.h>
+#endif /* !__ASSEMBLY__ */
+
+/* Provide empty architecture-dependent LCPU part as default */
+#ifndef LCPU_ARCH_SIZE
+#define LCPU_ARCH_SIZE			0x00
+
+#ifndef __ASSEMBLY__
+struct lcpu_arch { };
+#endif /* !__ASSEMBLY__ */
+#endif /* !LCPU_ARCH_SIZE */
+
+/*
+ * LCPU Startup Arguments
+ */
+#define LCPU_SARGS_ENTRY_OFFSET		0x00
+#define LCPU_SARGS_STACKP_OFFSET	(LCPU_SARGS_ENTRY_OFFSET + 0x08)
+
+#define LCPU_SARGS_SIZE			0x10
+
+#ifndef __ASSEMBLY__
+struct lcpu_sargs {
+	ukplat_lcpu_entry_t entry;
+	void *stackp;
+};
+
+UK_CTASSERT(__offsetof(struct lcpu_sargs, entry)  == LCPU_SARGS_ENTRY_OFFSET);
+UK_CTASSERT(__offsetof(struct lcpu_sargs, stackp) == LCPU_SARGS_STACKP_OFFSET);
+
+UK_CTASSERT(sizeof(struct lcpu_sargs) == LCPU_SARGS_SIZE);
+#endif /* !__ASSEMBLY__ */
+
+/*
+ * Logical CPU (LCPU) Structure
+ */
+#define LCPU_STATE_OFFSET		0x00
+#define LCPU_IDX_OFFSET			(LCPU_STATE_OFFSET + 0x04)
+#define LCPU_ID_OFFSET			(LCPU_IDX_OFFSET   + 0x04)
+#define LCPU_ENTRY_OFFSET		(LCPU_ID_OFFSET    + 0x08)
+#define LCPU_STACKP_OFFSET		(LCPU_ENTRY_OFFSET + 0x08)
+#define LCPU_ERR_OFFSET			(LCPU_ENTRY_OFFSET + 0x00)
+#define LCPU_ARCH_OFFSET		(LCPU_ENTRY_OFFSET + 0x10)
+
+#ifdef CONFIG_HAVE_SMP
+#define LCPU_FUNC_SIZE			0x10
+#endif /* CONFIG_HAVE_SMP */
+
+#define LCPU_MEMBERS_SIZE		(LCPU_ARCH_OFFSET  + LCPU_ARCH_SIZE)
+#define LCPU_SIZE						\
+	ALIGN_UP(LCPU_MEMBERS_SIZE, CACHE_LINE_SIZE)
+
+#ifndef __ASSEMBLY__
+struct __align(CACHE_LINE_SIZE) lcpu {
+	/* Current CPU state (LCPU_STATE_*).
+	 * Working on it with atomic instructions - must be 8-byte aligned
+	 */
+	volatile int state __align(8);
+
+	__lcpuidx idx;
+	__lcpuid id;
+
+	union {
+		/* Startup arguments
+		 * Only valid in LCPU_STATE_INIT
+		 */
+		struct lcpu_sargs s_args;
+
+		/* Remote function to execute
+		 * Only valid in LCPU_STATE_IDLE and busy states
+		 */
+#ifdef CONFIG_HAVE_SMP
+		struct ukplat_lcpu_func fn;
+#endif /* CONFIG_HAVE_SMP */
+
+		/* Error code indicating the halt reason
+		 * Only valid in LCPU_STATE_HALTED
+		 */
+		int error_code;
+	};
+
+	/* Architecture-dependent part */
+	struct lcpu_arch arch;
+};
+
+#ifdef CONFIG_HAVE_SMP
+UK_CTASSERT(sizeof(struct ukplat_lcpu_func)        == LCPU_FUNC_SIZE);
+#endif /* CONFIG_HAVE_SMP */
+
+UK_CTASSERT(__offsetof(struct lcpu, state)         == LCPU_STATE_OFFSET);
+UK_CTASSERT(__offsetof(struct lcpu, idx)           == LCPU_IDX_OFFSET);
+UK_CTASSERT(__offsetof(struct lcpu, id)            == LCPU_ID_OFFSET);
+UK_CTASSERT(__offsetof(struct lcpu, s_args.entry)  == LCPU_ENTRY_OFFSET);
+UK_CTASSERT(__offsetof(struct lcpu, s_args.stackp) == LCPU_STACKP_OFFSET);
+UK_CTASSERT(__offsetof(struct lcpu, error_code)    == LCPU_ERR_OFFSET);
+UK_CTASSERT(__offsetof(struct lcpu, arch)          == LCPU_ARCH_OFFSET);
+
+UK_CTASSERT(sizeof(struct lcpu) == LCPU_SIZE);
+UK_CTASSERT(LCPU_MEMBERS_SIZE <= LCPU_SIZE);
+#endif /* !__ASSEMBLY__ */
+
+/**
+ * LCPU States
+ * The following state transitions are safe to execute.
+ *
+ *                         lcpu_init
+ *                   ┌───────────────────┐lcpu_run
+ *        lcpu_start │          ┌──────┐ │ ┌─────┐   ┌────
+ * ┌─────────┐   ┌───┴──┐   ┌───┴──┐ ┌─▼─▼─┴─┐ ┌─▼───┴─┐
+ * │ OFFLINE ├──►│ INIT │   │ IDLE │ │ BUSY0 │ │ BUSY1 │
+ * └─────────┘   └───┬──┘   └─┬─▲──┘ └─┬─┬─▲─┘ └─┬─┬─▲─┘
+ *                   │        │ └──────┘ │ └─────┘ │ └────
+ * ┌────────┐        │        │          │ RUN_IRQ │
+ * │ HALTED │◄───────┴────────┴──────────┴─────────┴──────
+ * └────────┘        lcpu_halt (ONLY ALLOWED FOR THIS CPU)
+ */
+#define LCPU_STATE_HALTED		-1 /* CPU stopped, needs reset */
+#define LCPU_STATE_OFFLINE		 0 /* CPU not started */
+#define LCPU_STATE_INIT			 1 /* CPU started, init not finished */
+#define LCPU_STATE_IDLE			 2 /* CPU is idle */
+#define LCPU_STATE_BUSY0		 3 /* >= CPU is busy */
+
+#ifndef __ASSEMBLY__
+/**
+ * Return 1 if the given LCPU is online, 0 otherwise
+ */
+static inline int lcpu_state_is_online(int state)
+{
+	return (state >= LCPU_STATE_IDLE);
+}
+
+/**
+ * Return 1 if the given LCPU is busy, 0 otherwise.
+ * NOTE: The negation (i.e., the LCPU is idle) does not have be true!
+ */
+static inline int lcpu_state_is_busy(int state)
+{
+	return (state >= LCPU_STATE_BUSY0);
+}
+
+#ifdef CONFIG_HAVE_SMP
+/**
+ * Allocate a logical CPU and assign the provided CPU ID. This function may
+ * only be called from one thread running on the bootstrap processor before
+ * secondary CPUs are started.
+ *
+ * @param id ID of the CPU for which to allocate an LCPU structure
+ * @return an LCPU on success, which is in OFFLINE state with the lock, id, and
+ *    idx initialized; NULL on failure.
+ */
+struct lcpu *lcpu_alloc(__lcpuid id);
+#endif /* CONFIG_HAVE_SMP */
+
+/**
+ * Return the LCPU structure for the logical CPU with the given index.
+ *
+ * @param idx the index of the requested LCPU. The index must be less than
+ *    the value returned by ukplat_lcpu_count(), otherwise behavior is
+ *    undefined
+ * @return pointer to the requested LCPU structure
+ */
+struct lcpu *lcpu_get(__lcpuidx idx);
+
+#define _lcpu_lcpuidx_list_entry(list, i, n)				\
+	(((i) < (n)) ?							\
+	  lcpu_get((list) ? (list)[i] : (__lcpuidx) (i))		\
+	  : NULL)
+
+#define lcpu_lcpuidx_list_foreach(list, num, n, i, lcpu)		\
+	if ((num) == NULL) {						\
+		UK_ASSERT(!(list));					\
+		(n) = ukplat_lcpu_count();				\
+	} else	{							\
+		UK_ASSERT((*num) <= ukplat_lcpu_count());		\
+		(n) = *(num);						\
+	}								\
+	for ((i) = 0,							\
+	     ({ if (num) *num = i; }),					\
+	     (lcpu) = _lcpu_lcpuidx_list_entry(list, i, n);		\
+	     (i) < (n);							\
+	     (i)++,							\
+	     ({ if (num) *num = i; }),					\
+	     (lcpu) = _lcpu_lcpuidx_list_entry(list, i, n))
+
+/**
+ * Return the LCPU structure for the CPU executing this function
+ */
+struct lcpu *lcpu_get_current(void);
+
+/**
+ * Return the LCPU structure for the bootstraping CPU
+ */
+static inline struct lcpu *lcpu_get_bsp(void)
+{
+	/* The BSP is always index 0 */
+	return lcpu_get(0);
+}
+
+/**
+ * Return 1 if the supplied LCPU is the boottrap processor, 0 otherwise
+ */
+static inline int lcpu_is_bsp(struct lcpu *lcpu)
+{
+	return (lcpu == lcpu_get_bsp());
+}
+
+/**
+ * Return 1 if the executed on the bootstrap processor, 0 otherwise
+ */
+static inline int lcpu_current_is_bsp(void)
+{
+	return lcpu_is_bsp(lcpu_get_current());
+}
+
+/**
+ * Initialize a logical CPU. The function must be executed on the CPU
+ * represented by the LCPU as early as possible after startup.
+ *
+ * @param this_lcpu pointer to the LCPU structure representing the CPU
+ *    executing this function
+ * @return 0 on success, -errno otherwise
+ */
+int lcpu_init(struct lcpu *this_lcpu);
+
+#ifdef CONFIG_HAVE_SMP
+/* The IRQ vectors passed to lcpu_mp_init */
+extern const unsigned long * const lcpu_run_irqv;
+extern const unsigned long * const lcpu_wakeup_irqv;
+
+/**
+ * Initialize multi-processor functions. Must only be executed once on the
+ * bootstrap processor (BSP)
+ *
+ * @param run_irq the IRQ vector to use for running remote functions
+ * @param wakeup_irq the IRQ vector to use for waking up CPUs
+ * @param arg an optional parameter from the boot code that is passed to the
+ *    architectural initialization
+ *
+ * @return 0 on success, -errno otherwise
+ */
+int lcpu_mp_init(unsigned long run_irq, unsigned long wakeup_irq, void *arg);
+
+/**
+ * Default entry function for secondary logical CPUs. Will call lcpu_init() and
+ * If the logical CPU's startup arguments supply an entry function, the
+ * original stack pointer will be restored and execution continues in the
+ * supplied entry function with interrupts still disabled. Otherwise, interrupts
+ * are enabled and the CPU enters a low-power state to wait for interrupts and
+ * calls of ukplat_lcpu_run() that are destined for this CPU.
+ *
+ * NOTE: The function may be replaced with a custom implementation by
+ *    overriding the function symbol.
+ *
+ * NOTE: The architecture's CPU startup code (typically an assembler trampoline)
+ *    must jump to this function with interrupts disabled and prepare the stack
+ *    and/or registers according to the respective calling convention to
+ *    provide the following parameters:
+ *
+ * @param this_lcpu pointer to the LCPU structure representing the CPU
+ *    executing this function
+ */
+void __weak __noreturn lcpu_entry_default(struct lcpu *this_lcpu);
+
+/**
+ * Enqueue a function to the supplied LCPU
+ *
+ * @param lcpu the LCPU to enqueue the function to
+ * @param fn the function to enqueue
+ *
+ * @return 0 on success, -errno otherwise
+ */
+int lcpu_fn_enqueue(struct lcpu *lcpu, const struct ukplat_lcpu_func *fn);
+#endif /* CONFIG_HAVE_SMP */
+
+/*
+ * Definitions that must be satisfied by the architectural implementation.
+ * DO NOT CALL DIRECTLY. Use the ukplat_* and lcpu_* non-architectural versions.
+ */
+
+/**
+ * Return the hardware ID of the CPU executing this function. Must be able to
+ * return the ID of the bootstrap processor without initialization of the MP
+ * functions.
+ */
+__lcpuid lcpu_arch_id(void);
+
+/**
+ * Initialize the architectural part of the LCPU. The function is
+ * executed on the CPU represented by the LCPU as part of lcpu_init().
+ *
+ * @param this_lcpu pointer to the LCPU structure representing the CPU
+ *    executing this function
+ * @return 0 on success, -errno otherwise
+ */
+int lcpu_arch_init(struct lcpu *this_lcpu);
+
+/**
+ * Switch to the specified stack and jump to the entry function
+ *
+ * @param sp new stack pointer
+ * @param entry the function to jump to
+ */
+void __noreturn lcpu_arch_jump_to(void *sp, ukplat_lcpu_entry_t entry);
+
+#ifdef CONFIG_HAVE_SMP
+/**
+ * Initialize the architectural part of the multi-processor functions. This
+ * should perform CPU discovery and call lcpu_alloc() for each discovered CPU.
+ * The bootstrap processor is already allocated with index 0 and must not be
+ * added.
+ *
+ * @param arg an optional parameter from the boot code. Can be NULL
+ * @return 0 on success, -errno otherwise
+ */
+int lcpu_arch_mp_init(void *arg);
+
+/**
+ * Start the given logical CPU. The CPU should execute the entry function
+ * with the supplied stack. The CPU will be in INIT state.
+ *
+ * @param lcpu logical CPU to start
+ * @param flags flags for controling how to start the given CPU
+ *    (see UKPLAT_LCPU_SFLG_* if available)
+ *
+ * @return 0 on success, -errno otherwise
+ */
+int lcpu_arch_start(struct lcpu *lcpu, unsigned long flags);
+
+#ifdef LCPU_ARCH_MULTI_PHASE_STARTUP
+/**
+ * An optional post start routine that is invoked by ukplat_lcpu_start() after
+ * issuing a start command to all specified logical CPUs. This can be used on
+ * architectures that have a multi-phase startup sequence like x86.
+ *
+ * @param lcpuidx the list of logical CPU indices specified in the call to
+ *	ukplat_lcpu_start()
+ * @param num the number of entries in the list
+ *
+ * @return 0 on success, -errno otherwise
+ */
+int lcpu_arch_post_start(const __lcpuidx lcpuidx[], unsigned int *num);
+#endif /* LCPU_ARCH_MULTI_PHASE_STARTUP */
+
+/**
+ * Queue a function to the given logical CPU and send a run IRQ. The
+ * implementation may also choose to handle the execution of the function
+ * differently, for example, if certain flags are applied.
+ *
+ * @param lcpu the target logical CPU which should execute the function
+ * @param fn the function to execute on the remote CPU
+ * @param flags flags that control how the function should be run
+ *    (see UKPLAT_LCPU_RFLG_* if available)
+ *
+ * @return 0 on success, -errno otherwise
+ */
+int lcpu_arch_run(struct lcpu *lcpu, const struct ukplat_lcpu_func *fn,
+		  unsigned long flags);
+
+/**
+ * Send a wakeup IRQ to the specified logical CPU. The wakeup IRQ may be
+ * implemented in such a way that the IRQ handler just acknowledges the IRQ and
+ * immediately returns to keep the overhead minimal. However, in that case, it
+ * must be guaranteed that no other IRQs (e.g., for devices) use the same
+ * vector.
+ *
+ * @param lcpu pointer to the LCPU structure of the CPU to wake up
+ * @return 0 on success, -errno otherwise
+ */
+int lcpu_arch_wakeup(struct lcpu *lcpu);
+#endif /* CONFIG_HAVE_SMP */
+
+#endif /* !__ASSEMBLY__ */
+
+#endif /* __PLAT_CMN_LCPU_H__ */

--- a/plat/common/lcpu.c
+++ b/plat/common/lcpu.c
@@ -1,8 +1,15 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * Authors: Costin Lupu <costin.lupu@cs.pub.ro>
+ *          Marc Rittinghaus <marc.rittinghaus@kit.edu>
+ *          Răzvan Vîrtan <virtanrazvan@gmail.com>
+ *          Cristian Vijelie <cristianvijelie@gmail.com>
  *
  * Copyright (c) 2018, NEC Europe Ltd., NEC Corporation. All rights reserved.
+ * Copyright (c) 2022, Karlsruhe Institute of Technology (KIT)
+ *                     All rights reserved.
+ * Copyright (c) 2022, University Politehnica of Bucharest.
+ *                     All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,14 +37,149 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <uk/essentials.h>
+#include <uk/arch/atomic.h>
 #include <uk/plat/lcpu.h>
+#include <uk/plat/irq.h>
+#include <uk/plat/time.h>
 #include <uk/plat/common/cpu.h>
+#include <uk/plat/common/lcpu.h>
 #include <uk/plat/common/_time.h>
+#include <uk/print.h>
 
-void ukplat_lcpu_halt(void)
+#include <limits.h>
+#include <errno.h>
+
+/**
+ * Array of LCPUs, one for every CPU in the system.
+ *
+ * TODO: Preferably have a more flexible solution that does not waste memory
+ * for non-present CPUs and does not force us to configure the maximum number
+ * of CPUs beforehand.
+ */
+struct lcpu lcpus[CONFIG_UKPLAT_LCPU_MAXCOUNT];
+
+#ifdef CONFIG_HAVE_SMP
+/**
+ * Number of allocated logical CPUs in the system.
+ * Must be [1, CONFIG_UKPLAT_LCPU_MAXCOUNT) after boot
+ */
+static __u32 lcpu_count = 1;
+
+struct lcpu *lcpu_alloc(__lcpuid id)
+{
+	struct lcpu *lcpu;
+
+	if (lcpu_count == CONFIG_UKPLAT_LCPU_MAXCOUNT)
+		return NULL;
+
+	lcpu = &lcpus[lcpu_count];
+	lcpu->state = LCPU_STATE_OFFLINE;
+	lcpu->id    = id;
+	lcpu->idx   = lcpu_count;
+
+	lcpu_count++;
+
+	return lcpu;
+}
+
+__u32 ukplat_lcpu_count(void)
+{
+	return lcpu_count;
+}
+#else
+#define lcpu_count	(1)
+
+/* Provide weak default implementations for the case that the architecture does
+ * not support multi-processor configurations.
+ */
+__lcpuid __weak lcpu_arch_id(void)
+{
+	return 0;
+}
+
+int __weak lcpu_arch_init(struct lcpu *this_lcpu __unused)
+{
+	return 0;
+}
+#endif /* !CONFIG_HAVE_SMP */
+
+struct lcpu *lcpu_get(__lcpuidx idx)
+{
+	UK_ASSERT(idx < lcpu_count);
+
+	return &lcpus[idx];
+}
+
+struct lcpu *lcpu_get_current(void)
+{
+	return lcpu_get(ukplat_lcpu_idx());
+}
+
+int lcpu_init(struct lcpu *this_lcpu)
+{
+	int rc;
+
+	/*
+	 * NOTE: Do not use anything that might need initialized exception
+	 * traps until after lcpu_arch_init(), as traps might not be
+	 * initialized for this CPU yet!
+	 */
+
+	/* Initialize the bootstrap CPU */
+	if (lcpu_is_bsp(this_lcpu)) {
+		if (unlikely(lcpu_count > 1))
+			return -EPERM;
+
+		this_lcpu->idx   = 0;
+		this_lcpu->id    = lcpu_arch_id();
+		this_lcpu->state = LCPU_STATE_INIT;
+	} else {
+		/* We should already be in INIT state for secondary CPUs */
+		UK_ASSERT(this_lcpu->state == LCPU_STATE_INIT);
+	}
+
+	/* Do architecture-specific initialization */
+	rc = lcpu_arch_init(this_lcpu);
+	if (unlikely(rc))
+		return rc;
+
+	UK_ASSERT(ukplat_lcpu_irqs_disabled());
+
+#ifdef CONFIG_HAVE_SMP
+	this_lcpu->fn.fn = NULL;
+#endif /* CONFIG_HAVE_SMP */
+
+	/* Write back changes before marking CPU as online */
+	wmb();
+
+	/* Put the CPU in busy state. This will mark it as online. After this
+	 * point, functions may be queued to the CPU. However, IRQs are still
+	 * disabled.
+	 */
+	this_lcpu->state = LCPU_STATE_BUSY0;
+
+	return 0;
+}
+
+static void __noreturn lcpu_halt(struct lcpu *this_cpu, int error_code)
 {
 	ukplat_lcpu_disable_irq();
-	halt();
+
+	this_cpu->state = LCPU_STATE_HALTED;
+	this_cpu->error_code = error_code;
+
+	while (1) {
+		/* Although we should not be able to recover via regular
+		 * interrupts, we might receive NMIs so loop to be safe.
+		 */
+		halt();
+	}
+}
+
+void __noreturn ukplat_lcpu_halt(void)
+{
+	lcpu_halt(lcpu_get_current(), 0);
 }
 
 void ukplat_lcpu_halt_to(__nsec until)
@@ -48,3 +190,450 @@ void ukplat_lcpu_halt_to(__nsec until)
 	time_block_until(until);
 	ukplat_lcpu_restore_irqf(flags);
 }
+
+__lcpuid ukplat_lcpu_id(void)
+{
+	return lcpu_arch_id();
+}
+
+#ifdef CONFIG_HAVE_SMP
+#ifdef CONFIG_UKPLAT_LCPU_IDISIDX
+/* For many VMMs the CPU ID is simply a sequentially increasing number with
+ * the BSP always at index 0. This is essentially the definition of __lcpuidx
+ * so in this case, we can simply use the ID as IDX.
+ */
+__lcpuidx ukplat_lcpu_idx(void)
+{
+	__lcpuidx this_cpu_idx = (__lcpuidx) ukplat_lcpu_id();
+
+	UK_ASSERT(this_cpu_idx < lcpu_count);
+	UK_ASSERT(lcpus[this_cpu_idx].idx == this_cpu_idx);
+	return this_cpu_idx;
+}
+#else /* CONFIG_UKPLAT_LCPU_IDISIDX */
+__lcpuidx ukplat_lcpu_idx(void)
+{
+	__lcpuid this_cpu_id  = ukplat_lcpu_id();
+	__u32 i, this_cpu_idx = (__u32) (-1);
+
+	/** TODO: Until we have a better way just do a linear search */
+	for (i = 0; i < lcpu_count; i++)
+		if (lcpus[i].id == this_cpu_id) {
+			UK_ASSERT(lcpus[i].idx == (__lcpuidx) i);
+			this_cpu_idx = i;
+			break;
+		}
+
+	UK_ASSERT(this_cpu_idx != (__u32) (-1));
+
+	return (__lcpuidx) this_cpu_idx;
+}
+#endif /* CONFIG_UKPLAT_LCPU_IDISIDX */
+
+int lcpu_fn_enqueue(struct lcpu *lcpu, const struct ukplat_lcpu_func *fn)
+{
+	void (*old_fn)(struct __regs *, void *);
+
+	UK_ASSERT(fn->fn);
+
+	old_fn = ukarch_load_n(&lcpu->fn.fn);
+
+	/* Check if the slot is empty */
+	if (old_fn != NULL)
+		return -EAGAIN;
+
+	/* It is empty, try to store the function */
+	if (ukarch_compare_exchange_sync(&lcpu->fn.fn, old_fn,
+					 fn->fn) != fn->fn)
+		return -EAGAIN;
+
+	/* We have acquired the slot! Also store the user argument.
+	 * It is safe to do it afterwards, because the RUN IRQ handler will
+	 * only take one function and return afterwards. And we only raise the
+	 * IRQ after finishing setup.
+	 */
+	lcpu->fn.user = fn->user;
+
+	/* Ensure everything is written back when we return and the arch
+	 * support code will raise the IRQ
+	 */
+	wmb();
+
+	return 0;
+}
+
+static void lcpu_fn_dequeue(struct lcpu *this_lcpu, struct ukplat_lcpu_func *fn)
+{
+	*fn = this_lcpu->fn;
+
+	/* Ensure that we have captured the whole function object */
+	rmb();
+
+	UK_ASSERT(fn->fn);
+
+	/* Free the slot. Another function object can be queued afterwards */
+	this_lcpu->fn.fn = NULL;
+}
+
+static int lcpu_ipi_run_handler(void *args __unused)
+{
+	struct lcpu *this_lcpu = lcpu_get_current();
+	struct ukplat_lcpu_func fn;
+
+	lcpu_fn_dequeue(this_lcpu, &fn);
+
+	/* TODO: Provide the register snapshot from the trap frame */
+	fn.fn(NULL, fn.user);
+
+	/* If we had a transition from BUSY to HALTED in fn, we would
+	 * not reach this code but sit in the error halt loop. We can
+	 * thus safely just decrement without worrying about the HALTED
+	 * state.
+	 */
+	UK_ASSERT(lcpu_state_is_busy(this_lcpu->state));
+	ukarch_dec(&this_lcpu->state);
+
+	return 1;
+}
+
+static int lcpu_ipi_wakeup_handler(void *args __unused)
+{
+	/* Nothing to do */
+	return 1;
+}
+
+/* We want these to be externally defined as const to clarify that the vectors
+ * cannot be changed after initialization. However, we still need them non-const
+ * so we can still set them here. While we can do a DECONST and force allocation
+ * in .bss, we enter undefined behavior territory. So we just export a const
+ * pointer as proxy. This is still faster than calling a getter function and
+ * with LTO this will be optimized to a direct access.
+ */
+static unsigned long _lcpu_run_irqv;
+static unsigned long _lcpu_wakeup_irqv;
+
+const unsigned long * const lcpu_run_irqv = &_lcpu_run_irqv;
+const unsigned long * const lcpu_wakeup_irqv = &_lcpu_wakeup_irqv;
+
+int lcpu_mp_init(unsigned long run_irq, unsigned long wakeup_irq, void *arg)
+{
+	int rc;
+
+	/* Make sure this is run on the BSP only */
+	UK_ASSERT(lcpu_count == 1);
+	UK_ASSERT(lcpu_current_is_bsp());
+
+	/* Initialize architecture-dependent functionality. This will also do
+	 * CPU discovery and allocation
+	 */
+	rc = lcpu_arch_mp_init(arg);
+	if (unlikely(rc))
+		return rc;
+
+	/* Register the lcpu_run and lcpu_wakeup interrupt handlers */
+	rc = ukplat_irq_register(run_irq, lcpu_ipi_run_handler, NULL);
+	if (unlikely(rc)) {
+		uk_pr_crit("Could not register handler for IPI IRQ %ld\n",
+			   run_irq);
+		return rc;
+	}
+
+	rc = ukplat_irq_register(wakeup_irq, lcpu_ipi_wakeup_handler, NULL);
+	if (unlikely(rc)) {
+		uk_pr_crit("Could not register handler for wakeup IRQ %ld\n",
+			   wakeup_irq);
+		return rc;
+	}
+
+	_lcpu_run_irqv = run_irq;
+	_lcpu_wakeup_irqv = wakeup_irq;
+
+	return 0;
+}
+
+void __weak __noreturn lcpu_entry_default(struct lcpu *this_lcpu)
+{
+	struct lcpu_sargs s_args = this_lcpu->s_args;
+	int rc;
+
+	UK_ASSERT(!lcpu_is_bsp(this_lcpu));
+
+	/* Finish initialization. As there is nothing to return to, we
+	 * just enter halted state if an error occurs.
+	 */
+	rc = lcpu_init(this_lcpu);
+	if (unlikely(rc))
+		lcpu_halt(this_lcpu, rc);
+
+	/* If the user supplied an entry function jump to it */
+	if (s_args.entry && s_args.entry != lcpu_entry_default) {
+		/* Does not return */
+		lcpu_arch_jump_to(s_args.stackp, s_args.entry);
+	} else {
+		/* We are coming from BUSY0 state and want to transition to
+		 * IDLE state. However, there can be functions queued already
+		 * so we have to use a decrement here.
+		 */
+		ukarch_dec(&this_lcpu->state);
+
+		/* Enable IRQs. If there are functions queued we will
+		 * immediately jump to the IRQ handler.
+		 */
+		ukplat_lcpu_enable_irq();
+		while (1) {
+			/* Besides interrupts in general, the halt can be
+			 * interrupted by calls to ukplat_lcpu_run().
+			 */
+			halt();
+		}
+	}
+}
+
+int ukplat_lcpu_start(const __lcpuidx lcpuidx[], unsigned int *num, void *sp[],
+		      const ukplat_lcpu_entry_t entry[], unsigned long flags)
+{
+	__lcpuid this_cpu_id = ukplat_lcpu_id();
+	struct lcpu *lcpu;
+	unsigned int i, n, argi = 0;
+	const int new = LCPU_STATE_INIT;
+	int old;
+	int rc = 0;
+#ifdef LCPU_ARCH_MULTI_PHASE_STARTUP
+	int rc2;
+#endif /* LCPU_ARCH_MULTI_PHASE_STARTUP */
+
+	UK_ASSERT(((lcpuidx) && (num)) || ((!lcpuidx) && (!num)));
+	UK_ASSERT(sp);
+
+	lcpu_lcpuidx_list_foreach(lcpuidx, num, n, i, lcpu) {
+		if (lcpu->id == this_cpu_id) {
+			/* If the caller did not supply an index array, we
+			 * assume that we do not have parameters and a stack
+			 * for the executing CPU. Otherwise, i.e., if the
+			 * caller explicitly put the executing CPU in, we still
+			 * ignore it but need to skip the parameters.
+			 */
+			if (lcpuidx)
+				argi++;
+
+			continue;
+		}
+
+retry:
+		old = ukarch_load_n(&lcpu->state);
+
+		/* We ignore CPUs that are already started */
+		if (unlikely(old != LCPU_STATE_OFFLINE)) {
+			uk_pr_warn("Failed to start CPU 0x%lx: not offline\n",
+				   lcpu->id);
+
+			/* Skip CPU and its arguments*/
+			argi++;
+			continue;
+		}
+
+		/* Try to acquire the CPU for initialization. If another thread
+		 * was faster, we will return to the state comparison and
+		 * report that the CPU is not offline.
+		 */
+		if (ukarch_compare_exchange_sync((int *)&lcpu->state, old,
+						 new) != new)
+			goto retry;
+
+		UK_ASSERT(lcpu->state == LCPU_STATE_INIT);
+
+		/* Setup startup arguments.
+		 * Since we are ignoring the executing CPU, we must keep a
+		 * separate counter to index the arguments.
+		 */
+		lcpu->s_args.entry = (entry && entry[argi]) ?
+			entry[argi] : lcpu_entry_default;
+		lcpu->s_args.stackp = sp[argi];
+
+		/* Ensure that the startup arguments have been written back
+		 * before issuing the startup call
+		 */
+		wmb();
+
+		rc = lcpu_arch_start(lcpu, flags);
+		if (unlikely(rc)) {
+			lcpu->state = LCPU_STATE_HALTED;
+			lcpu->error_code = rc;
+
+			/* There is a serious problem. Stop here. The caller
+			 * can skip the CPU by using the value of *num.
+			 */
+			break;
+		}
+
+		/* Move to next argument */
+		argi++;
+	}
+
+#ifdef LCPU_ARCH_MULTI_PHASE_STARTUP
+	/* At this point, i has been set to the number of successfully
+	 * started CPUs. So if there has been an error, we won't touch
+	 * any CPUs not started.
+	 */
+	rc2 = lcpu_arch_post_start(lcpuidx, &i);
+	if (unlikely(rc2)) {
+		if (num) {
+			UK_ASSERT(i <= *num);
+			*num = i;
+		}
+
+		/* Return the first error */
+		return (rc) ? rc : rc2;
+	}
+#endif /* LCPU_ARCH_MULTI_PHASE_STARTUP */
+
+	UK_ASSERT(num == NULL || *num == i);
+	return rc;
+}
+
+static inline int lcpu_transition_safe(struct lcpu *lcpu, int incr)
+{
+	int old, new;
+
+	/* Transition the CPU to a different busy level. The CPU could not be
+	 * online or fall into a halted state at any moment, we thus cannot
+	 * just atomically in-/decrement the state. Otherwise, we might corrupt
+	 * the non-online state.
+	 */
+	do {
+		old = ukarch_load_n(&lcpu->state);
+
+		/* We must not change the state if the CPU is not online */
+		if (!lcpu_state_is_online(old))
+			return 0;
+
+		UK_ASSERT(old <= INT_MAX - incr);
+		UK_ASSERT(old >= INT_MIN + incr);
+		new = old + incr;
+
+		UK_ASSERT(lcpu_state_is_online(new));
+	} while (ukarch_compare_exchange_sync((int *)&lcpu->state, old,
+					      new) != new);
+
+	return 1;
+}
+
+int ukplat_lcpu_run(const __lcpuidx lcpuidx[], unsigned int *num,
+		    const struct ukplat_lcpu_func *fn, unsigned long flags)
+{
+	__lcpuid this_cpu_id = ukplat_lcpu_id();
+	struct lcpu *lcpu;
+	unsigned int n, i;
+	int rc;
+
+	UK_ASSERT(((lcpuidx) && (num)) || ((!lcpuidx) && (!num)));
+	UK_ASSERT(fn);
+
+	lcpu_lcpuidx_list_foreach(lcpuidx, num, n, i, lcpu) {
+		if (lcpu->id == this_cpu_id)
+			continue;
+
+		/* Try to transition state to a higher busy level.
+		 * We ignore CPUs that are not online
+		 */
+		if (!lcpu_transition_safe(lcpu, 1))
+			continue;
+
+		/* We successfully performed the state transition. Now queue
+		 * the function and trigger its execution
+		 */
+		while (1) {
+			rc = lcpu_arch_run(lcpu, fn, flags);
+			if (unlikely(rc)) {
+				/* Retry if we could not enqueue the function
+				 * and it is ok to block
+				 */
+				if ((rc == -EAGAIN) &&
+				    (!(flags & UKPLAT_LCPU_RFLG_DONOTBLOCK)))
+					continue;
+
+				/* Try to transition back one busy level. We
+				 * don't care if the CPU is no longer online
+				 */
+				lcpu_transition_safe(lcpu, -1);
+
+				return rc;
+			}
+
+			break;
+		}
+	}
+
+	return 0;
+}
+
+int ukplat_lcpu_wait(const __lcpuidx lcpuidx[], unsigned int *num,
+		     __nsec timeout)
+{
+	__lcpuid this_cpu_id = ukplat_lcpu_id();
+	struct lcpu *lcpu;
+	unsigned int n, i;
+	int state;
+	__nsec end;
+
+	UK_ASSERT(((lcpuidx) && (num)) || ((!lcpuidx) && (!num)));
+
+	if (timeout > 0)
+		end = ukplat_monotonic_clock() + timeout;
+
+	lcpu_lcpuidx_list_foreach(lcpuidx, num, n, i, lcpu) {
+		if (lcpu->id == this_cpu_id)
+			continue;
+
+		/* Perform a busy wait until we reach IDLE state. However, we
+		 * do not want to wait on HALTED or OFFLINE CPUs. So we are
+		 * continuing while the LCPU is in INIT or BUSY state and the
+		 * timeout has not been reached.
+		 */
+		while (1) {
+			state = UK_READ_ONCE(lcpu->state);
+
+			if ((state == LCPU_STATE_OFFLINE) ||
+			    (state == LCPU_STATE_HALTED))
+				break;
+
+			if (state == LCPU_STATE_IDLE)
+				break;
+
+			if (timeout && (ukplat_monotonic_clock() >= end))
+				return -ETIMEDOUT; /* Timed out */
+		}
+	}
+
+	return 0;
+}
+
+int ukplat_lcpu_wakeup(const __lcpuidx lcpuidx[], unsigned int *num)
+{
+	__lcpuid this_cpu_id = ukplat_lcpu_id();
+	struct lcpu *lcpu;
+	unsigned int n, i;
+	int rc;
+
+	UK_ASSERT(((lcpuidx) && (num)) || ((!lcpuidx) && (!num)));
+
+	lcpu_lcpuidx_list_foreach(lcpuidx, num, n, i, lcpu) {
+		if (lcpu->id == this_cpu_id)
+			continue;
+
+		/* We ignore CPUs that are not online. Note that the CPU may
+		 * change to HALTED state afterwards. However, that is not a
+		 * problem, as the halt loop will return to sleep after the
+		 * wakeup
+		 */
+		if (!lcpu_state_is_online(lcpu->state))
+			continue;
+
+		rc = lcpu_arch_wakeup(lcpu);
+		if (unlikely(rc))
+			return rc;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_HAVE_SMP */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_UKPLAT_LCPU_MAXCOUNT > 1`

-->

 - `CONFIG_UKPLAT_LCPU_MAXCOUNT > 1`

### Description of changes

This PR provides an implementation of the architecture-independent parts of the SMP API based on the common code developed in the PRs for x86 (#244) and ARM64 (#373). The architecture implementation must provide the following functions as described in `plat/common/include/uk/plat/common/lcpu.h`:

- `lcpu_arch_mp_init` which is executed on the BSP by `lcpu_mp_init()` during system boot to allow architecture-dependent initialization of the multi-processor functionality. This function should perform CPU enumeration and allocate LCPUs using `lcpu_alloc()`. The first LCPU must be the BSP itself (it does not need to be explicitly allocated).
- `lcpu_arch_init()` which is executed on the a CPU when calling `lcpu_init()`. This function can be used to initialize extended CPU features or setup traps and interrupts for the newly started CPU.
- `lcpu_arch_id()` which queries the hardware ID of the CPU which executes the function using architecture-dependent instructions / facilities.
- `lcpu_arch_start()` which signals a certain CPU to begin with the startup sequence (e.g., by issuing a special interprocessor interrupt (IPI))
- `lcpu_arch_post_start()` [OPTIONAL] if the architecture defines `LCPU_ARCH_MULTI_PHASE_STARTUP` and which is called in `ukplat_lcpu_start()` after all LCPUs specified in the call have received an `lcpu_arch_start()` call. This can be used to speed up starting multiple CPUs at the same time on some architectures like x86.
- `lcpu_arch_run()` which queues a function supplied to `ukplat_lcpu_run()` to the given LCPU and signals the corresponding CPU to wake up and dispatch queued functions. The common code expects this to be triggered by a special IPI whose vector has to be defined via `LCPU_ARCH_IPI_RUN_IRQ`
- `lcpu_arch_wakeup()` which forces the given CPU to wake up from a temporary halt state. The common code expects this to be triggered by a special IPI whose vector has to be defined via `LCPU_ARCH_IPI_WAKEUP_IRQ`. The architecture may decide to implement a very lightweight IRQ handler for this vector which just acknowledges the IRQ and returns. However, in that case, the architecture must ensure that no other handlers will be registered for this vector.

The platform boot code (usually in `setup.c`) should call `lcpu_init()` to setup the current BSP and afterwards call `lcpu_mp_init()` to initialize multi-processor functionality including CPU discovery. The boot code should crash the system if any of these initializations fail. If `lcpu_init()` fails on a secondary CPU, the CPU should be put into a halt state using `lcpu_halt()` with an error code indicating the reason. Secondary CPUs must not call `lcpu_mp_init()`.