### PR TITLE
lib/posix-event: Fix type of `revents` pointer

### DIFF
--- a/lib/posix-event/poll.c
+++ b/lib/posix-event/poll.c
@@ -128,7 +128,7 @@ static int do_ppoll(struct pollfd *fds, nfds_t nfds, const __nsec *timeout,
 		UK_ASSERT(events[i].data.ptr);
 
 		/* We have a pointer to revents of the corresponding pollfd */
-		*((int *)events[i].data.ptr) = events[i].events;
+		*((short *)events[i].data.ptr) = events[i].events;
 	}
 
 ERR_FREE_EVENTS:


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:
-->

 - `CONFIG_LIBPOSIX_EVENTS=y`


### Description of changes

The type of revents is a `short` and not an `int`. This caused out-of-bounds writes and possibly in stack corruption.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
