### PR TITLE
lib/uktest: insert .uk_testtab after data section

### DIFF
--- a/lib/uktest/tests.ld
+++ b/lib/uktest/tests.ld
@@ -9,4 +9,4 @@ SECTIONS
 		uk_asserttab_end = .;
 	}
 }
-INSERT AFTER .rodata;
+INSERT AFTER .data;

--- a/plat/kvm/x86/multiboot.S
+++ b/plat/kvm/x86/multiboot.S
@@ -51,7 +51,7 @@ multiboot_header:
 	.long -(MULTIBOOT_HEADER_MAGIC+MULTIBOOT_FLAGS) /* checksum */
 	.long multiboot_header				/* header addr */
 	.long 0x100000					/* load addr */
-	.long _edata					/* load end addr */
+	.long __bss_start				/* load end addr */
 	.long _end					/* bss end addr */
 	.long multiboot_start32				/* entry addr */
 


### PR DESCRIPTION
the problem with inserting uk_testtab after .rodata, is that uk_testtab appears on the same page with .rodata, what means .uk_testtab would be write protected in some cases, that may lead to the data abort when executing libuktest macros.

```
[    0.000000] Info: [libukboot] <boot.c @  199> Unikraft constructor table at 0x40126000 - 0x40126030
test: uktest_myself_testsuite->uktest_test_sanity
    :	expected `((void *) 0)` to be 0 and was 0 ....................................... [ PASSED ]
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  192> EL1 sync trap caught
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  158> 	 SP       : 0x0000000047fbccc0
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  159> 	 ESR_EL1  : 0x000000009600004f
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  160> 	 ELR_EL1  : 0x000000004011cef8
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  161> 	 LR (x30) : 0x000000004011ce5c
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  162> 	 PSTATE   : 0x00000000800003c5
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  163> 	 FAR_EL1  : 0x000000004012c7ac
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  166> 	 x00 ~ x03: 0x0000000000000001 0x000000004012c7ac 0x0000000000000000 0x000000000000002a
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  166> 	 x04 ~ x07: 0x000000000000ffff 0x0000000047fbc997 0x0000000000000067 0x000000000000000a
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  166> 	 x08 ~ x11: 0x0000000000000073 0x0000000000000000 0x000000004011115c 0x0000000000000000
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  166> 	 x12 ~ x15: 0x0000000047fbcde0 0x0000000000000020 0x00000000ffffffe8 0x0000000000000020
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  166> 	 x16 ~ x19: 0x0000000000000000 0x0000000000000000 0x0000000047fbc8a8 0x000000004012c750
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  166> 	 x20 ~ x23: 0x000000000000002a 0x000000004012c7e4 0x000000004012c430 0x000000004012c448
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  166> 	 x24 ~ x27: 0x0000000040129b58 0x000000004012c7df 0x000000004012b0d8 0x000000004012e000
[    0.000000] CRIT: [libkvmplat] <traps_arm64.c @  170> 	 x28 ~ x29: 0x0000000000000000 0x0000000047fbcde0
```
the problem arises on arm64 if paging & w_xor_x options are enabled.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Description of changes

the ukttestab section moved in linker script to be included after data section.

