### PR TITLE
Fix double fault and failing mmap

### DIFF
--- a/lib/posix-mmap/mmap.c
+++ b/lib/posix-mmap/mmap.c
@@ -85,7 +85,8 @@ static int do_mmap(void **addr, size_t len, int prot, int flags, int fd,
 	}
 
 	if (flags & MAP_ANONYMOUS) {
-		if ((flags & MAP_SHARED) || (flags & MAP_SHARED_VALIDATE)) {
+		if ((flags & MAP_SHARED) ||
+		    (flags & MAP_SHARED_VALIDATE) == MAP_SHARED_VALIDATE) {
 			/* MAP_SHARED(_VALIDATE): Note, we ignore it for
 			 * anonymous memory since we only have a single
 			 * process. There is no one to share the mapping with.
@@ -122,7 +123,8 @@ static int do_mmap(void **addr, size_t len, int prot, int flags, int fd,
 		vops  = &uk_vma_anon_ops;
 	} else {
 #ifdef CONFIG_LIBVFSCORE
-		if ((flags & MAP_SHARED) || (flags & MAP_SHARED_VALIDATE))
+		if ((flags & MAP_SHARED) ||
+		    (flags & MAP_SHARED_VALIDATE) == MAP_SHARED_VALIDATE)
 			vflags |= UK_VMA_FILE_SHARED;
 		else if (unlikely(!(flags & MAP_PRIVATE)))
 			return -EINVAL;

--- a/lib/posix-mmap/mmap.c
+++ b/lib/posix-mmap/mmap.c
@@ -184,6 +184,7 @@ static int do_mmap(void **addr, size_t len, int prot, int flags, int fd,
 		vaddr = __VADDR_ANY;
 	} while (1);
 
+	*addr = (void *)vaddr;
 	return rc;
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

This PR fixes two problems with `posix-mmap` and `ukvmem` (see commit messages). The PR should close #786 and #787 
