### PR TITLE
plat/arm/lcpu: Fix warnings about unused variables

### DIFF
--- a/plat/common/arm/lcpu.c
+++ b/plat/common/arm/lcpu.c
@@ -38,20 +38,7 @@
 #include <libfdt.h>
 #include <ofw/fdt.h>
 
-/**
- * The number of cells for the size field should be 0 in cpu nodes.
- * The number of cells in the address field is set by default to 2 in cpu
- * nodes. This is also the maximum number of cells for the address field that
- * we can currently support.
- */
-#define FDT_SIZE_CELLS_DEFAULT 0
-#define FDT_ADDR_CELLS_DEFAULT 2
 #define CPU_ID_MASK 0xff00ffffffUL
-
-static void *dtb;
-void lcpu_start(struct lcpu *cpu);
-static __paddr_t lcpu_start_paddr;
-extern struct _gic_dev *gic;
 
 __lcpuid lcpu_arch_id(void)
 {
@@ -64,6 +51,20 @@ __lcpuid lcpu_arch_id(void)
 }
 
 #ifdef CONFIG_HAVE_SMP
+/**
+ * The number of cells for the size field should be 0 in cpu nodes.
+ * The number of cells in the address field is set by default to 2 in cpu
+ * nodes. This is also the maximum number of cells for the address field that
+ * we can currently support.
+ */
+#define FDT_SIZE_CELLS_DEFAULT 0
+#define FDT_ADDR_CELLS_DEFAULT 2
+
+static void *dtb;
+void lcpu_start(struct lcpu *cpu);
+static __paddr_t lcpu_start_paddr;
+extern struct _gic_dev *gic;
+
 int lcpu_arch_init(struct lcpu *this_lcpu)
 {
 	int ret = 0;


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

When SMP is not enabled the local variables are not used which triggers
warning. We thus move everything that is only needed for SMP into the
`CONFIG_HAVE_SMP` part.
