### PR TITLE
Makefile: Add flags for cross-compiler `LLVM` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -634,6 +634,13 @@ CC_VER_MAJOR   := $(word 2,$(subst ., ,$(CC_INFO)))
 CC_VER_MINOR   := $(word 3,$(subst ., ,$(CC_INFO)))
 CC_VERSION     := $(CC_VER_MAJOR).$(CC_VER_MINOR)
 
+ifeq ($(call have_clang),y)
+ifeq ("$(ARCH)", "arm64")
+ARCHFLAGS             += --target=aarch64-none-elf
+ISR_ARCHFLAGS         += --target=aarch64-none-elf
+endif
+endif
+
 ASFLAGS		+= -DCC_VERSION=$(CC_VERSION)
 CFLAGS		+= -DCC_VERSION=$(CC_VERSION)
 CXXFLAGS	+= -DCC_VERSION=$(CC_VERSION)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `AArch64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

- Download the cross-compiling toolchain. Get it from [the official ARM developer website](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads); look out for the `AArch64 bare-metal target (aarch64-none-elf)`.

- Disable all erratum options from `Architecture Selection` -> `Arm8 Compatible` -> `Workaround for [...] erratum` (for now, until #949 gets upstreamed)

- Build your app:
```console
make CC=clang CROSS_COMPILE=~/toolchains/gcc-arm-11.2-2022.02-x86_64-aarch64-none-elf/bin/aarch64-none-elf-
```

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
If one wishes to compile an app using `clang`, for instance, they would have to choose the  `Custom cross-compiler LLVM target` option from the make build system, and manually set the flags.

This commit adds flags needed for cross-compiling with `clang` for `AArch64`.
Instead of the extra step of filling in the cross-compiler in the `Custom cross-compiler LLVM target` field, we harcode it to be `aarch64-none-elf`, which with `clang`, works like a charm (it doesn't get a trap due to the `emutls` issue - https://github.com/unikraft/docs/issues/153).

Fixes: #921

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>
