### PR TITLE
build: Generate uk_clean_list in bulk.

### DIFF
--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -950,15 +950,18 @@ endef
 #
 #################################################
 # Generates a phony clean rule for a given library
-
+#
+# FIXME: The sed command replaces ' ' with newlines instead of enumerating
+#        paths. This will break if there are any spaces in the file path.
+#
 # cleanrule_lib $libname
 define cleanrule_lib =
 clean-$(1):
-	$(file >$(BUILD_DIR)/$(1)/uk_clean_list) \
-            $(foreach O,$($(call vprefix_lib,$(1),CLEAN-y)),\
-                $(file >>$(BUILD_DIR)/$(1)/uk_clean_list,$O)) \
-            $(foreach O,$($(call vprefix_lib,$(1),CLEAN)),\
-                $(file >>$(BUILD_DIR)/$(1)/uk_clean_list,$O))
+	$(file >$(BUILD_DIR)/$(1)/uk_clean_list, \
+            $($(call vprefix_lib,$(1),CLEAN-y)) \
+            $($(call vprefix_lib,$(1),CLEAN))) \
+	$(shell $(SED) -E -e 's/^ +//g' -e 's/ +$$//g' -e 's/ +/\n/g' \
+	            -i $(BUILD_DIR)/$(1)/uk_clean_list)
 	$(call verbose_cmd,CLEAN,$(1),\
             $(XARGS) $(RM) <$(BUILD_DIR)/$(1)/uk_clean_list)
 


### PR DESCRIPTION
Makefile.clean is included on every call of make and generates the uk_clean_list files while processing the makefile.
Depending on the number of files to be cleaned, that can take a while before the first make rule is even executed.

This PR writes all files to clean of a library into the uk_clean_list in bulk and use sed to turn spaces into linebreaks, while trimming leading and tailing spaces. This produces the same uk_clean_list as before, but is a lot faster when building libraries with a lot of sources, for example when building with lib-musl.

Before: >35s
```
Including unikraft/support/build/Makefile.clean...
09:55:00.926917921
09:55:35.070894521
```
After: <0.2s
```
Including unikraft/support/build/Makefile.clean...
11:38:41.496502750
11:38:41.673154878
```
This is _low priority issue for me_, but it did bother me too much. I opened an issue (fixes #508) before.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Additional configuration

For measuring the time:
```
# support/build/Makefile.clean
ifneq ($(call qstrip,$(UK_LIBS) $(UK_LIBS-y)),)
$(shell date +"%T.%N" 1>&2) \
$(foreach L,$(UK_LIBS) $(UK_LIBS-y), \
$(eval $(call cleanrule_lib,$(L))); \
) \
$(shell date +"%T.%N" 1>&2)
endif
```

### Description of changes

- write to the uk_clean_list file once instead for each item
- use sed
    -  `-i (BUILD_DIR)/$(1)/uk_clean_list` update uk_clean_list directly
    - `-e 's/^ +//g'` trim leading spaces
    - `-e 's/ +$$//g'` trim trailing spaces
    - `-e 's/ +/\n/g' ` replace separating spaces with linebreaks

Problems will occur with spaces in a file path, but I would assume that would break other make rules also.