### PR TITLE
Add Shadow Stack support for a simple app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -616,6 +616,10 @@ CC_VERSION	:= $(shell $(CC) --version | \
 CC_VER_MAJOR   := $(word 1,$(subst ., ,$(CC_VERSION)))
 CC_VER_MINOR   := $(word 2,$(subst ., ,$(CC_VERSION)))
 
+CFLAGS         += --target=$(CONFIG_LLVM_TARGET_ARCH)
+ASFLAGS        += --target=$(CONFIG_LLVM_TARGET_ARCH)
+CXXFLAGS       += --target=$(CONFIG_LLVM_TARGET_ARCH)
+
 ASFLAGS		+= -DCC_VERSION=$(CC_VERSION)
 CFLAGS		+= -DCC_VERSION=$(CC_VERSION)
 CXXFLAGS	+= -DCC_VERSION=$(CC_VERSION)

--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -35,9 +35,19 @@
 
 #include <uk/config.h>
 
+/*
+* initial workaround, needed for STACK_SIZE
+*/
+#include <uk/plat/config.h>
+
 #include <stddef.h>
 #include <stdio.h>
 #include <errno.h>
+
+/*
+* DELETEME: we use stdlib for now
+* TODO: use uk allocators later, for better performance
+*/
 #include <stdlib.h>
 
 #if CONFIG_LIBUKBOOT_INITBBUDDY
@@ -84,7 +94,7 @@ struct thread_main_arg {
 
 void __attribute__ ((constructor)) __attribute__((no_sanitize("shadow-call-stack"))) setup_x18()
 {
-	void *shadow = malloc(16384);
+	void *shadow = malloc(STACK_SIZE);
 	__asm __volatile ( "mov x18, %0" : : "r" (shadow) );
 }
 

--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -140,7 +140,9 @@ static void main_thread_func(void *arg)
 	 * from its OS being initialized.
 	 */
 
+#ifndef CONFIG_LIBUKSCHED
 	setup_x18();
+#endif
 	uk_pr_info("Pre-init table at %p - %p\n",
 		   &__preinit_array_start[0], &__preinit_array_end);
 	uk_ctortab_foreach(ctorfn,

--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -38,6 +38,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <errno.h>
+#include <stdlib.h>
 
 #if CONFIG_LIBUKBOOT_INITBBUDDY
 #include <uk/allocbbuddy.h>
@@ -81,6 +82,12 @@ struct thread_main_arg {
 	char **argv;
 };
 
+void __attribute__ ((constructor)) __attribute__((no_sanitize("shadow-call-stack"))) setup_x18()
+{
+	void *shadow = malloc(16384);
+	__asm __volatile ( "mov x18, %0" : : "r" (shadow) );
+}
+
 static void main_thread_func(void *arg)
 {
 	int i;
@@ -122,6 +129,8 @@ static void main_thread_func(void *arg)
 	 * mimic what a regular user application (e.g., BSD, Linux) would expect
 	 * from its OS being initialized.
 	 */
+
+	setup_x18();
 	uk_pr_info("Pre-init table at %p - %p\n",
 		   &__preinit_array_start[0], &__preinit_array_end);
 	uk_ctortab_foreach(ctorfn,

--- a/lib/uksched/include/uk/sched.h
+++ b/lib/uksched/include/uk/sched.h
@@ -259,6 +259,9 @@ static inline
 void uk_sched_thread_switch(struct uk_sched *sched,
 		struct uk_thread *prev, struct uk_thread *next)
 {
+#ifdef _SHADOW_STACK_
+	__asm __volatile ( "mov x18, %0" : : "r" (next->shadow_stack) );
+#endif
 	ukplat_thread_ctx_switch(&sched->plat_ctx_cbs, prev->ctx, next->ctx);
 }
 

--- a/lib/uksched/include/uk/thread.h
+++ b/lib/uksched/include/uk/thread.h
@@ -55,6 +55,9 @@ struct uk_sched;
 struct uk_thread {
 	const char *name;
 	void *stack;
+#ifdef _SHADOW_STACK_
+	void *shadow_stack;
+#endif
 	void *tls;
 	void *ctx;
 	UK_TAILQ_ENTRY(struct uk_thread) thread_list;

--- a/lib/uksched/sched.c
+++ b/lib/uksched/sched.c
@@ -207,6 +207,9 @@ struct uk_thread *uk_sched_thread_create(struct uk_sched *sched,
 {
 	struct uk_thread *thread = NULL;
 	void *stack = NULL;
+#ifdef _SHADOW_STACK_
+	void *shadow_stack = NULL;
+#endif
 	int rc;
 	void *tls = NULL;
 
@@ -222,6 +225,18 @@ struct uk_thread *uk_sched_thread_create(struct uk_sched *sched,
 	stack = create_stack(sched->allocator);
 	if (stack == NULL)
 		goto err;
+
+#ifdef _SHADOW_STACK_
+	shadow_stack = create_stack(sched->allocator);
+	if (shadow_stack == NULL)
+		goto err;
+
+	/*
+	* FIXME: include the shadow stack initialization in the uk_thread_init function
+	*/
+	thread->shadow_stack = shadow_stack;
+#endif
+	
 	if (have_tls_area() && !(tls = uk_thread_tls_create(sched->allocator)))
 		goto err;
 

--- a/lib/uksched/sched.c
+++ b/lib/uksched/sched.c
@@ -262,7 +262,7 @@ err:
 
 #ifdef _SHADOW_STACK_
 	if (shadow_stack)
-		uk_free(sched->allocator, shadow_stack)
+		uk_free(sched->allocator, shadow_stack);
 #endif /* _SHADOW_STACK_ */
 
 	if (thread)

--- a/lib/uksched/sched.c
+++ b/lib/uksched/sched.c
@@ -142,6 +142,9 @@ struct uk_sched *uk_sched_create(struct uk_alloc *a, size_t prv_size)
 void uk_sched_start(struct uk_sched *sched)
 {
 	UK_ASSERT(sched != NULL);
+#ifdef _SHADOW_STACK_
+	__asm __volatile ( "mov x18, %0" : : "r" (sched->idle.shadow_stack) );
+#endif
 	ukplat_thread_ctx_start(&sched->plat_ctx_cbs, sched->idle.ctx);
 }
 

--- a/plat/common/pci_ecam.c
+++ b/plat/common/pci_ecam.c
@@ -226,7 +226,10 @@ int gen_pci_irq_parse(const fdt32_t *addr, struct fdt_phandle_args *out_irq)
 	fdt32_t initial_match_array[16];
 	const fdt32_t *match_array = initial_match_array;
 	const fdt32_t *tmp, *imap, *imask;
-	const fdt32_t dummy_imask[] = { 0 };
+	const fdt32_t dummy_imask[] = {cpu_to_fdt32(~0), cpu_to_fdt32(~0), cpu_to_fdt32(~0), cpu_to_fdt32(~0),
+								   cpu_to_fdt32(~0), cpu_to_fdt32(~0), cpu_to_fdt32(~0), cpu_to_fdt32(~0),
+								   cpu_to_fdt32(~0), cpu_to_fdt32(~0), cpu_to_fdt32(~0), cpu_to_fdt32(~0),
+								   cpu_to_fdt32(~0), cpu_to_fdt32(~0), cpu_to_fdt32(~0), cpu_to_fdt32(~0), cpu_to_fdt32(~0)};
 	int intsize, newintsize;
 	int addrsize, newaddrsize = 0;
 	int imaplen, match, i, rc = -EINVAL;

--- a/plat/common/pci_ecam.c
+++ b/plat/common/pci_ecam.c
@@ -226,7 +226,7 @@ int gen_pci_irq_parse(const fdt32_t *addr, struct fdt_phandle_args *out_irq)
 	fdt32_t initial_match_array[16];
 	const fdt32_t *match_array = initial_match_array;
 	const fdt32_t *tmp, *imap, *imask;
-	const fdt32_t dummy_imask[] = { [0 ... 16] = cpu_to_fdt32(~0) };
+	const fdt32_t dummy_imask[] = { 0 };
 	int intsize, newintsize;
 	int addrsize, newaddrsize = 0;
 	int imaplen, match, i, rc = -EINVAL;

--- a/plat/common/sw_ctx.c
+++ b/plat/common/sw_ctx.c
@@ -37,6 +37,7 @@
 #include <uk/assert.h>
 #include <uk/plat/common/tls.h>
 #include <uk/plat/common/cpu.h>
+#include <uk/plat/config.h>
 
 static size_t sw_ctx_size(void);
 static void  sw_ctx_init(void *ctx, unsigned long sp, unsigned long tlsp);
@@ -71,6 +72,14 @@ static void sw_ctx_init(void *ctx,
 
 extern void asm_ctx_start(unsigned long sp, unsigned long ip) __noreturn;
 
+void setupx18(struct sw_ctx *sw_ctx)
+{
+	void *shadow = sw_ctx->sp & STACK_SIZE;
+
+	shadow += STACK_SIZE;
+	__asm __volatile ( "mov x18, %0" : : "r" (shadow) );
+}
+
 static void sw_ctx_start(void *ctx)
 {
 	struct sw_ctx *sw_ctx = ctx;
@@ -78,6 +87,10 @@ static void sw_ctx_start(void *ctx)
 	UK_ASSERT(sw_ctx != NULL);
 
 	set_tls_pointer(sw_ctx->tlsp);
+#ifdef _SHADOW_STACK_
+	setupx18(sw_ctx);
+#endif /* _SHADOW_STACK_ */
+
 	/* Switch stacks and run the thread */
 	asm_ctx_start(sw_ctx->sp, sw_ctx->ip);
 
@@ -94,6 +107,9 @@ static void sw_ctx_switch(void *prevctx, void *nextctx)
 	save_extregs(p);
 	restore_extregs(n);
 	set_tls_pointer(n->tlsp);
+#ifdef _SHADOW_STACK_
+	setupx18(n);
+#endif /* _SHADOW_STACK_ */
 	asm_sw_ctx_switch(prevctx, nextctx);
 }
 

--- a/plat/common/sw_ctx.c
+++ b/plat/common/sw_ctx.c
@@ -72,14 +72,6 @@ static void sw_ctx_init(void *ctx,
 
 extern void asm_ctx_start(unsigned long sp, unsigned long ip) __noreturn;
 
-void setupx18(struct sw_ctx *sw_ctx)
-{
-	void *shadow = sw_ctx->sp & STACK_SIZE;
-
-	shadow += STACK_SIZE;
-	__asm __volatile ( "mov x18, %0" : : "r" (shadow) );
-}
-
 static void sw_ctx_start(void *ctx)
 {
 	struct sw_ctx *sw_ctx = ctx;
@@ -87,9 +79,6 @@ static void sw_ctx_start(void *ctx)
 	UK_ASSERT(sw_ctx != NULL);
 
 	set_tls_pointer(sw_ctx->tlsp);
-#ifdef _SHADOW_STACK_
-	setupx18(sw_ctx);
-#endif /* _SHADOW_STACK_ */
 
 	/* Switch stacks and run the thread */
 	asm_ctx_start(sw_ctx->sp, sw_ctx->ip);
@@ -107,9 +96,6 @@ static void sw_ctx_switch(void *prevctx, void *nextctx)
 	save_extregs(p);
 	restore_extregs(n);
 	set_tls_pointer(n->tlsp);
-#ifdef _SHADOW_STACK_
-	setupx18(n);
-#endif /* _SHADOW_STACK_ */
 	asm_sw_ctx_switch(prevctx, nextctx);
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `AArch64`
 - Platform(s): `KVM`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

You'll need to update the `Makefile.uk` of your app by adding this (let our app be `helloworld` for the sake of simplicity)
```
APPHELLOWORLD_CINCLUDES-y += -fsanitize=shadow-call-stack -ffixed-x18 -fno-exceptions
COMPFLAGS-y += -ffixed-x18 -fno-exceptions
```

Shadow Stack support comes with `clang` as a compiler, you'll have to build the app accordingly.

Build using
```
make CC=clang LD=~/toolchains/gcc-arm-11.2-2022.02-x86_64-aarch64-none-elf/bin/aarch64-none-elf-gcc OBJCOPY=~/toolchains/gcc-arm-11.2-2022.02-x86_64-aarch64-none-elf/bin/aarch64-none-elf-objcopy STRIP=~/toolchains/gcc-arm-11.2-2022.02-x86_64-aarch64-none-elf/bin/aarch64-none-elf-strip
```

You'll need the gcc cross-compiling toolchain installed. Get it from [here](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/downloads).

Also, make sure to have erratum options disabled when using `menuconfig` (`Architecture Selection` -> `Arm8 Compatible` -> `Workaround for [...] erratum`).

What's more, you'll have to configure the `Custom cross-compiler LLVM target` too (`Build Options` -> `Custom cross-compiler LLVM target`); just write `aarch64-none-elf` and you should be good to go.



### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR aims to demonstrate how the Shadow Stack support will behave.

It brings minor changes in order to make possible the compilation with `clang`, as this security mechanism is supported by `clang` and `gcc-12`.

Further changes were made in `boot.c` in order to initialize the Shadow Stack.

Future changes will bring better performance by changing the memory allocator to a Unikraft based one and by integrating the constructor in the Unikraft constructor table.

For Proof of Concept and other information, refer [this](https://github.com/mariasfiraiala/scs-work/blob/master/unikraft-scs/unikraft-scs-for-helloworld.md).