### PR TITLE
arch/x86_64: Align the stack to 16 bytes

### DIFF
--- a/arch/x86/x86_64/include/uk/asm/ctx.h
+++ b/arch/x86/x86_64/include/uk/asm/ctx.h
@@ -39,7 +39,7 @@
 		__sp__;					\
 	})
 
-#define UKARCH_SP_ALIGN		(1 << 1)
+#define UKARCH_SP_ALIGN		(1 << 4)
 #define UKARCH_SP_ALIGN_MASK	(UKARCH_SP_ALIGN - 1)
 
 #define ukarch_gen_sp(base, len)					\


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

The System V x86_64 ABI mandates that the stack must be aligned to 16 bytes. Recent compilers have much more aggressive auto-vectorizers and will also use SIMD instructions to set multiple values on the stack with one instruction. If the stack is not aligned to 16 bytes, the processor will generate a general protection fault. This changes the alignment to the correct 16 bytes.


<!--
Please provide a detailed description of the changes made in this new PR.
-->
