### PR TITLE
plat/kvm_x86 : adding ASLR to Unikraft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -725,9 +725,18 @@ $(BUILD_DIR)/uk-gdb.py: $(SCRIPTS_DIR)/uk-gdb.py
 	$(call verbose_cmd,GEN,$(notdir $@), \
 	sed '/scripts_dir = / s/os.path.dirname(os.path.realpath(__file__))/"$(SCRIPTS_DIR_BACKSLASHED)"/g' $^ > $@)
 
+ifeq ($(CONFIG_LINK_ASLR),y)
+prepare-ASLR:
+	$(eval ASLR_BASE_ADDRESS := $(shell $(SCRIPTS_DIR)/ASLR/ASLR.py --setup_file="$(LIBKVMPLAT_BASE)/x86/entry64.S"))
+else
+prepare-ASLR:
+	$(eval ASLR_BASE_ADDRESS :=  $(shell $(SCRIPTS_DIR)/ASLR/ASLR.py --setup_file="$(LIBKVMPLAT_BASE)/x86/entry64.S" \
+		--base_addr="100000"))
+endif
+
 gdb_helpers: $(GDB_HELPER_LINKS) $(BUILD_DIR)/uk-gdb.py
 
-all: images gdb_helpers
+all: prepare-ASLR images gdb_helpers
 ################################################################################
 # Cleanup rules
 ################################################################################

--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -77,6 +77,23 @@ endif
 
 endmenu
 
+menu "Memory security"
+
+config LINK_ASLR
+	bool "Libraries ASLR activation"
+	default n
+	help
+		Activates the ASLR, it consists in modifying the lib addresses during linking time in order
+		to have different microlibs memory layouts.
+
+config RUNTIME_ASLR
+	bool "Heap/stack ASLR activation"
+	default n
+	select LIBUKSWRAND
+	help
+		Activates the ASLR, it consists in modifying the heap/lib addresses when booting the kernel.
+endmenu
+
 config KVM_MAX_IRQ_HANDLER_ENTRIES
        int "Maximum number of handlers per IRQ"
        default 8

--- a/plat/kvm/Linker.uk
+++ b/plat/kvm/Linker.uk
@@ -16,7 +16,57 @@ KVM_LD_SCRIPT_FLAGS := $(addprefix -Wl$(comma)-dT$(comma),\
 			 $(UK_PLAT_KVM_DEF_LDS))
 KVM_LD_SCRIPT_FLAGS += $(addprefix -Wl$(comma)-T$(comma),\
 			$(KVM_LD_SCRIPT-y) $(EXTRA_LD_SCRIPT-y))
+KVM_LD_SCRIPT_FLAGS_ASLR := $(addprefix -Wl$(comma)-dT$(comma),\
+			 $(UK_PLAT_KVM_DEF_LDS_ASLR))
+KVM_LD_SCRIPT_FLAGS_ASLR += $(addprefix -Wl$(comma)-T$(comma),\
+			$(KVM_LD_SCRIPT-y) $(EXTRA_LD_SCRIPT-y))
 
