### PR TITLE
lib/posix-process: Fix typecast warnings

### DIFF
--- a/lib/posix-socket/socket.c
+++ b/lib/posix-socket/socket.c
@@ -481,7 +481,7 @@ EXIT_ERR:
 /* Provide wrapper (if not provided by Musl) or some other libc. */
 ssize_t recv(int sock, void *buf, size_t len, int flags)
 {
-	return uk_syscall_e_recvfrom(sock, buf, len, flags, NULL, NULL);
+	return uk_syscall_e_recvfrom(sock, (long) buf, len, flags, (long) NULL, (long) NULL);
 }
 #endif /* UK_LIBC_SYSCALLS */
 
@@ -596,7 +596,7 @@ EXIT_ERR:
 /* Provide wrapper (if not provided by Musl) or some other libc. */
 ssize_t send(int sock, const void *buf, size_t len, int flags)
 {
-	return uk_syscall_e_sendto(sock, buf, len, flags, NULL, 0);
+	return uk_syscall_e_sendto(sock, (long) buf, len, flags, (long) NULL, 0);
 }
 #endif /* UK_LIBC_SYSCALLS */
 


### PR DESCRIPTION
The commits 3d5423 "lib/posix-socket: Use uk_syscall_e versions for recvfrom / sendto" created calls to `uk_syscall_e_recvfrom` and `uk_syscall_e_sendto`. It triggers build warnings because a typecast to `(long)` of the arguments was missing.

This commit fixes the warnings by using the `(long)` typecast.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

Use LWIP (and, thus, integrate `CONFIG_LIBPOSIX_SOCKET=y`).