### PR TITLE
support/scripts: Change the SECINFO_EXP regex to be more permissive

### DIFF
--- a/support/scripts/mkbootinfo.py
+++ b/support/scripts/mkbootinfo.py
@@ -9,7 +9,7 @@ import subprocess
 import re
 import os
 
-SECINFO_EXP = r'^\s+\d+\s+.uk_bootinfo\s+([0-9,a-f]+)'
+SECINFO_EXP = r'^\s*\d+\s+\.uk_bootinfo\s+([0-9,a-f]+)'
 PHDRS_EXP = r'^\s+LOAD.+vaddr\s(0x[0-9,a-f]+).+\n.+memsz\s(0x[0-9,a-f]+)\sflags\s([rwx|-]{3})$'
 
 # Memory region types (see include/uk/plat/memory.h)


### PR DESCRIPTION
Currently, the regex for matching the `.uk_bootinfo` section does not consider the case of the section having a number bigger than 99 as a result of objdump -h. This PR changes the regex to consider that case.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`, `arm`]
 - Platform(s): [N/A]
 - Application(s): [ N/A]


