### PR TITLE
lib/vfscore: Cast initrd vbase to (void *)

### DIFF
--- a/lib/vfscore/rootfs.c
+++ b/lib/vfscore/rootfs.c
@@ -104,9 +104,10 @@ static int vfscore_rootfs(void)
 		}
 
 		uk_pr_info("Extracting initrd @ %p (%"__PRIsz" bytes) to /...\n",
-			   initrd->vbase, initrd->len);
+			   (void *) initrd->vbase, initrd->len);
 
-		error = ukcpio_extract("/", initrd->vbase, initrd->len);
+		error = ukcpio_extract("/", (void *) initrd->vbase,
+				       initrd->len);
 		if (error != UKCPIO_SUCCESS) {
 			uk_pr_crit("Failed to extract cpio archive to /: %d\n",
 				   error);


### PR DESCRIPTION
PR #722 introduced an update to `struct ukplat_memregion_desc` where the virtual base of a memory region is now specified as a __vaddr_t integer value. Since it is a virtual address we can cast it to (void *) to avoid build warnings in `lib/vfscore/rootfs.c`.