### PR TITLE
plat/kvm: Change unhandled irq message to a tracepoint

### DIFF
--- a/plat/kvm/irq.c
+++ b/plat/kvm/irq.c
@@ -34,11 +34,15 @@
 #include <kvm/intctrl.h>
 #include <uk/assert.h>
 #include <uk/event.h>
+#include <uk/trace.h>
 #include <uk/print.h>
 #include <errno.h>
 #include <uk/bitops.h>
 
 UK_EVENT(UKPLAT_EVENT_IRQ);
+
+UK_TRACEPOINT(trace_plat_kvm_unhandled_irq, "Unhandled irq=%lu\n",
+	      unsigned long);
 
 /* IRQ handlers declarations */
 struct irq_handler {
@@ -136,7 +140,7 @@ void _ukplat_irq_handle(struct __regs *regs, unsigned long irq)
 	 * devices, and (2) to minimize impact on drivers that share one
 	 * interrupt line that would then stay disabled.
 	 */
-	uk_pr_crit("Unhandled irq=%lu\n", irq);
+	trace_plat_kvm_unhandled_irq(irq);
 
 exit_ack:
 	intctrl_ack_irq(irq);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

It's not possible to call a print function in an interrupt context, because these are not ISR safe and will mess up the interrupted context.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
