### PR TITLE
build: Enable build argument file for all build rules

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -180,12 +180,6 @@ if RECORD_BUILDTIME
 	endchoice
 endif
 
-config BUILD_ARGS_FILE
-	bool "Use file for long build arguments"
-	default n
-	help
-		Uses a file to pass long arguments to the build commands.
-
 config CROSS_COMPILE
 	string "Custom cross-compiler tool prefix (optional)"
 	help

--- a/Makefile
+++ b/Makefile
@@ -1077,3 +1077,9 @@ help:
 	@echo ''
 
 endif #umask
+
+# This is used to detect if a makefile macro expansion is immediate or deferred.
+# As the last statement in the main makefile, this is read in the end of the
+# immediate expansion phase. Therefore, UK_DEFERRED_EXPANSION is expanded to a
+# empty string in immediate expansion and to 'y' in a deferred expansion.
+UK_DEFERRED_EXPANSION := y

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -99,3 +99,4 @@ endif
 ASFLAGS-$(call have_clang)     += -mllvm -asm-macro-max-nesting-depth=1000
 COMPFLAGS-$(call have_clang)	+= -fno-builtin -fno-PIC
 LDFLAGS-$(call have_clang)	+= -no-pie
+

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -252,30 +252,29 @@ verbose_cmd = @printf '  %-7s %s\n' '$(1)'  '$(2)' && $(3)
 verbose_cmd_inner = printf '  %-7s %s\n' '$(1)'  '$(2)' && $(3)
 endif
 
-# Writes arguments into a build_args file
+# Writes to a file during deferred expansion
 #
-# write_build_args $target,$longargs(optional)
-ifeq ($(CONFIG_BUILD_ARGS_FILE),y)
-write_build_args = $(if $(2),$(file > $(addsuffix .build_args,$(1)),$(2))@$(addsuffix .build_args,$(1)),)
-else
-write_build_args = $(2)
-endif
+# write_file_deferred $filepath,$content
+write_file_deferred = $(if $(UK_DEFERRED_EXPANSION),$(file > $(1),$(2)),$$(file > $(1),$(2)))
 
 # Calls a command that creates an object
 #
-# build_cmd $quietlabel,$libname(optional),$target,$command,$longargs(optional)
+# build_cmd $quietlabel,$libname(optional),$target,$command
 ifeq ($(CONFIG_RECORD_BUILDTIME_TIME),y)
 define build_cmd =
-$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)),$(TIME) $(TIMEFLAGS) -o $(addsuffix .time,$(3)) $(4) $(call write_build_args,$(3),$(5)))
+$(call write_file_deferred,$(addsuffix .cmd,$(3)),$(strip $(4)))\
+$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)),$(TIME) $(TIMEFLAGS) -o $(addsuffix .time,$(3)) $(SHELL) $(addsuffix .cmd,$(3)))
 endef
 else
 ifeq ($(CONFIG_RECORD_BUILDTIME_LIFTOFF),y)
 define build_cmd =
-$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)),$(LIFTOFF) $(LITFOFFFLAGS) -o $(addsuffix .liftoff,$(3)) -- $(4) $(call write_build_args,$(3),$(5)))
+$(call write_file_deferred,$(addsuffix .cmd,$(3)),$(strip $(4)))\
+$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)),$(LIFTOFF) $(LITFOFFFLAGS) -o $(addsuffix .liftoff,$(3)) -- $(SHELL) $(addsuffix .cmd,$(3)))
 endef
 else
 define build_cmd =
-$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)),$(4) $(call write_build_args,$(3),$(5)))
+$(call write_file_deferred,$(addsuffix .cmd,$(3)),$(strip $(4)))\
+$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)), $(SHELL) $(addsuffix .cmd,$(3)))
 endef
 endif
 endif
@@ -290,7 +289,7 @@ tmp_depfile = $(dir $1).$(notdir $1).d
 depflags = -Wp$(comma)-MD$(comma)$(call tmp_depfile,$(1))
 define build_cmd_fixdep =
 	$(call build_cmd,$1,$2,$3,$4)
-	$Q $(UK_FIXDEP) $(call tmp_depfile,$3) $3 '$(call strip,$4)' \
+	$Q $(UK_FIXDEP) $(call tmp_depfile,$3) $3 '$(SHELL) $(addsuffix .cmd,$(3))' \
 		> $(call out2dep,$3) && \
 		$(RM) $(call tmp_depfile,$3)
 endef
