### PR TITLE
lib/syscall_shim: Add `syscall` alias to `uk_syscall`

### DIFF
--- a/lib/syscall_shim/uk_syscall.awk
+++ b/lib/syscall_shim/uk_syscall.awk
@@ -56,4 +56,5 @@ END {
 	printf "\tva_end(ap);\n"
 	printf "\treturn ret;\n"
 	printf "}\n"
+	printf "long syscall() __attribute__ ((weak, alias (\"uk_syscall\")));\n"
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:
-->

 - `CONFIG_LIBSYSCALL_SHIM=y`


### Description of changes

The symbol is required for binaries that were compiled against a Linux musl and use musl's system call wrapper.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
