### PR TITLE
arch/arm64: Add data barrier after PTE writes

### DIFF
--- a/arch/arm/arm64/include/uk/asm/paging.h
+++ b/arch/arm/arm64/include/uk/asm/paging.h
@@ -211,6 +211,8 @@ static inline int ukarch_pte_write(__vaddr_t pt_vaddr, unsigned int lvl,
 #endif /* CONFIG_LIBUKDEBUG */
 
 	*((__pte_t *)pt_vaddr + idx) = pte;
+	dsb(ishst);
+	isb();
 
 	return 0;
 }


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): arm64
 - Platform(s): KVM
 - Application(s): N/A


### Additional configuration

None
<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Add a barrier after PTE writes to prevent a subsequent access
to fetch a stale descriptor.