### PR TITLE
plat/common: Ensure the `.eh_frame` section stays

### DIFF
--- a/plat/common/include/uk/plat/common/common.lds.h
+++ b/plat/common/include/uk/plat/common/common.lds.h
@@ -82,16 +82,16 @@
 	__eh_frame_start = .;						\
 	.eh_frame :							\
 	{								\
-		*(.eh_frame)						\
-		*(.eh_frame.*)						\
+		KEEP(*(.eh_frame))					\
+		KEEP(*(.eh_frame.*))					\
 	}								\
 	__eh_frame_end = .;						\
 									\
 	__eh_frame_hdr_start = .;					\
 	.eh_frame_hdr :							\
 	{								\
-		*(.eh_frame_hdr)					\
-		*(.eh_frame_hdr.*)					\
+		KEEP(*(.eh_frame_hdr))					\
+		KEEP(*(.eh_frame_hdr.*))				\
 	}								\
 	__eh_frame_hdr_end = .;
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

-->

 - `CONFIG_OPTIMIZE_DEADELIM=y`


### Description of changes

Using the `CONFIG_OPTIMIZE_DEADELIM` KConfig option adds the `--gc-sections` command-line flag to the linker. Because the `.eh_frame` section is not really referenced anywhere the linker will happily throw it away. The solution is to mark it with `KEEP` in the linker scripts.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