@@ -298,15 +297,12 @@ endef
 # Returns a list of files to be cleaned when build_cmd was used
 #
 # build_clean $target
-build_clean = $(1)
+build_clean = $(1) $(addsuffix .cmd,$(1))
 ifeq ($(CONFIG_RECORD_BUILDTIME_TIME),y)
 build_clean += $(addsuffix .time,$(1))
 endif
 ifeq ($(CONFIG_RECORD_BUILDTIME_LIFTOFF),y)
 build_clean += $(addsuffix .liftoff,$(1))
-endif
-ifeq ($(CONFIG_BUILD_ARGS_FILE),y)
-build_clean += $(addsuffix .build_args,$(1))
 endif
 
 # Helper that generates a command for validating a checksum for
@@ -886,8 +882,7 @@ $(call libname2preolib,$(1)): $($(call vprefix_lib,$(1),OBJS)) \
 			      $($(call vprefix_lib,$(1),DTB)) \
 			      $($(call vprefix_lib,$(1),DTB-y))
 	$(call build_cmd,LD,,$(call libname2preolib,$(1)),\
-		$(LD),\
-		      $(LIBLDFLAGS) $(LIBLDFLAGS-y) \
+		$(LD) $(LIBLDFLAGS) $(LIBLDFLAGS-y) \
 		      $($(call vprefix_lib,$(1),LDFLAGS)) \
 		      $($(call vprefix_lib,$(1),LDFLAGS-y)) \
 		      $($(call vprefix_lib,$(1),OBJS)) \

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -869,44 +869,44 @@ endef
 
 # buildrule_olib $libname
 define buildrule_olib =
-$(call libname2preolib,$(1)): $($(call vprefix_lib,$(1),OBJS)) \
-			      $($(call vprefix_lib,$(1),OBJS-y)) \
-			      $(EACHOLIB_OBJS) \
-			      $(EACHOLIB_OBJS-y) \
-			      $($(call vprefix_lib,$(1),ALIBS)) \
-			      $($(call vprefix_lib,$(1),ALIBS-y)) \
-			      $(EACHOLIB_ALIBS) \
-			      $(EACHOLIB_ALIBS-y) \
-			      $($(call vprefix_lib,$(1),LDS)) \
-			      $($(call vprefix_lib,$(1),LDS-y)) \
-			      $($(call vprefix_lib,$(1),DTB)) \
-			      $($(call vprefix_lib,$(1),DTB-y))
+$(call libname2preolib,$(1)): $$($(call vprefix_lib,$(1),OBJS)) \
+			      $$($(call vprefix_lib,$(1),OBJS-y)) \
+			      $$(EACHOLIB_OBJS) \
+			      $$(EACHOLIB_OBJS-y) \
+			      $$($(call vprefix_lib,$(1),ALIBS)) \
+			      $$($(call vprefix_lib,$(1),ALIBS-y)) \
+			      $$(EACHOLIB_ALIBS) \
+			      $$(EACHOLIB_ALIBS-y) \
+			      $$($(call vprefix_lib,$(1),LDS)) \
+			      $$($(call vprefix_lib,$(1),LDS-y)) \
+			      $$($(call vprefix_lib,$(1),DTB)) \
+			      $$($(call vprefix_lib,$(1),DTB-y))
 	$(call build_cmd,LD,,$(call libname2preolib,$(1)),\
-		$(LD) $(LIBLDFLAGS) $(LIBLDFLAGS-y) \
-		      $($(call vprefix_lib,$(1),LDFLAGS)) \
-		      $($(call vprefix_lib,$(1),LDFLAGS-y)) \
-		      $($(call vprefix_lib,$(1),OBJS)) \
-		      $($(call vprefix_lib,$(1),OBJS-y)) \
-		      $(EACHOLIB_OBJS) \
-		      $(EACHOLIB_OBJS-y) \
+		$(LD) $$(LIBLDFLAGS) $$(LIBLDFLAGS-y) \
+		      $$($(call vprefix_lib,$(1),LDFLAGS)) \
+		      $$($(call vprefix_lib,$(1),LDFLAGS-y)) \
+		      $$($(call vprefix_lib,$(1),OBJS)) \
+		      $$($(call vprefix_lib,$(1),OBJS-y)) \
+		      $$(EACHOLIB_OBJS) \
+		      $$(EACHOLIB_OBJS-y) \
 		      -Wl$(comma)--start-group \
-		      $($(call vprefix_lib,$(1),ALIBS)) \
-		      $($(call vprefix_lib,$(1),ALIBS-y)) \
-		      $(EACHOLIB_ALIBS) \
-		      $(EACHOLIB_ALIBS-y) \
+		      $$($(call vprefix_lib,$(1),ALIBS)) \
+		      $$($(call vprefix_lib,$(1),ALIBS-y)) \
+		      $$(EACHOLIB_ALIBS) \
+		      $$(EACHOLIB_ALIBS-y) \
 		      -Wl$(comma)--end-group \
 		      -o $(call libname2preolib,$(1)))
 
 $(call libname2olib,$(1)): $(call libname2preolib,$(1)) \
-			   $($(call vprefix_lib,$(1),EXPORTS)) $($(call vprefix_lib,$(1),EXPORTS-y)) \
-			   $($(call vprefix_lib,$(1),LOCALS)) $($(call vprefix_lib,$(1),LOCALS-y)) \
-			   $(EACHOLIB_LOCALS) $(EACHOLIB_LOCALS-y)
+			   $$($(call vprefix_lib,$(1),EXPORTS)) $$($(call vprefix_lib,$(1),EXPORTS-y)) \
+			   $$($(call vprefix_lib,$(1),LOCALS)) $$($(call vprefix_lib,$(1),LOCALS-y)) \
+			   $$(EACHOLIB_LOCALS) $$(EACHOLIB_LOCALS-y)
 	$(call build_cmd,OBJCOPY,,$(call libname2olib,$(1)),\
-		$(OBJCOPY) $(addprefix --keep-global-symbols=,$($(call vprefix_lib,$(1),EXPORTS)) $($(call vprefix_lib,$(1),EXPORTS-y))) \
-			   $(addprefix --localize-symbols=,$($(call vprefix_lib,$(1),LOCALS)) $($(call vprefix_lib,$(1),LOCALS-y))) \
-			   $(addprefix --localize-symbols=,$(EACHOLIB_LOCALS) $(EACHOLIB_LOCALS-y)) \
-		           $(OBJCFLAGS) $(OBJCFLAGS-y) \
-		           $($(call vprefix_lib,$(1),OBJCFLAGS)) $($(call vprefix_lib,$(1),OBJCFLAGS-y)) \
+		$(OBJCOPY) $$(addprefix --keep-global-symbols=,$$($(call vprefix_lib,$(1),EXPORTS)) $$($(call vprefix_lib,$(1),EXPORTS-y))) \
+			   $$(addprefix --localize-symbols=,$$($(call vprefix_lib,$(1),LOCALS)) $$($(call vprefix_lib,$(1),LOCALS-y))) \
+			   $$(addprefix --localize-symbols=,$$(EACHOLIB_LOCALS) $$(EACHOLIB_LOCALS-y)) \
+		           $$(OBJCFLAGS) $$(OBJCFLAGS-y) \
+		           $$($(call vprefix_lib,$(1),OBJCFLAGS)) $$($(call vprefix_lib,$(1),OBJCFLAGS-y)) \
 			   $(call libname2preolib,$(1)) $(call libname2olib,$(1)))
 
 $(eval $(call vprefix_lib,$(1),CLEAN-y) += $(call build_clean,$(call libname2preolib,$(1))))


### PR DESCRIPTION
This PR is a continuation of https://github.com/unikraft/unikraft/pull/619

An big amount of includes directories files can **potentially** lead to problems if paired with a long path to the application directory:
```
make[2]: execvp: /bin/bash: Argument list too long
```
This PR makes changes that enable reading command line arguments from build tools that support it.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s):
 - Platform(s):
 - Application(s):

### Additional configuration

- Reconfigure to enable the config build option `BUILD_ARGS_FILE` by checking `Build Options  ---> Use file for long build arguments`

### Description of changes

This PR:
- adds the longargs parameter to `build_cmd_fixdep`
- uses the longargs command to in all relevant buildrules and removes the secondary expansion (e48f9653922679cb6ae230faa90c22f989a0bbbb) as arguments need to by known when they are written into the file

Known problems with possible solutions:
- the longargs parameter is not part of the fixdep command line, which could potentially break fixdepth
   - needs register all changes to the commandline -> maybe add hash of the `build_args` file
- secondary expansion (e48f9653922679cb6ae230faa90c22f989a0bbbb) is removed, which may cause issues
    - look if secondary expansion is necessary
    - write arguments only during secondary expansion if that is possible

Alternatives and their problems:
- use relative paths
   - absolute paths can come from any library, not a central point in the build system
   - libraries could potentially be outside the "common" root directory and still introduce long paths