### PR TITLE
include/event: Expose HANDLED_CONT return value

### DIFF
--- a/include/uk/event.h
+++ b/include/uk/event.h
@@ -260,9 +260,14 @@ struct uk_event {
  * @param data
  *   Optional data supplied to the event handlers
  * @returns
- *   UK_EVENT_HANDLED if at least one handler indicated that it successfully
- *   handled the event, otherwise returns UK_EVENT_NOT_HANDLED. If a handler
- *   returns a negative value, then this negative value is returned.
+ *   A negative error value if a handler returns one. Event processing
+ *   immediately stops in this case. Otherwise:
+ *   - UK_EVENT_HANDLED if a handler indicated that it successfully handled
+ *     the event and event processing should stop with this handler.
+ *   - UK_EVENT_HANDLED_CONT if at least one handler indicated that it
+ *     successfully handled the event but event handling can continue, and no
+ *     other handler returned UK_EVENT_HANDLED.
+ *   - UK_EVENT_NOT_HANDLED if no handler handled the event.
  */
 static inline int uk_raise_event_ptr(struct uk_event *e, void *data)
 {
@@ -276,10 +281,11 @@ static inline int uk_raise_event_ptr(struct uk_event *e, void *data)
 		if (unlikely(rc < 0))
 			return rc;
 
-		if (rc > 0)
-			ret = UK_EVENT_HANDLED;
 		if (rc == UK_EVENT_HANDLED)
-			break;
+			return UK_EVENT_HANDLED;
+
+		if (rc == UK_EVENT_HANDLED_CONT)
+			ret = UK_EVENT_HANDLED_CONT;
 	}
 
 	return ret;


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

The previous changes to the event (#691) hide if the last handler that successfully handled the event allowed further event processing (i.e., on success always `UK_EVENT_HANDLED` is returned). This commit fixes this so that the caller of `uk_raise_event()` is informed about if event processing can continue by other means or if it should stop.

This is a prerequisite for:
- https://github.com/unikraft/unikraft/pull/699