### PR TITLE
lib/uksched: Fix race condition during context switch

### DIFF
--- a/lib/uksched/include/uk/thread.h
+++ b/lib/uksched/include/uk/thread.h
@@ -141,6 +141,14 @@ struct uk_thread *uk_thread_current(void)
 #define UK_THREADF_UKTLS      (0x002)	/**< Unikraft allocated TLS */
 #define UK_THREADF_RUNNABLE   (0x004)
 #define UK_THREADF_EXITED     (0x008)
+/*
+ *  A flag used for marking that a thread could potentially
+ *  be added to the run queue. A thread marked as such must
+ *  neither be running (except when it's about to be scheduled
+ *  out from the CPU during a context switch), nor be already
+ *  present in the run queue.
+ */
+#define UK_THREADF_QUEUEABLE  (0x010)
 
 #define uk_thread_is_exited(t)   ((t)->flags & UK_THREADF_EXITED)
 #define uk_thread_is_runnable(t) (!uk_thread_is_exited(t) \
@@ -148,11 +156,16 @@ struct uk_thread *uk_thread_current(void)
 #define uk_thread_is_blocked(t)  ((t)->flags &				\
 				  (UK_THREADF_EXITED | UK_THREADF_RUNNABLE) == \
 				  0x0)
+#define uk_thread_is_queueable(t) ((t)->flags & UK_THREADF_QUEUEABLE)
 
 #define uk_thread_set_runnable(t) \
 	do { (t)->flags |= UK_THREADF_RUNNABLE; } while (0)
 #define uk_thread_set_blocked(t) \
 	do { (t)->flags &= ~UK_THREADF_RUNNABLE; } while (0)
+#define uk_thread_set_queueable(t) \
+	do { (t)->flags |= UK_THREADF_QUEUEABLE; } while (0)
+#define uk_thread_clear_queueable(t) \
+	do { (t)->flags &= ~UK_THREADF_QUEUEABLE; } while (0)
 /* NOTE: Setting a thread as EXITED cannot be undone. */
 /* NOTE: Never change the EXIT flag manually. Trnasition to exit state reqiures
  * the terminate funcrtiomns to be called.

--- a/lib/ukschedcoop/schedcoop.c
+++ b/lib/ukschedcoop/schedcoop.c
@@ -115,6 +115,16 @@ static void schedcoop_schedule(struct uk_sched *s)
 		next = &c->idle;
 	}
 
+	if (next != prev) {
+		/*
+		 * Queueable is used to cover the case when during a
+		 * context switch, the thread that is about to be
+		 * evacuated is interrupted and woken up.
+		 */
+		uk_thread_set_queueable(prev);
+		uk_thread_clear_queueable(next);
+	}
+
 	ukplat_lcpu_restore_irqf(flags);
 
 	/* Interrupting the switch is equivalent to having the next thread
@@ -168,8 +178,10 @@ static void schedcoop_thread_woken(struct uk_sched *s, struct uk_thread *t)
 
 	if (t->wakeup_time > 0)
 		UK_TAILQ_REMOVE(&c->sleep_queue, t, queue);
-	if (t != uk_thread_current() && uk_thread_is_runnable(t))
+	if (uk_thread_is_queueable(t) && uk_thread_is_runnable(t)) {
 		UK_TAILQ_INSERT_TAIL(&c->run_queue, t, queue);
+		uk_thread_clear_queueable(t);
+	}
 }
 
 static __noreturn void idle_thread_fn(void *argp)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`, `x86_64`
 - Platform(s): `kvm`
 - Application(s): `app-python3`, `app-redis`, `app-sqlite`


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The sched refactor effort introduced a race condition: if the current thread blocks and yields, and an interrupt is triggered right before the context switch, the interrupt handler tries to wake up the current thread.
The thread will remain blocked (potentially forever) until the next interrupt fires, because the current thread cannot be added to the run_queue list. The reason is that the condition `uk_thread_current() != t` is way too restrictive and does not cover the corner case where the current thread is just about to be evacuated.

This PR sets a flag on the current thread as soon as the next thread is scheduled. The interrupt will queue the current thread if it's also marked as queueable, in addition to it being runnable.

There was a similar commit (606f5f5) that was disregarded once the sched-refactoring work was upstreamed. This PR brings those changes up-to-date with the new API.

Github-Fixes: https://github.com/unikraft/unikraft/issues/643
Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>
Signed-off-by: Eduard Vintilă <eduard.vintila47@gmail.com>