### PR TITLE
lib/nolibc: Use Linux-compatible stat structure

### DIFF
--- a/lib/nolibc/include/sys/stat.h
+++ b/lib/nolibc/include/sys/stat.h
@@ -20,6 +20,16 @@ extern "C" {
 
 #include <nolibc-internal/shareddefs.h>
 
+/*
+ * Imported from Musl (arch/x86_64/bits/stat.h)
+ *
+ * Copied from kernel definition, but with padding replaced
+ * by the corresponding correctly-sized userspace types.
+ *
+ * FIXME: This structure is defined for x86_64. On Musl, the ARM layout
+ * is different.
+ */
+
 struct stat {
 	dev_t st_dev;
 	ino_t st_ino;
@@ -37,6 +47,7 @@ struct stat {
 	struct timespec st_atim;
 	struct timespec st_mtim;
 	struct timespec st_ctim;
+	long unused[3];
 };
 
 #define st_atime st_atim.tv_sec


### PR DESCRIPTION
Use fields and field types for nolibc `stat` structure to make it compatible with Linux. It is required for binary compatibility mode.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]

### Additional configuration

You can test it in binary compatibility mode with a binary Linux application such as [this](https://github.com/unikraft/static-pie-apps/tree/master/small/stat).