### PR TITLE
lib/uktest: Change the printing function from printf to _uk_printk

### DIFF
--- a/lib/uktest/Config.uk
+++ b/lib/uktest/Config.uk
@@ -3,6 +3,7 @@ menuconfig LIBUKTEST
 	default n
 	select LIBNOLIBC if !HAVE_LIBC
 	select LIBUKDEBUG
+	select LIBUKDEBUG_PRINTK
 
 if LIBUKTEST
 

--- a/lib/uktest/include/uk/test.h
+++ b/lib/uktest/include/uk/test.h
@@ -200,10 +200,8 @@
 
 /* Custom print method. */
 #define uk_test_printf(fmt, ...)					\
-	printf("    "							\
-	       LVLC_TESTNAME ":"					\
-	       UK_ANSI_MOD_RESET "\t"					\
-	       fmt, ##__VA_ARGS__)
+	_uk_printk(KLVL_INFO, __NULL, __NULL, 0x0,			\
+	"\t" fmt, ##__VA_ARGS__)
 
 
 /**

--- a/lib/uktest/test.c
+++ b/lib/uktest/test.c
@@ -178,14 +178,14 @@ uk_testsuite_run(struct uk_testsuite *suite)
 #endif /* CONFIG_LIBUKTEST_LOG_STATS */
 
 #ifdef CONFIG_LIBUKTEST_LOG_TESTS
-		printf(LVLC_TESTNAME "test:" UK_ANSI_MOD_RESET
-		       " %s->%s",
-		       suite->name,
-		       esac->name);
+		_uk_printk(KLVL_INFO, __NULL, __NULL, 0x0,
+			(LVLC_TESTNAME "test:" UK_ANSI_MOD_RESET
+			" %s->%s"), suite->name, esac->name);
 		if (esac->desc != NULL)
-			printf(": %s\n", esac->desc);
+			_uk_printk(KLVL_INFO, __NULL, __NULL, 0x0, ": %s\n",
+			esac->desc);
 		else
-			printf("\n");
+			_uk_printk(KLVL_INFO, __NULL, __NULL, 0x0, "\n");
 #endif /* CONFIG_LIBUKTEST_LOG_TESTS */
 
 		esac->func(esac);


### PR DESCRIPTION
This commit changes the printing function of uktest from printf _uk_printk. This is needed because with the new musl changes the printf will be dependent of the tcb intialisation. This causes a problem when trying to run uktests before the tcb initialisation, like the sanity tests of uktest.

Signed-off-by: Florin Postolache <florin.postolache80@gmail.com>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
