### PR TITLE
plat/kvm/x86: Fix cmdline parsing

### DIFF
--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -287,7 +287,7 @@ static inline int cmdline_init(struct ukplat_bootinfo *bi)
 
 static void __noreturn _ukplat_entry2(void)
 {
-	ukplat_entry_argp(NULL, cmdline, sizeof(cmdline));
+	ukplat_entry_argp(NULL, cmdline, cmdline_len);
 
 	ukplat_lcpu_halt();
 }


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x]  Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

In the boot refactoring, we replaced the statically allocated command line buffer with a dynamically allocated one. However, the length argument was not updated, which leads to the cmdline being not properly parsed.