### PR TITLE
lib/nolibc: Expose rmdir/rename from nolibc

### DIFF
--- a/lib/nolibc/include/stdio.h
+++ b/lib/nolibc/include/stdio.h
@@ -86,6 +86,10 @@ void psignal(int sig, const char *s);
 int fputc(int _c, FILE *fp);
 int putchar(int c);
 
+#if CONFIG_LIBVFSCORE
+int rename(const char *oldpath, const char *newpath);
+#endif
+
 #ifdef __STDIO_H_DEFINED_va_list
 #undef va_list
 #endif

--- a/lib/nolibc/include/unistd.h
+++ b/lib/nolibc/include/unistd.h
@@ -91,6 +91,7 @@ int dup2(int oldfd, int newfd);
 int dup3(int oldfd, int newfd, int flags);
 int unlink(const char *pathname);
 off_t lseek(int fd, off_t offset, int whence);
+int rmdir(const char *pathname);
 #endif
 
 #if CONFIG_LIBUKSIGNAL


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

-->

 - `CONFIG_LIBVFSCORE=y`

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
These two functions were not exposed by the nolibc library but are implemented by vfscore.
