### PR TITLE
plat/kvm/x86: Add call to _init_paging in setup.c

### DIFF
--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -453,6 +453,9 @@ void _libkvmplat_entry(void *arg)
 	_get_cmdline(&bootinfo);
 	_init_mem(&bootinfo);
 	_init_initrd(&bootinfo);
+#ifdef CONFIG_PAGING
+	_init_paging(mi);
+#endif /* CONFIG_PAGING */
 
 	if (_libkvmplat_cfg.initrd.len)
 		uk_pr_info("        initrd: %p\n",


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]

### Additional configuration

### Description of changes

This PR fixes a missing call to `_init_paging` in `plat/kvm/x86/setup.c`, needed for paging to work properly
