### PR TITLE
lib/syscall_shim: Ignore only unnumbered legacy syscalls

### DIFF
--- a/lib/syscall_shim/Config.uk
+++ b/lib/syscall_shim/Config.uk
@@ -39,4 +39,11 @@ if LIBSYSCALL_SHIM
 		bool "Enable debug messages"
 		default n
 		select LIBUKDEBUG_PRINTD
+
+	config LIBSYSCALL_SHIM_LEGACY_VERBOSE
+		bool "Warn for unmapped legacy syscalls"
+		default y
+		help
+			Generates a warning during the build process for each legacy syscall
+			that is not mapped to a syscall number.
 endif

--- a/lib/syscall_shim/include/uk/legacy_syscall.h
+++ b/lib/syscall_shim/include/uk/legacy_syscall.h
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Authors: Răzvan Vîrtan <virtanrazvan@gmail.com>
+ *
+ *
+ * Copyright (c) 2022, University Politehnica of Bucharest. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This file defines the syscalls that are marked as legacy.
+ *
+ * A legacy syscall is a syscall that is missing on some architectures, but
+ * it's functionality can be implemented using a newer syscall. Therefore,
+ * this syscalls will not generate build failures on the architectures that
+ * don't implement them.
+ *
+ * The format for marking a system call as legacy is the following one:
+ * `#define LEGACY_SYS_<syscall_name>` (see the list below).
+ */
+
+#ifndef __UK_LEGACY_SYSCALL_H__
+#define __UK_LEGACY_SYSCALL_H__
+
+#define LEGACY_SYS_fork /* modern: clone */
+#define LEGACY_SYS_vfork /* modern: clone */
+#define LEGACY_SYS_getpgrp /* modern: getpgid */
+#define LEGACY_SYS_readlink /* modern: readlinkat */
+#define LEGACY_SYS_symlink /* modern: symlinkat */
+#define LEGACY_SYS_unlink /* modern: unlinkat */
+#define LEGACY_SYS_link /* modern: linkat */
+#define LEGACY_SYS_access /* modern: faccessat */
+#define LEGACY_SYS_open /* modern: openat */
+#define LEGACY_SYS_creat /* modern: openat */
+#define LEGACY_SYS_mkdir /* modern: mkdirat */
+#define LEGACY_SYS_rmdir /* modern: unlinkat */
+#define LEGACY_SYS_mknod /* modern: mknodat */
+#define LEGACY_SYS_chmod /* modern: fchmodat */
+#define LEGACY_SYS_lchown /* modern: fchownat */
+#define LEGACY_SYS_chown /* modern: fchownat */
+#define LEGACY_SYS_rename /* modern: renameat */
+#define LEGACY_SYS_lstat /* modern: fstatat */
+#define LEGACY_SYS_stat /* modern: fstatat */
+#define LEGACY_SYS_getdents /* modern: getdents64 */
+#define LEGACY_SYS_time /* modern: gettimeofday */
+#define LEGACY_SYS_futimesat /* modern: utimensat */
+#define LEGACY_SYS_utime /* modern: utimensat */
+#define LEGACY_SYS_utimes /* modern: utimensat */
+#define LEGACY_SYS_dup2 /* modern: dup3 */
+#define LEGACY_SYS_pipe /* modern: pipe2 */
+#define LEGACY_SYS_pause /* modern: sigsuspend */
+#define LEGACY_SYS_alarm /* modern: timer_settime */
+
+#endif

--- a/lib/syscall_shim/include/uk/syscall.h
+++ b/lib/syscall_shim/include/uk/syscall.h
@@ -41,6 +41,7 @@
 #include <errno.h>
 #include <stdarg.h>
 #include <uk/print.h>
+#include "legacy_syscall.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Prerequisite checklist
 - [X] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [X] Updated relevant documentation.


### Base target
 - Architecture(s): [`x86_64`, `arm64`]
 - Platform(s): [e.g. `kvm`]

### Description of changes

Currently, all the unnumbered system calls are ignored during the build process.
This shouldn't be the case for architecture specific syscalls. Those should
generate the failure of the build process if their numbere is not defined
for the corresponding architecture (see arch_prctl).
This commit introduces a separate header file that allows us to only ignore
unnumbered legacy syscalls from the architecture specific ones.

Currently, all the syscalls that caused problems on ARM64 are legacy syscalls.
However, when architecture specific syscalls will be introduced, those should be placed
between corresponding guards, as in [1].

[1] https://github.com/unikraft/unikraft/pull/336

Signed-off-by: Răzvan Vîrtan <virtanrazvan@gmail.com>
