### PR TITLE
build: Consider obj-only libs for linking

### DIFF
--- a/support/build/Makefile.build
+++ b/support/build/Makefile.build
@@ -25,16 +25,15 @@
 
 ifneq ($(call qstrip,$(UK_LIBS) $(UK_LIBS-y)),)
 $(foreach L,$(UK_LIBS) $(UK_LIBS-y), \
-$(if $(call qstrip,$($(call uc,$(L))_SRCS) $($(call uc,$(L))_SRCS-y) \
-	    $(EACHOLIB_SRCS) $(EACHOLIB_SRCS-y)), \
 $(foreach S,$($(call uc,$(L))_SRCS) $($(call uc,$(L))_SRCS-y) \
 	    $(EACHOLIB_SRCS) $(EACHOLIB_SRCS-y), \
 $(eval $(call buildrule_libobj_multitarget,$(L),$(S))) \
 ); \
+$(if $(call qstrip,$($(call uc,$(L))_OBJS) $($(call uc,$(L))_OBJS-y)), \
 $(eval $(call buildrule_olib,$(L))); \
 $(eval UK_OLIBS-y += $(call libname2olib,$(L))); \
 , \
-$(call verbose_info,Warning: '$(L)' has no sources$(comma) ignoring...) \
+$(call verbose_info,Warning: '$(L)' has no sources or object files$(comma) ignoring...) \
 ) \
 )
 endif
@@ -50,16 +49,15 @@ ifneq ($(call qstrip,$(UK_PLATS) $(UK_PLATS-y)),)
 $(foreach P,$(UK_PLATS) $(UK_PLATS-y), \
 $(if $(call qstrip,$($(call uc,$(P))_LIBS) $($(call uc,$(P))_LIBS-y)), \
 $(foreach L,$($(call uc,$(P))_LIBS) $($(call uc,$(P))_LIBS-y), \
-$(if $(call qstrip,$($(call uc,$(L))_SRCS) $($(call uc,$(L))_SRCS-y) \
-     $(EACHOLIB_SRCS) $(EACHOLIB_SRCS-y)), \
 $(foreach S,$($(call uc,$(L))_SRCS) $($(call uc,$(L))_SRCS-y) \
 	    $(EACHOLIB_SRCS) $(EACHOLIB_SRCS-y), \
 $(eval $(call buildrule_libobj_multitarget,$(L),$(S))) \
 ); \
+$(if $(call qstrip,$($(call uc,$(L))_OBJS) $($(call uc,$(L))_OBJS-y)), \
 $(eval $(call buildrule_olib,$(L))); \
 $(eval $(call uc,$(P))_OLIBS-y    += $(call libname2olib,$(L))); \
 , \
-$(call verbose_info,Warning: '$(L) has no sources$(comma) ignoring...) \
+$(call verbose_info,Warning: '$(L)' has no sources or object files$(comma) ignoring...) \
 ) \
 ) \
 , \


### PR DESCRIPTION
**This patch enables linking libraries consisting only of prebuilt object files, but no source files.**
Currently, libraries without any source files are ingored by the build system. The patch also fixes a related problem with libraries consisting only of device tree source (DTS) files.

Both types of libraries might by desirably:
- distribution of libraries without source code
- libraries that provide a shared device tree for multiple applications

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): all
 - Platform(s): all
 - Application(s): all

### Additional configuration

There are 2 scenarios that do not build originally, but build after applying this patch.

#### DTS-only libraries

Libraries consisting only of DTS files break the build. For testing purposes, you can add [this example library](https://github.com/kubanrob/lib-nosource) to any application and select _only_ "Provide DTS source" in the configuration.

#### Object-only libraries

Libraries consisting only of object files will be ignored. For testing purposes, you can add [this example library](https://github.com/kubanrob/lib-nosource) to the app-helloworld application

1. Use (for example print) `extern const char* libnosource_export` in the application.
2. Build with _only_ "Provide C source" in the configuration (should succeed)
2. Build with _only_ "Provide prebuild object file" in the configuration (should fail)

### Description of changes


Generating the build rules, libraries without any object files need to be filtered out in order to avoid calling the linker without any input files. This patch changes the requirement for including an olib in a build from checking for source files to checking for object files. As `buildrule_libobj_multitarget` adds the object files corresponding to the source files into `LIBNAME_OBJS-y`, "normal" libraries consisting of source files still build properly.
