### PR TITLE
Add asm flag for compilation with clang on x86

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -96,5 +96,6 @@ LIBLDFLAGS-$(CONFIG_OPTIMIZE_LTO) += -flinker-output=nolto-rel
 LDFLAGS-$(CONFIG_OPTIMIZE_LTO) += -flinker-output=nolto-rel
 endif
 
+ASFLAGS-$(call have_clang)     += -mllvm -asm-macro-max-nesting-depth=1000
 COMPFLAGS-$(call have_clang)	+= -fno-builtin -fno-PIC
 LDFLAGS-$(call have_clang)	+= -no-pie


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`, `AArch64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

Build your application using `clang`:
```
make CC=clang
```

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR increases the nested macro limit from 20 (which results in a compilation error) to 1000, making possible building `x86` apps using `clang`.

Fixes issue #532.