+ASLR_LIBS += $(foreach P,$(UK_PLATS) $(UK_PLATS-y),\
+		$(if $(call qstrip,$($(call uc,$(P))_LIBS) $($(call uc,$(P))_LIBS-y)),\
+		$(foreach L,$($(call uc,$(P))_LIBS) $($(call uc,$(P))_LIBS-y), \
+		$(if $(call qstrip,$($(call vprefix_lib,$(L),SRCS)) $($(call vprefix_lib,$(L),SRCS-y))), \
+		$(L) \
+		)))) \
+		$(UK_LIBS) $(UK_LIBS-y)
+
+ASLR_args += --base_addr=$(ASLR_BASE_ADDRESS) --file_path=$(UK_PLAT_KVM_DEF_LDS) \
+	--lib_list="$(ASLR_LIBS)" --output_path=$(UK_PLAT_KVM_DEF_LDS_ASLR) 
+
+ifeq (y,$(CONFIG_LINK_ASLR))
+$(KVM_DEBUG_IMAGE): $(KVM_ALIBS) $(KVM_ALIBS-y) $(KVM_OLIBS) $(KVM_OLIBS-y) \
+		    $(UK_ALIBS) $(UK_ALIBS-y) $(UK_OLIBS) $(UK_OLIBS-y)
+
+	$(call build_cmd,ASLR,,$@,\
+		$(SCRIPTS_DIR)/ASLR/ASLR.py \
+			$(ASLR_args))
+
+	$(call build_cmd,LD,,$(KVM_IMAGE).ld.o,\
+	       $(LD) -r $(LIBLDFLAGS) $(LIBLDFLAGS-y) \
+			$(KVM_LDFLAGS) $(KVM_LDFLAGS-y) \
+			$(KVM_OLIBS) $(KVM_OLIBS-y) \
+			$(UK_OLIBS) $(UK_OLIBS-y) \
+			-Wl$(comma)--start-group \
+			$(KVM_ALIBS) $(KVM_ALIBS-y) \
+			$(UK_ALIBS) $(UK_ALIBS-y) \
+			$(KVM_LINK_LIBGCC_FLAG) \
+			-Wl$(comma)--end-group \
+			-o $(KVM_IMAGE).ld.o)
+			
+	$(call build_cmd,OBJCOPY,,$(KVM_IMAGE).o,\
+		$(OBJCOPY) -w -G kvmos_* -G _libkvmplat_entry \
+			$(KVM_IMAGE).ld.o $(KVM_IMAGE).o)
+	
+	$(call build_cmd,COPY,,ASLR scripts,\
+		cp $(SCRIPTS_DIR)/ASLR/relink_ELF.sh ./../; \
+		cp $(SCRIPTS_DIR)/ASLR/string_script.py ./../)
+	
+	$(call build_cmd,LD,,$@,\
+	       $(LD) $(LDFLAGS) $(LDFLAGS-y) \
+		     $(KVM_LDFLAGS) $(KVM_LDFLAGS-y) \
+		     $(KVM_LD_SCRIPT_FLAGS_ASLR)\
+		     -L$(BUILD_DIR) \
+		     -o $@)
+else
 $(KVM_DEBUG_IMAGE): $(KVM_ALIBS) $(KVM_ALIBS-y) $(KVM_OLIBS) $(KVM_OLIBS-y) \
 		    $(UK_ALIBS) $(UK_ALIBS-y) $(UK_OLIBS) $(UK_OLIBS-y)
 	$(call build_cmd,LD,,$(KVM_IMAGE).ld.o,\
@@ -38,6 +88,7 @@ $(KVM_DEBUG_IMAGE): $(KVM_ALIBS) $(KVM_ALIBS-y) $(KVM_OLIBS) $(KVM_OLIBS-y) \
 		     $(KVM_LDFLAGS) $(KVM_LDFLAGS-y) \
 		     $(KVM_LD_SCRIPT_FLAGS) \
 		     $(KVM_IMAGE).o -o $@)
