### PR TITLE
Add dlang support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,14 @@ RUSTCFLAGS :=
 RUSTCFLAGS-y :=
 GOCINCLUDES :=
 GOCINCLUDES-y :=
+DMDFLAGS :=
+DMDFLAGS-y :=
+DMDINCLUDES :=
+DMDINCLUDES-y :=
+GDCFLAGS :=
+GDCFLAGS-y :=
+GDCINCLUDES :=
+GDCINCLUDES-y :=
 DBGFLAGS :=
 DBGFLAGS-y :=
 LDFLAGS :=
@@ -588,6 +596,8 @@ RUSTC		:= rustc --target=$(CONFIG_LLVM_TARGET_ARCH)
 else
 RUSTC		:= rustc
 endif
+DMD		:= $(CONFIG_CROSS_COMPILE)dmd
+GDC		:= $(CONFIG_CROSS_COMPILE)gdc
 AS		:= $(CC)
 AR		:= $(CONFIG_CROSS_COMPILE)gcc-ar
 NM		:= $(CONFIG_CROSS_COMPILE)gcc-nm
@@ -628,6 +638,7 @@ ASFLAGS		+= -DCC_VERSION=$(CC_VERSION)
 CFLAGS		+= -DCC_VERSION=$(CC_VERSION)
 CXXFLAGS	+= -DCC_VERSION=$(CC_VERSION)
 GOCFLAGS	+= -DCC_VERSION=$(CC_VERSION)
+GDCFLAGS	+= -DCC_VERSION=$(CC_VERSION)
 
 # ensure $(BUILD_DIR)/kconfig, $(BUILD_DIR)/include and $(BUILD_DIR)/include/uk exists
 $(call mk_sub_build_dir,kconfig)
@@ -638,6 +649,8 @@ ASINCLUDES            += -I$(UK_GENERATED_INCLUDES)
 CINCLUDES             += -I$(UK_GENERATED_INCLUDES)
 CXXINCLUDES           += -I$(UK_GENERATED_INCLUDES)
 GOCINCLUDES           += -I$(UK_GENERATED_INCLUDES)
+DMDINCLUDES           += -I$(UK_GENERATED_INCLUDES)
+GDCINCLUDES           += -I$(UK_GENERATED_INCLUDES)
 
 ################################################################################
 # Build rules

--- a/Makefile
+++ b/Makefile
@@ -356,6 +356,11 @@ UK_HAVE_DOT_CONFIG := y
 endif
 endif
 
+ifneq ($(CONFIG_HAVE_DRUNTIME), y)
+GDCFLAGS-y := -fno-druntime
+DMDFLAGS-y := -betterC
+endif
+
 # parameter N: UK_NAME ###
 # # Use N variable if set on the command line, otherwise use directory name
 ifeq ("$(origin N)", "command line")

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -16,10 +16,13 @@ COMPFLAGS-$(call have_clang)	+= -Wdocumentation -Wdocumentation-pedantic
 
 ASFLAGS      += -D__ASSEMBLY__
 
+GDCFLAGS     += -nostdlib -nophoboslib
+
 ASINCLUDES   += -I$(CONFIG_UK_BASE)/include
 CINCLUDES    += -I$(CONFIG_UK_BASE)/include
 CXXINCLUDES  += -I$(CONFIG_UK_BASE)/include
 GOCINCLUDES  += -I$(CONFIG_UK_BASE)/include
+GDCINCLUDES  += -I$(CONFIG_UK_BASE)/include
 
 RUSTCFLAGS-y	+= --emit=obj --crate-type=rlib --edition=2018 \
 		-Cpanic=abort -Cembed-bitcode=n \

--- a/lib/Config.uk
+++ b/lib/Config.uk
@@ -32,3 +32,7 @@ config HAVE_SYSCALL
 config HAVE_X86PKU
 	bool
 	default n
