### PR TITLE
 lib/uksched: Change occurences of `uk_thread_tcb_fini` to `uk_thread_uktcb_fini`

### DIFF
--- a/lib/uksched/thread.c
+++ b/lib/uksched/thread.c
@@ -451,7 +451,7 @@ void _uk_thread_struct_free_alloc(struct uk_thread *t)
 	/* Free memory that was allocated by us */
 	if (t->_mem.uktls_a && t->_mem.uktls) {
 #if CONFIG_LIBUKSCHED_TCB_INIT
-		uk_thread_tcb_fini(t, uk_thread_uktcb(t));
+		uk_thread_uktcb_fini(t, uk_thread_uktcb(t));
 #endif /* CONFIG_LIBUKSCHED_TCB_INIT */
 		uk_free(t->_mem.uktls_a, t->_mem.uktls);
 		t->_mem.uktls_a = NULL;
@@ -909,7 +909,7 @@ void uk_thread_release(struct uk_thread *t)
 
 #if CONFIG_LIBUKSCHED_TCB_INIT
 	if (tls_a && tls)
-		uk_thread_tcb_fini(t, uk_thread_uktcb(t));
+		uk_thread_uktcb_fini(t, uk_thread_uktcb(t));
 #endif /* CONFIG_LIBUKSCHED_TCB_INIT */
 	if (t->dtor)
 		t->dtor(t);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes a typo in which the function`uk_thread_uktcb_fini()`, as declared in the `tcb_impl.h` header, was incorrectly referred to as `uk_thread_tcb_fini()`.

A similar typo was found in `lib-musl`, which means this PR must be merged together with https://github.com/unikraft/lib-musl/pull/26.

Closes #658 

Signed-off-by: Eduard Vintilă <eduard.vintila47@gmail.com>
