### PR TITLE
arch/arm64: Use ukarch_random_seed to seed MTE keys

### DIFF
--- a/arch/arm/arm64/memtag.c
+++ b/arch/arm/arm64/memtag.c
@@ -75,7 +75,7 @@ int ukarch_memtag_init(void)
 	if (ukarch_random_init())
 		UK_CRASH("Arch random not available\n");
 
-	if (ukarch_random_u64(&seed))
+	if (ukarch_random_seed_u64(&seed))
 		UK_CRASH("Could not generate MTE seed\n");
 
 #if CONFIG_ARM64_FEAT_MTE_TCF_ASYNC


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Generating seed values should be done using the ukarch_random_seed interface, as it provides values higher brute-force resistance than numbers generated by the DRBG-based output of ukarch_random.

Use ukarch_random_seed to populate RGSR_EL1.