### PR TITLE
.github: Update `CODEOWNERS` with latest libs and remove reviewer teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,83 +1,101 @@
 # https://help.github.com/articles/about-codeowners/
 
 # These owners are the default owners for all Unikraft core files.
-*			@unikraft/maintainers-core @unikraft/reviewers-core
+*			@unikraft/maintainers-core
 
 # These owners oversee the core parts of Unikraft.
-/lib/isrlib/		@unikraft/maintainers-core @unikraft/reviewers-core
-/lib/nolibc/		@unikraft/maintainers-core @unikraft/reviewers-core
-/lib/uktime/		@unikraft/maintainers-core @unikraft/reviewers-core
-/lib/uktimeconv/	@unikraft/maintainers-core @unikraft/reviewers-core
-/lib/uklibparam/	@unikraft/maintainers-core @unikraft/reviewers-core
-/lib/posix-libdl	@unikraft/maintainers-core @unikraft/reviewers-core
-/lib/syscall_shim/	@unikraft/maintainers-core @unikraft/reviewers-core
-/lib/ukboot/		@unikraft/maintainers-core @unikraft/reviewers-core
-/lib/ukargparse/	@unikraft/maintainers-core @unikraft/reviewers-core
-/lib/uksglist/		@unikraft/maintainers-core @unikraft/reviewers-core
+/lib/isrlib		@unikraft/maintainers-core
+/lib/nolibc		@unikraft/maintainers-core
+/lib/posix-libdl	@unikraft/maintainers-core
+/lib/posix-sysinfo	@unikraft/maintainers-core
+/lib/syscall_shim	@unikraft/maintainers-core
+/lib/ukargparse		@unikraft/maintainers-core
+/lib/ukboot		@unikraft/maintainers-core
+/lib/uklibparam		@unikraft/maintainers-core
+/lib/ukring		@unikraft/maintainers-core
+/lib/uksglist		@unikraft/maintainers-core
+/lib/ukstore		@unikraft/maintainers-core
+/lib/uktime		@unikraft/maintainers-core
+/lib/uktimeconv		@unikraft/maintainers-core
 
 # These owners oversee the APIs.
-/include/		@unikraft/maintainers-api @unikraft/reviewers-api
-/arch/*/include/	@unikraft/maintainers-api @unikraft/reviewers-api
-/arch/*/*/include/	@unikraft/maintainers-api @unikraft/reviewers-api
-/plat/include/		@unikraft/maintainers-api @unikraft/reviewers-api
+/arch/*/*/include	@unikraft/maintainers-api
+/arch/*/include		@unikraft/maintainers-api
+/include		@unikraft/maintainers-api
+/plat/include		@unikraft/maintainers-api
+
+# These owners oversee all architectures.
+/arch			@unikraft/maintainers-arch
 
 # These owners oversee the ARM architecture.
-/lib/fdt/		@unikraft/maintainers-arch-arm @unikraft/reviewers-arch-arm
-/arch/arm/		@unikraft/maintainers-arch-arm @unikraft/reviewers-arch-arm
-/plat/*/arm/		@unikraft/maintainers-arch-arm @unikraft/reviewers-arch-arm
-/plat/*/include/*-arm/	@unikraft/maintainers-arch-arm @unikraft/reviewers-arch-arm
+/arch/arm		@unikraft/maintainers-arch-arm
+/lib/fdt		@unikraft/maintainers-arch-arm
+/plat/*/arm		@unikraft/maintainers-arch-arm
+/plat/*/include/*-arm	@unikraft/maintainers-arch-arm
 
 # These owners oversee the x86 architecture.
-/arch/x86/		@unikraft/maintainers-arch-x86 @unikraft/reviewers-arch-x86
-/plat/*/x86/		@unikraft/maintainers-arch-x86 @unikraft/reviewers-arch-x86
-/plat/*/include/*-x86/	@unikraft/maintainers-arch-x86 @unikraft/reviewers-arch-x86
+/arch/x86		@unikraft/maintainers-arch-x86
+/plat/*/include/*-x86	@unikraft/maintainers-arch-x86
+/plat/*/x86		@unikraft/maintainers-arch-x86
+
+# These owners oversee all platforms.
+/plat			@unikraft/maintainers-plat
 
 # These owners oversee the KVM platform.
-/plat/kvm/		@unikraft/maintainers-plat-kvm @unikraft/reviewers-plat-kvm
+/plat/kvm		@unikraft/maintainers-plat-kvm
 
 # These owners oversee the Xen platform.
-/plat/xen/		@unikraft/maintainers-plat-xen @unikraft/reviewers-plat-xen
+/plat/xen		@unikraft/maintainers-plat-xen
 
 # These owners oversee the linuxu platform.
-/plat/linuxu/		@unikraft/maintainers-plat-linuxu @unikraft/reviewers-plat-linuxu
+/plat/linuxu/		@unikraft/maintainers-plat-linuxu
 
 # These owners oversee the scheduler-related components.
-/lib/uksched*		@unikraft/maintainers-sched @unikraft/reviewers-sched
-/lib/uklock/		@unikraft/maintainers-sched @unikraft/reviewers-sched
-/lib/ukmpi/		@unikraft/maintainers-sched @unikraft/reviewers-sched
-/lib/posix-process/	@unikraft/maintainers-sched @unikraft/reviewers-sched
+/lib/posix-process	@unikraft/maintainers-sched
+/lib/uklock		@unikraft/maintainers-sched
+/lib/ukmpi		@unikraft/maintainers-sched
+/lib/uksched*		@unikraft/maintainers-sched
+/lib/uksignal		@unikraft/maintainers-sched
 
 # These owners oversee the memory manangement-related components.
