### PR TITLE
plat/kvm/arm: Preserve x18 in exception vectors

### DIFF
--- a/plat/kvm/arm/exceptions.S
+++ b/plat/kvm/arm/exceptions.S
@@ -127,7 +127,7 @@
 	ldp x24, x25, [sp, #16 * 12]
 	ldp x22, x23, [sp, #16 * 11]
 	ldp x20, x21, [sp, #16 * 10]
-	ldp x18, x19, [sp, #16 * 9]
+	/* Skip x18, x19 */
 	ldp x16, x17, [sp, #16 * 8]
 	ldp x14, x15, [sp, #16 * 7]
 	ldp x12, x13, [sp, #16 * 6]
@@ -138,15 +138,21 @@
 	ldp x2, x3, [sp, #16 * 1]
 	ldp x0, x1, [sp, #16 * 0]
 
-	/* x18 can be used freely */
 .if \el == 0
 	/* Restore stack pointer for exception from EL0 */
 	ldr x18, [sp, #__SP_EL0_OFFSET]
 	msr sp_el0, x18
+
+	/* Restore x18, x19 */
+	ldp x18, x19, [sp, #16 * 9]
 .else
 	/* Restore stack pointer for exception from EL1 */
 	ldr x18, [sp, #__SP_OFFSET]
+	mov x19, sp
 	mov sp, x18
+
+	/* Restore x18, x19 */
+	ldp x18, x19, [x19, #16 * 9]
 .endif
 	add sp, sp, #__TRAP_STACK_SIZE
 


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): arm64
 - Platform(s): kvm
 - Application(s): N/A


### Additional configuration

None
<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
This fixes a bug in the exception vectors, where x18 is not preserved. According to the APCS:

> The role of register r18 is platform specific. If a platform ABI has need of a dedicated general-purpose register to carry inter-procedural state (for example, the thread context) then it should use this register for that purpose. If the platform ABI has no such requirements, then it should use r18 as an additional temporary register. The platform ABI specification must document the usage for this register.

This means that x18 needs to be restored either way.

[1] https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs64/aapcs64.rst