### PR TITLE
plat/drivers: Fix GICv3 redistributor access

### DIFF
--- a/plat/drivers/gic/gic-v3.c
+++ b/plat/drivers/gic/gic-v3.c
@@ -51,7 +51,9 @@
 #include <gic/gic-v3.h>
 #include <ofw/fdt.h>
 
-#define GIC_RDIST_REG(gdev, r) ((void *)(gdev.rdist_mem_addr + (r)))
+#define GIC_RDIST_REG(gdev, r)					\
+	((void *)(gdev.rdist_mem_addr + (r) +			\
+	lcpu_get_current()->idx * GICR_STRIDE))
 
 #define GIC_AFF_TO_ROUTER(aff, mode)				\
 	((((uint64_t)(aff) << 8) & MPIDR_AFF3_MASK) | ((aff) & 0xffffff) | \

--- a/plat/drivers/include/gic/gic-v3.h
+++ b/plat/drivers/include/gic/gic-v3.h
@@ -117,6 +117,7 @@
 #define GICR_TYPER_PROC_NUM_MASK	(0xffff << GICR_TYPER_PROC_NUM_SHIFT)
 
 /* GICR frames offset */
+#define GICR_STRIDE			(0x20000)
 #define GICR_RD_BASE			(0)
 #define GICR_SGI_BASE			(0x10000)
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [arm64]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

The implementation of the GICv3 driver assumes that the GICR_ registers access each core's local redistributor. This is not true, as the redistributor registers of all are mapped in 64KiB adjascent regions, with GICR_BASE being the offset to the register of the first core. This results into a bug where all cores update the registributor registers of the first core.

Update the GIC_RDIST_REG macro to access the right region for a given core, using the current lcpu index.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
