### PR TITLE
plat/kvm/arm: Use 48-bit virtual addressing for PARange >= 52

### DIFF
--- a/plat/kvm/arm/pagetable64.S
+++ b/plat/kvm/arm/pagetable64.S
@@ -70,7 +70,15 @@ ENTRY(start_mmu)
 	ldr x5, =tcr_ips_bits
 	ubfx x4, x3, #0, #4
 	ldrb w4, [x5, x4]
-
+	cmp x4, #52
+	b.lt setup_tcr_el1
+	/*
+	 * We currently do not provide 5-level page tables used in
+	 * implementing 52-bit virtual addresing with 4K granularity, so we
+	 * enforce the max VA to 48-bit for PARange >= 52.
+	 */
+	mov x4, #48
+setup_tcr_el1:
 	/* Setup TCR_EL1_TxSZ(64 - VIRT_BITS) for TCR_INIT_FLAGS */
 	mov x5, #64
 	sub x5, x5, x4


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Latest versions of QEMU (>= 7) might provide a 52-bit physical address space when passing `max` as the `cpu` option. This information is found in the `PARange` field of the `ID_AA64MMFR0_EL1` register.

When the Virtual Memory API is not enabled (i.e. the `CONFIG_PAGING` macro is not set), the `T0SZ` field from the `TCR_EL1` register is set up such that the VA space size matches the PA one.  However, we currently do not provide a 5-level paging scheme at all in order to implement 52-bit virtual addresing, so we need to enforce 48-bit VA space for PARange >= 52.

If this is not enforced, in the current state it seems that every app that runs with the `max` CPU on such versions of QEMU do not boot at all.

Signed-off-by: Eduard Vintilă <eduard.vintila47@gmail.com>