### PR TITLE
lib/posix-socket: Add UK_LIBC_SYSCALLS guard around send() and recv()

### DIFF
--- a/lib/posix-socket/socket.c
+++ b/lib/posix-socket/socket.c
@@ -463,11 +463,13 @@ EXIT_ERR:
 	return ret;
 }
 
-/* Not a system call */
+#if UK_LIBC_SYSCALLS
+/* Provide wrapper (if not provided by Musl) or some other libc. */
 ssize_t recv(int sock, void *buf, size_t len, int flags)
 {
 	return recvfrom(sock, buf, len, flags, NULL, NULL);
 }
+#endif /* UK_LIBC_SYSCALLS */
 
 UK_TRACEPOINT(trace_posix_socket_recvmsg, "%d %p %d", int, struct msghdr*, int);
 UK_TRACEPOINT(trace_posix_socket_recvmsg_ret, "%d", int);
@@ -576,11 +578,13 @@ EXIT_ERR:
 	return ret;
 }
 
-/* Not a system call */
+#if UK_LIBC_SYSCALLS
+/* Provide wrapper (if not provided by Musl) or some other libc. */
 ssize_t send(int sock, const void *buf, size_t len, int flags)
 {
 	return sendto(sock, buf, len, flags, NULL, 0);
 }
+#endif /* UK_LIBC_SYSCALLS */
 
 UK_TRACEPOINT(trace_posix_socket_socketpair, "%d %d %d %p", int, int, int,
 	      int *);

--- a/lib/posix-socket/socket.c
+++ b/lib/posix-socket/socket.c
@@ -467,7 +467,7 @@ EXIT_ERR:
 /* Provide wrapper (if not provided by Musl) or some other libc. */
 ssize_t recv(int sock, void *buf, size_t len, int flags)
 {
-	return recvfrom(sock, buf, len, flags, NULL, NULL);
+	return uk_syscall_e_recvfrom(sock, buf, len, flags, NULL, NULL);
 }
 #endif /* UK_LIBC_SYSCALLS */
 
@@ -582,7 +582,7 @@ EXIT_ERR:
 /* Provide wrapper (if not provided by Musl) or some other libc. */
 ssize_t send(int sock, const void *buf, size_t len, int flags)
 {
-	return sendto(sock, buf, len, flags, NULL, 0);
+	return uk_syscall_e_sendto(sock, buf, len, flags, NULL, 0);
 }
 #endif /* UK_LIBC_SYSCALLS */
 


### PR DESCRIPTION
`send()` and `recv()` are defined as wrappers in `posix-socket` to be used in case they aren't already defined by a libc (such as Musl). Once a libc is used, there will be a conflict, since the libc would define the `send()` and `recv()` functions itself.

This commits adds a `#if UK_LIBC_SYSCALLS` guard around the two functions, such that they will be defined only when a libc is not present. If a libc (such as Musl) is present, the functions are masked out.
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]

### Additional configuration

Test this PR using Musl. You can use [these scripts](https://github.com/unikraft-upb/scripts/tree/main/musl).