### PR TITLE
drivers/virtio: Fix interrupt flag check

### DIFF
--- a/plat/drivers/virtio/virtio_ring.c
+++ b/plat/drivers/virtio/virtio_ring.c
@@ -114,7 +114,7 @@ int virtqueue_intr_enable(struct virtqueue *vq)
 	vrq = to_virtqueue_vring(vq);
 	/* Check if there are no more packets enabled */
 	if (!virtqueue_hasdata(vq)) {
-		if (vrq->vring.avail->flags | VRING_AVAIL_F_NO_INTERRUPT) {
+		if (vrq->vring.avail->flags & VRING_AVAIL_F_NO_INTERRUPT) {
 			vrq->vring.avail->flags &=
 				(~VRING_AVAIL_F_NO_INTERRUPT);
 			/**


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

The check used a bit-OR instead of a bit-AND to check whether the flag is set.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
