### PR TITLE
plat/x86: Add `write-combined` page entry attribute

### DIFF
--- a/arch/x86/x86_64/include/uk/asm/lcpu.h
+++ b/arch/x86/x86_64/include/uk/asm/lcpu.h
@@ -138,6 +138,7 @@ static inline void ukarch_spinwait(void)
 #define X86_CPUID1_ECX_AVX      (1 << 28)
 #define X86_CPUID1_ECX_RDRAND	(1 << 30)
 #define X86_CPUID1_EDX_FPU      (1 << 0)
+#define X86_CPUID1_EDX_PAT      (1 << 16)
 #define X86_CPUID1_EDX_FXSR     (1 << 24)
 #define X86_CPUID1_EDX_SSE      (1 << 25)
 /* CPUID feature bits in EBX and ECX when EAX=7, ECX=0 */

--- a/arch/x86/x86_64/include/uk/asm/paging.h
+++ b/arch/x86/x86_64/include/uk/asm/paging.h
@@ -193,6 +193,7 @@ static inline int ukarch_vaddr_range_isvalid(__vaddr_t start, __vaddr_t end)
 #define PAGE_ATTR_PROT_READ		0x01 /* Page is readable */
 #define PAGE_ATTR_PROT_WRITE		0x02 /* Page is writeable */
 #define PAGE_ATTR_PROT_EXEC		0x04 /* Page is executable */
+#define PAGE_ATTR_WRITECOMBINE		0x08 /* Page allows write-combining */
 
 /* Page fault error code bits */
 #define X86_PF_EC_P			0x0001UL /* 0=non-present, 1=prot */

--- a/arch/x86/x86_64/include/uk/asm/paging.h
+++ b/arch/x86/x86_64/include/uk/asm/paging.h
@@ -205,6 +205,27 @@ static inline int ukarch_vaddr_range_isvalid(__vaddr_t start, __vaddr_t end)
 #define X86_PF_EC_SGX			0x8000UL /* SGX access control viol. */
 #define X86_PF_EC_HLAT			0x0080UL /* no translation using HLAT */
 
+/* Page attribute table (PAT) */
+#define X86_PAT_UC			0x00 /* Uncacheable (UC)*/
+#define X86_PAT_WC			0x01 /* Write combining (WC) */
+#define X86_PAT_WT			0x04 /* Write through (WT) */
+#define X86_PAT_WP			0x05 /* Write protected (WP) */
+#define X86_PAT_WB			0x06 /* Write back (WB) */
+#define X86_PAT_UCM			0x07 /* Uncached (UC-) */
+
+#define X86_PAT_ENTRY(i, val)		((unsigned long)(val) << ((i) * 8UL))
+
+/* Default PAT value (see SDM Vol 3, 11.12.4 Programming the PAT) */
+#define X86_PAT_DEFAULT						\
+	(X86_PAT_ENTRY(0, X86_PAT_WB) |				\
+	 X86_PAT_ENTRY(1, X86_PAT_WT) |				\
+	 X86_PAT_ENTRY(2, X86_PAT_UCM) |			\
+	 X86_PAT_ENTRY(3, X86_PAT_UC) |				\
+	 X86_PAT_ENTRY(4, X86_PAT_WB) |				\
+	 X86_PAT_ENTRY(5, X86_PAT_WT) |				\
+	 X86_PAT_ENTRY(6, X86_PAT_UCM) |			\
+	 X86_PAT_ENTRY(7, X86_PAT_UC))
+
 #ifndef CONFIG_PARAVIRT
 #ifndef __ASSEMBLY__
 static inline int ukarch_pte_read(__vaddr_t pt_vaddr, unsigned int lvl,

--- a/plat/common/include/x86/cpu_defs.h
+++ b/plat/common/include/x86/cpu_defs.h
@@ -99,6 +99,8 @@
 #define X86_MSR_CSTAR		0xc0000083
 /* EFLAGS mask for syscall */
 #define X86_MSR_SYSCALL_MASK	0xc0000084
+/* page attribute table configuration */
+#define X86_MSR_PAT		0x277
 
 /* MSR EFER bits */
 #define X86_EFER_SCE		(1 << 0)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

This attribute is useful for memory-mapped devices and can reduce the amount of transactions necessary when communicating with the device.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
