### PR TITLE
plat/pci_ecam.c: Fix `gcc`-ism for `clang` compilation

### DIFF
--- a/plat/common/pci_ecam.c
+++ b/plat/common/pci_ecam.c
@@ -226,7 +226,7 @@ int gen_pci_irq_parse(const fdt32_t *addr, struct fdt_phandle_args *out_irq)
 	fdt32_t initial_match_array[16];
 	const fdt32_t *match_array = initial_match_array;
 	const fdt32_t *tmp, *imap, *imask;
-	const fdt32_t dummy_imask[] = { [0 ... 16] = cpu_to_fdt32(~0) };
+	fdt32_t dummy_imask[17];
 	int intsize, newintsize;
 	int addrsize, newaddrsize = 0;
 	int imaplen, match, i, rc = -EINVAL;
@@ -234,6 +234,7 @@ int gen_pci_irq_parse(const fdt32_t *addr, struct fdt_phandle_args *out_irq)
 	const fdt32_t *prop;
 
 	ipar = gen_pci_fdt;
+	memset((void *)dummy_imask, cpu_to_fdt32(~0), ARRAY_SIZE(dummy_imask));
 
 	/* First get the #interrupt-cells property of the current cursor
 	 * that tells us how to interpret the passed-in intspec. If there


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `AArch64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

- `CONFIG_LLVM_TARGET_ARCH`=`aarch64-none-elf`

- Download the cross-compiling toolchain. Get it from [the official ARM developer website](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads); look out for the `AArch64 bare-metal target (aarch64-none-elf)`.

- Disable all erratum options from `Architecture Selection` -> `Arm8 Compatible` -> `Workaround for [...] erratum`

- Configure the `Custom cross-compiler LLVM target` from `Build Options` -> `Custom cross-compiler LLVM target`; write `aarch64-none-elf`

- Build your app:
```console
make CC=clang LD=~/toolchains/gcc-arm-11.2-2022.02-x86_64-aarch64-none-elf/bin/aarch64-none-elf-gcc OBJCOPY=~/toolchains/gcc-arm-11.2-2022.02-x86_64-aarch64-none-elf/bin/aarch64-none-elf-objcopy STRIP=~/toolchains/gcc-arm-11.2-2022.02-x86_64-aarch64-none-elf/bin/aarch64-none-elf-strip
```

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR replaces a small `gcc`-ism from `plat/common/pci_ecam.c` that makes impossible any `clang` compilation on `AArch64`.

The `dummy_imask[] = { [0 ... 16] = cpu_to_fdt32(~0) };` syntax is a [GNU extension](https://gcc.gnu.org/onlinedocs/gcc/Designated-Inits.html), ergo, it is not recognized by LLVM's `clang` and was changed accordingly.

Depends-On: #685 

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>

