### PR TITLE
plat/x86: Improve unwind information for x86 architecture

### DIFF
--- a/arch/x86/x86_64/include/uk/asm/cfi.h
+++ b/arch/x86/x86_64/include/uk/asm/cfi.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2022, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+#ifndef __UKARCH_CFI_X86_64_H__
+#define __UKARCH_CFI_X86_64_H__
+
+#ifdef __ASSEMBLY__
+
+.macro pushq_cfi value
+	pushq \value
+	.cfi_adjust_cfa_offset 8
+.endm
+
+.macro pushq_reg_cfi reg
+	pushq %\reg
+	.cfi_adjust_cfa_offset 8
+	.cfi_rel_offset \reg, 0
+.endm
+
+.macro popq_reg_cfi reg
+	popq %\reg
+	.cfi_adjust_cfa_offset -8
+	.cfi_restore \reg
+.endm
+
+#else  /* !defined(__ASSEMBLY__) */
+
+#define ukarch_cfi_unwind_end() __asm__ (".cfi_undefined rip\n")
+
+#endif /* !defined(__ASSEMBLY__) */
+
+#endif /* __UKARCH_CFI_X86_64_H__ */

--- a/plat/common/x86/syscall.S
+++ b/plat/common/x86/syscall.S
@@ -32,39 +32,46 @@
  */
 
 #include <uk/arch/lcpu.h>
+#include <uk/asm/cfi.h>
 
 #define ENTRY(X) .globl X ; X :
 
 ENTRY(_ukplat_syscall)
+	.cfi_startproc simple
+	.cfi_def_cfa rsp, 0
+	.cfi_register rip, rcx
 	cli
 	/*
 	 * Push arguments in the order of 'struct __regs' to the stack.
 	 * We are going to handover a refernce to this stack area as
 	 * `struct __regs *` argument to the system call handler.
 	 */
-	pushq $0	/* exception frame filled with zeros */
-	pushq $0	/* (rip, cs, eflags, rsp, ss)        */
-	pushq $0	/*                                   */
-	pushq $0	/*                                   */
-	pushq $0	/*                                   */
-	pushq %rax 	/* orig_rax */
-	pushq %rdi
-	pushq %rsi
-	pushq %rdx
-	pushq %rcx
-	pushq %rax
-	pushq %r8
-	pushq %r9
-	pushq %r10
-	pushq %r11
-	pushq %rbx
-	pushq %rbp
-	pushq %r12
-	pushq %r13
-	pushq %r14
-	pushq %r15
+	pushq_cfi $0		/* exception frame filled with zeros */
+	pushq_cfi $0		/* (rip, cs, eflags, rsp, ss)        */
+	pushq_cfi $0		/*                                   */
+	pushq_cfi $0		/*                                   */
+	pushq_cfi $0		/*                                   */
+	pushq_reg_cfi rax	/* orig_rax */
+	pushq_reg_cfi rdi
+	pushq_reg_cfi rsi
+	pushq_reg_cfi rdx
+	pushq_reg_cfi rcx
+	.cfi_rel_offset rip, 0
+	pushq_reg_cfi rax
+	pushq_reg_cfi r8
+	pushq_reg_cfi r9
+	pushq_reg_cfi r10
+	pushq_reg_cfi r11
+	pushq_reg_cfi rbx
+	pushq_reg_cfi rbp
+	pushq_reg_cfi r12
+	pushq_reg_cfi r13
+	pushq_reg_cfi r14
+	pushq_reg_cfi r15
+
 	/* padding */
 	subq  $(__REGS_PAD_SIZE), %rsp
+	.cfi_adjust_cfa_offset __REGS_PAD_SIZE
 	sti
 
 	/*
@@ -81,32 +88,37 @@ ENTRY(_ukplat_syscall)
 	 */
 	movq %rsp, %rbp
 	and $~15, %rsp
+	.cfi_def_cfa_register rbp
 
 	call ukplat_syscall_handler
 
 	/* Restore original stack pointer */
 	movq %rbp, %rsp