+endif
 
 $(KVM_IMAGE): $(KVM_IMAGE).dbg
 	$(call build_cmd,SCSTRIP,,$@,\

--- a/plat/kvm/Makefile.uk
+++ b/plat/kvm/Makefile.uk
@@ -34,6 +34,9 @@ LIBKVMPLAT_CXXFLAGS            += -DKVMPLAT
 ## Default Linker script
 ifeq ($(CONFIG_ARCH_X86_64),y)
 UK_PLAT_KVM_DEF_LDS            := $(CONFIG_UK_BASE)/plat/kvm/x86/link64.lds.S
+ifeq ($(CONFIG_LINK_ASLR),y)
+UK_PLAT_KVM_DEF_LDS_ASLR := $(BUILD_DIR)/libkvmplat/link64_ASLR.lds
+endif
 else
 ifeq ($(CONFIG_ARCH_ARM_64),y)
 UK_PLAT_KVM_DEF_LDS            := $(CONFIG_UK_BASE)/plat/kvm/arm/link64.lds.S

--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -42,6 +42,9 @@
 #include <uk/assert.h>
 #include <uk/essentials.h>
 #include <x86/acpi/acpi.h>
+#ifdef CONFIG_RUNTIME_ASLR
+#include <uk/swrand.h>
+#endif
 
 #include <uk/plat/lcpu.h>
 #include <uk/plat/common/lcpu.h>
@@ -155,6 +158,37 @@ static inline void _get_cmdline(struct uk_bootinfo *bi)
 
 static inline void _init_mem(struct uk_bootinfo *bi)
 {
+#ifdef CONFIG_RUNTIME_ASLR
+	int ASLR_offset;
+	int divisor = 1;
+	/*
+	 * Since we can't modify __STACK_SIZE which is a macro, we place first the 
+	 * stack and then the heap. 
+	 */
+	ASLR_offset = uk_swrand_randr() % (bi->max_addr/4);
+	_libkvmplat_cfg.bstack.end = ALIGN_UP(bi->max_addr - ASLR_offset, __PAGE_SIZE);
+	_libkvmplat_cfg.bstack.start   = _libkvmplat_cfg.bstack.end-__STACK_SIZE;
+	_libkvmplat_cfg.bstack.len   = __STACK_SIZE;
+	
+	uk_pr_info(" ASLR - Stack : s: %p e: %p\n",_libkvmplat_cfg.bstack.start,
+	_libkvmplat_cfg.bstack.end);
+	
+	do{
+	ASLR_offset = uk_swrand_randr() % (bi->max_addr/(4*divisor));
+	_libkvmplat_cfg.heap.start = ALIGN_UP((uintptr_t) __END+ASLR_offset, __PAGE_SIZE);
+	divisor++;
+	}
+	while(_libkvmplat_cfg.heap.start >= _libkvmplat_cfg.bstack.start);
+
+	_libkvmplat_cfg.heap.end = (uintptr_t) _libkvmplat_cfg.bstack.start;
+	_libkvmplat_cfg.heap.len   = _libkvmplat_cfg.heap.end
+				     - _libkvmplat_cfg.heap.start;
+	uk_pr_info(" ASLR - Heap : s: %p e: %p len: %p\n",_libkvmplat_cfg.heap.start,
+	_libkvmplat_cfg.heap.end,_libkvmplat_cfg.heap.len );
+				 
+	
+	
+#else
 	_libkvmplat_cfg.heap.start = ALIGN_UP((uintptr_t)__END, __PAGE_SIZE);
 	_libkvmplat_cfg.heap.end = (uintptr_t)bi->max_addr - __STACK_SIZE;
 	_libkvmplat_cfg.heap.len =
@@ -162,6 +196,7 @@ static inline void _init_mem(struct uk_bootinfo *bi)
 	_libkvmplat_cfg.bstack.start = _libkvmplat_cfg.heap.end;
 	_libkvmplat_cfg.bstack.end = bi->max_addr;
 	_libkvmplat_cfg.bstack.len = __STACK_SIZE;
+#endif
 }
 
 static inline void _init_initrd(struct uk_bootinfo *bi)
@@ -446,7 +481,32 @@ static void __noreturn _libkvmplat_entry2(void)
 
 	ukplat_lcpu_halt();
 }
