### PR TITLE
lib/posix-futex: Implement subset of FUTEX_WAIT_BITSET

### DIFF
--- a/lib/posix-futex/futex.c
+++ b/lib/posix-futex/futex.c
@@ -59,6 +59,7 @@
 #include <uk/print.h>
 #include <uk/spinlock.h>
 #include <uk/plat/lcpu.h>
+#include <uk/plat/time.h>
 
 /** @struct uk_futex
  *  @brief Futex structure.
@@ -82,18 +83,17 @@ static uk_spinlock futex_list_lock = UK_SPINLOCK_INITIALIZER();
  * expected one. If the futex was not removed from the list when the thread was
  * unblocked, then it means that it timed out.
  *
- * @param uaddr	The futex userspace address
- * @param val	The expected value
- * @param tm	Timespec structure which contains the timeout for which the
- *		thread will blocked. If it is null, the thread will wait
- *		indefinitely.
+ * @param uaddr		The futex userspace address
+ * @param val		The expected value
+ * @param timeout	The deadline until the function will block at most.
+ * 			If it is NULL, the thread will wait indefinitely.
  *
  * @return
  *	0: uaddr contains val and the thread finished waiting;
  *	<1: -EAGAIN (uaddr does not contain val) or -ETIMEDOUT (the futex timed
  *       out)
  */
-static int futex_wait(uint32_t *uaddr, uint32_t val, const struct timespec *tm)
+static int futex_wait(uint32_t *uaddr, uint32_t val, const __nsec *timeout)
 {
 	unsigned long irqf;
 	struct uk_list_head *itr, *tmp;
@@ -111,9 +111,9 @@ static int futex_wait(uint32_t *uaddr, uint32_t val, const struct timespec *tm)
 		uk_spin_unlock(&futex_list_lock);
 		ukplat_lcpu_restore_irqf(irqf);
 
-		if (tm)
-			/* Block for at most timeout nanosecs */
-			uk_thread_block_timeout(current, tm->tv_nsec);
+		if (timeout)
+			/* Block at most until `timeout` nanosecs */
+			uk_thread_block_until(current, (__snsec)*timeout);
 		else
 			/* Block indefinitely */
 			uk_thread_block(current);
@@ -276,10 +276,42 @@ UK_LLSYSCALL_R_DEFINE(int, futex, uint32_t *, uaddr, int, futex_op,
 		      uint32_t, val, const struct timespec *, timeout,
 		      uint32_t *, uaddr2, uint32_t, val3)
 {
+	__nsec timeout_ns;
+
+	/*
+	 * N.B. CLOCK_(MONOTONIC|REALTIME|...) are at the moment all the same in
+	 * Unikraft. Therefore, we can just use CLOCK_MONOTONIC for timeouts in
+	 * the following code.
+	 */
 	switch (futex_op) {
 	case FUTEX_WAIT:
 	case FUTEX_WAIT_PRIVATE:
-		return futex_wait(uaddr, val, timeout);
+		/*
+		 * `timeout` is relative to "now" (whenever that is). To
+		 * simplify the implementation regarding overflows, we will only
+		 * honor the nanosecond part of the timespec.
+		 */
+		if (timeout)
+			timeout_ns = ukplat_monotonic_clock() +
+				     ukarch_time_sec_to_nsec(timeout->tv_sec) +
+				     timeout->tv_nsec;
+		return futex_wait(uaddr, val, timeout ? &timeout_ns : NULL);
+
+	case FUTEX_WAIT_BITSET:
+	case FUTEX_WAIT_BITSET_PRIVATE:
+		/*
+		 * Special case implementation for cases where the val3/mask has
+		 * all bits set. Some applications do this to use the absolute
+		 * timeout mode. We return ENOSYS for all non-supported calls.
+		 */
+		if (val3 != UINT32_MAX)
+			return -ENOSYS;
+
+		if (timeout)
+			timeout_ns = ukarch_time_sec_to_nsec(timeout->tv_sec)
+				     + timeout->tv_nsec;
+
+		return futex_wait(uaddr, val, timeout ? &timeout_ns : NULL);
 
 	case FUTEX_WAKE:
 	case FUTEX_WAKE_PRIVATE:

--- a/lib/posix-futex/futex.c
+++ b/lib/posix-futex/futex.c
@@ -283,9 +283,8 @@ UK_LLSYSCALL_R_DEFINE(int, futex, uint32_t *, uaddr, int, futex_op,
 	 * Unikraft. Therefore, we can just use CLOCK_MONOTONIC for timeouts in
 	 * the following code.
 	 */
-	switch (futex_op) {
+	switch (futex_op & FUTEX_CMD_MASK) {
 	case FUTEX_WAIT:
-	case FUTEX_WAIT_PRIVATE:
 		/*
 		 * `timeout` is relative to "now" (whenever that is). To
 		 * simplify the implementation regarding overflows, we will only
@@ -298,7 +297,6 @@ UK_LLSYSCALL_R_DEFINE(int, futex, uint32_t *, uaddr, int, futex_op,
 		return futex_wait(uaddr, val, timeout ? &timeout_ns : NULL);
 
 	case FUTEX_WAIT_BITSET:
-	case FUTEX_WAIT_BITSET_PRIVATE:
 		/*
 		 * Special case implementation for cases where the val3/mask has
 		 * all bits set. Some applications do this to use the absolute
@@ -314,7 +312,6 @@ UK_LLSYSCALL_R_DEFINE(int, futex, uint32_t *, uaddr, int, futex_op,
 		return futex_wait(uaddr, val, timeout ? &timeout_ns : NULL);
 
 	case FUTEX_WAKE:
-	case FUTEX_WAKE_PRIVATE:
 		return futex_wake(uaddr, val);
 
 	case FUTEX_FD:

--- a/lib/uksched/exportsyms.uk
+++ b/lib/uksched/exportsyms.uk
@@ -31,6 +31,7 @@ uk_thread_create_fn1
 uk_thread_create_fn2
 uk_thread_set_exited
 uk_thread_release
+uk_thread_block_until
 uk_thread_block_timeout
 uk_thread_block
 uk_thread_wake

--- a/lib/uksched/include/uk/thread.h
+++ b/lib/uksched/include/uk/thread.h
@@ -593,6 +593,7 @@ struct uk_thread *uk_thread_create_fn2(struct uk_alloc *a,
 				       uk_thread_dtor_t dtor);
 
 void uk_thread_release(struct uk_thread *t);
+void uk_thread_block_until(struct uk_thread *thread, __snsec until);
 void uk_thread_block_timeout(struct uk_thread *thread, __nsec nsec);
 void uk_thread_block(struct uk_thread *thread);
 void uk_thread_wake(struct uk_thread *thread);

--- a/lib/uksched/thread.c
+++ b/lib/uksched/thread.c
@@ -923,7 +923,7 @@ void uk_thread_release(struct uk_thread *t)
 		uk_free(a, t);
 }
 
-static void uk_thread_block_until(struct uk_thread *thread, __snsec until)
+void uk_thread_block_until(struct uk_thread *thread, __snsec until)
 {
 	unsigned long flags;
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:



-->
 - `CONFIG_LIBPOSIX_FUTEX=y`

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Many modern applications use `FUTEX_WAIT_BITSET` to be able to set an absolute timeout. To accomplish that they set all bits in the `val3`/mask parameter, which makes the operation equivalent to a normal `FUTEX_WAIT` (except the absolute timeout value).