### PR TITLE
lib/uksched: Align allocated stacks to arch requirement

### DIFF
--- a/lib/uksched/thread.c
+++ b/lib/uksched/thread.c
@@ -368,7 +368,7 @@ static int _uk_thread_struct_init_alloc(struct uk_thread *t,
 	int rc;
 
 	if (a_stack && stack_len) {
-		stack = uk_malloc(a_stack, stack_len);
+		stack = uk_memalign(a_stack, UKARCH_SP_ALIGN, stack_len);
 		if (!stack) {
 			rc = -ENOMEM;
 			goto err_out;


### PR DESCRIPTION
This PR introduces aligns stack allocation that are done by `lib/uksched` to the requirement of the target architecture. Without aligned stacks, random crashed may occur because the compiler is assuming such an alignment. An incorrect stack alignment can cause crashes because the compiler may placed instructions in the code that will fail when accessing values on the stack if not properly aligned.