### PR TITLE
lib/vfscore: Fix `lstat()` infinite loop

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1604,8 +1604,7 @@ UK_TRACEPOINT(trace_vfs_lstat, "pathname=%s, stat=%p", const char*,
 UK_TRACEPOINT(trace_vfs_lstat_ret, "");
 UK_TRACEPOINT(trace_vfs_lstat_err, "errno=%d", int);
 
-#if UK_LIBC_SYSCALLS
-int __lxstat(int ver __unused, const char *pathname, struct stat *st)
+int __lxstat_helper(int ver __unused, const char *pathname, struct stat *st)
 {
 	struct task *t = main_task;
 	char path[PATH_MAX];
@@ -1631,6 +1630,12 @@ int __lxstat(int ver __unused, const char *pathname, struct stat *st)
 	return -error;
 }
 
+#if UK_LIBC_SYSCALLS
+int __lxstat(int ver __unused, const char *pathname, struct stat *st)
+{
+	return __lxstat_helper(1, pathname, st);
+}
+
 #ifdef __lxstat64
 #undef __lxstat64
 #endif
@@ -1642,7 +1647,7 @@ int __lxstat(int ver, const char *pathname, struct stat *st);
 
 UK_SYSCALL_R_DEFINE(int, lstat, const char*, pathname, struct stat*, st)
 {
-	return __lxstat(1, pathname, st);
+	return __lxstat_helper(1, pathname, st);
 }
 
 static int __fxstatat_helper(int ver __unused, int dirfd, const char *pathname,


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

Build a simple app (such as `helloworld`) on `x86` and call `lstat()`.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Including `musl` with even simple apps and attempting to call `lstat()` on `x86` results in an infinite loop due to `__lxstat()`, a helper function, existing in `musl` as well.

This PR changes the function called by `lstat()` in order to stop referencing `musl` by adding an extra wrapper, used by `__lxstat()` too. The change was made in order to be consistent to other implementations found in `vfscore`, such as [this one](https://github.com/unikraft/unikraft/blob/staging/lib/vfscore/main.c#L315).

Fixes: #652

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>
