### PR TITLE
lib/uksched:Fix for issue #730

### DIFF
--- a/lib/uksched/include/uk/sched.h
+++ b/lib/uksched/include/uk/sched.h
@@ -179,7 +179,7 @@ struct uk_thread *uk_sched_thread_create_fn0(struct uk_sched *s,
 					     bool no_ectx,
 					     const char *name,
 					     void *priv,
-					     uk_thread_dtor_t dtor) __nonnull;
+					     uk_thread_dtor_t dtor);
 
 /**
  * Similar to `uk_sched_thread_create_fn0()` but with a thread function
@@ -193,7 +193,7 @@ struct uk_thread *uk_sched_thread_create_fn1(struct uk_sched *s,
 					     bool no_ectx,
 					     const char *name,
 					     void *priv,
-					     uk_thread_dtor_t dtor) __nonnull;
+					     uk_thread_dtor_t dtor);
 
 /**
  * Similar to `uk_sched_thread_create_fn0()` but with a thread function
@@ -207,7 +207,7 @@ struct uk_thread *uk_sched_thread_create_fn2(struct uk_sched *s,
 					     bool no_ectx,
 					     const char *name,
 					     void *priv,
-					     uk_thread_dtor_t dtor) __nonnull;
+					     uk_thread_dtor_t dtor);
 
 /* Shortcut for creating a thread with default settings */
 #define uk_sched_thread_create(s, fn1, argp, name)		\

--- a/lib/uksched/include/uk/sched.h
+++ b/lib/uksched/include/uk/sched.h
@@ -107,9 +107,9 @@ static inline void uk_sched_yield(void)
 	s->yield(s);
 }
 
-int uk_sched_thread_add(struct uk_sched *s, struct uk_thread *t);
+int uk_sched_thread_add(struct uk_sched *s, struct uk_thread *t) __nonnull;
 
