### PR TITLE
include/uk/plat/memory.h: Add check for memory region descriptor

### DIFF
--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -190,7 +190,7 @@ static struct uk_alloc *heap_init()
 			    (void *)md->vbase, (void *)(md->vbase + md->len),
 			    md->flags,
 #if CONFIG_UKPLAT_MEMRNAME
-			    md->name
+			    md->name,
 #else /* CONFIG_UKPLAT_MEMRNAME */
 			    ""
 #endif /* !CONFIG_UKPLAT_MEMRNAME */

--- a/plat/linuxu/memory.c
+++ b/plat/linuxu/memory.c
@@ -127,10 +127,13 @@ static int __linuxu_plat_initrd_init(void)
 
 int ukplat_memregion_count(void)
 {
+	static int init = 0;
 	static int have_heap = 0;
 	static int have_initrd = 0;
 	int rc = 0;
 
+	if (init)
+		return init;
 	/*
 	 * NOTE: The heap size and initrd file can be changed by a
 	 * library parameter. We assume that those ones are processed
@@ -147,7 +150,9 @@ int ukplat_memregion_count(void)
 		have_initrd = (rc == 0) ? 1 : 0;
 	}
 
-	return have_heap + have_initrd;
+	init = have_heap + have_initrd;
+
+	return init;
 }
 
 int ukplat_memregion_get(int i, struct ukplat_memregion_desc **m)
@@ -156,6 +161,9 @@ int ukplat_memregion_get(int i, struct ukplat_memregion_desc **m)
 	int ret;
 
 	UK_ASSERT(m);
+	if (i >= ukplat_memregion_count())
+		return -1;
+
 
 	if (i == 0 && _liblinuxuplat_opts.heap.base) {
 		mrd[0].pbase = (__paddr_t)_liblinuxuplat_opts.heap.base;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [X] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [X] Updated relevant documentation.


### Base target

 - Architecture(s): x86_64
 - Platform(s): linuxu
 - Application(s): [e.g. `helloword` or N/A]


### Additional configuration
none

### Description of changes
according to https://github.com/unikraft/unikraft/issues/766 the helloworld example was broken because an invalid memory allocator. 
~~~~
[443184.280410] Info: [libukboot] <boot.c @  245> Unikraft constructor table at 0x40e000 - 0x40e008
[443184.280459] dbg:  [libukboot] <boot.c @  249> Call constructor: 0x40d400())...
[443184.280509] dbg:  [libcontext] <ectx.c @   72> Load/store of extended CPU state: XSAVEOPT
[443184.280547] Info: [libukboot] <boot.c @  264> Initialize memory allocator...
[443184.280570] CRIT: [libukboot] <boot.c @  268> Failed to initialize memory allocator
[Inferior 1 (process 34651) exited with code 01]
~~~~

This problem occurred because you attempted to access a page without first determining the total number of available pages. To clarify further, the function ukplat_memregion_find_next requires the count of memory regions to be validated before calling the ukplat_memregion_find_next function to obtain the desired memory region.

For this reason I add a sanity check  count = ukplat_memregion_count(); that will avoid the program to advance if the memory region is greater or equal than memory region count. 

With this changes the hello world  works as expected

---output after fixing
~~~~
 ./helloworld_linuxu-x86_64
[447357.835182] dbg:  [libukboot] <boot.c @  249> Call constructor: 0x40c1f0())...
[447357.835227] dbg:  [libcontext] <ectx.c @   72> Load/store of extended CPU state: XSAVEOPT
[447357.835281] dbg:  [liblinuxuplat] <memory.c @   84> No initrd present.
[447357.835321] dbg:  [libukboot] <boot.c @  189> Trying 0x7f1c14674000-0x7f1c14a74000 0x00
[447357.835401] dbg:  [libukallocbbuddy] <bbuddy.c @  471> 7f1c14674000: Add allocate unit 7f1c14676000 - 7f1c14678000 (order 1)
[447357.835440] dbg:  [libukallocbbuddy] <bbuddy.c @  471> 7f1c14674000: Add allocate unit 7f1c14678000 - 7f1c14680000 (order 3)
[447357.835508] dbg:  [libukallocbbuddy] <bbuddy.c @  471> 7f1c14674000: Add allocate unit 7f1c14680000 - 7f1c14700000 (order 7)
[447357.835590] dbg:  [libukallocbbuddy] <bbuddy.c @  471> 7f1c14674000: Add allocate unit 7f1c14700000 - 7f1c14800000 (order 8)
[447357.835687] dbg:  [libukallocbbuddy] <bbuddy.c @  471> 7f1c14674000: Add allocate unit 7f1c14800000 - 7f1c14a00000 (order 9)
[447357.835810] dbg:  [libukallocbbuddy] <bbuddy.c @  471> 7f1c14674000: Add allocate unit 7f1c14a00000 - 7f1c14a40000 (order 6)
[447357.835865] dbg:  [libukallocbbuddy] <bbuddy.c @  471> 7f1c14674000: Add allocate unit 7f1c14a40000 - 7f1c14a60000 (order 5)
[447357.835920] dbg:  [libukallocbbuddy] <bbuddy.c @  471> 7f1c14674000: Add allocate unit 7f1c14a60000 - 7f1c14a70000 (order 4)
[447357.835995] dbg:  [libukallocbbuddy] <bbuddy.c @  471> 7f1c14674000: Add allocate unit 7f1c14a70000 - 7f1c14a74000 (order 2)
[447357.836074] dbg:  [libcontext] <tls.c @  173> tls_area_init: target: 0x7f1c14676020 (16 bytes)
[447357.836110] dbg:  [libcontext] <tls.c @  175> tls_area_init: copy (.tdata): 0 bytes
[447357.836163] dbg:  [libcontext] <tls.c @  177> tls_area_init: uninitialized (.tbss): 4 bytes
[447357.836203] dbg:  [libcontext] <tls.c @  179> tls_area_init: pad: 4 bytes
[447357.836257] dbg:  [libcontext] <tls.c @  181> tls_area_init: tcb: 8 bytes
[447357.836327] dbg:  [libcontext] <tls.c @  183> tls_area_init: tcb self ptr: 0x7f1c14676028
[447357.836370] dbg:  [libcontext] <tls.c @  204> (tls_area): 7f1c14676020  00 00 00 00 00 00 00 00  28 60 67 14 1c 7f 00 00  |........(`g.....|
[447357.836642] dbg:  [libuksched] <thread.c @  254> uk_thread 0x7f1c146770b0 (idle): ctx:0x7f1c146770b0, ectx:0x7f1c14a70040, tlsp:0x7f1c14a70028
[447357.836678] dbg:  [libcontext] <tls.c @  173> tls_area_init: target: 0x7f1c14a70020 (16 bytes)
[447357.836727] dbg:  [libcontext] <tls.c @  175> tls_area_init: copy (.tdata): 0 bytes
[447357.836775] dbg:  [libcontext] <tls.c @  177> tls_area_init: uninitialized (.tbss): 4 bytes
[447357.836818] dbg:  [libcontext] <tls.c @  179> tls_area_init: pad: 4 bytes
[447357.836840] dbg:  [libcontext] <tls.c @  181> tls_area_init: tcb: 8 bytes
[447357.836862] dbg:  [libcontext] <tls.c @  183> tls_area_init: tcb self ptr: 0x7f1c14a70028
[447357.836887] dbg:  [libcontext] <tls.c @  204> (tls_area): 7f1c14a70020  00 00 00 00 00 00 00 00  28 00 a7 14 1c 7f 00 00  |........(.......|
[447357.837259] dbg:  [libcontext] <ctx.c @  133> ukarch_ctx 0x7f1c146770b0: entry:0x40af80(7f1c14677018), sp:0x7f1c14a50018
[447357.837308] dbg:  [libuksched] <thread.c @  254> uk_thread 0x7f1c14a71018 (init): ctx:0x7f1c14a71018, ectx:0x7f1c14a71100, tlsp:0x7f1c14676028
Powered by
o.   .o       _ _               __ _
Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
oOo oOO| | | | |   (| | | (_) |  _) :_
 OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
      Epimetheus 0.12.0~4c7352c0-custom
Hello world!
Arguments:  "./helloworld_linuxu-x86_64"

      _
    c'_'o  .--'
    (| |)_/            [447357.837418] dbg:  [libposix_time] <time.c @   65> (in      _                ep((const struct timespec*) 0x7ffd00121bc0, (struct times    c'o'o  .--.
    (| |)_/            [447358.087798] dbg:  [libposix_time] <time.c @   65> (in      _                ep((const struct timespec*) 0x7ffd00121bc0, (struct times    c'_'o  .-.
    (| |)_/   `        [447358.338165] dbg:  [libposix_time] <time.c @   65> (in      _                ep((const struct timespec*) 0x7ffd00121bc0, (struct times
~~~~
 

<!--
Please provide a detailed description of the changes made in this new PR.
-->
#766 