### PR TITLE
lib/vfscore: Fix fget in flock()

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -933,10 +933,9 @@ UK_SYSCALL_R_DEFINE(int, flock, int, fd, int, operation)
 	struct vfscore_file *file;
 	int error;
 
-	if (!fget(fd, &file)) {
-		error = EBADF;
+	error = fget(fd, &file);
+	if (error)
 		goto out_error;
-	}
 
 	switch (operation) {
 	case LOCK_SH:


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

fget returns a non-zero value on error, 0 otherwise. This commit fixes the wrong check in flock, which assumes the opposite. It also takes the error value from fget.