### PR TITLE
lib/posix-info: Comment out unused sysinfo buffer

### DIFF
--- a/lib/posix-sysinfo/include/sys/sysinfo.h
+++ b/lib/posix-sysinfo/include/sys/sysinfo.h
@@ -45,8 +45,8 @@ struct sysinfo {
 	unsigned short procs, pad;
 	unsigned long totalhigh;
 	unsigned long freehigh;
-	unsigned mem_unit;
-	char __reserved[256];
+	unsigned int mem_unit;
+	char _f[20-2*sizeof(unsigned long)-sizeof(unsigned int)];
 };
 
 int sysinfo (struct sysinfo *);


### PR DESCRIPTION
The sysinfo structure defines the `reserved` buffer. This is however not present on Linux, meaning that binary-compatibile applications use a shorter buffer. This results in a buffer overflow when transferring information from Unikraft to the buffer in binary-compatible app.

This commit fixes this by commenting out the `reserved` buffer in the `sysinfo` structure.

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [`kvm`]
 - Application(s): [binary-compatible applications using `sysconf()`]

### Additional configuration

Use `CONFIG_LIBPOSIX_SYSINFO` in binary compatibility mode. You can run [this binary application](https://github.com/unikraft/static-pie-apps/tree/master/small/sysconf) under binary compatibility mode.