### PR TITLE
plat/pci_ecam: Fix FDT interrupt node lacking address-cells

### DIFF
--- a/drivers/ukbus/pci/pci_ecam.c
+++ b/drivers/ukbus/pci/pci_ecam.c
@@ -350,10 +350,16 @@ int gen_pci_irq_parse(const fdt32_t *addr, struct fdt_phandle_args *out_irq)
 			prop = fdt_getprop(dtb, newpar, "#address-cells",
 					   &plen);
 			if (prop == NULL) {
-				uk_pr_info(" -> parent lacks #address-cells!\n");
+#ifdef CONFIG_DTB_INTERRUPT_ADDRESS_CELLS_ERRATA
+				uk_pr_info(" -> parent lacks #address-cells, assume 0 cells\n");
+				newaddrsize = 0;
+#else
+				uk_pr_info(" -> parent lacks #address-cells! abort parsing...\n");
 				goto fail;
+#endif
+			} else {
+				newaddrsize = fdt32_to_cpu(prop[0]);
 			}
-			newaddrsize = fdt32_to_cpu(prop[0]);
 
 			uk_pr_debug(" -> newintsize=%d, newaddrsize=%d\n",
 			    newintsize, newaddrsize);

--- a/plat/Config.uk
+++ b/plat/Config.uk
@@ -115,3 +115,12 @@ config FPSIMD
 	depends on ARCH_ARM_64
 	help
 		Enable support FPU usage in application
+
+config DTB_INTERRUPT_ADDRESS_CELLS_ERRATA
+	bool "Errata for uncomplying device trees"
+	default n
+	depends on ARCH_ARM_64
+	help
+		Errata for parsing certain uncomplying device trees
+		which lack the #address-cells property for interrupt
+		controllers.


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [ N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The `gen_pci_irq_parse` function fails when an interrupt parent node is missing the `#address-cells` property. Even though the Devicetree spec states that this property shall be explicitly defined, some DTBs (such as the RISC-V DTB generated by QEMU <= 7.1) do not include this property for the interrupt controller. However, when the parent unit address is missing from the DTB, we can assume that the parent node's `#address-size` property is equal to 0 to maintain compatibility with such DTBs. The specification even says that "If a unit address component is not required, `#address-cells` shall be explicitly defined to be zero.".

We can thus introduce a new CONFIG option, `DTB_INTERRUPT_ADDRESS_CELLS_ERRATA`, which should provide an errata for uncomplying device trees when parsing the interrupt nodes.

Since this particular issue doesn't manifest on the ARM `virt` machine from QEMU, one can possibly test this with other platforms, or with the RISC-V PR: https://github.com/unikraft/unikraft/pull/461.

Signed-off-by: Eduard Vintilă <eduard.vintila47@gmail.com>
