### PR TITLE
build: Detect if `gawk` can be used instead of `awk`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -599,7 +599,12 @@ M4		:= m4
 AR		:= ar
 CAT		:= cat
 SED		:= sed
+# Prefer using GNU AWK because of provided error messages on script errors
+ifeq (, $(shell which gawk))
 AWK		:= awk
+else
+AWK		:= gawk --lint
+endif
 YACC		:= bison
 LEX     	:= flex
 PATCH		:= patch


### PR DESCRIPTION
This commit lets the build system pick preferably `gawk` as drop-in replacement for `awk`. GNU AWK has the advantage that it emits understandable error messages on AWK script errors. This simplifies developing or editing awk files.

There was a related discussion about using `gawk --lint` on Discord end of last year:
https://discord.com/channels/762976922531528725/954287263741771816/1045698142051520674