### PR TITLE
plat/kvm: Ensure time monotonicity for tscclock

### DIFF
--- a/plat/kvm/x86/tscclock.c
+++ b/plat/kvm/x86/tscclock.c
@@ -205,6 +205,8 @@ __u64 tscclock_monotonic(void)
 	 */
 	tsc_now = rdtsc();
 	tsc_delta = tsc_now - tsc_base;
+	if (tsc_delta >= UINT64_MAX / 2)
+		tsc_delta = 1;
 	time_base += mul64_32(tsc_delta, tsc_mult);
 	tsc_base = tsc_now;
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): x86_64
 - Platform(s): kvm
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The TSC is not synchronized perfectly on some systems. Examples of such systems are multi-socket system or newer AMD processors. This patch ensure that this does not cause an unwanted underflow in the delta calculation.

This fixes issue #334.

