### PR TITLE
Cleanup GIC-v2/GIC-v3 code

### DIFF
--- a/plat/drivers/gic/gic-v2.c
+++ b/plat/drivers/gic/gic-v2.c
@@ -365,9 +365,9 @@ static void gicv2_handle_irq(void)
 		irq = stat & GICC_IAR_INTID_MASK;
 
 #ifndef CONFIG_HAVE_SMP
-		uk_pr_debug("EL1 IRQ#%d trap caught\n", irq);
+		uk_pr_debug("EL1 IRQ#%"__PRIu32" caught\n", irq);
 #else /* !CONFIG_HAVE_SMP */
-		uk_pr_debug("Core %d: EL1 IRQ#%d trap caught\n",
+		uk_pr_debug("Core %"__PRIu64": EL1 IRQ#%"__PRIu32" caught\n",
 			    ukplat_lcpu_id(), irq);
 #endif /* CONFIG_HAVE_SMP */
 

--- a/plat/drivers/gic/gic-v3.c
+++ b/plat/drivers/gic/gic-v3.c
@@ -462,10 +462,10 @@ static void gicv3_handle_irq(void)
 		irq = stat & GICC_IAR_INTID_MASK;
 
 #ifndef CONFIG_HAVE_SMP
-		uk_pr_debug("EL1 IRQ#%d trap caught\n", irq);
+		uk_pr_debug("EL1 IRQ#%"__PRIu32" caught\n", irq);
 #else /* !CONFIG_HAVE_SMP */
-		uk_pr_debug("Core %d: EL1 IRQ#%d trap caught\n",
-				ukplat_lcpu_id(), irq);
+		uk_pr_debug("Core %"__PRIu64": EL1 IRQ#%"__PRIu32" caught\n",
+			    ukplat_lcpu_id(), irq);
 #endif /* CONFIG_HAVE_SMP */
 
 		/* Ensure interrupt processing starts only after ACK */

--- a/plat/drivers/include/gic/gic-v2.h
+++ b/plat/drivers/include/gic/gic-v2.h
@@ -287,7 +287,7 @@ enum sgi_filter {
  * @param target an 8-bit bitmap with 1 bit per CPU 0-7. A `1` bit
  *    indicates that the SGI should be forwarded to the respective CPU
  */
-void gic_sgi_gen_to_list(uint32_t sgintid, uint8_t target);
+void gicv2_sgi_gen_to_list(uint32_t sgintid, uint8_t target);
 
 /**
  * Forward the SGI to all CPU interfaces except that of the processor
@@ -295,7 +295,7 @@ void gic_sgi_gen_to_list(uint32_t sgintid, uint8_t target);
  *
  * @param sgintid the SGI ID [0-15]
  */
-void gic_sgi_gen_to_others(uint32_t sgintid);
+void gicv2_sgi_gen_to_others(uint32_t sgintid);
 
 /**
  * Forward the SGI only to the CPU interface of the processor
@@ -303,7 +303,7 @@ void gic_sgi_gen_to_others(uint32_t sgintid);
  *
  * @param sgintid the SGI ID [0-15]
  */
-void gic_sgi_gen_to_self(uint32_t sgintid);
+void gicv2_sgi_gen_to_self(uint32_t sgintid);
 
 /**
  * Probe device tree for GICv2


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

This PR bundles some cleanups for the GIC-v2 implementation that improves documentation, adds additional assertations and renames the `gic_`-prefix to `gicv2_` to be inline with the GIC-v3 implementation. The PR also fixes a warning about a wrong format specifier used for `__lcpuid` in GIC-v2 and GIC-v3.