-/lib/ukmmap/		@unikraft/maintainers-mem @unikraft/reviewers-mem
-/lib/ukalloc*		@unikraft/maintainers-mem @unikraft/reviewers-mem
+/lib/ukalloc*		@unikraft/maintainers-mem
+/lib/ukfalloc*		@unikraft/maintainers-mem
+/lib/ukmmap		@unikraft/maintainers-mem
 
 # These owners oversee the security-related components.
-/lib/uksp/		@unikraft/maintainers-security @unikraft/reviewers-security
-/lib/ukswrand/		@unikraft/maintainers-security @unikraft/reviewers-security
-/lib/uksp/		@unikraft/maintainers-security @unikraft/reviewers-security
+/lib/ubsan		@unikraft/maintainers-security
+/lib/uksp		@unikraft/maintainers-security
+/lib/ukswrand		@unikraft/maintainers-security
 
 # These owners oversee the network-related components.
-/lib/uknetdev/		@unikraft/maintainers-net @unikraft/reviewers-net
+/lib/uknetdev		@unikraft/maintainers-net
 
 # These owners oversee the filesystem-related components.
-/lib/vfscore/		@unikraft/maintainers-fs @unikraft/reviewers-fs
-/lib/ukblkdev/		@unikraft/maintainers-fs @unikraft/reviewers-fs
-/lib/posix-user/	@unikraft/maintainers-fs @unikraft/reviewers-fs
-/lib/ukcpio/		@unikraft/maintainers-fs @unikraft/reviewers-fs
-/lib/uk9p/		@unikraft/maintainers-fs @unikraft/reviewers-fs
-/lib/9pfs/		@unikraft/maintainers-fs @unikraft/reviewers-fs
-/lib/devfs/		@unikraft/maintainers-fs @unikraft/reviewers-fs
-/lib/ramfs/		@unikraft/maintainers-fs @unikraft/reviewers-fs
+/lib/9pfs		@unikraft/maintainers-fs
+/lib/devfs		@unikraft/maintainers-fs
+/lib/posix-user		@unikraft/maintainers-fs
+/lib/ramfs		@unikraft/maintainers-fs
+/lib/uk9p		@unikraft/maintainers-fs
+/lib/ukblkdev		@unikraft/maintainers-fs
+/lib/ukcpio		@unikraft/maintainers-fs
+/lib/vfscore		@unikraft/maintainers-fs
 
 # These owners oversee the device-related components.
-/lib/ukbus/		@unikraft/maintainers-device @unikraft/reviewers-device
+/lib/ukbus		@unikraft/maintainers-device
 
 # These owners oversee the build system.
-/Makefile		@unikraft/maintainers-build @unikraft/reviewers-build
-/Makefile.uk		@unikraft/maintainers-build @unikraft/reviewers-build
-/lib/Config.uk		@unikraft/maintainers-build @unikraft/reviewers-build
-/lib/Makefile.uk	@unikraft/maintainers-build @unikraft/reviewers-build
-/support/		@unikraft/maintainers-build @unikraft/reviewers-build
+/lib/Config.uk		@unikraft/maintainers-build
+/lib/Makefile.uk	@unikraft/maintainers-build
+/Makefile		@unikraft/maintainers-build
+/Makefile.uk		@unikraft/maintainers-build
+/support		@unikraft/maintainers-build
 
 # These owners oversee the debugging support.
-/lib/ukdebug/		@unikraft/maintainers-debug @unikraft/reviewers-debug
+/lib/ukdebug		@unikraft/maintainers-debug
+
+# These owners oversee internal use of Rust within Unikraft.
+/lib/ukrust		@unikraft/maintainers-lang-rust
+
+# These owners oversee testing within Unikraft.
+/lib/uktest		@unikraft/maintainers-test
+tests/test_*		@unikraft/maintainers-test


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit makes a number of changes to the `CODEOWNERS` file which at present is currently out-of-date and erroring on GitHub.

This commit makes the following changes:

 * Orders all entries alphabetically and removes the trailing forward slash from directory names;
 * Remove `@unikraft/reviewers-*` as these members would be granted the same privilege as maintainers;
 * Attribute ownership of `posix-sysinfo` to @unikraft/maintainers-core;
 * Attribute ownership of `ubsan` to @unikraft/maintainers-security;
 * Remove duplicate entry for `uksp`;
 * Attribute ownership of `ukfalloc*` to @unikraft/maintainers-mem;
 * Attribute ownership of `ukring` to @unikraft/maintainers-core;
 * Attribute ownership of `ukrust` to @unikraft/maintainers-lang-rust;
 * Attribute ownership of `uksignal` to @unikraft/maintainers-sched;
 * Attribute ownership of `uktest` to @unikraft/maintainers-test;
 * Attribute ownership of `/arch` to @unikraft/maintainers-arch;
 * Attribute ownership of `/plat` to @unikraft/maintainers-plat; and,
 * Attribute ownership of `ukstore` to @unikraft/maintainers-core.

Signed-off-by: Alexander Jung <alex@unikraft.org>