### PR TITLE
lib/ukmmap: Unit test:  Add a simple test for mmap and munmap

### DIFF
--- a/lib/ukmmap/Config.uk
+++ b/lib/ukmmap/Config.uk
@@ -1,5 +1,14 @@
-config LIBUKMMAP
+menuconfig LIBUKMMAP
 	bool "ukmmap: mmap system call"
 	default n
 	select LIBNOLIBC if !HAVE_LIBC
 	select LIBUKALLOC
+
+if LIBUKMMAP
+
+config LIBUKMMAP_TEST
+	bool "Enable unit tests"
+	default n
+	select LIBUKTEST
+
+endif

--- a/lib/ukmmap/Makefile.uk
+++ b/lib/ukmmap/Makefile.uk
@@ -4,3 +4,7 @@ LIBUKMMAP_SRCS-y += $(LIBUKMMAP_BASE)/mmap.c
 
 UK_PROVIDED_SYSCALLS-$(CONFIG_LIBUKMMAP) += mmap-6 munmap-2 madvise-3
 UK_PROVIDED_SYSCALLS-$(CONFIG_LIBUKMMAP) += mremap-5 mprotect-3
+
+ifneq ($(filter y,$(CONFIG_LIBUKMMAP_TEST) $(CONFIG_LIBUKTEST_ALL)),)
+LIBUKMMAP_SRCS-y += $(LIBUKMMAP_BASE)/tests/test_mmap.c
+endif

--- a/lib/ukmmap/mmap.c
+++ b/lib/ukmmap/mmap.c
@@ -187,12 +187,12 @@ void *mremap(void *old_address __unused, size_t old_size __unused,
 
 UK_SYSCALL_R_DEFINE(int, madvise, void*, addr, size_t, length, int, advice)
 {
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	return 0;
 }
 
 UK_SYSCALL_R_DEFINE(int, mprotect, void*, addr, size_t, len, int, prot)
 {
-	WARN_STUBBED();
+	UK_WARN_STUBBED();
 	return 0;
 }

--- a/lib/ukmmap/tests/test_mmap.c
+++ b/lib/ukmmap/tests/test_mmap.c
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+
+#define _GNU_SOURCE
+
+#include <sys/mman.h>
+#include <uk/vmem.h>
+#include <uk/test.h>
+
+UK_TESTCASE(ukmmap, test_mmap)
+{
+	void *addr;
+	int rc;
+
+	addr = mmap(NULL, 2 * PAGE_SIZE, PROT_READ | PROT_WRITE,
+		    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	UK_TEST_EXPECT(addr != MAP_FAILED);
+
+	rc = munmap(addr, 2 * PAGE_SIZE);
+	UK_TEST_EXPECT_ZERO(rc);
+}
+
+uk_testsuite_register(ukmmap, NULL);


### PR DESCRIPTION
Signed-off-by: Kha Dinh <dalo2903@gmail.com>

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64` 
 - Platform(s): `kvm` 
 - Application(s): `helloworld`


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Hi unikraft, this is my first commit ever. I saw in [#580](https://github.com/unikraft/unikraft/issues/580) that some items are missing unit tests.
I added new unit tests for `ukmmap`. It is just a copy from `posix_mmap_test.c` without`vas_init`  and `vas_clean`.
I also changed the use of deprecated `WARN_STUBBED` in to `UK_WARN_STUBBED`.