### PR TITLE
syscall_shim: Add syscalls in `legacy_syscalls.h`

### DIFF
--- a/lib/syscall_shim/include/uk/legacy_syscall.h
+++ b/lib/syscall_shim/include/uk/legacy_syscall.h
@@ -74,5 +74,10 @@
 #define LEGACY_SYS_pipe /* modern: pipe2 */
 #define LEGACY_SYS_pause /* modern: sigsuspend */
 #define LEGACY_SYS_alarm /* modern: timer_settime */
+#define LEGACY_SYS_poll /* modern: ppoll */
+#define LEGACY_SYS_select /* modern: pselect */
+#define LEGACY_SYS_epoll_create /* modern: epoll_create1 */
+#define LEGACY_SYS_epoll_wait /* modern: epoll_pwait */
+#define LEGACY_SYS_eventfd /* modern: eventfd2 */
 
 #endif


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `AArch64`
 - Platform(s): `kvm`
 - Application(s): `redis`

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Musl on `AArch64` requires `poll`, `select`, `epoll_create`, `epoll_wait` and `eventfd` syscalls. This PR adds them in `legacy_syscalls.h.`

Closes: #632 

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>
