### PR TITLE
lib/ukalloc: Ensure the ifpages metadata does not break any alignments

### DIFF
--- a/lib/nolibc/include/nolibc-internal/shareddefs.h
+++ b/lib/nolibc/include/nolibc-internal/shareddefs.h
@@ -79,6 +79,15 @@ typedef unsigned gid_t;
 #define __DEFINED_gid_t
 #endif
 
+#if defined(__NEED_max_align_t) && !defined(__DEFINED_max_align_t)
+typedef struct {
+	long long __longlongf;
+
+	long double __longdoublef;
+} max_align_t;
+#define __DEFINED_max_align_t
+#endif
+
 #if defined(__NEED_useconds_t) && !defined(__DEFINED_useconds_t)
 typedef unsigned useconds_t;
 #define __DEFINED_useconds_t

--- a/lib/nolibc/include/stddef.h
+++ b/lib/nolibc/include/stddef.h
@@ -48,6 +48,7 @@ typedef __sptr ptrdiff_t;
 
 #define __NEED_NULL
 #define __NEED_size_t
+#define __NEED_max_align_t
 #include <nolibc-internal/shareddefs.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

-->
 - `CONFIG_LIBUKALLOC=y`


### Description of changes

By using the rounded version of the metadata size, we can ensure that the resulting alignments are suitable for any C scalar type. This is a requirement for any malloc implementation. 
(For x86_64 the current metadata structure size would cause any allocation to be only aligned to 8-byte, which is not enough for `max_align_t`.)

<!--
Please provide a detailed description of the changes made in this new PR.
-->