+
+config HAVE_DRUNTIME
+	bool
+	default n

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -625,7 +625,7 @@ endef
 define buildrule_dmd =
 $(4): $(2) | prepare
 	$(call build_cmd,DMD,$(1),$(4),\
-		$(DMD) -betterC $(DMDINCLUDES) $(DMDINCLUDES-y) \
+		$(DMD) $(DMDINCLUDES) $(DMDINCLUDES-y) \
 			$($(call vprefix_lib,$(1),DMDINCLUDES)) $($(call vprefix_lib,$(1),DMDINCLUDES-y)) \
 			$(DMDFLAGS) $(DMDFLAGS-y) $($(call vprefix_lib,$(1),DMDFLAGS)) \
 			$($(call vprefix_lib,$(1),DMDFLAGS-y)) \

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -622,6 +622,52 @@ $(eval $(call vprefix_lib,$(1),OBJS-y) += $(4))
 $(eval $(call vprefix_lib,$(1),CLEAN-y) += $(call build_clean,$(4)) $(call out2dep,$(4)))
 endef
 
+define buildrule_dmd =
+$(3): $(2) | prepare
+    $(call build_cmd,DMD,$(1),$(3),\
+        $(DMD) -betterC $(DMDINCLUDES) $(DMDINCLUDES-y) \
+            $($(call vprefix_lib,$(1),DMDINCLUDES)) $($(call vprefix_lib,$(1),DMDINCLUDES-y)) \
+            $(DMDFLAGS) $(DMDFLAGS-y) $($(call vprefix_lib,$(1),DMDFLAGS)) \
+            $($(call vprefix_lib,$(1),DMDFLAGS-y)) \
+            $(2) -c -od=$(dir $(3))
+    )
+
+UK_SRCS-y += $(2)
+UK_DEPS-y += $(call out2dep,$(3))
+UK_OBJS-y += $(3)
+$(eval $(call vprefix_lib,$(1),OBJS-y) += $(3))
+$(eval $(call vprefix_lib,$(1),CLEAN-y) += $(call build_clean,$(3)) $(call out2dep,$(3)))
+endef
+
+define buildrule_gdc =
+$(3): $(2) | prepare
+    $(call build_cmd,GDC,$(1),$(3),\
+            $(GDC) $(GDCINCLUDES) $(GDCINCLUDES-y) \
+            $($(call vprefix_lib,$(1),GDCINCLUDES)) $($(call vprefix_lib,$(1),GDCINCLUDES-y)) \
+            $(GDCFLAGS) $(GDCFLAGS-y) $(DBGFLAGS) $(DBGFLAGS-y) \
+            $($(call vprefix_lib,$(1),GDCFLAGS)) $($(call vprefix_lib,$(1),GDCFLAGS-y)) \
+            $(4) -D__LIBNAME__=$(1) -D__BASENAME__=$(notdir $(2)) \
+            -c $(2) -o $(3) $(depflags)
+    )
+
+UK_SRCS-y += $(2)
+UK_DEPS-y += $(call out2dep,$(3))
+UK_OBJS-y += $(3)
+$(eval $(call vprefix_lib,$(1),OBJS-y) += $(3))
+$(eval $(call vprefix_lib,$(1),CLEAN-y) += $(call build_clean,$(3)) $(call out2dep,$(3)))
+endef
+
+ifeq ($(D_COMPILER),dmd)
+    define buildrule_d =
+        $(buildrule_dmd)
+    endef
+else
+    define buildrule_d =
+        $(buildrule_gdc)
+    endef
+endif
+
+
 define add_lds_to_plat =
 $(eval $(call uc,$(2))_LD_SCRIPT-y += $(1))
 endef

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -623,38 +623,38 @@ $(eval $(call vprefix_lib,$(1),CLEAN-y) += $(call build_clean,$(4)) $(call out2d
 endef
 
 define buildrule_dmd =
-$(3): $(2) | prepare
-    $(call build_cmd,DMD,$(1),$(3),\
-        $(DMD) -betterC $(DMDINCLUDES) $(DMDINCLUDES-y) \
-            $($(call vprefix_lib,$(1),DMDINCLUDES)) $($(call vprefix_lib,$(1),DMDINCLUDES-y)) \
-            $(DMDFLAGS) $(DMDFLAGS-y) $($(call vprefix_lib,$(1),DMDFLAGS)) \
-            $($(call vprefix_lib,$(1),DMDFLAGS-y)) \
-            $(2) -c -od=$(dir $(3))
-    )
+$(4): $(2) | prepare
+	$(call build_cmd,DMD,$(1),$(4),\
+		$(DMD) -betterC $(DMDINCLUDES) $(DMDINCLUDES-y) \
+			$($(call vprefix_lib,$(1),DMDINCLUDES)) $($(call vprefix_lib,$(1),DMDINCLUDES-y)) \
+			$(DMDFLAGS) $(DMDFLAGS-y) $($(call vprefix_lib,$(1),DMDFLAGS)) \
+			$($(call vprefix_lib,$(1),DMDFLAGS-y)) \
+			$(2) -c -od=$(dir $(4))
+	)
 
 UK_SRCS-y += $(2)
-UK_DEPS-y += $(call out2dep,$(3))
-UK_OBJS-y += $(3)
-$(eval $(call vprefix_lib,$(1),OBJS-y) += $(3))
-$(eval $(call vprefix_lib,$(1),CLEAN-y) += $(call build_clean,$(3)) $(call out2dep,$(3)))
+UK_DEPS-y += $(call out2dep,$(4))
+UK_OBJS-y += $(4)
+$(eval $(call vprefix_lib,$(1),OBJS-y) += $(4))
+$(eval $(call vprefix_lib,$(1),CLEAN-y) += $(call build_clean,$(4)) $(call out2dep,$(4)))
 endef
 
 define buildrule_gdc =
-$(3): $(2) | prepare
-    $(call build_cmd,GDC,$(1),$(3),\
-            $(GDC) $(GDCINCLUDES) $(GDCINCLUDES-y) \
-            $($(call vprefix_lib,$(1),GDCINCLUDES)) $($(call vprefix_lib,$(1),GDCINCLUDES-y)) \
-            $(GDCFLAGS) $(GDCFLAGS-y) $(DBGFLAGS) $(DBGFLAGS-y) \
-            $($(call vprefix_lib,$(1),GDCFLAGS)) $($(call vprefix_lib,$(1),GDCFLAGS-y)) \
-            $(4) -D__LIBNAME__=$(1) -D__BASENAME__=$(notdir $(2)) \
-            -c $(2) -o $(3) $(depflags)
-    )
+$(4): $(2) | prepare
+	$(call build_cmd,GDC,$(1),$(4),\
+		$(GDC) $(GDCINCLUDES) $(GDCINCLUDES-y) \
+			$($(call vprefix_lib,$(1),GDCINCLUDES)) $($(call vprefix_lib,$(1),GDCINCLUDES-y)) \
+			$(GDCFLAGS) $(GDCFLAGS-y) $(DBGFLAGS) $(DBGFLAGS-y) \
+			$($(call vprefix_lib,$(1),GDCFLAGS)) $($(call vprefix_lib,$(1),GDCFLAGS-y)) \
+			$(5) -D__LIBNAME__=$(1) -D__BASENAME__=$(notdir $(2)) \
+			-c $(2) -o $(4) $(depflags)
+	)
 
 UK_SRCS-y += $(2)
-UK_DEPS-y += $(call out2dep,$(3))
-UK_OBJS-y += $(3)
-$(eval $(call vprefix_lib,$(1),OBJS-y) += $(3))
-$(eval $(call vprefix_lib,$(1),CLEAN-y) += $(call build_clean,$(3)) $(call out2dep,$(3)))
+UK_DEPS-y += $(call out2dep,$(4))
+UK_OBJS-y += $(4)
+$(eval $(call vprefix_lib,$(1),OBJS-y) += $(4))
+$(eval $(call vprefix_lib,$(1),CLEAN-y) += $(call build_clean,$(4)) $(call out2dep,$(4)))
 endef
 
 ifeq ($(D_COMPILER),dmd)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.



### Description of changes

* Add D build rules for `GDC` and `DMD` from #245
* Add a new config option that checks if there is any Druntime library present (similar to the libc one).
  This is needed since when building with no D runtime library, some extra flags are required at build (`-betterC` for `dmd` and `-fno-druntime` for `gdc`).

Supersedes #245
Depends-on: lib-musl PR: [#37](https://github.com/unikraft/lib-musl/pull/37)


The dlang support with no runtime can be tested with the script [here](https://github.com/StefanJum/helloworld-dlang-script/blob/master/do_dlang_betterc.sh) (`./do_dlang_betterc.sh run` does everything). It builds and runs the app [here](https://github.com/unikraft-upb/app-helloworld-dlang-betterc).

The dlang support with runtime enabled can be tested by using the script [here](https://github.com/StefanJum/helloworld-dlang-script/blob/master/do_dlang.sh) (`./do_dlang run` does everything), that builds and runs the app [here](https://github.com/unikraft-upb/app-helloworld-dlang).
For now, if using druntime, [this line](https://github.com/unikraft/unikraft/blob/staging/lib/uksignal/signal.c#L59) in `uksignal` must be commented out when building in order to avoid a segfault. This is done by the script.