### PR TITLE
plat/common/pci: Implement subclass matching

### DIFF
--- a/plat/common/include/pci/pci_bus.h
+++ b/plat/common/include/pci/pci_bus.h
@@ -78,6 +78,8 @@
 struct pci_device_id {
 	/**< Class ID or PCI_CLASS_ANY_ID. */
 	uint32_t class_id;
+	/**< Sub class ID or PCI_CLASS_ANY_ID. */
+	uint32_t sub_class_id;
 	/**< Vendor ID or PCI_ANY_ID. */
 	uint16_t vendor_id;
 	/**< Device ID or PCI_ANY_ID. */
@@ -98,6 +100,7 @@ struct pci_device_id {
  */
 #define PCI_DEVICE_ID(vend, dev)           \
 	.class_id = PCI_CLASS_ANY_ID,      \
+	.sub_class_id = PCI_CLASS_ANY_ID,  \
 	.vendor_id = (vend),               \
 	.device_id = (dev),                \
 	.subsystem_vendor_id = PCI_ANY_ID, \
@@ -105,6 +108,7 @@ struct pci_device_id {
 
 #define PCI_ANY_DEVICE_ID                  \
 	.class_id = PCI_CLASS_ANY_ID,      \
+	.sub_class_id = PCI_CLASS_ANY_ID,  \
 	.vendor_id = PCI_ANY_ID,           \
 	.device_id = PCI_ANY_ID,           \
 	.subsystem_vendor_id = PCI_ANY_ID, \

--- a/plat/common/pci_bus.c
+++ b/plat/common/pci_bus.c
@@ -66,6 +66,11 @@ static inline int pci_device_id_match(const struct pci_device_id *id0,
 	    (id0->class_id != id1->class_id)) {
 		return 0;
 	}
+	if ((id0->sub_class_id != PCI_CLASS_ANY_ID) &&
+	    (id1->sub_class_id != PCI_CLASS_ANY_ID) &&
+	    (id0->sub_class_id != id1->sub_class_id)) {
+		return 0;
+	}
 	if ((id0->vendor_id != PCI_ANY_ID) &&
 	    (id1->vendor_id != PCI_ANY_ID) &&
 	    (id0->vendor_id != id1->vendor_id)) {
@@ -92,6 +97,7 @@ static inline int pci_device_id_match(const struct pci_device_id *id0,
 static inline int pci_device_id_is_any(const struct pci_device_id *id)
 {
 	if ((id->class_id == PCI_CLASS_ANY_ID) &&
+	    (id->sub_class_id == PCI_CLASS_ANY_ID) &&
 	    (id->vendor_id == PCI_ANY_ID) &&
 	    (id->device_id == PCI_ANY_ID) &&
 	    (id->subsystem_vendor_id == PCI_ANY_ID) &&

--- a/plat/common/x86/pci_bus_x86.c
+++ b/plat/common/x86/pci_bus_x86.c
@@ -115,7 +115,7 @@ static void probe_bus(uint32_t);
  */
 static int probe_function(uint32_t bus, uint32_t device, uint32_t function)
 {
-	uint32_t config_addr, config_data, subclass, secondary_bus;
+	uint32_t config_addr, config_data, secondary_bus;
 	struct pci_address addr;
 	struct pci_device_id devid;
 	struct pci_driver *drv;
@@ -144,7 +144,7 @@ static int probe_function(uint32_t bus, uint32_t device, uint32_t function)
 	 */
 	PCI_CONF_READ(uint32_t, &devid.class_id,
 			config_addr, CLASS_ID);
-	PCI_CONF_READ(uint32_t, &subclass,
+	PCI_CONF_READ(uint32_t, &devid.sub_class_id,
 			config_addr, SUBCLASS_ID);
 	PCI_CONF_READ(uint16_t, &devid.vendor_id,
 			config_addr, VENDOR_ID);
@@ -172,7 +172,7 @@ static int probe_function(uint32_t bus, uint32_t device, uint32_t function)
 	}
 
 	/* 0x06 = Bridge Device, 0x04 = PCI-to-PCI bridge */
-	if ((devid.class_id == 0x06) && (subclass == 0x04)) {
+	if ((devid.class_id == 0x06) && (devid.sub_class_id == 0x04)) {
 		PCI_CONF_READ(uint32_t, &secondary_bus,
 				config_addr, SECONDARY_BUS);
 		probe_bus(secondary_bus);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The class is usually not precise enough to identify the correct driver for a device. For example, a NVM driver can only talk to devices which are in the subclass of NVM storage devices but not other devices in the larger storage class.