### PR TITLE
lib/nolibc: Remove warnings related to timespec

### DIFF
--- a/lib/nolibc/include/sys/stat.h
+++ b/lib/nolibc/include/sys/stat.h
@@ -116,8 +116,8 @@ int mknod(const char *, mode_t, dev_t);
 int mknodat(int, const char *, mode_t, dev_t);
 #endif
 
-int futimens(int, const struct timespec [2]);
-int utimensat(int, const char *, const struct timespec [2], int);
+int futimens(int, const struct timespec *);
+int utimensat(int, const char *, const struct timespec *, int);
 
 #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
 int lchmod(const char *, mode_t);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]

### Additional configuration

- `CONFIG_LIBVFSCORE=y`
<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The following warnings are removed by changing the definition of timespec argument in nolibc from array to pointer style as same as newlib.

```
unikraft/unikraft/lib/vfscore/main.c:2422:96: warning: argument 3 of type ‘const struct timespec *’ declared as a pointer [-Warray-parameter=]
 2422 | UK_SYSCALL_R_DEFINE(int, utimensat, int, dirfd, const char*, pathname, const struct timespec*, times, int, flags)

unikraft/unikraft/lib/vfscore/main.c:2444:45: warning: argument 2 of type ‘const struct timespec *’ declared as a pointer [-Warray-parameter=]
 2444 | int futimens(int fd, const struct timespec *times)
```

