### PR TITLE
lib/vfscore: Include `statfs_to_statvfs` in `UK_LIBC_SYSCALLS` guard

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1724,6 +1724,7 @@ UK_SYSCALL_R_DEFINE(int, fstatfs, int, fd, struct statfs*, buf)
 
 LFS64(fstatfs);
 
+#if UK_LIBC_SYSCALLS
 static int
 statfs_to_statvfs(struct statvfs *dst, struct statfs *src)
 {
@@ -1741,7 +1742,6 @@ statfs_to_statvfs(struct statvfs *dst, struct statfs *src)
 	return 0;
 }
 
-#if UK_LIBC_SYSCALLS
 int
 statvfs(const char *pathname, struct statvfs *buf)
 {
@@ -1757,9 +1757,7 @@ statvfs(const char *pathname, struct statvfs *buf)
 #endif
 
 LFS64(statvfs);
-#endif /* UK_LIBC_SYSCALLS */
 
-#if UK_LIBC_SYSCALLS
 int
 fstatvfs(int fd, struct statvfs *buf)
 {


### PR DESCRIPTION
The function `statfs_to_statvfs()` is only called from `statvfs()` and `fstatvfs()`, that are guarded by the `UK_LIBC_SYSCALLS` macro.

This commit adds `statfs_to_statvfs()` to the `UK_LIBC_SYSCALLS` guard. Apart from making sense, it also removes a unused function warning in the case `UK_LIBC_SYSCALLS` is not enabled.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s): [e.g. N/A]
 - Platform(s): [e.g. N/A]
 - Application(s): [e.g. N/A]