### PR TITLE
virtio-net fixes

### DIFF
--- a/plat/drivers/virtio/virtio_net.c
+++ b/plat/drivers/virtio/virtio_net.c
@@ -1152,6 +1152,9 @@ static int virtio_net_start(struct uk_netdev *n)
 	virtio_dev_drv_up(d->vdev);
 	uk_pr_info(DRIVER_NAME": %"__PRIu16" started\n", d->uid);
 
+	for (i = 0; i < d->rx_vqueue_cnt; i++)
+		virtqueue_host_notify(d->rxqs[i].vq);
+
 	return 0;
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

N/A

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR proposes a couple small fixes to the `virtio-net` driver:

- A fix for the `VIRTIO_NET_F_MTU` feature flag check;
- A fix for notifying the virtio-net device of available RX buffers upon driver start.