### PR TITLE
plat/virtio_pci: Fix buffer length argument when calling `virtio_cread_bytes_many`

### DIFF
--- a/plat/drivers/virtio/virtio_pci.c
+++ b/plat/drivers/virtio/virtio_pci.c
@@ -273,10 +273,15 @@ static int vpci_legacy_pci_config_get(struct virtio_dev *vdev, __u16 offset,
 				VIRTIO_PCI_CONFIG_OFF + offset, buf, len,
 				type_len);
 	} else {
+		__u32 len_bytes;
+
+		if (__builtin_umul_overflow(len, type_len, &len_bytes))
+			return -EFAULT;
+
 		rc = virtio_cread_bytes_many(
 				(void *) (unsigned long)vpdev->pci_base_addr,
-				VIRTIO_PCI_CONFIG_OFF + offset,	buf, len);
-		if (rc != (int)len)
+				VIRTIO_PCI_CONFIG_OFF + offset,	buf, len_bytes);
+		if (unlikely(rc != (int) len_bytes))
 			return -EFAULT;
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`, `aarch64`]
 - Platform(s): [kvm]
 - Application(s): [redis, sqlite, nginx]


### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
This PR fixes an incorrect call to the `virtio_cread_bytes_many` function which is used to read a virtio PCI device's configuration. The function expects a `len` argument which is the total size of the buffer where the configuration bytes will be copied. However, the `vpci_legacy_pci_config_get` function invokes this routine by specifying the number of elements in the buffer, not its total size in bytes. This results in issues for example in the 9pfs filesystem initialization phase, where the filesystem tag (usuallly `fs0`) is incorrectly read and could result in filesystem setup failure. Problems could even arise past the configuration phase. More detalis can be found here in Issue #518 made by @mariasfiraiala.

Signed-off-by: Eduard Vintilă <eduard.vintila47@gmail.com>