+	.cfi_def_cfa_register rsp
 
 	cli
 	/* Load the updated state back to registers */
 	addq $(__REGS_PAD_SIZE), %rsp
-	popq %r15
-	popq %r14
-	popq %r13
-	popq %r12
-	popq %rbp
-	popq %rbx
-	popq %r11
-	popq %r10
-	popq %r9
-	popq %r8
-	popq %rax
-	popq %rcx
-	popq %rdx
-	popq %rsi
-	popq %rdi
+	.cfi_adjust_cfa_offset -__REGS_PAD_SIZE
+	popq_reg_cfi r15
+	popq_reg_cfi r14
+	popq_reg_cfi r13
+	popq_reg_cfi r12
+	popq_reg_cfi rbp
+	popq_reg_cfi rbx
+	popq_reg_cfi r11
+	popq_reg_cfi r10
+	popq_reg_cfi r9
+	popq_reg_cfi r8
+	popq_reg_cfi rax
+	popq_reg_cfi rcx
+	.cfi_register rip, rcx
+	popq_reg_cfi rdx
+	popq_reg_cfi rsi
+	popq_reg_cfi rdi
 	/* orig_rax and exception frame */
 	addq $(6 * 8), %rsp
+	.cfi_adjust_cfa_offset -(6 * 8)
 	sti
 
 	/*
@@ -118,3 +130,4 @@ ENTRY(_ukplat_syscall)
 	 *     Conference on Virtual Execution Environments (VEE 2019))
 	 */
 	jmp *%rcx
+	.cfi_endproc

--- a/plat/kvm/x86/cpu_vectors_x86_64.S
+++ b/plat/kvm/x86/cpu_vectors_x86_64.S
@@ -25,83 +25,118 @@
 /* Taken from solo5 */
 
 #include <x86/traps.h>
+#include <uk/asm/cfi.h>
 
 #define ENTRY(X)     .global X ; .type X, @function ; X:
 
 .macro PUSH_CALLER_SAVE
-	pushq %rdi
-	pushq %rsi
-	pushq %rdx
-	pushq %rcx
-	pushq %rax
-	pushq %r8
-	pushq %r9
-	pushq %r10
-	pushq %r11
-	pushq %rbx
-	pushq %rbp
-	pushq %r12
-	pushq %r13
-	pushq %r14
-	pushq %r15
+	pushq_reg_cfi rdi
+	pushq_reg_cfi rsi
+	pushq_reg_cfi rdx
+	pushq_reg_cfi rcx
+	pushq_reg_cfi rax
+	pushq_reg_cfi r8
+	pushq_reg_cfi r9
+	pushq_reg_cfi r10
+	pushq_reg_cfi r11
+	pushq_reg_cfi rbx
+	pushq_reg_cfi rbp
+	pushq_reg_cfi r12
+	pushq_reg_cfi r13
+	pushq_reg_cfi r14
+	pushq_reg_cfi r15
 .endm
 
 .macro POP_CALLER_SAVE
-	popq %r15
-	popq %r14
-	popq %r13
-	popq %r12
-	popq %rbp
-	popq %rbx
-	popq %r11
-	popq %r10
-	popq %r9
-	popq %r8
-	popq %rax
-	popq %rcx
-	popq %rdx
-	popq %rsi
-	popq %rdi
+	popq_reg_cfi r15
+	popq_reg_cfi r14
+	popq_reg_cfi r13
+	popq_reg_cfi r12
+	popq_reg_cfi rbp
+	popq_reg_cfi rbx
+	popq_reg_cfi r11
+	popq_reg_cfi r10
+	popq_reg_cfi r9
+	popq_reg_cfi r8
+	popq_reg_cfi rax
+	popq_reg_cfi rcx
+	popq_reg_cfi rdx
+	popq_reg_cfi rsi
+	popq_reg_cfi rdi
 .endm
 
 .macro TRAP_ENTRY trapname, has_ec
 ENTRY(ASM_TRAP_SYM(\trapname))
