### PR TITLE
lib/syscall_shim: Force argument order also for uk_vsyscall_r

### DIFF
--- a/lib/syscall_shim/gen_uk_syscall_r.awk
+++ b/lib/syscall_shim/gen_uk_syscall_r.awk
@@ -7,6 +7,11 @@ BEGIN {
 
 	print "long uk_vsyscall_r(long nr, va_list arg)\n{"
 	print "\t(void) arg;\n"
+
+	printf "\t__maybe_unused long "
+	for (i = 1; i < max_args; i++)
+		printf "a%d, ", i
+	printf "a%d;\n", max_args
 	print "\tswitch (nr) {"
 }
 
@@ -18,11 +23,13 @@ BEGIN {
 	args_nr = $2 + 0
 	printf "#ifdef HAVE_uk_syscall_%s\n", name;
 	printf "\tcase %s:\n", sys_name;
+	for (i = 1; i <= args_nr; i++)
+		printf "\t\ta%s = va_arg(arg, long);\n", i;
 	printf "\t\treturn %s(", uk_syscall_r;
 	for (i = 1; i < args_nr; i++)
-		printf("va_arg(arg, long), ")
+		printf "a%d, ", i;
 	if (args_nr > 0)
-		printf("va_arg(arg, long)")
+		printf "a%d", args_nr;
 	printf(");\n")
 	printf "#endif /* HAVE_uk_syscall_%s */\n\n", name;
 }


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Commit 9acbeacedc91 forces the evaluation order of the arguments in `uk_vsyscall`. This commit applies the exact same fix to `uk_vsyscall_r`.