### PR TITLE
lib/posix-socket: Align posix_socket_driver to 8 bytes in binary

### DIFF
--- a/lib/posix-socket/include/uk/socket_driver.h
+++ b/lib/posix-socket/include/uk/socket_driver.h
@@ -60,7 +60,7 @@ struct eventpoll_cb;
  * The POSIX socket driver defines the operations to be used for the
  * specified AF family as well as the memory allocator.
  */
-struct posix_socket_driver {
+struct __align(8) posix_socket_driver {
 	/** The AF family ID */
 	const int family;
 	/** Name of the driver library */
@@ -620,7 +620,8 @@ posix_socket_family_count(void);
  * Creates a static struct posix_socket_driver for the AF family
  */
 #define _POSIX_SOCKET_FAMILY_REGISTER(lib, fam, vops)			\
-	__used __section("." _POSIX_SOCKET_FAMILY_SECNAME(lib, fam))	\
+	__used __align(8)						\
+		__section("." _POSIX_SOCKET_FAMILY_SECNAME(lib, fam))	\
 	static struct posix_socket_driver				\
 	_POSIX_SOCKET_FAMILY_DRVRNAME(lib, fam) = {			\
 		.family = fam,						\


### PR DESCRIPTION
Instances of the `posix_socket_driver` structure (on for each socket family) are expected to be consecutive in the memory layout. By default, they are not.

This commit fixes it by aligning the structure to 8 bytes. This ensures structure instances are consecutively placed in the resulting binary (and then when loaded in memory).

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): `app-python3`, `app-redis`