+	.cfi_startproc simple
+	.cfi_signal_frame
+	.cfi_def_cfa rsp, 0
+.if \has_ec
+	/* Error code is pushed on the stack after the return address */
+	.cfi_def_cfa_offset 16
+.else
+	/* There is only the return address on the stack */
+	.cfi_def_cfa_offset 8
+.endif
+	.cfi_offset rip, -8
+	/* Description of the stack with active IST */
+	.cfi_offset cs, 0
+	.cfi_offset rflags, 8
+	.cfi_offset rsp, 16
+	.cfi_offset ss, 24
 	cld
 
 .if !\has_ec
-	pushq $0                            /* no error code, pass 0 */
+	pushq_cfi $0                        /* no error code, pass 0 */
 .endif
 	PUSH_CALLER_SAVE
 	subq $__REGS_PAD_SIZE, %rsp         /* we have some padding */
+	.cfi_adjust_cfa_offset __REGS_PAD_SIZE
 
 	movq %rsp, %rdi
 	movq __REGS_OFFSETOF_ORIG_RAX(%rsp), %rsi
 	call do_\trapname
 
 	addq $__REGS_PAD_SIZE, %rsp         /* we have some padding */
+	.cfi_adjust_cfa_offset -__REGS_PAD_SIZE
 	POP_CALLER_SAVE
 	addq $8, %rsp                       /* discard error code */
+	.cfi_adjust_cfa_offset -8
 
 	iretq
+	.cfi_endproc
 .endm
 
 .macro IRQ_ENTRY irqno
 ENTRY(cpu_irq_\irqno)
+	.cfi_startproc simple
+	.cfi_signal_frame
+	.cfi_def_cfa rsp, 8
+	.cfi_offset rip, -8
+
+	/* Description of the stack with active IST */
+	.cfi_offset cs, 0
+	.cfi_offset rflags, 8
+	.cfi_offset rsp, 16
+	.cfi_offset ss, 24
 	cld
 
-	pushq $0                            /* no error code */
+	pushq_cfi $0                        /* no error code */
 	PUSH_CALLER_SAVE
 	subq $__REGS_PAD_SIZE, %rsp         /* we have some padding */
+	.cfi_adjust_cfa_offset __REGS_PAD_SIZE
 
 	movq %rsp, %rdi
 	movq $\irqno, %rsi
 	call _ukplat_irq_handle
 
 	addq $__REGS_PAD_SIZE, %rsp         /* we have some padding */
+	.cfi_adjust_cfa_offset -__REGS_PAD_SIZE
 	POP_CALLER_SAVE
 	addq $8, %rsp
+	.cfi_adjust_cfa_offset -8
 
 	iretq
+	.cfi_endproc
 .endm
 
 TRAP_ENTRY divide_error,     0

--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -11,6 +11,7 @@
 #include <uk/arch/limits.h>
 #include <uk/arch/types.h>
 #include <uk/arch/paging.h>
+#include <uk/asm/cfi.h>
 #include <uk/plat/console.h>
 #include <uk/assert.h>
 #include <uk/essentials.h>
@@ -287,6 +288,13 @@ static inline int cmdline_init(struct ukplat_bootinfo *bi)
 
 static void __noreturn _ukplat_entry2(void)
 {
+	/* It's not possible to unwind past this function, because the stack
+	 * pointer was overwritten in lcpu_arch_jump_to. Therefore, mark the
+	 * previous instruction pointer as undefined, so that debuggers or
+	 * profilers stop unwinding here.
+	 */
+	ukarch_cfi_unwind_end();
+
 	ukplat_entry_argp(NULL, cmdline, cmdline_len);
 
 	ukplat_lcpu_halt();


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Without this information debugging tools do not know how to properly unwind the _ukplat_syscall/interrupt/exception handler frames. For example, this causes them to output garbage output for back traces.


<!--
Please provide a detailed description of the changes made in this new PR.
-->