+#ifdef CONFIG_RUNTIME_ASLR
+__u32 _gen_seed32(){
+	__u32 low,high;
+	__asm__ __volatile__ ("rdtsc" : "=a" (low), "=d" (high));
+	return ((unsigned long long)high << 32) | low;
+}
+static int uk_swrand_init(void)
+{
+	unsigned int i;
+#ifdef CONFIG_LIBUKSWRAND_CHACHA
+	unsigned int seedc = 10;
+	__u32 seedv[10];
+#else
+	unsigned int seedc = 2;
+	__u32 seedv[2];
+#endif
+	uk_pr_info("Initialize random number generator...\n");
 
+	for (i = 0; i < seedc; i++)
+		seedv[i] = _gen_seed32();
+
+	uk_swrand_init_r(&uk_swrand_def, seedc, seedv);
+
+	return seedc;
+}
+#endif
 void _libkvmplat_entry(struct lcpu *lcpu, void *arg)
 {
 	struct multiboot_info *mi = (struct multiboot_info *)arg;
@@ -464,6 +524,10 @@ void _libkvmplat_entry(struct lcpu *lcpu, void *arg)
 
 	intctrl_init();
 
+	#ifdef CONFIG_RUNTIME_ASLR
+	uk_swrand_init();
+	#endif
+	
 	uk_pr_info("Entering from KVM (x86)...\n");
 	uk_pr_info("     multiboot: %p\n", mi);
 

--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -1,5 +1,4 @@
-/* SPDX-License-Identifier: ISC */
-/*
+/* SPDX-License-Identifier: ISC
  * Authors: Dan Williams
  *          Martin Lucina
  *          Ricardo Koller

--- a/support/scripts/ASLR/ASLR.py
+++ b/support/scripts/ASLR/ASLR.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3.10
+# Written by Loslever Terry 
+# University of Liege
+# Contact : terry.loslever@student.uliege.be
+# 2021-2022
+# foo_start = .;
+# ....
+# foo_end = .; is considered to be a region.
+#
+# .foo : { } is also a region if not between the elements defined upper.
+
+from Analyzer import Analyzer
+import sys
+from random import SystemRandom
+from utils import extract_conf,extract_libs
+import argparse
+import re
+
+def print_sym_table(table):
+	"""
+	In : Takes a table of symbols
+	Prints what the table contains in a format . | . | . \n or . | . \n depending
+	on the col count.
+	"""
+	for element in table:
+		if len(element) == 3:
+			print( element[0] + " | " + element[1]+ " | " + str(element[2]))
+		else:
+			print( element[0] + " | " + element[1])
+
+#Takes 2 string and returns the longest prefix/suffix between them
+def alike(s1,s2):
+	"""
+		In : s1,s2 two strings
+		returns the number of similar letters either in the prefix or in the suffix.
+		Depending on which is the most alike.
+	"""
+	lenS1 = len(s1)
+	lenS2 = len(s2)
+	
+	lettersPre = 0
+	lettersSuf = 0
+	
+	stopPre = False
+	stopSuf = False
+	#Prefix
+	for i in range(lenS1):
+		if i >= lenS2 or (stopSuf and stopPre):
+			break
+		if s1[lenS1-i-1] == s2[lenS2-i-1] and not stopSuf:
+			lettersSuf +=1
+		else:
+			stopSuf = True
+		
+		if s1[i]==s2[i] and not stopPre:
+			lettersPre +=1
+		else:
+			stopPre = True
+	
+	if lettersPre > lettersSuf :
+		return lettersPre
+	else :
+		return lettersSuf
+
+def region_handler(table,sysRand,libList,debug,baseAddr):
+	"""
+	In : Takes a table of symbols from the linker file, a random engine, 
+	the list of libraries contained in the executable, a debug boolean and a baseAddress.
+	Returns regionTable which is a table recreating regions based on memory pointers set in the linker script.
+	Those pointers are matched based on their names : i.e foo_start = . ; ..... foo_end  = . ; are matched together
+	"""
+	tableLen = len(table)
+	regionTable = []
+	textRegion = None
+	#For now randomizes current address (. = 0x....) and swap the regions (not subregions)
+	for i in range(tableLen): 
+		maxCompatIndex = 0
+		maxCompat = 0
+		compat = 0
+		atEnd = False
+		tableSize = len(regionTable)
+		if table[i][0] == "assign":
+			for j in range(i+1,tableLen):
+			
+				#Qemu expects text to be the first region
+				#and bss the last one, so we don't swap them
+				#Breaks a second time not to take the ending pointer 
+				#for another region
+				if table[j][0] == "bss " or table[j-2][0] == "bss ":
+					break
+				if table[j][0] != "assign":
+					continue
+
+				compat = alike(table[i][1],table[j][1]) / (j-i)
+				if compat > maxCompat:
+					maxCompat = compat
+					maxCompatIndex = j
+					
+			#Checks if the elements that starts the region closes already another one
+			for j in range(tableSize):
+				if regionTable[tableSize-1-j][1] == i or i < regionTable[tableSize-1-j][1]:
+					atEnd = True
+					break
+			if (tableSize == 0 or not atEnd) and i <= maxCompatIndex:
+				#Modifies the lib position
+				if table[i][1] == ' _text ' :
+					table[i+1] = library_region(table[i+1],sysRand,libList,debug)
+				
+				#Tries to drag pre-configured memory layout with it
+				if i-1 >= 0 and table[i-1][0] == "curAdd" and table[i-1][1].startswith('ALIGN'):
+					regionTable.append([i-1,maxCompatIndex])
+				else:
+					regionTable.append([i,maxCompatIndex])
+		
+		#Randomizes static addresses
+		elif(table[i][0] == "curAdd" and not table[i][1].startswith('ALIGN')):
+			#Replaces the starting address
+			if i == 0:
+				table[i][1] = '0x'+baseAddr
+			else:
+				table[i][1] = '0x'+''.join('{:02X}'.format(int(table[i][1],16)+(sysRand.randint(0,65536))))
+	
+	return regionTable, table
+
+def library_region(textRegion,sysRand,libListOrigin,debug):
+	"""
+	In : textRegion is a string of the whole text segment, a random engine, the list of libraries contained in the executable and a debug boolean.
+	Returns a modified version of the textregion with padding and shuffled micro libs.
+	"""
+	libList = libListOrigin.copy()
+	if debug == 'True':
+		index = textRegion[1].find("*(.text)")
+		padding = '. = . + 0x'+''.join('{:02X}'.format(sysRand.randint(0,65536)))+";\n"
+		modfiedRegion = textRegion[1][0:index] +"}"
+		nextLib = libList.pop(0)
+		modfiedRegion += "  .text."+nextLib+" . :{ "+nextLib+".o (.text);}\n"
+		while len(libList) != 0:
+			padding = '. = . + 0x'+''.join('{:02X}'.format(sysRand.randint(0,65536)))+";\n"
+			nextLib = sysRand.choice(libList)
+			libList.remove(nextLib)
+			modfiedRegion += "  .text."+nextLib+" . :{ "
+			modfiedRegion += padding+"  "
+			modfiedRegion += nextLib+".o (.text);}\n"
+		
+		textRegion[1] = modfiedRegion
+		return textRegion
+	else:
+		index = textRegion[1].find("*(.text)")
+		padding = '. = . + 0x'+''.join('{:02X}'.format(sysRand.randint(0,65536)))+";\n"
+		modfiedRegion = textRegion[1][0:index]
+		while len(libList) != 0:
+			padding = '. = . + 0x'+''.join('{:02X}'.format(sysRand.randint(0,65536)))+";\n"
+			nextLib = sysRand.choice(libList)
+			libList.remove(nextLib)
+			modfiedRegion += "  " + padding
+			modfiedRegion += nextLib+".o (.text);\n"
+		
+		textRegion[1] = modfiedRegion+textRegion[1][index-2:]
+		return textRegion
+
+def main(openFile,output,debug,libList,baseAddr,dedu):
+	
+	analyzer = Analyzer(openFile)
+	table = analyzer.analyze()
+	regionTable = []
+	sysRand = SystemRandom()
+	if debug == 'True':
+		print_sym_table(table)
+	
+	regionTable, table = region_handler(table,sysRand,libList,debug,baseAddr)
+	#Swap memory regions
+	table = swap_regions(table,regionTable,sysRand)
+		
+	print_back(openFile,output,table,debug,dedu)
+	
+	return 0
+
+def swap_regions(table,regionTable,sysRand):
+	"""
+	In : Takes a table of symbols from the linker file, the table of the linker's memory segments and a random engine.
+	Return a swapped version of the linker script's segment according to some rules specified by Qemu.
+	"""
+	regionCopy = regionTable.copy()
+	iterations = len(regionCopy)
+	regionTableIndex = 0
+	maxInter = len(table)
+	newTable = []
+	index = 0
+	#Set text,uk_*tab as first regions in order to avoid errors.
+	toDel = []
+	added = False
+	setRoData = False
+
+	for ind in regionCopy :
+		if table[ind[1]][1] == " uk_inittab_end " or \
+		table[ind[1]][1] == " _etext " or \
+		table[ind[1]][1] == " uk_ctortab_end ":
+			toDel.append(ind)
+	
+	if len(toDel) == 0:
+		print("[ASLR] {Error} Missing important memory regions : _text, uk_inittab_start, uk_ctortab_start",file=sys.stderr)
+		sys.exit()
+	
+	#if there's only one element there's no point swapping it.
+	if iterations > 0:
+		while index < maxInter:
+		
+			if len(toDel) != 0 and index == toDel[0][0] and added:
+				index = toDel[0][1]
+				toDel.pop(0)
+			elif regionTableIndex < iterations and index == regionTable[regionTableIndex][0]:
+				#Set text,uk_*tab as first regions in order toclear avoid errors.
+				if regionTableIndex == 0 and added != True:
+					for el in toDel:
+						newTable += table[el[0]:el[1]+1]
+						regionCopy.remove(el)
+						regionTable.remove(el)
+						added = True
+						iterations -= 1
+					continue
+				else:
+					#Takes an element at random without replacement
+					tmpRegion = None
+					while tmpRegion == None or (table[tmpRegion[1]][1] == ' _edata ' and not setRoData):
+						tmpRegion = sysRand.choice(regionCopy)
+
+					if table[tmpRegion[1]][1] == " _erodata ":
+						setRoData = True
+					#Makes the right jump in the table
+					index = regionTable[regionTableIndex][1]
+					#Append the region to the newtable
+					newTable += table[tmpRegion[0]:tmpRegion[1]+1]
+					regionCopy.remove(tmpRegion)
+					regionTableIndex += 1
+			#If it's a singleton
+			else :
+				newTable.append(table[index])
+
+			index += 1
+		return newTable
+	return table
+
+def print_back(openFile,output,table,debug,dedu):
+	"""
+	In : openFile is the linker script to modify,output the file in which the programs writes, 
+	table is the table containing the modified linker script, debug a boolean and a char activating or not
+	deduplication compatibility.
+	Writes back the modified linker script into the file openFile.
+	"""
+	deduFile = None
+	writeFile = open(output,"w")
+	if not writeFile:
+		print("[ASLR] {Error} Can't open the output file.",file=sys.stderr)
+		sys.exit()
+	if dedu != './':
+		deduFile = open(dedu,"r")
+		if not deduFile:
+			print("[ASLR] {Error} Can't open the deduplication config file.",file=sys.stderr)
+			sys.exit()
+	#clears the file and save headers
+	openFile.seek(0)
+	header = openFile.read().split("SECTIONS\n{\n")
+	openFile.seek(0)
+	
+	
+	#Writes back
+	previous = ""
+	if debug:
+		#Doesn't set ENTRY in debug mode otherwise causes double import
+		writeFile.write("SECTIONS\n{\n")
+	else :
+		writeFile.write(header[0]+"SECTIONS\n{\n")
+	
+	for element in table:
+		
+		if element[0] == "curAdd":
+			#Avoid having ALIGN cascade
+			if not (previous.startswith('ALIGN') and element[1].startswith('ALIGN')):
+				writeFile.write(". = "+element[1]+";\n")
+		elif element[0] == "assign":
+			if len(element) == 3:
+				writeFile.write(element[1]+"= ."+element[2]+";\n")
+			else:
+				writeFile.write(element[1]+"= .;\n")
+			if element[1] == " _etext " and deduFile:
+				conf = extract_conf(deduFile)
+				addr = conf.pop(0)[0]
+				fill = 0
+				for lib in conf:
+					fill += int(lib[1],16)
+				writeFile.write(". = ALIGN(0x1000);\n.ind "+addr+" : {FILL(0X90);. = . + "+hex(fill)+";BYTE(0X90)}\n")
+		else:
+			writeFile.write("."+element[0]+":"+element[1]+"\n")
+		previous = element[1]
+		
+		
+	writeFile.write("}")
+	writeFile.close()
+	return 0
+
+def handleSetup(file,address):
+	regex = re.compile(".long 0[xX][0-9a-fA-F]+")
+	newString = ""
+
+	if address == "-1":
+		patch = ''.join('{:02X}'.format(SystemRandom().randint(1048576,1048576*4)))
+	else:
+		patch = address
+	for line in file.readlines():
+		detect = re.split(regex,line)
+		if len(detect) > 1:
+			#that int is 0x100000 in hexa 
+			print(patch)
+			newString += ".long 0x"+ patch + detect [1]
+		else:
+			newString += line
+
+	file.seek(0)
+	file.write(newString)
+
+	return patch
+if __name__ == '__main__':
+	#Gets back the path of the linker script to modify
+	parser = argparse.ArgumentParser(prog="Unikraft ASLR, linker script implementation")
+
+	parser.add_argument('--setup_file', dest='setup', default='./', help="Path leading to the entry64.S file.")	
+	
+	parser.add_argument('--base_addr', dest='baseAddr', default='-1', help="ASLR's base address")
+	
+	parser.add_argument('--file_path', dest='path', default='./', help="Path leading to the file.")
+
+	parser.add_argument('--output_path', dest='output', default='./', help="Path and name of the file to create.")	
+	
+	parser.add_argument('--lib_list', dest='build', default=None, help="All the libs in the ELF file.")	
+	
+	parser.add_argument('--deduplication', dest='dedu', default='./', help="Creates the table or not")
+	
+	parser.add_argument('--debug', dest='debug', default='False', 
+		help="Prints on the standard input debug informations.")
+
+	params , _ = parser.parse_known_args(sys.argv[1:])
+
+	if params.setup != "./":
+		openFile = open(params.setup,"r+")
+		if(openFile == None):
+			print("[ASLR] {Error} Couldn't open the entropy.S file, path may be wrong.")
+			sys.exit()
+		handleSetup(openFile,params.baseAddr)
+		openFile.close()
+	
+	elif params.baseAddr != '-1':
+		openFile = open(params.path,"r+")
+		if(openFile == None):
+			print("[ASLR] {Error} Couldn't open the file, path may be wrong.")
+			sys.exit()
+		
+		libList = extract_libs(params.build,False)
+		if len(libList) == 0:
+			print("[ASLR] {Error} No lib list given to the program abort.",file=sys.stderr)
+			sys.exit()
+		main(openFile,params.output,params.debug,libList,params.baseAddr,params.dedu)
+		openFile.close()
+	
+	else:
+		print("[ASLR] {Error} Base address should be positive or given.",file=sys.stderr)
+		sys.exit()
+
+	
+	

--- a/support/scripts/ASLR/ASLR.py
+++ b/support/scripts/ASLR/ASLR.py
@@ -1,8 +1,17 @@
 #!/usr/bin/env python3.10
-# Written by Loslever Terry 
-# University of Liege
-# Contact : terry.loslever@student.uliege.be
-# 2021-2022
+#
+# Copyright (c) 2022, NEC Laboratories Europe GmbH, NEC Corporation.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
 # foo_start = .;
 # ....
 # foo_end = .; is considered to be a region.

--- a/support/scripts/ASLR/Analyzer.py
+++ b/support/scripts/ASLR/Analyzer.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python3
-# Written by Loslever Terry 
-# University of Liege
-# Contact : terry.loslever@student.uliege.be
-# 2021
+#
+# Copyright (c) 2022, NEC Laboratories Europe GmbH, NEC Corporation.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
 
 import re
 

--- a/support/scripts/ASLR/Analyzer.py
+++ b/support/scripts/ASLR/Analyzer.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Written by Loslever Terry 
+# University of Liege
+# Contact : terry.loslever@student.uliege.be
+# 2021
+
+import re
+
+class Analyzer:
+	
+	def __init__(self,openFile):
+		self.file = openFile;
+		self.keywords = re.compile("SECTIONS")
+		self.symbolTable = [];
+		self.buffer = '';
+		self.braceCounter = 0
+		self.address = re.compile("\.\s*=\s*(.*)\s*;")
+		self.assign = re.compile("(.*)=\s*\.(.*);")
+		self.region = re.compile("\.\s*(.*)\s*:\s*")
+		self.skippedBraces = 0
+	
+	def __handlesLine(self,string):
+		#If that's header elements we skip it
+		strLen = len(string)
+		string = re.sub(self.keywords,'',string)
+		if(len(string) != strLen):
+			self.skippedBraces += 1
+		
+		#Proceed with analysis
+		for letter in string:
+			self.buffer += letter
+			#Checks for current address assignement for outside pointers
+			#They are usually around memoryblocks
+			secSplit = re.split(self.assign, self.buffer)[1:]
+			if len(secSplit) > 0 and self.braceCounter==0:
+				if(secSplit[1] != ''):
+					self.symbolTable.append(["assign",secSplit[0],secSplit[1]])
+				else:
+					self.symbolTable.append(["assign",secSplit[0]])
+				self.buffer = ''
+			
+			#Checks for fixed addresses
+			secSplit = re.split(self.address, self.buffer)[1:]
+			if len(secSplit) > 0 and self.braceCounter==0:
+				self.symbolTable.append(["curAdd",secSplit[0]])
+				self.buffer = ''
+			
+			match letter:
+				case '{':
+					if(self.skippedBraces == 0):
+						self.braceCounter += 1
+					elif len(self.buffer)  == 1:
+						letter = ''
+				case '}':
+					self.braceCounter -= 1
+					#Means that we skipped an opening brace before
+					if(self.braceCounter < 0):
+						self.skippedBraces -= 1
+						self.braceCounter += 1
+					#Flushes the section in the table
+					if( self.braceCounter == 0):
+						secSplit = re.split(self.region, self.buffer)[1:]
+
+						if len(secSplit) > 0:
+							self.symbolTable.append([secSplit[0],secSplit[1]])
+							self.buffer = ''
+				#Wildcard
+				case _:
+					continue
+	def analyze(self):
+		
+		lines = self.file.readlines()
+		for line in lines:
+			self.__handlesLine(line)
+		
+		return self.symbolTable.copy()

--- a/support/scripts/ASLR/relink_ELF.sh
+++ b/support/scripts/ASLR/relink_ELF.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/sh
+
+if [ "$#" -ne 3 ]; then
+    echo " Script usage : relink_ELF BUILD_DIR NAME_EXEC UNIKRAFT_FOLDER"
+else
+    libkvm=$1/libkvmplat
+    lib=$(python3.10 string_script.py "$(make print-libs)")
+    addr=$(python3.10 $3/support/scripts/ASLR/ASLR.py --setup_file="$3/plat/kvm/x86/entry64.S" --base_addr="-2")
+    #Shuffles the linking script
+    $3/support/scripts/ASLR/ASLR.py --file_path=$libkvm/link64.lds --lib_list="$lib" --output_path=$libkvm/link64_ASLR.lds --base_addr="$addr"
+    gcc -nostdlib -Wl,--omagic -Wl,--build-id=none -nostdinc -no-pie  -Wl,-m,elf_x86_64 -T$libkvm/link64_ASLR.lds -L$1 -o $1/$2.dbg
+    python3 $3/support/scripts/sect-strip.py --with-objcopy=""objcopy $1/$2.dbg -o $1/$2 && ""strip -s $1/$2
+fi

--- a/support/scripts/ASLR/string_script.py
+++ b/support/scripts/ASLR/string_script.py
@@ -1,4 +1,16 @@
 #!/usr/bin/python
+#
+# Copyright (c) 2022, NEC Laboratories Europe GmbH, NEC Corporation.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
 
 import sys
 

--- a/support/scripts/ASLR/string_script.py
+++ b/support/scripts/ASLR/string_script.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+
+import sys
+
+if __name__ == '__main__':
+	if len(sys.argv) != 2:
+		print(sys.argv)
+		print("[Error] bad number of args fed to the script.")
+		sys.exit()
+	string = sys.argv[1]
+	if type(string) is not str:
+		print("[Error] the argument should be a string containing lib names.")
+		sys.exit()
+		
+	splittedString = string.split()
+	libString = ""
+	for index,words in enumerate(splittedString):
+		if words.startswith("lib"):
+			libString += (words+" ")
+		elif index+1 < len(splittedString) and index-1 > 0 and \
+			splittedString[index-1].startswith("lib") and \
+			splittedString[index+1].startswith("lib"):
+			libString += (words+" ")
+	print(libString)

--- a/support/scripts/ASLR/utils.py
+++ b/support/scripts/ASLR/utils.py
@@ -1,3 +1,18 @@
+#!/usr/bin/python
+
+# Copyright (c) 2019, NEC Laboratories Europe GmbH, NEC Corporation.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+
+
 def check_file(elfFile):
 
 	if len(elfFile) > 4 and elfFile[1:4] == b'ELF':

--- a/support/scripts/ASLR/utils.py
+++ b/support/scripts/ASLR/utils.py
@@ -1,0 +1,67 @@
+def check_file(elfFile):
+
+	if len(elfFile) > 4 and elfFile[1:4] == b'ELF':
+		if elfFile[4] == 2:
+			return True
+		else:
+			print("[ERROR] - The file should be a x86 binary file.")
+	else:
+			print("[ERROR] - Entered file is not an ELF file.")
+	return False
+def str_to_hex(op):
+	try:
+		#It's an address
+		tmp = int(op,16)
+	except ValueError:
+		#it's a register
+		tmp = None
+	
+	return tmp
+def extract_libs(string,onlyLibs):
+	"""
+	In : string, a string
+	onlyLibs, a boolean
+	"""
+	wordList = []
+	returnList = []
+	if string != None:
+		wordList = string.split()
+		
+	if onlyLibs:
+		for libs in wordList:
+			if not libs.startswith("lib"):
+				continue
+			else:
+				if(type(libs) is list):
+					print("[ERROR] - the lib list contains something unexpected")
+					sys.exit()
+				returnList.append(libs)
+		return returnList
+	else:
+		return wordList
+def extract_conf(openConf):
+	'''
+	In : openConf is the config file.
+	Returns a dictionnary that maps the name of the lib with an address.
+	Skips comments : #This is a comment
+	'''
+	content = openConf.readlines()
+	conf = []
+	default = 0
+	first = True
+	i = 0
+	for line in content:
+		if not line.startswith("#"):
+			words = line.split(" : ")
+			if len(words) == 2 and words[1].rstrip("\n") != '':
+				conf.append([words[0],words[1].rstrip("\n")])
+				if first:
+					default = words[1].rstrip("\n")
+					first = False
+			elif len(words) == 2 and not first:
+				conf.append([words[0].rstrip("\n"),default])
+			else:
+				print("[Error] - line "+str(i)+" of the config file doesn't respect the format.")
+		i += 1
+	return conf
+


### PR DESCRIPTION
### Base target

 - Architecture(s): x86_64
 - Platform:  kvm
 - Application: code base and python3/3.10

### Additional configuration

CONFIG_LINK_ASLR=y
CONFIG_RUNTIME_ASLR=y
(the last requires CONFIG_LIBUKSWRAND)

### Description of changes

The PR adds python scripts that change the memory display of the Unikraft image.
It also modifies the code base to place the stack and the heap randomly in memory while booting.

### Impacted files
-> kvm/plat/x86/setup.c
-> created a new folder in support/scripts: 'ASLR'

Regarding documentation, contact me via Discord or mail and I'll send you a copy of my thesis.
