### PR TITLE
plat/kvm/arm/lcpu.c: fix warning undeclared function halt()

### DIFF
--- a/plat/kvm/arm/lcpu.c
+++ b/plat/kvm/arm/lcpu.c
@@ -32,6 +32,7 @@
 #include <stdint.h>
 #include <uk/plat/lcpu.h>
 #include <arm/irq.h>
+#include <arm/cpu.h>
 
 void ukplat_lcpu_enable_irq(void)
 {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `ARM`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

N/A

### Description of changes

This patch resolves undeclared function warning for the function `halt()` in `plat/kvm/arm/lcpu.c`. Without this patch, building for `kvm` `ARM` outputs the following warning:
```
unikraft/plat/kvm/arm/lcpu.c:49:2: warning: implicit declaration of function 'halt' [-Wimplicit-function-declaration]
   49 |  halt();
```