### PR TITLE
lib/vfscore: Change `pipe()` call to `uk_syscall_r_pipe()`

### DIFF
--- a/lib/vfscore/pipe.c
+++ b/lib/vfscore/pipe.c
@@ -692,7 +692,7 @@ UK_SYSCALL_R_DEFINE(int, pipe2, int*, pipefd, int, flags)
 {
 	int rc;
 
-	rc = pipe(pipefd);
+	rc = uk_syscall_r_pipe((long) pipefd);
 	if (rc)
 		return rc;
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`aarch64`]
 - Platform(s): [`kvm`]
 - Application(s): [`app-redis`]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The `pipe2` implementation in vfscore relies on `pipe`. This commit ensures that we call the `pipe` system call from unikraft core and not a libc wrapper which in turn might call `pipe2` and thus end in an infinite loop. Musl ends up wrapping `pipe` exactly this way on `aarch64`, for example.

Signed-off-by: Eduard Vintilă <eduard.vintila47@gmail.com>