### PR TITLE
lib/posix-process: Reduce checkpatch errors and warnings

### DIFF
--- a/lib/posix-process/musl-imported/include/sys/resource.h
+++ b/lib/posix-process/musl-imported/include/sys/resource.h
@@ -45,12 +45,12 @@ struct rusage {
 	long    __reserved[16];
 };
 
-int getrlimit (int, struct rlimit *);
-int setrlimit (int, const struct rlimit *);
-int getrusage (int, struct rusage *);
+int getrlimit(int, struct rlimit *);
+int setrlimit(int, const struct rlimit *);
+int getrusage(int, struct rusage *);
 
-int getpriority (int, id_t);
-int setpriority (int, id_t, int);
+int getpriority(int, id_t);
+int setpriority(int, id_t, int);
 
 #ifdef _GNU_SOURCE
 int prlimit(pid_t, int, const struct rlimit *, struct rlimit *);

--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -336,7 +336,7 @@ UK_SYSCALL_R_DEFINE(int, setpriority, int, which, id_t, who, int, prio)
 			rc = -ESRCH;
 		}
 		break;
-default:
+	default:
 		rc = -EINVAL;
 		break;
 	}


### PR DESCRIPTION
This commit reduces coding style errors from the posix-process library.

This pr is a copy of #367 and addresses the issue #199 .

The original pr makes changes to multiple libraries at the same time and might be dangerous to integrate all of them at once. This copy separates these changes into multiple PR's that can be integrated more easily.

Signed-off-by: Florin Postolache <florin.postolache80@gmail.com>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A