### PR TITLE
WIP: Fix linking of alibs

### DIFF
--- a/plat/kvm/Linker.uk
+++ b/plat/kvm/Linker.uk
@@ -25,19 +25,22 @@ $(KVM_DEBUG_IMAGE): $(KVM_ALIBS) $(KVM_ALIBS-y) $(KVM_OLIBS) $(KVM_OLIBS-y) \
 			$(KVM_OLIBS) $(KVM_OLIBS-y) \
 			$(UK_OLIBS) $(UK_OLIBS-y) \
 			-Wl$(comma)--start-group \
-			$(KVM_ALIBS) $(KVM_ALIBS-y) \
-			$(UK_ALIBS) $(UK_ALIBS-y) \
 			$(KVM_LINK_LIBGCC_FLAG) \
 			-Wl$(comma)--end-group \
 			-o $(KVM_IMAGE).ld.o)
 	$(call build_cmd,OBJCOPY,,$(KVM_IMAGE).o,\
-		$(OBJCOPY) -w -G kvmos_* -G _libkvmplat_entry \
-			$(KVM_IMAGE).ld.o $(KVM_IMAGE).o)
+		$(OBJCOPY) $(KVM_IMAGE).ld.o $(KVM_IMAGE).o)
+
 	$(call build_cmd,LD,,$@,\
 	       $(LD) $(LDFLAGS) $(LDFLAGS-y) \
 		     $(KVM_LDFLAGS) $(KVM_LDFLAGS-y) \
 		     $(KVM_LD_SCRIPT_FLAGS) \
-		     $(KVM_IMAGE).o -o $@)
+		     $(KVM_IMAGE).o \
+		     -Wl$(comma)--whole-archive \
+		     $(KVM_ALIBS) $(KVM_ALIBS-y) \
+		     $(UK_ALIBS) $(UK_ALIBS-y) \
+		     -Wl$(comma)--no-whole-archive \
+		     -o $@)
 
 $(KVM_IMAGE): $(KVM_IMAGE).dbg
 	$(call build_cmd,SCSTRIP,,$@,\

--- a/support/build/Makefile.build
+++ b/support/build/Makefile.build
@@ -29,9 +29,11 @@ $(foreach S,$($(call uc,$(L))_SRCS) $($(call uc,$(L))_SRCS-y) \
 	    $(EACHOLIB_SRCS) $(EACHOLIB_SRCS-y), \
 $(eval $(call buildrule_libobj_multitarget,$(L),$(S))) \
 ); \
-$(if $(call qstrip,$($(call uc,$(L))_OBJS) $($(call uc,$(L))_OBJS-y)), \
+$(if $(call qstrip,$($(call uc,$(L))_OBJS) $($(call uc,$(L))_OBJS-y) \
+                   $($(call uc,$(L))_ALIBS) $($(call uc,$(L))_ALIBS-y)), \
 $(eval $(call buildrule_olib,$(L))); \
 $(eval UK_OLIBS-y += $(call libname2olib,$(L))); \
+$(eval UK_ALIBS-y += $($(call uc,$(L))_ALIBS) $($(call uc,$(L))_ALIBS-y)); \
 , \
 $(call verbose_info,Warning: '$(L)' has no sources or object files$(comma) ignoring...) \
 ) \
@@ -53,9 +55,11 @@ $(foreach S,$($(call uc,$(L))_SRCS) $($(call uc,$(L))_SRCS-y) \
 	    $(EACHOLIB_SRCS) $(EACHOLIB_SRCS-y), \
 $(eval $(call buildrule_libobj_multitarget,$(L),$(S))) \
 ); \
-$(if $(call qstrip,$($(call uc,$(L))_OBJS) $($(call uc,$(L))_OBJS-y)), \
+$(if $(call qstrip,$($(call uc,$(L))_OBJS) $($(call uc,$(L))_OBJS-y) \
+                   $($(call uc,$(L))_ALIBS) $($(call uc,$(L))_ALIBS-y)), \
 $(eval $(call buildrule_olib,$(L))); \
 $(eval $(call uc,$(P))_OLIBS-y    += $(call libname2olib,$(L))); \
+$(eval UK_ALIBS-y += $($(call uc,$(L))_ALIBS) $($(call uc,$(L))_ALIBS-y)); \
 , \
 $(call verbose_info,Warning: '$(L)' has no sources or object files$(comma) ignoring...) \
 ) \

--- a/support/build/Makefile.build
+++ b/support/build/Makefile.build
@@ -31,8 +31,10 @@ $(eval $(call buildrule_libobj_multitarget,$(L),$(S))) \
 ); \
 $(if $(call qstrip,$($(call uc,$(L))_OBJS) $($(call uc,$(L))_OBJS-y) \
                    $($(call uc,$(L))_ALIBS) $($(call uc,$(L))_ALIBS-y)), \
+$(if $(call qstrip,$($(call uc,$(L))_OBJS) $($(call uc,$(L))_OBJS-y)), \
 $(eval $(call buildrule_olib,$(L))); \
 $(eval UK_OLIBS-y += $(call libname2olib,$(L))); \
+,); \
 $(eval UK_ALIBS-y += $($(call uc,$(L))_ALIBS) $($(call uc,$(L))_ALIBS-y)); \
 , \
 $(call verbose_info,Warning: '$(L)' has no sources or object files$(comma) ignoring...) \
@@ -57,8 +59,10 @@ $(eval $(call buildrule_libobj_multitarget,$(L),$(S))) \
 ); \
 $(if $(call qstrip,$($(call uc,$(L))_OBJS) $($(call uc,$(L))_OBJS-y) \
                    $($(call uc,$(L))_ALIBS) $($(call uc,$(L))_ALIBS-y)), \
+$(if $(call qstrip,$($(call uc,$(L))_OBJS) $($(call uc,$(L))_OBJS-y)), \
 $(eval $(call buildrule_olib,$(L))); \
 $(eval $(call uc,$(P))_OLIBS-y    += $(call libname2olib,$(L))); \
+,); \
 $(eval UK_ALIBS-y += $($(call uc,$(L))_ALIBS) $($(call uc,$(L))_ALIBS-y)); \
 , \
 $(call verbose_info,Warning: '$(L)' has no sources or object files$(comma) ignoring...) \

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -848,10 +848,6 @@ $(call libname2preolib,$(1)): $($(call vprefix_lib,$(1),OBJS)) \
 			      $($(call vprefix_lib,$(1),OBJS-y)) \
 			      $(EACHOLIB_OBJS) \
 			      $(EACHOLIB_OBJS-y) \
-			      $($(call vprefix_lib,$(1),ALIBS)) \
-			      $($(call vprefix_lib,$(1),ALIBS-y)) \
-			      $(EACHOLIB_ALIBS) \
-			      $(EACHOLIB_ALIBS-y) \
 			      $($(call vprefix_lib,$(1),LDS)) \
 			      $($(call vprefix_lib,$(1),LDS-y)) \
 			      $($(call vprefix_lib,$(1),DTB)) \
@@ -865,10 +861,6 @@ $(call libname2preolib,$(1)): $($(call vprefix_lib,$(1),OBJS)) \
 		      $(EACHOLIB_OBJS) \
 		      $(EACHOLIB_OBJS-y) \
 		      -Wl$(comma)--start-group \
-		      $($(call vprefix_lib,$(1),ALIBS)) \
-		      $($(call vprefix_lib,$(1),ALIBS-y)) \
-		      $(EACHOLIB_ALIBS) \
-		      $(EACHOLIB_ALIBS-y) \
 		      -Wl$(comma)--end-group \
 		      -o $(call libname2preolib,$(1)))
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): all
 - Platform(s): kvm


### Additional configuration

None

### Description of changes

Fix linking of ALIBS (.a files). Previously, ALIBS are partially linked to object files. This does not work as noted in the "ld" documentation:

       -r
       --relocatable
           Generate relocatable output---i.e., generate an output file that
           can in turn serve as input to ld.  This is often called partial
           linking.
           ...

           When an input file does not have the same format as the output
           file, partial linking is only supported if that input file does not
           contain any relocations.  Different output formats can have further
           restrictions; for example some "a.out"-based formats do not support
           partial linking with input files in other formats at all.

           This option does the same thing as -i.

When partially linking object files, they are discarded by the linker without an error or warning. Link the ALIBS at final image link time to avoid discarding them.

The current implementation seems to be a bug, as original plan of the build system seemed to follow the changes in this PR: https://cdn.discordapp.com/attachments/881080515912925244/883787132706119720/unknown.png
