### PR TITLE
lib/syscall_shim: uk_prsyscall: Fix typecast for PT_BUFP

### DIFF
--- a/lib/syscall_shim/uk_prsyscall.c
+++ b/lib/syscall_shim/uk_prsyscall.c
@@ -624,7 +624,7 @@ static void pr_param(struct uk_streambuf *sb, int fmtf,
 					uk_streambuf_printf(sb, "%c", *c);
 				else
 					uk_streambuf_printf(sb, "\\x%02X",
-							    (int) *c);
+							    (int) ((__u8) *c));
 			}
 			uk_streambuf_strcpy(sb, "\"");
 			uk_streambuf_shcc(sb, fmtf, RESET);


### PR DESCRIPTION
### Base target

 - Architecture(s): [all]
 - Platform(s): [all]
 - Application(s): [all]

### Additional configuration

 - `CONFIG_LIBSYSCALL_SHIM=y`

### Description of changes

PT_BUFP prints binary buffer content human readable but had one particular problem: Due to incomplete typecasting, printing of a negative byte (__s8) caused printing a 4-byte hex sequence instead of just one byte with the format: `\0xHH`. This commit fixes this with proper typecasting.
