### PR TITLE
build: Add support for long application directory paths

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -180,6 +180,12 @@ if RECORD_BUILDTIME
 	endchoice
 endif
 
+config BUILD_ARGS_FILE
+	bool "Use file for long build arguments"
+	default n
+	help
+		Uses a file to pass long arguments to the build commands.
+
 config CROSS_COMPILE
 	string "Custom cross-compiler tool prefix (optional)"
 	help

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -252,21 +252,30 @@ verbose_cmd = @printf '  %-7s %s\n' '$(1)'  '$(2)' && $(3)
 verbose_cmd_inner = printf '  %-7s %s\n' '$(1)'  '$(2)' && $(3)
 endif
 
+# Writes arguments into a build_args file
+#
+# write_build_args $target,$longargs(optional)
+ifeq ($(CONFIG_BUILD_ARGS_FILE),y)
+write_build_args = $(if $(2),$(file > $(addsuffix .build_args,$(1)),$(2))@$(addsuffix .build_args,$(1)),)
+else
+write_build_args = $(2)
+endif
+
 # Calls a command that creates an object
 #
-# build_cmd $quietlabel,$libname(optional),$target,$command
+# build_cmd $quietlabel,$libname(optional),$target,$command,$longargs(optional)
 ifeq ($(CONFIG_RECORD_BUILDTIME_TIME),y)
 define build_cmd =
-$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)),$(TIME) $(TIMEFLAGS) -o $(addsuffix .time,$(3)) $(4))
+$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)),$(TIME) $(TIMEFLAGS) -o $(addsuffix .time,$(3)) $(4) $(call write_build_args,$(3),$(5)))
 endef
 else
 ifeq ($(CONFIG_RECORD_BUILDTIME_LIFTOFF),y)
 define build_cmd =
-$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)),$(LIFTOFF) $(LITFOFFFLAGS) -o $(addsuffix .liftoff,$(3)) -- $(4))
+$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)),$(LIFTOFF) $(LITFOFFFLAGS) -o $(addsuffix .liftoff,$(3)) -- $(4) $(call write_build_args,$(3),$(5)))
 endef
 else
 define build_cmd =
-$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)),$(4))
+$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)),$(4) $(call write_build_args,$(3),$(5)))
 endef
 endif
 endif
@@ -289,14 +298,15 @@ endef
 # Returns a list of files to be cleaned when build_cmd was used
 #
 # build_clean $target
-ifeq ($(CONFIG_RECORD_BUILDTIME_TIME),y)
-build_clean = $(1) $(addsuffix .time,$(1))
-else
-ifeq ($(CONFIG_RECORD_BUILDTIME_LIFTOFF),y)
-build_clean = $(1) $(addsuffix .liftoff,$(1))
-else
 build_clean = $(1)
+ifeq ($(CONFIG_RECORD_BUILDTIME_TIME),y)
+build_clean += $(addsuffix .time,$(1))
 endif
+ifeq ($(CONFIG_RECORD_BUILDTIME_LIFTOFF),y)
+build_clean += $(addsuffix .liftoff,$(1))
+endif
+ifeq ($(CONFIG_BUILD_ARGS_FILE),y)
+build_clean += $(addsuffix .build_args,$(1))
 endif
 
 # Helper that generates a command for validating a checksum for
@@ -857,7 +867,8 @@ $(call libname2preolib,$(1)): $($(call vprefix_lib,$(1),OBJS)) \
 			      $($(call vprefix_lib,$(1),DTB)) \
 			      $($(call vprefix_lib,$(1),DTB-y))
 	$(call build_cmd,LD,,$(call libname2preolib,$(1)),\
-		$(LD) $(LIBLDFLAGS) $(LIBLDFLAGS-y) \
+		$(LD),\
+		      $(LIBLDFLAGS) $(LIBLDFLAGS-y) \
 		      $($(call vprefix_lib,$(1),LDFLAGS)) \
 		      $($(call vprefix_lib,$(1),LDFLAGS-y)) \
 		      $($(call vprefix_lib,$(1),OBJS)) \


### PR DESCRIPTION
Linking of libraries with huge amount of object files can lead to problems if paired with a long path to the application directory:
```
make[2]: execvp: /bin/bash: Argument list too long
```
This PR makes changes that enable reading command line arguments from build tools that support it.



 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s): 
 - Platform(s):
 - Application(s):

### Additional configuration

- Create a directory with a very long name, for example: `long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-name`
- In this directory, checkout the helloworld app, lib-musl, and unikraft.
- Configure app-helloworld to build with musl
- BUILD: fails with `make[2]: execvp: /bin/bash: Argument list too long`
- Reconfigure to enable the config build option `BUILD_ARGS_FILE` by checking `Build Options  ---> Use file for long build arguments`
- REBUILD: application is build as expected
  
### Description of changes

This PR adds a macro that writes potentially long build arguments into a file in order to avoid running into argument size limits. This behavior can be controlled by the config option `BUILD_ARGS_FILE`.
The build tool can then read the arguments from the file, which is an option for most tools in the gcc toolchain.

The PR includes a commit to implement the basic functionallity for `build_cmd`, and a second one enabling it for `build_cmd_fixdep` and making changes to the build rules.