### PR TITLE
build: Check doc comments when compiling with clang

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -12,6 +12,7 @@ ifneq ($(HAVE_STACKPROTECTOR),y)
 COMPFLAGS    += -fno-stack-protector
 endif
 COMPFLAGS    += -Wall -Wextra
+COMPFLAGS-$(call have_clang)	+= -Wdocumentation -Wdocumentation-pedantic
 
 ASFLAGS      += -D__ASSEMBLY__
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

This requires using clang as the C compiler.

### Description of changes

The diagnostic can check for various issues related to doxygen documentation comments. A list of detectable issues can be found at \[1\].

\[1\]: https://clang.llvm.org/docs/DiagnosticsReference.html#wdocumentation

<!--
Please provide a detailed description of the changes made in this new PR.
-->
