### PR TITLE
lib/vfscore: Fix implicit declaration of `__lxstat`

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1598,6 +1598,8 @@ int __lxstat(int ver __unused, const char *pathname, struct stat *st)
 #endif
 
 LFS64(__lxstat);
+#else
+int __lxstat(int ver, const char *pathname, struct stat *st);
 #endif /* UK_LIBC_SYSCALLS */
 
 UK_SYSCALL_R_DEFINE(int, lstat, const char*, pathname, struct stat*, st)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

If the `UK_LIBC_SYSCALLS` macro is not set, then `__lxstat` is to be provided by the libc. Since `__lxstat` isn't actually part of any header file, we must include a forward declaration of the function in order to avoid any compile-time warnings.

Closes #659 

Signed-off-by: Eduard Vintilă <eduard.vintila47@gmail.com>
