### PR TITLE
lib/posix-process: Add RLIMIT_DATA resource for prlimit64

### DIFF
--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -375,6 +375,8 @@ UK_LLSYSCALL_R_DEFINE(int, prlimit64, int, pid, unsigned int, resource,
 	 * Lookup if resource can be set/retrieved
 	 */
 	switch (resource) {
+	case RLIMIT_DATA:
+		break;
 	case RLIMIT_STACK:
 		break;
 #if CONFIG_LIBVFSCORE


### PR DESCRIPTION
This commit provides simple implementation for the `RLIMIT_DATA` resource for the `prlimit64` syscall.

### Prerequisite checklist


 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A
