### PR TITLE
lib/vfscore: stdio: Include missing syscall.h

### DIFF
--- a/lib/vfscore/stdio.c
+++ b/lib/vfscore/stdio.c
@@ -34,6 +34,7 @@
 #include <vfscore/file.h>
 #include <vfscore/fs.h>
 #include <uk/plat/console.h>
+#include <uk/syscall.h>
 #include <uk/essentials.h>
 #include <termios.h>
 #include <vfscore/vnode.h>


### PR DESCRIPTION
The header `<uk/syscall.h>` was not included in `stdio.c`. This caused a build warning because the prototype definition of `uk_syscall_r_dup2()` was missing.