### PR TITLE
plat/kvm/x86: Extend static PT to 4GiB

### DIFF
--- a/plat/kvm/x86/pagetable64.S
+++ b/plat/kvm/x86/pagetable64.S
@@ -112,7 +112,13 @@
 
 /* x86-64 Boot Page Table
  *
- * 0x0000000000000000 - 0x0000000000000000 Mapping of first 4GB
+ * We map the first 4GB using max 2MB pages to keep compatibility for systems
+ * without 1GB page support. If the paging API is enabled, we also do a 1:1
+ * mapping of the first 512GB of physical memory at the high end of the address
+ * space. We use 1GB pages for this. The paging API can thus only be used on
+ * systems supporting 1GB pages.
+ *
+ * 0x0000000000000000 - 0x00000000ffffffff Mapping of first 4GB
  *
  * However, the first 1M is inaccessible, except for:
  * 0x0000000000009000 - 0x0000000000009fff Multiboot info @ 0x09500 (read-only)
@@ -123,7 +129,7 @@
  * 0xffffff8000000000 - 0xffffffffffffffff Mapping of first 512GB (for PTs)
  */
 .align 0x1000
-x86_bpt_pt0_0_0:
+x86_bpt_pt0_0_0: /* 4K pages */
 	pte_zero 0x0000000000000000, 0x009
 	pte_fill 0x0000000000009000, 0x008, PT_LVL, PTE_RO
 	pte_zero 0x0000000000010000, 0x0a7
@@ -133,19 +139,31 @@ x86_bpt_pt0_0_0:
 	pte_fill 0x0000000000100000, 0x100, PT_LVL, PTE_RW
 
 .align 0x1000
-x86_bpt_pd0_0:
+x86_bpt_pd0_0: /* 2M pages */
 	pte	 x86_bpt_pt0_0_0, PTE_RW
 	pte_fill 0x0000000000200000, 0x1ff, PD_LVL, PTE_RW
 
+x86_bpt_pd0_1: /* 2M pages */
+	pte_fill 0x0000000040000000, 0x200, PD_LVL, PTE_RW
+
+x86_bpt_pd0_2: /* 2M pages */
+	pte_fill 0x0000000080000000, 0x200, PD_LVL, PTE_RW
+
+x86_bpt_pd0_3: /* 2M pages */
+	pte_fill 0x00000000c0000000, 0x200, PD_LVL, PTE_RW
+
 .align 0x1000
-x86_bpt_pdpt0:
+x86_bpt_pdpt0: /* 1G pages */
 	pte	 x86_bpt_pd0_0, PTE_RW
-	pte_zero , 0x1ff
+	pte	 x86_bpt_pd0_1, PTE_RW
+	pte	 x86_bpt_pd0_2, PTE_RW
+	pte	 x86_bpt_pd0_3, PTE_RW
+	pte_zero , 0x1fc
 
 /* Page table for 512 GiB direct-mapped physical memory */
 #ifdef CONFIG_PAGING
 .align 0x1000
-x86_bpt_pdpt511:
+x86_bpt_pdpt511: /* 1G pages */
 	pte_fill 0x0000000000000000, 0x200, PDPT_LVL, PTE_RW
 #endif /* CONFIG_PAGING */
 

--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -49,7 +49,7 @@
 #endif /* CONFIG_PAGING */
 
 #define PLATFORM_MEM_START 0x100000
-#define PLATFORM_MAX_MEM_ADDR 0x40000000
+#define PLATFORM_MAX_MEM_ADDR 0x100000000 /* 4 GiB */
 
 #define MAX_CMDLINE_SIZE 8192
 static char cmdline[MAX_CMDLINE_SIZE];
@@ -351,9 +351,10 @@ static void _init_paging(struct multiboot_info *mi)
 	if (unlikely(rc))
 		goto EXIT_FATAL;
 
-	/* Unmap all 1:1 mappings extending over the kernel image and initrd.
-	 * The boot page table maps the first 1 GiB with everything starting
-	 * from 2 MiB mapped as 2 MiB large pages (see pagetable64.S).
+	/* Unmap all 1:1 mappings extending over the first megabyte, the kernel
+	 * image and initrd. The boot page table maps the first 4 GiB with
+	 * everything starting from 2 MiB mapped as 2 MiB large pages (see
+	 * pagetable64.S).
 	 */
 	offset = mr[0]->start - PAGE_LARGE_ALIGN_UP(mr[0]->start);
 	start  = PAGE_LARGE_ALIGN_UP(mr[0]->start);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Many memory-mapped I/O devices have their registers mapped above 1GiB, which is the current maximum mapping of the static boot page table. This commit modifies the page table to do a 1:1 mapping for the first 4GiB. We use 2M pages for this to preserve compatibility with systems that do not support 1GiB pages.

This PR is a prerequisite for x86 SMP support.

