### PR TITLE
lib/posix-event: Implement the EFD_NONBLOCK flag for eventfd

### DIFF
--- a/lib/posix-event/eventfd.c
+++ b/lib/posix-event/eventfd.c
@@ -316,7 +316,7 @@ static int do_eventfd(struct uk_alloc *a, unsigned int initval, int flags)
 	struct dentry *vfs_dentry;
 	struct vnode *vfs_vnode;
 
-	if (unlikely(flags & ~(EFD_CLOEXEC | EFD_SEMAPHORE)))
+	if (unlikely(flags & ~(EFD_CLOEXEC | EFD_SEMAPHORE | EFD_NONBLOCK)))
 		return -EINVAL;
 
 	/* Reserve a file descriptor number */
@@ -380,6 +380,12 @@ static int do_eventfd(struct uk_alloc *a, unsigned int initval, int flags)
 
 	/* Only the dentry should hold a reference; release ours */
 	vput(vfs_vnode);
+
+	if (flags & EFD_NONBLOCK) {
+		ret = fcntl(vfs_fd, F_SETFL, O_NONBLOCK);
+		/* Setting the O_NONBLOCK here must not fail */
+		UK_ASSERT(ret != -1);
+	}
 
 	return vfs_fd;
 


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

-->

 - `CONFIG_LIBPOSIXEVENT=y`

### Description of changes

This flag allows conveniently setting O_NONBLOCK without having to use a separate `fcntl` call.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
