### PR TITLE
Fix for .tdata warning

### DIFF
--- a/plat/common/include/uk/plat/common/common.lds.h
+++ b/plat/common/include/uk/plat/common/common.lds.h
@@ -127,7 +127,7 @@
 		*(.tdata)						\
 		*(.tdata.*)						\
 		*(.gnu.linkonce.td.*)					\
-	} :tls								\
+	} :tls :tls_load						\
 	_etdata = .;							\
 	.tbss :								\
 	{								\

--- a/plat/kvm/arm/link64.lds.S
+++ b/plat/kvm/arm/link64.lds.S
@@ -48,6 +48,7 @@ PHDRS
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
 	tls PT_TLS;
+	tls_load PT_LOAD;
 	stack PT_GNU_STACK FLAGS(PHDRS_PF_RW);
 }
 

--- a/plat/kvm/x86/link64.lds.S
+++ b/plat/kvm/x86/link64.lds.S
@@ -32,6 +32,7 @@ PHDRS
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
 	tls PT_TLS;
+	tls_load PT_LOAD;
 	stack PT_GNU_STACK FLAGS(PHDRS_PF_RW);
 }
 

--- a/plat/xen/arm/link32.lds.S
+++ b/plat/xen/arm/link32.lds.S
@@ -35,6 +35,7 @@ PHDRS
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
 	tls PT_TLS;
+	tls_load PT_LOAD;
 	stack PT_GNU_STACK FLAGS(PHDRS_PF_RW);
 }
 

--- a/plat/xen/x86/link64.lds.S
+++ b/plat/xen/x86/link64.lds.S
@@ -35,6 +35,7 @@ PHDRS
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
 	tls PT_TLS;
+	tls_load PT_LOAD;
 	stack PT_GNU_STACK FLAGS(PHDRS_PF_RW);
 }
 

--- a/support/scripts/mkbootinfo.py
+++ b/support/scripts/mkbootinfo.py
@@ -80,7 +80,6 @@ def main():
     # struct ukplat_memregion_desc (see include/uk/plat/memory.h).
     with open(opt.output, 'wb') as secobj:
         nsecs      = 0
-        last_pbase = 0
 
         cap = bootsec_size
         cap = cap - UKPLAT_BOOTINFO_SIZE
@@ -105,9 +104,6 @@ def main():
             if pbase < opt.min_address:
                 continue
 
-            if pbase != (pbase & ~(PAGE_SIZE - 1)):
-                raise Exception("Segment base address 0x{:x} is not page-aligned".format(pbase))
-
             flags = 0
             if phdr[2][0] == 'r':
                 flags |= UKPLAT_MEMRF_READ
@@ -123,8 +119,6 @@ def main():
             size = (int(phdr[1], base=16) + (PAGE_SIZE - 1)) & ~(PAGE_SIZE - 1)
 
             assert nsecs < cap
-            assert pbase >= last_pbase
-            last_pbase = pbase
             nsecs += 1
 
             secobj.write(pbase.to_bytes(8, endianness)) # pbase


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`, `arm64`, `arm`]
 - Platform(s): [`kvm`, `xen`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Since PR #698 building Unikraft may show the following warning: 
`warning: allocated section .tdata not in segment`.

This PR fixes this by putting `.tdata` into its own loadable segment. However, this will also lead to the boot info containing overlapping memory regions which violates how the boot information should be
structured. While this works for now, this should be addressed by removing overlapping segments from the bootinfo in the `mkbootinfo.py` script.
