### PR TITLE
lib/vfscore: Fix `getdents` count unit

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1086,7 +1086,7 @@ UK_SYSCALL_R_DEFINE(int, getdents, int, fd, struct dirent*, dirp,
 	struct dirent entry, *result;
 	int error;
 
-	do {
+	while ((i + 1) * sizeof(struct dirent) <= count) {
 		error = readdir_r(&dir, &entry, &result);
 		if (error) {
 			trace_vfs_getdents_err(error);
@@ -1102,7 +1102,7 @@ UK_SYSCALL_R_DEFINE(int, getdents, int, fd, struct dirent*, dirp,
 		} else
 			break;
 
-	} while (i < count);
+	}
 
 	return (i * sizeof(struct dirent));
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

N/A

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

libc expects the `count` parameter of `getdents` to represent the output buffer size.  Unikraft instead uses this as the number of directory entries to fill, significantly overfilling the output buffer.  This commit fixes `getdents` to use the correct interpretation of `count`.

A simple way to reproduce this problem is to list a directory with a few dozen files, preferably several times.