### PR TITLE
area/docs: Replace kraft to kraftkit in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Unikraft supports the construction of multiple architectures, platforms, and ima
 
 ## Getting Started
 
-The fastest way to get started configuring, building and deploying Unikraft unikernels is to use our companion tool, [**kraft**][kraft].
+The fastest way to get started configuring, building and deploying Unikraft unikernels is to use our companion tool, [**kraftkit**][kraftkit].
 
-With kraft installed, you can download Unikraft components, configure your unikernel to your needs, build it and run it -- there's no need to be an expert!
+With `kraft` installed, you can download Unikraft components, configure your unikernel to your needs, build it and run it -- there's no need to be an expert!
 
 ## Contributing
 
@@ -108,7 +108,7 @@ Unikraft is licensed under a BSD-3-Clause.  For more information, please refer t
 [unikraft-security]: https://unikraft.org/docs/features/security/
 [unikraft-green]: https://unikraft.org/docs/features/green/
 [unikraft-discord]: https://bit.ly/UnikraftDiscord
-[kraft]: https://github.com/unikraft/kraft/
+[kraftkit]: https://github.com/unikraft/kraftkit/
 [github-issues]: https://github.com/unikraft/unikraft/issues
 [github-projects]: https://github.com/unikraft/unikraft/labels/kind/project
 [dockerhub-kraft]: https://hub.docker.com/r/unikraft/kraft

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The fastest way to get started configuring, building and deploying Unikraft unik
 
 You can quickly and easily install KraftKit using the interactive installer. Simply run the following command to get started:
 
-```
+```bash
 curl --proto '=https' --tlsv1.2 -sSf https://get.kraftkit.sh | sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,15 @@ Unikraft supports the construction of multiple architectures, platforms, and ima
 
 ## Getting Started
 
-The fastest way to get started configuring, building and deploying Unikraft unikernels is to use our companion tool, [**kraftkit**][kraftkit].
+The fastest way to get started configuring, building and deploying Unikraft unikernels is to use the companion framework [KraftKit][kraftkit].
 
-With `kraft` installed, you can download Unikraft components, configure your unikernel to your needs, build it and run it -- there's no need to be an expert!
+You can quickly and easily install KraftKit using the interactive installer. Simply run the following command to get started:
+
+```
+curl --proto '=https' --tlsv1.2 -sSf https://get.kraftkit.sh | sh
+```
+
+Alternatively, you can download the binaries from the [releases pages](https://github.com/unikraft/kraftkit/releases).
 
 ## Contributing
 


### PR DESCRIPTION
I think it makes sense to route users to `kraftkit`
instead the deprecated `kraft`

Signed-off-by: Richard Kovacs <kovacsricsi@gmail.com>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [X] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regard...oject;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on yo...his PR;
 - [X] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The kraft link in the readme points to a deprecated project,
so this change tries to route users to supported tool.