### PR TITLE
lib/vfscore: Replace `access` and `stat` with unikraft syscalls

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -2076,7 +2076,7 @@ UK_SYSCALL_R_DEFINE(int, faccessat, int, dirfd, const char*, pathname, int, mode
 	}
 
 	if (pathname[0] == '/' || dirfd == AT_FDCWD) {
-		return access(pathname, mode);
+		return uk_syscall_r_access(pathname, mode);
 	}
 
 	struct vfscore_file *fp;
@@ -2096,7 +2096,7 @@ UK_SYSCALL_R_DEFINE(int, faccessat, int, dirfd, const char*, pathname, int, mode
 	strlcat(p, "/", PATH_MAX);
 	strlcat(p, pathname, PATH_MAX);
 
-	error = access(p, mode);
+	error = uk_syscall_r_access(p, mode);
 
 	vn_unlock(vp);
 	fdrop(fp);
@@ -2107,7 +2107,7 @@ UK_SYSCALL_R_DEFINE(int, faccessat, int, dirfd, const char*, pathname, int, mode
 
 int euidaccess(const char *pathname, int mode)
 {
-	return access(pathname, mode);
+	return uk_syscall_r_access(pathname, mode);
 }
 
 __weak_alias(euidaccess,eaccess);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `AArch64`
 - Platform(s): `kvm`
 - Application(s): `SQLite`, `redis`


### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Current `access` and `stat` calls from `vfscore` generate infinite loops when used with `musl` due to these calls being interpreted as library function calls.

Consequently, we shouldn't be relying on calling wrappers when inside `unikraft` core, but on our own "syscalls". For the `access` function case, that would be `uk_syscall_r_access`, for the `stat` family function that would be `uk_syscall_r_stat`, `uk_syscall_r_fstat`, `uk_syscall_r_lstat` and this PR changes them accordingly.

Closes: #635 

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>
