### PR TITLE
plat/x86: Enable NX bit when initializing paging

### DIFF
--- a/plat/common/include/x86/paging.h
+++ b/plat/common/include/x86/paging.h
@@ -43,6 +43,9 @@
 
 #include <errno.h>
 
+#include "cpu_defs.h"
+#include "cpu.h"
+
 /* We do not support 32-bit virtual address spaces as they do not provide
  * enough space for the direct mapping of page tables. In this case, we would
  * have to use temporary mappings or recursive page table mapping
@@ -240,6 +243,7 @@ pgarch_init(void)
 {
 	__u32 eax, ebx, ecx, edx;
 	__u32 max_addr_bit;
+	__u64 efer;
 
 	/* Check for availability of extended features */
 	ukarch_x86_cpuid(0x80000000, 0, &eax, &ebx, &ecx, &edx);
@@ -256,6 +260,11 @@ pgarch_init(void)
 		uk_pr_crit("%s not supported.\n", "1GiB pages");
 		return -ENOTSUP;
 	}
+
+	/* Enable the NX bit */
+	efer = rdmsrl(X86_MSR_EFER);
+	efer |= X86_EFER_NXE;
+	wrmsrl(X86_MSR_EFER, efer);
 
 #if PT_LEVELS == 5
 	ukarch_x86_cpuid(0x7, 0, &eax, &ebx, &ecx, &edx);

--- a/plat/kvm/x86/lcpu_start.S
+++ b/plat/kvm/x86/lcpu_start.S
@@ -152,8 +152,7 @@ gdt64_ptr:
 	  X86_CR4_PAE	/* Physical Address Extension */
 
 #define EFER_BOOT32_SETTINGS						\
-	  X86_EFER_LME	/* IA-32e Mode */				\
-	| X86_EFER_NXE	/* Execute Disable Bit */
+	  X86_EFER_LME	/* IA-32e Mode */
 
 #define CR0_BOOT32_SETTINGS						\
 	  X86_CR0_PE	/* Protected mode */				\


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:
-->

 - `CONFIG_PAGING=y`

### Description of changes

There are a few reasons to enable the NX bit in the paging init routine:
* Setting the bit before checking for actual support is risky. Currently, the check happens in the paging initialization routine.
* The bit is not used, when the Unikraft paging support is not enabled.
* Every boot entry point (32-bit/64-bit) would have a duplicated enable.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
