### PR TITLE
lib/uktest: Modify uktest to print custom formats

### DIFF
--- a/lib/uktest/include/uk/test.h
+++ b/lib/uktest/include/uk/test.h
@@ -694,7 +694,8 @@ _uk_test_do_assert(struct uk_testcase *esac, unsigned short line, int cond,
 #define UK_TEST_EXPECT(cond)						\
 	UK_TEST_ASSERTF(						\
 		(cond),							\
-		"expected `" STRINGIFY(cond) "` to be true"		\
+		"expected `%s` to be true",				\
+		STRINGIFY(cond)						\
 	)
 
 #define UK_TEST_ASSERT(cond) UK_TEST_EXPECT(cond)
@@ -723,9 +724,10 @@ _uk_test_do_assert(struct uk_testcase *esac, unsigned short line, int cond,
 		int _cond = (a_v cond b_v);				\
 		UK_TEST_ASSERTF(					\
 			_cond,						\
-			"expected `" STRINGIFY(a) "` to " desc		\
+			"expected `%s` to " desc			\
 			" " fmt " %s was " fmt,				\
-			b_v, _cond ? "and" : "but", a_v			\
+			STRINGIFY(a), b_v,				\
+			_cond ? "and" : "but", a_v			\
 		);							\
 	} while (0)
 
@@ -796,9 +798,9 @@ _uk_test_do_assert(struct uk_testcase *esac, unsigned short line, int cond,
 		void *b_p = (void *)(b);				\
 		UK_TEST_ASSERTF(					\
 			memcmp(a_p, b_p, size) == 0,			\
-			"expected `" STRINGIFY(a) "` at %p "		\
-			"to equal `" STRINGIFY(b) "` at %p",		\
-			b_p, a_p					\
+			"expected `%s` at %p "				\
+			"to equal `%s` at %p",				\
+			STRINGIFY(a), b_p, STRINGIFY(b), a_p		\
 		);							\
 	} while (0)
 


### PR DESCRIPTION
At the moment some assertions like `UK_TEST_EXPECT` and
`UK_TEST_EXPECT_BYTES_EQ` don't work properly when
you try to test a function that uses format specifiers
like '%s' or %d.
This commit modifies those functions to call `UK_TEST_ASSERTF`
correctly.

Signed-off-by: Florin Postolache <florin.postolache80@gmail.com>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