-int uk_sched_thread_remove(struct uk_thread *t);
+int uk_sched_thread_remove(struct uk_thread *t) __nonnull;
 
 static inline void uk_sched_thread_blocked(struct uk_thread *t)
 {
@@ -139,7 +139,7 @@ static inline void uk_sched_thread_woken(struct uk_thread *t)
 /**
  * Create a main thread from current context and call thread starter function
  */
-int uk_sched_start(struct uk_sched *sched);
+int uk_sched_start(struct uk_sched *sched) __nonnull;
 
 /**
  * Allocates a uk_thread and assigns it to a scheduler.
@@ -179,7 +179,7 @@ struct uk_thread *uk_sched_thread_create_fn0(struct uk_sched *s,
 					     bool no_ectx,
 					     const char *name,
 					     void *priv,
-					     uk_thread_dtor_t dtor);
+					     uk_thread_dtor_t dtor) __nonnull;
 
 /**
  * Similar to `uk_sched_thread_create_fn0()` but with a thread function
@@ -193,7 +193,7 @@ struct uk_thread *uk_sched_thread_create_fn1(struct uk_sched *s,
 					     bool no_ectx,
 					     const char *name,
 					     void *priv,
-					     uk_thread_dtor_t dtor);
+					     uk_thread_dtor_t dtor) __nonnull;
 
 /**
  * Similar to `uk_sched_thread_create_fn0()` but with a thread function
@@ -207,7 +207,7 @@ struct uk_thread *uk_sched_thread_create_fn2(struct uk_sched *s,
 					     bool no_ectx,
 					     const char *name,
 					     void *priv,
-					     uk_thread_dtor_t dtor);
+					     uk_thread_dtor_t dtor) __nonnull;
 
 /* Shortcut for creating a thread with default settings */
 #define uk_sched_thread_create(s, fn1, argp, name)		\
@@ -220,7 +220,7 @@ struct uk_thread *uk_sched_thread_create_fn2(struct uk_sched *s,
 #define uk_sched_foreach_thread_safe(sched, itr, tmp)			\
 	UK_TAILQ_FOREACH_SAFE((itr), &(sched)->thread_list, thread_list, (tmp))
 
-void uk_sched_dumpk_threads(int klvl, struct uk_sched *s);
+void uk_sched_dumpk_threads(int klvl, struct uk_sched *s) __nonnull;
 
 void uk_sched_thread_sleep(__nsec nsec);
 
@@ -233,7 +233,7 @@ void uk_sched_thread_exit(void) __noreturn;
 void uk_sched_thread_exit2(uk_thread_gc_t gc_fn, void *gc_argp) __noreturn;
 
 /* Terminates another thread */
-void uk_sched_thread_terminate(struct uk_thread *thread);
+void uk_sched_thread_terminate(struct uk_thread *thread) __nonnull;
 
 #ifdef __cplusplus
 }

--- a/lib/uksched/include/uk/sched_impl.h
+++ b/lib/uksched/include/uk/sched_impl.h
@@ -50,7 +50,7 @@ extern "C" {
 
 extern struct uk_sched *uk_sched_head;
 
-int uk_sched_register(struct uk_sched *s);
+int uk_sched_register(struct uk_sched *s) __nonnull;
 
 #define uk_sched_init(s, start_func, yield_func, \
 		thread_add_func, thread_remove_func, \
@@ -79,7 +79,7 @@ int uk_sched_register(struct uk_sched *s);
  *   - (0): No work was done
  *   - (>0): Number of threads that were cleaned up
  */
-unsigned int uk_sched_thread_gc(struct uk_sched *sched);
+unsigned int uk_sched_thread_gc(struct uk_sched *sched) __nonnull;
 
 static inline
 void uk_sched_thread_switch(struct uk_thread *next)

--- a/lib/uksched/include/uk/tcb_impl.h
+++ b/lib/uksched/include/uk/tcb_impl.h
@@ -67,7 +67,7 @@ extern "C" {
  *   - (>=0): Success, tcb is initialized.
  *   - (<0): Negative error code, thread creation is canceled.
  */
-int uk_thread_uktcb_init(struct uk_thread *thread, void *tcb);
+int uk_thread_uktcb_init(struct uk_thread *thread, void *tcb) __nonnull;
 
 /**
  * Called by `libuksched` as soon as a thread is released or uninitialized
@@ -79,7 +79,7 @@ int uk_thread_uktcb_init(struct uk_thread *thread, void *tcb);
  * @param tcb Reference to reserved space to custom thread control block
  *            that should be uninitialized.
  */
-void uk_thread_uktcb_fini(struct uk_thread *thread, void *tcb);
+void uk_thread_uktcb_fini(struct uk_thread *thread, void *tcb) __nonnull;
 #endif /* CONFIG_LIBUKSCHED_TCB_INIT */
 
 /**

--- a/lib/uksched/include/uk/thread.h
+++ b/lib/uksched/include/uk/thread.h
@@ -225,7 +225,7 @@ int uk_thread_init_bare(struct uk_thread *t,
 			struct ukarch_ectx *ectx,
 			const char *name,
 			void *priv,
-			uk_thread_dtor_t dtor) __nonnull;
+			uk_thread_dtor_t dtor);
 
 /**
  * Initializes a given uk_thread structure. Such a thread can then be
@@ -271,7 +271,7 @@ int uk_thread_init_bare_fn0(struct uk_thread *t,
 			    struct ukarch_ectx *ectx,
 			    const char *name,
 			    void *priv,
-			    uk_thread_dtor_t dtor) __nonnull;
+			    uk_thread_dtor_t dtor);
 
 /**
  * Similar to `uk_thread_init_bare_fn0()` but with a thread function accepting
@@ -286,7 +286,7 @@ int uk_thread_init_bare_fn1(struct uk_thread *t,
 			    struct ukarch_ectx *ectx,
 			    const char *name,
 			    void *priv,
-			    uk_thread_dtor_t dtor) __nonnull;
+			    uk_thread_dtor_t dtor);
 
 /**
  * Similar to `uk_thread_init_bare_fn0()` but with a thread function accepting
@@ -301,7 +301,7 @@ int uk_thread_init_bare_fn2(struct uk_thread *t,
 			    struct ukarch_ectx *ectx,
 			    const char *name,
 			    void *priv,
-			    uk_thread_dtor_t dtor) __nonnull;
+			    uk_thread_dtor_t dtor);
 
 /**
  * Initializes a `uk_thread` structure and allocates stack and optionally TLS.
@@ -351,7 +351,7 @@ int uk_thread_init_fn0(struct uk_thread *t,
 		       struct ukarch_ectx *ectx,
 		       const char *name,
 		       void *priv,
-		       uk_thread_dtor_t dtor) __nonnull;
+		       uk_thread_dtor_t dtor);
 
 /**
  * Similar to `uk_thread_init_fn0()` but with a thread function accepting
@@ -367,7 +367,7 @@ int uk_thread_init_fn1(struct uk_thread *t,
 		       struct ukarch_ectx *ectx,
 		       const char *name,
 		       void *priv,
-		       uk_thread_dtor_t dtor) __nonnull;
+		       uk_thread_dtor_t dtor);
 
 /**
  * Similar to `uk_thread_init_fn0()` but with a thread function accepting
@@ -383,7 +383,7 @@ int uk_thread_init_fn2(struct uk_thread *t,
 		       struct ukarch_ectx *ectx,
 		       const char *name,
 		       void *priv,
-		       uk_thread_dtor_t dtor) __nonnull;
+		       uk_thread_dtor_t dtor);
 
 /**
  * Allocates a bare uk_thread structure. Such a thread can then be assigned
@@ -425,7 +425,7 @@ struct uk_thread *uk_thread_create_bare(struct uk_alloc *a,
 					bool no_ectx,
 					const char *name,
 					void *priv,
-					uk_thread_dtor_t dtor) __nonnull;
+					uk_thread_dtor_t dtor);
 
 /**
  * Allocates a uk_thread container with stack and TLS. The entry point is not
@@ -466,7 +466,7 @@ struct uk_thread *uk_thread_create_container(struct uk_alloc *a,
 					     bool no_ectx,
 					     const char *name,
 					     void *priv,
-					     uk_thread_dtor_t dtor) __nonnull;
+					     uk_thread_dtor_t dtor);
 
 /**
  * Allocates a uk_thread container. Stack and TLS are given by the caller.
@@ -507,7 +507,7 @@ struct uk_thread *uk_thread_create_container2(struct uk_alloc *a,
 					      bool no_ectx,
 					      const char *name,
 					      void *priv,
-					      uk_thread_dtor_t dtor) __nonnull;
+					      uk_thread_dtor_t dtor);
 
 /*
  * Helper functions for initializing a thread container and setting it
@@ -561,7 +561,7 @@ struct uk_thread *uk_thread_create_fn0(struct uk_alloc *a,
 				       bool no_ectx,
 				       const char *name,
 				       void *priv,
-				       uk_thread_dtor_t dtor) __nonnull;
+				       uk_thread_dtor_t dtor);
 
 /**
  * Similar to `uk_thread_create_fn0()` but with a thread function accepting
@@ -575,7 +575,7 @@ struct uk_thread *uk_thread_create_fn1(struct uk_alloc *a,
 				       bool no_ectx,
 				       const char *name,
 				       void *priv,
-				       uk_thread_dtor_t dtor) __nonnull;
+				       uk_thread_dtor_t dtor);
 
 /**
  * Similar to `uk_thread_create_fn0()` but with a thread function accepting
@@ -590,7 +590,7 @@ struct uk_thread *uk_thread_create_fn2(struct uk_alloc *a,
 				       bool no_ectx,
 				       const char *name,
 				       void *priv,
-				       uk_thread_dtor_t dtor) __nonnull;
+				       uk_thread_dtor_t dtor);
 
 void uk_thread_release(struct uk_thread *t) __nonnull;
 void uk_thread_block_timeout(struct uk_thread *thread, __nsec nsec) __nonnull;

--- a/lib/uksched/include/uk/thread.h
+++ b/lib/uksched/include/uk/thread.h
@@ -170,7 +170,7 @@ struct uk_thread *uk_thread_current(void)
 /* NOTE: Never change the EXIT flag manually. Trnasition to exit state reqiures
  * the terminate funcrtiomns to be called.
  */
-void uk_thread_set_exited(struct uk_thread *t);
+void uk_thread_set_exited(struct uk_thread *t) __nonnull;
 
 /*
  * WARNING: The following functions allow threads being created without extended
@@ -225,7 +225,7 @@ int uk_thread_init_bare(struct uk_thread *t,
 			struct ukarch_ectx *ectx,
 			const char *name,
 			void *priv,
-			uk_thread_dtor_t dtor);
+			uk_thread_dtor_t dtor) __nonnull;
 
 /**
  * Initializes a given uk_thread structure. Such a thread can then be
@@ -271,7 +271,7 @@ int uk_thread_init_bare_fn0(struct uk_thread *t,
 			    struct ukarch_ectx *ectx,
 			    const char *name,
 			    void *priv,
-			    uk_thread_dtor_t dtor);
+			    uk_thread_dtor_t dtor) __nonnull;
 
 /**
  * Similar to `uk_thread_init_bare_fn0()` but with a thread function accepting
@@ -286,7 +286,7 @@ int uk_thread_init_bare_fn1(struct uk_thread *t,
 			    struct ukarch_ectx *ectx,
 			    const char *name,
 			    void *priv,
-			    uk_thread_dtor_t dtor);
+			    uk_thread_dtor_t dtor) __nonnull;
 
 /**
  * Similar to `uk_thread_init_bare_fn0()` but with a thread function accepting
@@ -301,7 +301,7 @@ int uk_thread_init_bare_fn2(struct uk_thread *t,
 			    struct ukarch_ectx *ectx,
 			    const char *name,
 			    void *priv,
-			    uk_thread_dtor_t dtor);
+			    uk_thread_dtor_t dtor) __nonnull;
 
 /**
  * Initializes a `uk_thread` structure and allocates stack and optionally TLS.
@@ -351,7 +351,7 @@ int uk_thread_init_fn0(struct uk_thread *t,
 		       struct ukarch_ectx *ectx,
 		       const char *name,
 		       void *priv,
-		       uk_thread_dtor_t dtor);
+		       uk_thread_dtor_t dtor) __nonnull;
 
 /**
  * Similar to `uk_thread_init_fn0()` but with a thread function accepting
@@ -367,7 +367,7 @@ int uk_thread_init_fn1(struct uk_thread *t,
 		       struct ukarch_ectx *ectx,
 		       const char *name,
 		       void *priv,
-		       uk_thread_dtor_t dtor);
+		       uk_thread_dtor_t dtor) __nonnull;
 
 /**
  * Similar to `uk_thread_init_fn0()` but with a thread function accepting
@@ -383,7 +383,7 @@ int uk_thread_init_fn2(struct uk_thread *t,
 		       struct ukarch_ectx *ectx,
 		       const char *name,
 		       void *priv,
-		       uk_thread_dtor_t dtor);
+		       uk_thread_dtor_t dtor) __nonnull;
 
 /**
  * Allocates a bare uk_thread structure. Such a thread can then be assigned
@@ -425,7 +425,7 @@ struct uk_thread *uk_thread_create_bare(struct uk_alloc *a,
 					bool no_ectx,
 					const char *name,
 					void *priv,
-					uk_thread_dtor_t dtor);
+					uk_thread_dtor_t dtor) __nonnull;
 
 /**
  * Allocates a uk_thread container with stack and TLS. The entry point is not
@@ -466,7 +466,7 @@ struct uk_thread *uk_thread_create_container(struct uk_alloc *a,
 					     bool no_ectx,
 					     const char *name,
 					     void *priv,
-					     uk_thread_dtor_t dtor);
+					     uk_thread_dtor_t dtor) __nonnull;
 
 /**
  * Allocates a uk_thread container. Stack and TLS are given by the caller.
@@ -507,19 +507,19 @@ struct uk_thread *uk_thread_create_container2(struct uk_alloc *a,
 					      bool no_ectx,
 					      const char *name,
 					      void *priv,
-					      uk_thread_dtor_t dtor);
+					      uk_thread_dtor_t dtor) __nonnull;
 
 /*
  * Helper functions for initializing a thread container and setting it
  * as runnable
  */
-void uk_thread_container_init_bare(struct uk_thread *t, uintptr_t ip);
-void uk_thread_container_init_fn0(struct uk_thread *t, uk_thread_fn0_t fn);
+void uk_thread_container_init_bare(struct uk_thread *t, uintptr_t ip) __nonnull;
+void uk_thread_container_init_fn0(struct uk_thread *t, uk_thread_fn0_t fn) __nonnull;
 void uk_thread_container_init_fn1(struct uk_thread *t, uk_thread_fn1_t fn,
-						       void *argp);
+						       void *argp) __nonnull;
 void uk_thread_container_init_fn2(struct uk_thread *t, uk_thread_fn2_t fn,
 						       void *argp0,
-						       void *argp1);
+						       void *argp1) __nonnull;
 
 /**
  * Allocates a raw uk_thread structure. Such a thread can then be assigned
@@ -561,7 +561,7 @@ struct uk_thread *uk_thread_create_fn0(struct uk_alloc *a,
 				       bool no_ectx,
 				       const char *name,
 				       void *priv,
-				       uk_thread_dtor_t dtor);
+				       uk_thread_dtor_t dtor) __nonnull;
 
 /**
  * Similar to `uk_thread_create_fn0()` but with a thread function accepting
@@ -575,7 +575,7 @@ struct uk_thread *uk_thread_create_fn1(struct uk_alloc *a,
 				       bool no_ectx,
 				       const char *name,
 				       void *priv,
-				       uk_thread_dtor_t dtor);
+				       uk_thread_dtor_t dtor) __nonnull;
 
 /**
  * Similar to `uk_thread_create_fn0()` but with a thread function accepting
@@ -590,12 +590,12 @@ struct uk_thread *uk_thread_create_fn2(struct uk_alloc *a,
 				       bool no_ectx,
 				       const char *name,
 				       void *priv,
-				       uk_thread_dtor_t dtor);
+				       uk_thread_dtor_t dtor) __nonnull;
 
-void uk_thread_release(struct uk_thread *t);
-void uk_thread_block_timeout(struct uk_thread *thread, __nsec nsec);
-void uk_thread_block(struct uk_thread *thread);
-void uk_thread_wake(struct uk_thread *thread);
+void uk_thread_release(struct uk_thread *t) __nonnull;
+void uk_thread_block_timeout(struct uk_thread *thread, __nsec nsec) __nonnull;
+void uk_thread_block(struct uk_thread *thread) __nonnull;
+void uk_thread_wake(struct uk_thread *thread) __nonnull;
 
 /**
  * Macro to access a Unikraft thread-local (UKTLS) variable of a


### PR DESCRIPTION
Add __nonnull keyword to appropriate function declarations in uksched

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes
Add __nonnull keyword to appropriate function declarations in uksched library
<!--
Please provide a detailed description of the changes made in this new PR.
-->
