### PR TITLE
lib/vfscore: readdir should return error in errno

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1126,8 +1126,10 @@ struct dirent *readdir(DIR *dir)
 	int ret;
 
 	ret = readdir_r(dir, &entry, &result);
-	if (ret)
-		return ERR2PTR(-ret);
+	if (ret) {
+		errno = ret;
+		return NULL;
+	}
 
 	errno = 0;
 	return result;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

 - `CONFIG_LIBVFSCORE=y`

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

In the case of an error, readdir should [return NULL and set errno](https://man7.org/linux/man-pages/man3/readdir.3.html#RETURN_VALUE).

<!--
Please provide a detailed description of the changes made in this new PR.
-->
