### PR TITLE
lib/uknetdev: Add note about RX netbuf length

### DIFF
--- a/lib/uknetdev/include/uk/netdev_core.h
+++ b/lib/uknetdev/include/uk/netdev_core.h
@@ -260,6 +260,8 @@ typedef void (*uk_netdev_queue_event_t)(struct uk_netdev *dev,
  *   Number of successful allocated netbufs,
  *   has to be in range [0, count].
  *   References to allocated packets are placed to pkts[0]...pkts[count -1].
+ *   The len field of the allocated netbufs should be set to the size usable
+ *   for receiving packets.
  */
 typedef uint16_t (*uk_netdev_alloc_rxpkts)(void *argp,
 					   struct uk_netbuf *pkts[],


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The length field is zero by default for most allocation functions. The virtio-net driver exposes the length field to the hypervisor, which would be unable to write any data into the buffers if the field is set to zero.
