### PR TITLE
lang/rust: Update rust version to latest nightly

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -22,7 +22,7 @@ GOCINCLUDES  += -I$(CONFIG_UK_BASE)/include
 
 RUSTCFLAGS-y	+= --emit=obj --crate-type=rlib --edition=2018 \
 		-Cpanic=abort -Cembed-bitcode=n \
-		-Zbinary_dep_depinfo=y -Zsymbol-mangling-version=v0 \
+		-Zbinary_dep_depinfo=y -Csymbol-mangling-version=v0 \
 		-Cforce-unwind-tables=n -Ccodegen-units=1 \
 		-Dunsafe_op_in_unsafe_fn -Drust_2018_idioms
 

--- a/lib/ukrust/Cargo.toml
+++ b/lib/ukrust/Cargo.toml
@@ -2,7 +2,7 @@
 license-file = "../../COPYING.md"
 name = "ukrust"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [profile.dev]
 panic = "abort"

--- a/lib/ukrust/Makefile.uk
+++ b/lib/ukrust/Makefile.uk
@@ -16,10 +16,10 @@ RUST_LIB_SRC ?= $(RUSTC_SYSROOT)/lib/rustlib/src/rust/library
 endif
 
 # Common flags
-LIBUKRUST_COMMON_FLAGS = --target=$(LIBUKRUST_BASE)/target.json --emit=dep-info,obj,metadata --edition=2018 \
+LIBUKRUST_COMMON_FLAGS = --target=$(LIBUKRUST_BASE)/target.json --emit=dep-info,obj,metadata --edition=2021 \
 	-Cpanic=abort -Cembed-bitcode=n -Clto=n -Crpath=n \
 	-Cforce-unwind-tables=n -Ccodegen-units=1 \
-	-Zbinary_dep_depinfo=y -Zsymbol-mangling-version=v0 \
+	-Zbinary_dep_depinfo=y -Csymbol-mangling-version=v0 \
 	-Dunsafe_op_in_unsafe_fn -Drust_2018_idioms \
 	--crate-type rlib
 

--- a/lib/ukrust/ukrust_sys/allocator.rs
+++ b/lib/ukrust/ukrust_sys/allocator.rs
@@ -79,3 +79,6 @@ pub fn __rust_alloc_zeroed(size: usize, _align: usize) -> *mut u8 {
 pub fn __rust_alloc_error_handler(_size: usize, _align: usize) -> ! {
     panic!("Alloc error handler");
 }
+
+#[no_mangle]
+static __rust_alloc_error_handler_should_panic: u8 = 1;

--- a/lib/ukrust/ukrust_sys/lib.rs
+++ b/lib/ukrust/ukrust_sys/lib.rs
@@ -35,8 +35,8 @@
     allocator_api,
     alloc_error_handler,
     associated_type_defaults,
-    const_fn_trait_bound,
     const_mut_refs,
+    lang_items,
     receiver_trait,
 )]
 use core;
@@ -47,7 +47,7 @@ pub mod c_types;
 
 #[alloc_error_handler]
 pub fn alloc_error(_layout: core::alloc::Layout) -> ! {
-        panic!("Alloc error");
+    panic!("Alloc error");
 }
 
 extern "C" {
@@ -59,4 +59,9 @@ fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
     unsafe {
         __ukrust_sys_crash();
     }
+}
+
+#[lang = "eh_personality"]
+#[no_mangle]
+pub extern fn rust_eh_personality() {
 }


### PR DESCRIPTION
Latest nightly compiler that this RP targets is: `rustc 1.68.0-nightly (388538fc9 2023-01-05)`

Signed-off-by: Fabian Patras <patras.fabi@gmail.com>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

Make sure to get the latest compiler version (and source files):
```
rustup update
rustup default nightly
rustup component add rust-src
```
### Description of changes