### PR TITLE
[RFC] include/uk: Remove ukarch_compare_exchange_sync

### DIFF
--- a/include/uk/arch/atomic.h
+++ b/include/uk/arch/atomic.h
@@ -76,15 +76,6 @@ extern "C" {
 #define ukarch_exchange_n(dst, v) \
 	__atomic_exchange_n(dst, v, __ATOMIC_SEQ_CST)
 
-#define ukarch_compare_exchange_sync(ptr, old, new)                            \
-	({                                                                     \
-		__typeof__(*ptr) stored = old;                                 \
-		__atomic_compare_exchange_n(                                   \
-		    ptr, &stored, new, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)  \
-		    ? new                                                      \
-		    : old;                                                     \
-	})
-
 #ifdef __cplusplus
 }
 #endif

--- a/plat/common/lcpu.c
+++ b/plat/common/lcpu.c
@@ -248,8 +248,8 @@ int lcpu_fn_enqueue(struct lcpu *lcpu, const struct ukplat_lcpu_func *fn)
 		return -EAGAIN;
 
 	/* It is empty, try to store the function */
-	if (ukarch_compare_exchange_sync(&lcpu->fn.fn, old_fn,
-					 fn->fn) != fn->fn)
+	if (!__atomic_compare_exchange_sync(&lcpu->fn.fn, &old_fn, fn->fn, 0,
+					    __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST))
 		return -EAGAIN;
 
 	/* We have acquired the slot! Also store the user argument.
@@ -434,9 +434,8 @@ int ukplat_lcpu_start(const __lcpuidx lcpuidx[], unsigned int *num, void *sp[],
 			continue;
 		}
 
-retry:
 		old = ukarch_load_n(&lcpu->state);
-
+	retry:
 		/* We ignore CPUs that are already started */
 		if (unlikely(old != LCPU_STATE_OFFLINE)) {
 			uk_pr_warn("Failed to start CPU 0x%lx: not offline\n",
@@ -451,8 +450,9 @@ retry:
 		 * was faster, we will return to the state comparison and
 		 * report that the CPU is not offline.
 		 */
-		if (ukarch_compare_exchange_sync((int *)&lcpu->state, old,
-						 new) != new)
+		if (!__atomic_compare_exchange_n((int *)&lcpu->state, &old, new,
+						 0, __ATOMIC_SEQ_CST,
+						 __ATOMIC_RELAXED))
 			goto retry;
 
 		UK_ASSERT(lcpu->state == LCPU_STATE_INIT);
@@ -515,8 +515,8 @@ static inline int lcpu_transition_safe(struct lcpu *lcpu, int incr)
 	 * just atomically in-/decrement the state. Otherwise, we might corrupt
 	 * the non-online state.
 	 */
+	old = ukarch_load_n(&lcpu->state);
 	do {
-		old = ukarch_load_n(&lcpu->state);
 
 		/* We must not change the state if the CPU is not online */
 		if (!lcpu_state_is_online(old))
@@ -527,8 +527,7 @@ static inline int lcpu_transition_safe(struct lcpu *lcpu, int incr)
 		new = old + incr;
 
 		UK_ASSERT(lcpu_state_is_online(new));
-	} while (ukarch_compare_exchange_sync((int *)&lcpu->state, old,
-					      new) != new);
+	} while (!__atomic_compare_exchange_n((int *)&lcpu->state, &old, new, 0, __ATOMIC_SEQ_CST, __ATOMIC_RELAXED));
 
 	return 1;
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
This macro had an unexpected semantic in case the comparison fails. In that case it returned the *old* instead of the *current* value. The builtin itself provides more sane semantics and therefore this also replaces all usages of the ukarch_compare_exchange_sync macro with the builtin itself.

As an alternative to this patch we could also fix the old macro and keep it as an abstraction layer. 
On the other hand we could also go further with this patch and also replace the other macros. These would also allow a more fine-grained memory ordering parameter.