### PR TITLE
arch/libcontext: arm64: Make TCB overlap configurable

### DIFF
--- a/arch/Makefile.rules
+++ b/arch/Makefile.rules
@@ -12,3 +12,10 @@ $(if $(strip $(_UKARCH_TLS_HAVE_TCB)),
 		$(eval CXXFLAGS-y+=-DCONFIG_UKARCH_TLS_HAVE_TCB=1) \
 		$(eval _UKARCH_TLS_HAVE_TCB:=1))
 endef
+
+# Indicate that no block of bytes is reserved at the end of the TCB
+# Usage:
+#  $(eval $(call aarch64_no_reserved_tcb_overlap))
+define aarch64_no_reserved_tcb_overlap =
+	$(eval LIBCONTEXT_CFLAGS-y+=-DCONFIG_AARCH64_NO_TCB_OVERLAP=1)
+endef


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`aarch64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The Aarch64 ABI requires 16 bytes of space after the `tlsp` pointer as part of the TCB. However, this space is not expected by newer versions of the `musl` library.

As such, this PR introduces a new Makefile rule by which a library can register whether this reserved space is not necessary. The rule sets a macro by which we can then decide to assume a 16-byte block space is reserved at the end of the TCB or not.

This maintains backwards compatibility with previous versions of `musl`, since if the rule is not invoked, it is assumed that the library expects the `AARCH64_RESERVED` block of 16 bytes described by the ABI.

Signed-off-by: Eduard Vintilă <eduard.vintila47@gmail.com>