### PR TITLE
lib/posix-user/user.c: Remove unusable __uk_tls

### DIFF
--- a/lib/posix-user/user.c
+++ b/lib/posix-user/user.c
@@ -50,7 +50,7 @@
 #define UK_DEFAULT_GROUP  "root"
 #define UK_DEFAULT_PASS   "x"
 
-static __uk_tls struct passwd_entry {
+static struct passwd_entry {
 	struct passwd *passwd;
 
 	UK_SLIST_ENTRY(struct passwd_entry) entries;
@@ -370,7 +370,7 @@ struct group *getgrgid(gid_t gid)
 	return res;
 }
 
-static __uk_tls struct group_entry {
+static struct group_entry {
 	struct group *group;
 
 	UK_SLIST_ENTRY(struct group_entry) entries;


### PR DESCRIPTION
Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>
Signed-off-by: Eduard Vintilă  <eduard.vintila47@gmail.com>
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `AArch64`
 - Platform(s): `kvm`
 - Application(s): `SQLite`, `nginx`


### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
This PR removes `__uk_tls` from `static __uk_tls struct passwd_entry` and `static __uk_tls struct group_entry` in order to facilitate running complex apps on `AArch64`.

Considering the fact that `TLS` isn't completely implemented for `AArch64` and the fact that the standard POSIX doesn't require the functions that use `static __uk_tls struct passwd_entry` and `static __uk_tls struct group_entry` to be multithreading safe, the changes made by this PR shouldn't affect anything more that running the aforementioned apps on the desired architecture.