### PR TITLE
lib/uktime: Fix warning in year_to_secs

### DIFF
--- a/lib/uktime/musl-imported/src/__year_to_secs.c
+++ b/lib/uktime/musl-imported/src/__year_to_secs.c
@@ -14,9 +14,10 @@ long long __year_to_secs(long long year, int *is_leap)
 	}
 
 	int cycles, centuries, leaps, rem;
+	int zero = 0;
 
 	if (!is_leap)
-		is_leap = &(int){0};
+		is_leap = &zero;
 	cycles = (year-100) / 400;
 	rem = (year-100) % 400;
 	if (rem < 0) {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

gcc 12.1 generates the following warnings for `is_leap` as the pointer may be initialized to an unnamed temporary, creating a dangling pointer.
```
  CC      libuktime: __year_to_secs.o
/home/unikraft/unikraft/lib/uktime/musl-imported/src/__year_to_secs.c: In function ‘__year_to_secs’:
/home/unikraft/unikraft/lib/uktime/musl-imported/src/__year_to_secs.c:52:45: warning: dangling pointer ‘is_leap’ to an unnamed temporary may be used [-Wdangling-pointer=]
   52 |         leaps += 97*cycles + 24*centuries - *is_leap;
      |                                             ^~~~~~~~
/home/unikraft/unikraft/lib/uktime/musl-imported/src/__year_to_secs.c:19:33: note: unnamed temporary defined here
   19 |                 is_leap = &(int){0};
      |                                 ^
/home/unikraft/unikraft/lib/uktime/musl-imported/src/__year_to_secs.c:27:26: warning: dangling pointer ‘is_leap’ to an unnamed temporary may be used [-Wdangling-pointer=]
   27 |                 *is_leap = 1;
      |                 ~~~~~~~~~^~~
/home/unikraft/unikraft/lib/uktime/musl-imported/src/__year_to_secs.c:19:33: note: unnamed temporary defined here
   19 |                 is_leap = &(int){0};
      |                                 ^
/home/unikraft/unikraft/lib/uktime/musl-imported/src/__year_to_secs.c:43:34: warning: dangling pointer ‘is_leap’ to an unnamed temporary may be used [-Wdangling-pointer=]
   43 |                         *is_leap = 0;
      |                         ~~~~~~~~~^~~
/home/unikraft/unikraft/lib/uktime/musl-imported/src/__year_to_secs.c:19:33: note: unnamed temporary defined here
   19 |                 is_leap = &(int){0};
      |                                 ^
/home/unikraft/unikraft/lib/uktime/musl-imported/src/__year_to_secs.c:48:34: warning: dangling pointer ‘is_leap’ to an unnamed temporary may be used [-Wdangling-pointer=]
   48 |                         *is_leap = !rem;
      |                         ~~~~~~~~~^~~~~~
/home/unikraft/unikraft/lib/uktime/musl-imported/src/__year_to_secs.c:19:33: note: unnamed temporary defined here
   19 |                 is_leap = &(int){0};
      |                                 ^
```
This commit replaces the temporary with a named variable with function scope.
