### PR TITLE
lib/vfscore: Fix stdio.c build warning

### DIFF
--- a/lib/vfscore/stdio.c
+++ b/lib/vfscore/stdio.c
@@ -44,6 +44,17 @@
 #include <vfscore/mount.h>
 #include <errno.h>
 
+/*
+ * When the syscall_shim library is not part of the build, there is warning
+ * of implicit declaration of uk_syscall_r_dup2.
+ * This declaration takes care of that when the syscall_shim library is not
+ * part of the build.
+ */
+
+#if !CONFIG_LIBSYSCALL_SHIM
+long uk_syscall_r_dup2(long oldfd, long newfd);
+#endif /* !CONFIG_LIBSYSCALL_SHIM */
+
 static int __write_fn(void *dst __unused, void *src, size_t *cnt)
 {
 	int ret = ukplat_coutk(src, *cnt);


### PR DESCRIPTION
When `lib/vfscore` is part of the build, but `lib/syscall_shim` isn't, there is a warning of implicit declaration of `uk_syscall_r_dup2` in `lib/vfscore/stdio.c`.

This commit takes care of the warning by declaring `uk_syscall_r_dup2` when the syscall shim is not part of the build.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

Use `lib/vfscore` (i.e. enable `CONFIG_LIBVFSCORE=y`) but do not use `lib/syscall_shim` (i.e. `CONFIG_LIBSYSCALL_SHIM=n`).
