### PR TITLE
Fix types for stat struct

### DIFF
--- a/lib/nolibc/include/nolibc-internal/shareddefs.h
+++ b/lib/nolibc/include/nolibc-internal/shareddefs.h
@@ -99,22 +99,22 @@ typedef unsigned id_t;
 #endif
 
 #if defined(__NEED_dev_t) && !defined(__DEFINED_dev_t)
-typedef __u64 dev_t;
+typedef unsigned long dev_t;
 #define __DEFINED_dev_t
 #endif
 
 #if defined(__NEED_ino_t) && !defined(__DEFINED_ino_t)
-typedef __u64 ino_t;
+typedef unsigned long ino_t;
 #define __DEFINED_ino_t
 #endif
 
 #if defined(__NEED_nlink_t) && !defined(__DEFINED_nlink_t)
-typedef __u32 nlink_t;
+typedef unsigned long nlink_t;
 #define __DEFINED_nlink_t
 #endif
 
 #if defined(__NEED_blkcnt_t) && !defined(__DEFINED_blkcnt_t)
-typedef __s64 blkcnt_t;
+typedef long blkcnt_t;
 #define __DEFINED_blkcnt_t
 #endif
 


### PR DESCRIPTION
When running the same program using the stat
structure in Linux and with Unikraft the sizes
of the structure's fields were different. This was caused by the fact that in Linux dev_t was declared as unsigned long, while in Unikraft it was declared as __u64. Similarly for ino_t, nlink_t, blkcnt_t.

Signed-off-by: Delia-Maria Pavel <delia_maria.pavel@stud.acs.upb.ro>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
