### PR TITLE
lib/posix-event: Add an empty implementation of ioctl to eventfd

### DIFF
--- a/lib/posix-event/eventfd.c
+++ b/lib/posix-event/eventfd.c
@@ -286,13 +286,15 @@ static int eventfd_vfscore_poll(struct vnode *vnode, unsigned int *revents,
 
 /* vnode operations */
 #define eventfd_vfscore_inactive ((vnop_inactive_t) vfscore_vop_einval)
+#define eventfd_vfscore_ioctl ((vnop_ioctl_t) vfscore_vop_einval)
 
 static struct vnops eventfd_vnops = {
 	.vop_close = eventfd_vfscore_close,
 	.vop_inactive = eventfd_vfscore_inactive,
 	.vop_read = eventfd_vfscore_read,
 	.vop_write = eventfd_vfscore_write,
-	.vop_poll = eventfd_vfscore_poll
+	.vop_poll = eventfd_vfscore_poll,
+	.vop_ioctl = eventfd_vfscore_ioctl
 };
 
 /* file system operations */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:
-->

 - `CONFIG_LIBPOSIX_EVENT=y`


### Description of changes

The fcntl function will forward fcntl(O_NONBLOCK), to the underlying vnode `ioctl` op function, when a definition of FIONBIO and FIOASYNC is present. This effectively makes `ioctl` a required function for the vnops structure.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
