### PR TITLE
Warning fix: uninitialized variable

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -575,6 +575,7 @@ static int do_pwritev(struct vfscore_file *fp, const struct iovec *iov,
 	return 0;
 
 out_error:
+	*bytes = -1;
 	return -error;
 }
 


### PR DESCRIPTION
Initialized the `bytes` variable. The previous use without initializtion was likely the cause of the build warnings.
Related to issue #545 

Signed-off-by: Maria Moșneag <mariamosneag@gmail.com>