### PR TITLE
Add virtio net multiqueue support

### DIFF
--- a/plat/drivers/include/virtio/virtio_bus.h
+++ b/plat/drivers/include/virtio/virtio_bus.h
@@ -106,7 +106,7 @@ struct virtio_config_ops {
 	__u8 (*status_get)(struct virtio_dev *vdev);
 	void (*status_set)(struct virtio_dev *vdev, __u8 status);
 	/** Find the virtqueue */
-	int (*vqs_find)(struct virtio_dev *vdev, __u16 num_vq, __u16 *vq_size);
+	int (*vq_find)(struct virtio_dev *vdev, __u16 vq_id, __u16 *vq_size);
 	/** Setup the virtqueue */
 	struct virtqueue *(*vq_setup)(struct virtio_dev *vdev, __u16 num_desc,
 				      __u16 queue_id,
@@ -268,25 +268,24 @@ static inline int virtio_config_get(struct virtio_dev *vdev, __u16 offset,
  * The helper function to find the number of the vqs supported on the device.
  * @param vdev
  *	A reference to the virtio device.
- * @param total_vqs
- *	The total number of virtqueues requested.
+ * @param vq_id
+ *	The virtqueue id whose size needs to be found out (0 to max_virqueues - 1)
  * @param vq_size
- *	An array of max descriptors on each virtqueue found on the
- *	virtio device
+ *	A reference to the virtq size, size of virt queue is stored in it
  * @return int
- *	On success, the function return the number of available virtqueues
+ *	On success, the function return 1 (The count of virtqueue found)
  *	On error,
  *		-ENOTSUP if the function is not supported.
  */
-static inline int virtio_find_vqs(struct virtio_dev *vdev, __u16 total_vqs,
+static inline int virtio_find_vq(struct virtio_dev *vdev, __u16 vq_id,
 				  __u16 *vq_size)
 {
 	int rc = -ENOTSUP;
 
 	UK_ASSERT(vdev);
 
-	if (likely(vdev->cops->vqs_find))
-		rc = vdev->cops->vqs_find(vdev, total_vqs, vq_size);
+	if (likely(vdev->cops->vq_find))
+		rc = vdev->cops->vq_find(vdev, vq_id, vq_size);
 
 	return rc;
 }

--- a/plat/drivers/include/virtio/virtio_net.h
+++ b/plat/drivers/include/virtio/virtio_net.h
@@ -80,6 +80,9 @@
 #define VIRTIO_NET_S_LINK_UP	1	/* Link is up */
 #define VIRTIO_NET_S_ANNOUNCE	2	/* Announcement is needed */
 
+/* Control queue hardware id: 2 * N */
+#define VIRTIO_NET_CTRLQ_ID(vndev) (2 * vndev->max_vqueue_pairs)
+
 struct virtio_net_config {
 	/* The config defining mac address (if VIRTIO_NET_F_MAC) */
 	__u8 mac[UK_NETDEV_HWADDR_LEN];

--- a/plat/drivers/virtio/virtio_9p.c
+++ b/plat/drivers/virtio/virtio_9p.c
@@ -296,7 +296,7 @@ static int virtio_9p_vq_alloc(struct virtio_9p_device *d)
 	int rc = 0;
 	__u16 qdesc_size;
 
-	vq_avail = virtio_find_vqs(d->vdev, 1, &qdesc_size);
+	vq_avail = virtio_find_vq(d->vdev, 0, &qdesc_size);
 	if (unlikely(vq_avail != 1)) {
 		uk_pr_err(DRIVER_NAME": Expected: %d queues, found %d\n",
 			  1, vq_avail);

--- a/plat/drivers/virtio/virtio_blk.c
+++ b/plat/drivers/virtio/virtio_blk.c
@@ -648,7 +648,10 @@ static int virtio_blkdev_queues_alloc(struct virtio_blk_device *vbdev,
 	}
 
 	vbdev->nb_queues = conf->nb_queues;
-	vq_avail = virtio_find_vqs(vbdev->vdev, conf->nb_queues, qdesc_size);
+
+	for (int i = 0; i < conf->nb_queues; i++)
+		vq_avail += virtio_find_vq(vbdev->vdev, i, &qdesc_size[i]);
+
 	if (unlikely(vq_avail != conf->nb_queues)) {
 		uk_pr_err("Expected: %d queues, Found: %d queues\n",
 				conf->nb_queues, vq_avail);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): x86_64, arm
 - Platform(s): kvm
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->
`CONFIG_LIBUKNETDEV_MAXNBQUEUES=10`

### Description of changes
Unikraft virtio net currently uses one transmit and receive queue pair.  But virtio-net device also offers the multiqueue support. We can request this feature by negotiating `VIRTIO_NET_F_MQ` feature bit and sending the `VIRTIO_NET_CTRL_MQ_VQ_PAIRS_SET`command on the control queue. This feature allows us to use the multiple receive and send queues. 
To allow this feature, we need to enable control queue feature too.  To make the control queue setup, possible I have done a small change in the interface of `virtio_find_vqs()`. This function now finds a single queue instead of finding the range of queues. This allows us to separately configure the control queue.
This PR involves the changes that are required to configure the control queue and send the command to device. This PR is not SMP safe but will introduce the multiqueue feature which we can use to improve the performance of netdevice during SMP support.

### How to run it
setup the bridge interface by referring to:  http://www.linux-kvm.org/page/Networking
You will also find qemu-ifup script in the above link, copy it to /etc/qemu-ifup and run following command.

`sudo qemu-system-x86_64 -device virtio-net-pci, mq=on,vectors=2N+2 -netdev tap,id=net0,script=/etc/qemu-ifup,queues=N -kernel path/to/build -nographic`

