### PR TITLE
build: Update reference to `liftoff`

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -173,8 +173,9 @@ if RECORD_BUILDTIME
 	config RECORD_BUILDTIME_LIFTOFF
 	bool "liftoff"
 	help
-		Use liftoff to record process statistics during building
-		Get it from https://github.com/sysml/liftoff
+		Use liftoff to record process statistics during building.
+		Get it from https://github.com/unikraft/liftoff and add
+		it to your command-line environment
 
 	endchoice
 endif


### PR DESCRIPTION
Updates the menu config description for the `liftoff` tool that can be used to track build time and build command calling. `liftoff` is available under https://github.com/unikraft/liftoff .