### PR TITLE
lib/posix-socket: Fix returning error codes

### DIFF
--- a/lib/posix-socket/socket_vnops.c
+++ b/lib/posix-socket/socket_vnops.c
@@ -287,7 +287,7 @@ posix_socket_vfscore_ioctl(struct vnode *vnode,
 	if (unlikely(ret < 0)) {
 		PSOCKET_ERR("ioctl on socket %d failed: %d\n", fp->fd,
 			    (int)ret);
-		ret = -ret;
+		return -ret;
 	}
 
 	return 0;
@@ -305,12 +305,10 @@ static int posix_socket_vfscore_poll(struct vnode *vnode, unsigned int *revents,
 	sock = (struct posix_socket_file *)vnode->v_data;
 
 	ret = posix_socket_poll(sock, revents, ecb);
-	if (ret < 0)
-		return -ret;
 	if (unlikely(ret < 0)) {
 		PSOCKET_ERR("poll on socket %d failed: %d\n",
 			    sock->vfs_file->fd, (int)ret);
-		ret = -ret;
+		return -ret;
 	}
 
 	return 0;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:
-->

 - `CONFIG_LIBPOSIX_SOCKET=y`


### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
For ioctl the error code was not returned at all. Poll had two error checks and the second check was dead code.
