### PR TITLE
lib/ukvmem: Compile all source files for ISR context

### DIFF
--- a/lib/ukvmem/Makefile.uk
+++ b/lib/ukvmem/Makefile.uk
@@ -4,16 +4,17 @@ CINCLUDES-y   += -I$(LIBUKVMEM_BASE)/include
 CXXINCLUDES-y += -I$(LIBUKVMEM_BASE)/include
 
 LIBUKVMEM_SRCS-y += $(LIBUKVMEM_BASE)/vmem.c|isr
-LIBUKVMEM_SRCS-y += $(LIBUKVMEM_BASE)/vma_rsvd.c
-LIBUKVMEM_SRCS-y += $(LIBUKVMEM_BASE)/vma_anon.c
-LIBUKVMEM_SRCS-y += $(LIBUKVMEM_BASE)/vma_stack.c
-LIBUKVMEM_SRCS-y += $(LIBUKVMEM_BASE)/vma_dma.c
+LIBUKVMEM_SRCS-y += $(LIBUKVMEM_BASE)/vma_rsvd.c|isr
+LIBUKVMEM_SRCS-y += $(LIBUKVMEM_BASE)/vma_anon.c|isr
+LIBUKVMEM_SRCS-y += $(LIBUKVMEM_BASE)/vma_stack.c|isr
+LIBUKVMEM_SRCS-y += $(LIBUKVMEM_BASE)/vma_dma.c|isr
 ifeq ($(CONFIG_LIBVFSCORE),y)
-LIBUKVMEM_SRCS-y += $(LIBUKVMEM_BASE)/vma_file.c
+LIBUKVMEM_SRCS-y += $(LIBUKVMEM_BASE)/vma_file.c|isr
 endif
 
 ifeq ($(CONFIG_HAVE_PAGING),y)
-LIBUKVMEM_SRCS-$(CONFIG_ARCH_X86_64) += $(LIBUKVMEM_BASE)/arch/x86_64/pagefault.c
+LIBUKVMEM_SRCS-$(CONFIG_ARCH_X86_64) += \
+	$(LIBUKVMEM_BASE)/arch/x86_64/pagefault.c|isr
 endif
 
 ifneq ($(filter y,$(CONFIG_LIBUKVMEM_TEST) $(CONFIG_LIBUKTEST_ALL)),)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

-->
 - `CONFIG_LIBUKVMEM=y`

### Description of changes

The main and individual pagefault handlers are executed in an ISR context. Not marking the files as `isr`, will cause the usual trouble (clobbered vector registers).

<!--
Please provide a detailed description of the changes made in this new PR.
-->
