### PR TITLE
plat/common/x86: 16-byte align syscall stack

### DIFF
--- a/plat/common/x86/syscall.S
+++ b/plat/common/x86/syscall.S
@@ -74,7 +74,18 @@ ENTRY(_ukplat_syscall)
 	 *       (calling convention: 1st arg on %rdi)
 	 */
 	movq %rsp, %rdi
+
+	/*
+	 * Make sure the stack is aligned to 16-bytes. We store the original
+	 * stack pointer in the frame pointer (callee saved)
+	 */
+	movq %rsp, %rbp
+	and $~15, %rsp
+
 	call ukplat_syscall_handler
+
+	/* Restore original stack pointer */
+	movq %rbp, %rsp
 
 	cli
 	/* Load the updated state back to registers */


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Currently, the user stack is used as kernel stack. This can be a problem if the stack is not aligned on syscall entry. However, it may be aligned for some calls. We thus cannot just push a fixed amount of words. Instead, we store the original stack pointer and align it using an and operation, which guarantees correct alignment in any case.
