### PR TITLE
include/uk/plat: Fix initrd0 macro

### DIFF
--- a/include/uk/plat/memory.h
+++ b/include/uk/plat/memory.h
@@ -180,7 +180,7 @@ ukplat_memregion_find_next(int i, __u32 type, __u32 flags, __u32 fmask,
  *   return value < 0 means that there is no initrd module.
  */
 #define ukplat_memregion_find_initrd0(mrd) \
-	ukplat_memregion_find_next(-1, UKPLAT_MEMRF_INITRD, 0, 0, mrd)
+	ukplat_memregion_find_next(-1, UKPLAT_MEMRT_INITRD, 0, 0, mrd)
 
 /**
  * Sets the platform memory allocator and triggers the platform memory mappings


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

This commit fixes a typo in the `ukplat_memregion_find_initrd0` macro.