### PR TITLE
issue #543 fix

### DIFF
--- a/lib/nolibc/string.c
+++ b/lib/nolibc/string.c
@@ -693,11 +693,9 @@ char *strncat(char *dest, const char *src, size_t n)
 
 	dest = dest + strlen(dest);
 
-	if (src != NULL) {
-		while (n && *src) {
-			n--;
-			*dest++ = *src++;
-		}
+	while (n && *src) {
+		n--;
+		*dest++ = *src++;
 	}
 
 	*dest++ = 0;


### PR DESCRIPTION
GCC <= 9 gives a build warning when comparing builtin function arguments with NULL. This is likely the case because compiler builtins use `__attribute(nonnull)__`.

This commit removes the NULL comparison in `strncat` that caused the build warning.

Signed-off-by: Maria Moșneag <<mariamosneag@gmail.com>>