### PR TITLE
lib/posix-sysinfo: Add _SC_PHYS_PAGES and _SC_AVPHYS_PAGES to sysconf

### DIFF
--- a/lib/posix-sysinfo/sysinfo.c
+++ b/lib/posix-sysinfo/sysinfo.c
@@ -41,6 +41,11 @@
 #include <sys/sysinfo.h>
 #include <uk/syscall.h>
 
+#ifdef CONFIG_HAVE_PAGING
+#include <uk/plat/paging.h>
+#include <uk/falloc.h>
+#endif /* CONFIG_HAVE_PAGING */
+
 #if CONFIG_LIBVFSCORE
 /* For FDTABLE_MAX_FILES. */
 #include <vfscore/file.h>
@@ -97,6 +102,22 @@ long sysconf(int name)
 
 	if (name == _SC_PAGESIZE)
 		return __PAGE_SIZE;
+
+#ifdef CONFIG_HAVE_PAGING
+	if (name == _SC_PHYS_PAGES) {
+		struct uk_pagetable *pt;
+
+		pt = ukplat_pt_get_active();
+		return pt->fa->total_memory / PAGE_SIZE;
+	}
+
+	if (name == _SC_AVPHYS_PAGES) {
+		struct uk_pagetable *pt;
+
+		pt = ukplat_pt_get_active();
+		return pt->fa->free_memory / PAGE_SIZE;
+	}
+#endif /* CONFIG_HAVE_PAGING */
 
 #if CONFIG_LIBVFSCORE
 	if (name == _SC_OPEN_MAX)


### PR DESCRIPTION
This commit handles the _SC_PHYS_PAGES and _SC_AVPHYS_PAGES
value in sysconf. _SC_PHYS_PAGES returns total number of
physical pages when paging is enabled. _SC_AVPHYS_PAGES
returns total free memory available.

Signed-off-by: Osama Muhammad <osmtendev@gmail.com>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
