### PR TITLE
lib/ukring: Fix build when ukring is enabled

### DIFF
--- a/lib/ukring/include/uk/ring.h
+++ b/lib/ukring/include/uk/ring.h
@@ -52,14 +52,14 @@ struct uk_ring {
 	int               br_prod_size;
 	int               br_prod_mask;
 	uint64_t          br_drops;
-	volatile uint32_t br_cons_head __aligned(CACHE_LINE_SIZE);
+	volatile uint32_t br_cons_head __align(CACHE_LINE_SIZE);
 	volatile uint32_t br_cons_tail;
 	int               br_cons_size;
 	int               br_cons_mask;
 #ifdef DEBUG_BUFRING
 	struct uk_mutex  *br_lock;
 #endif
-	void             *br_ring[0] __aligned(CACHE_LINE_SIZE);
+	void             *br_ring[0] __align(CACHE_LINE_SIZE);
 };
 
 /*

--- a/lib/ukring/ring.c
+++ b/lib/ukring/ring.c
@@ -46,7 +46,7 @@ uk_ring_alloc(int count, struct uk_alloc *a
 	/* buf ring must be size power of 2 */
 	UK_ASSERT(POWER_OF_2(count));
 
-	br = uk_malloc(a, sizeof(struct uk_ring) + count * sizeof(caddr_t));
+	br = uk_malloc(a, sizeof(struct uk_ring) + count * sizeof(void *));
 	if (br == NULL)
 		return NULL;
 #ifdef DEBUG_BUFRING


### PR DESCRIPTION
This commit fixes the building process that fails when ukring is
enabled.

Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>

### Prerequisite checklist

 - [ x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ x] Tested your changes against relevant architectures and platforms;
 - [ x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ x] Updated relevant documentation.


### Base target

 - Architecture(s): x86_64
 - Platform(s): kvm
 - Application(s): N/A


### Additional configuration

The building process fails when compiling /lib/ukring/ring.c (issue #357)

Although this issue shall be solved by replacing ukring with macronized implementation (as described in the ticket), this issue has been around for a while, so this PR can quickly solve the issue with the code in master. 

### Description of changes

Fix align macros and caddr_t reference.