### PR TITLE
lib/posix-event: Update `uio_offset` and `uio_resid` on successful reads

### DIFF
--- a/lib/posix-event/eventfd.c
+++ b/lib/posix-event/eventfd.c
@@ -171,6 +171,9 @@ static int eventfd_vfscore_read(struct vnode *vnode,
 
 	uk_mutex_unlock(&efd->lock);
 
+	buf->uio_resid = 0;
+	buf->uio_offset = sizeof(uint64_t);
+
 	return 0;
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [all]
 - Platform(s): [all]
 - Application(s): [all]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:



-->

 - `CONFIG_LIBPOSIX_EVENT=y`

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR updates (on a successful read) the `uio_offset` and `uio_resid` members of the `uio` structure passed to the `eventfd_vfscore_read` function. Without updating those members, the `read` function from the vfscore layer will always report that no bytes have been read at all.

The `eventfd_vfscore_write` function doesn't have the same bug, as it already updates its `uio` members after successful writes.
