### PR TITLE
build: Introduce command line parameter `N` for setting `UK_NAME`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,9 +243,6 @@ else
 export UK_FULLVERSION := $(UK_VERSION).$(UK_SUBVERSION)$(shell cd $(CONFIG_UK_BASE); $(SCRIPTS_DIR)/gitsha1)
 endif
 
-# Default image name
-export CONFIG_UK_NAME ?= $(notdir $(APP_DIR))
-
 export DATE := $(shell date +%Y%m%d)
 
 # Makefile targets
@@ -351,8 +348,17 @@ UK_HAVE_DOT_CONFIG := y
 endif
 endif
 
+# parameter N: UK_NAME ###
+# # Use N variable if set on the command line, otherwise use directory name
+ifeq ("$(origin N)", "command line")
+CONFIG_UK_NAME := $(N)
+else
+CONFIG_UK_NAME ?= $(notdir $(APP_DIR))
+endif
+
 # remove quotes from CONFIG_UK_NAME
 CONFIG_UK_NAME := $(call qstrip,$(CONFIG_UK_NAME))
+export CONFIG_UK_NAME
 
 ################################################################################
 # Host compiler and linker tools
@@ -1064,6 +1070,8 @@ help:
 	@echo '  C=[PATH]               - path to .config configuration file'
 	@echo '  O=[PATH]               - path to build output (will be created if it does not exist)'
 	@echo '  A=[PATH]               - path to Unikraft application'
+	@echo '  N=[NAME]               - use NAME as image name instead the one found in the configuration'
+	@echo '                           (note: the name in the configuration file is not overwritten)'
 	@echo '  L=[PATH]:[PATH]:..     - colon-separated list of paths to external libraries'
 	@echo '  P=[PATH]:[PATH]:..     - colon-separated list of paths to external platforms'
 	@echo ''


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

N/A

### Description of changes

This PR introduces a new command-line argument which can be used to overwrite the value of `CONFIG_UK_NAME` such that the resulting images have an easily settable name.

It can be used as following:

```shell
make -C path/to/unikraft A=$(pwd) N=appname
```

`N` will subsequently be evaluated into `CONFIG_UK_NAME` and `CONFIG_UK_DEFNAME`.