### PR TITLE
plat/drivers/ofw: Fix issues in FDT functions

### DIFF
--- a/plat/drivers/ofw/fdt.c
+++ b/plat/drivers/ofw/fdt.c
@@ -300,14 +300,17 @@ int fdt_get_address(const void *fdt, int nodeoffset, uint32_t index,
 int fdt_node_offset_by_compatible_list(const void *fdt, int startoffset,
 				  const char * const compatibles[])
 {
-	int idx, offset;
+	int idx, min_offset = INT_MAX, offset;
 
 	for (idx = 0; compatibles[idx] != NULL; idx++) {
 		offset = fdt_node_offset_by_compatible(fdt, startoffset,
 				  compatibles[idx]);
-		if (offset >= 0)
-			return offset;
+		if (offset >= 0 && offset < min_offset)
+			min_offset = offset;
 	}
+
+	if (min_offset != INT_MAX)
+		return min_offset;
 
 	return -FDT_ERR_NOTFOUND;
 }
@@ -315,18 +318,22 @@ int fdt_node_offset_by_compatible_list(const void *fdt, int startoffset,
 int fdt_node_offset_idx_by_compatible_list(const void *fdt, int startoffset,
 			  const char * const compatibles[], int *index)
 {
-	int idx, offset;
+	int idx, min_offset = INT_MAX, offset, compatible_idx;
 
 	for (idx = 0; compatibles[idx] != NULL; idx++) {
 		offset = fdt_node_offset_by_compatible(fdt, startoffset,
 				  compatibles[idx]);
-		if (offset >= 0) {
-			*index = idx;
-			return offset;
+		if (offset >= 0 && offset < min_offset) {
+			min_offset = offset;
+			compatible_idx = idx;
 		}
 	}
 
-	*index = idx;
+	if (min_offset != INT_MAX) {
+		*index = compatible_idx;
+		return min_offset;
+	}
+
 	return -FDT_ERR_NOTFOUND;
 }
 

--- a/plat/drivers/ofw/fdt.c
+++ b/plat/drivers/ofw/fdt.c
@@ -158,7 +158,7 @@ static int fdt_translate_one(const void *fdt, int parent, fdt32_t *addr,
 	if (!ranges)
 		return 1;
 	if (rlen == 0) {
-		offset = fdt_reg_read_number(addr, na);
+		offset = 0;
 		uk_pr_debug("empty ranges, 1:1 translation\n");
 		goto finish;
 	}
@@ -179,7 +179,7 @@ static int fdt_translate_one(const void *fdt, int parent, fdt32_t *addr,
 	memcpy(addr, ranges + na, 4 * pna);
 
 finish:
-	uk_pr_info("parent translation for:%p %x", addr, pna);
+	uk_pr_info("parent translation for:%p %x\n", addr, pna);
 
 	/* Translate it into parent bus space */
 	return fdt_default_translate(addr, offset, pna);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes issues found in three functions: `fdt_translate_one` and
`fdt_node_offset_idx_by_compatible_list` / `fdt_node_offset_by_compatible_list` :

`fdt_translate_one`:
When a node is missing the "ranges" property, offset should be set to 0. The current implementation sets offset to the address to be translated, which ignores the fact that the `fdt_default_translate function` is later called. The latter function adds the offset to the same address, resulting in doubling the effective address, when in fact a 1-to-1 mapping is necessary.

`fdt_node_offset_idx_by_compatible_list` / `fdt_node_offset_by_compatible_list`:
The current implementation returns as soon as a node that matches a compatible string is found. However, we should iterate through all of the compatible list to make sure that we return the node with the least offset value such that future searches will not skip any matching nodes.

As with https://github.com/unikraft/unikraft/pull/804, the issues happen to not arise on QEMU's ARM `virt` machine. x86 targets do not use this driver at all, so no luck there either. As such, one can maybe test this PR on other ARM platforms, or with the RISC-V PR (https://github.com/unikraft/unikraft/pull/461), which is directly affected by this problem.

Signed-off-by: Eduard Vintilă <eduard.vintila47@gmail.com>  
