### PR TITLE
plat/kvm/x86: Fix boot stack alignment

### DIFF
--- a/plat/common/x86/lcpu.c
+++ b/plat/common/x86/lcpu.c
@@ -77,9 +77,21 @@ void __noreturn lcpu_arch_jump_to(void *sp, ukplat_lcpu_entry_t entry)
 {
 	__asm__ (
 		"movq	%0, %%rsp\n"
+
+		/* According to System V AMD64 the stack pointer must be
+		 * aligned to 16-bytes. In other words, the value (RSP+8) must
+		 * be a multiple of 16 when control is transferred to the
+		 * function entry point (i.e., the compiler expects a
+		 * misalignment due to the return address having been pushed
+		 * onto the stack).
+		 */
+		"andq	$~0xf, %%rsp\n"
+		"subq	$0x8, %%rsp\n"
+
 #if !__OMIT_FRAMEPOINTER__
 		"xorq	%%rbp, %%rbp\n"
 #endif /* __OMIT_FRAMEPOINTER__ */
+
 		"jmp	*%1\n"
 		:
 		: "r"(sp), "r"(entry)

--- a/plat/kvm/x86/lcpu_start.S
+++ b/plat/kvm/x86/lcpu_start.S
@@ -284,6 +284,15 @@ no_args:
 	movq	LCPU_STACKP_OFFSET(%rbp), %rsp
 
 jump_to_entry:
+	/* According to System V AMD64 the stack pointer must be aligned to
+	 * 16-bytes. In other words, the value (RSP+8) must be a multiple of
+	 * 16 when control is transferred to the function entry point (i.e.,
+	 * the compiler expects a misalignment due to the return address having
+	 * been pushed onto the stack).
+	 */
+	andq	$~0xf, %rsp
+	subq	$0x8, %rsp
+
 	movq	%rbp, %rdi
 #if !__OMIT_FRAMEPOINTER__
 	/* Reset frame pointer */


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

The compiler expects the stack to be always 16-byte aligned and ending on `...8` when entering a function due to the call having pushed the return address. So the `pushq` in the prolog of the callee restores 16-byte alignment. However, at the moment we do not enforce any particular alignment for the boot stack. This can be a problem when the compiler uses instructions with alignment restrictions like `movaps`.

This commit enforces the required alignment.