### PR TITLE
lib/ukdebug/print.c: define LVLC_CALLER in case CONFIG_LIBUKDEBUG_ANSI_COLOR is not set

### DIFF
--- a/lib/ukdebug/print.c
+++ b/lib/ukdebug/print.c
@@ -70,7 +70,7 @@
 #else
 #define LVLC_RESET	""
 #define LVLC_TS		""
-#define LVLC_SP		""
+#define LVLC_CALLER	""
 #define LVLC_LIBNAME	""
 #define LVLC_SRCNAME	""
 #define LVLC_DEBUG	""


### PR DESCRIPTION
Related Issue: #556 

**lib/ukdebug/print.c**: define LVLC_CALLER in case CONFIG_LIBUKDEBUG_ANSI_COLOR is not set

This commit fixes a compilation error thrown when
`Show caller information` is enabled in ukdebug.

*Signed-off-by: Hamza Chandad <hchandad@proton.me>*

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
