### PR TITLE
lib/uklock: Add Doxygen-style comments

### DIFF
--- a/lib/uklock/include/uk/mutex.h
+++ b/lib/uklock/include/uk/mutex.h
@@ -95,6 +95,16 @@ extern __spinlock              _uk_mutex_metrics_lock;
 void uk_mutex_init(struct uk_mutex *m);
 void uk_mutex_get_metrics(struct uk_mutex_metrics *dst);
 
+/**
+ * Current thread acquires a mutex lock.
+ * Thread is blocked until
+ *     1) Lock count of mutex becomes 0.
+ *     2) Thread itself owns the mutex.
+ * Checks status between dis/enabling interrupts.
+ *
+ * @param m
+ *     A pointer to the mutex
+ */
 static inline void uk_mutex_lock(struct uk_mutex *m)
 {
 	struct uk_thread *current;
@@ -129,6 +139,17 @@ static inline void uk_mutex_lock(struct uk_mutex *m)
 	ukplat_lcpu_restore_irqf(irqf);
 }
 
+/**
+ * Current thread attempts to acquire a mutex lock.
+ * If unavailable, thread returns immediately returns
+ * Otherwise, updates mutex state, and its metrics.
+ *
+ * @param m
+ *     A pointer to the mutex
+ * @return
+ *     1 if lock was acquired, 0 otherwise
+ */
+
 static inline int uk_mutex_trylock(struct uk_mutex *m)
 {
 	struct uk_thread *current;
@@ -157,11 +178,27 @@ static inline int uk_mutex_trylock(struct uk_mutex *m)
 	return ret;
 }
 
+/**
+ * Checks if the mutex is acquired.
+ *
+ * @param m
+ *     A pointer to the mutex
+ * @return
+ *     1 if acquired, 0 otherwise
+ */
 static inline int uk_mutex_is_locked(struct uk_mutex *m)
 {
 	return m->lock_count > 0;
 }
 
+/**
+ * Releases the lock held by a thread.
+ * Decrement lock count, set owner to NULL, and wake up wait queue.
+ * Interrupts are disabled during this operation.
+ *
+ * @param m
+ *     A pointer to the mutex
+ */
 static inline void uk_mutex_unlock(struct uk_mutex *m)
 {
 	unsigned long irqf;

--- a/lib/uklock/include/uk/semaphore.h
+++ b/lib/uklock/include/uk/semaphore.h
@@ -51,6 +51,13 @@ struct uk_semaphore {
 
 void uk_semaphore_init(struct uk_semaphore *s, long count);
 
+/**
+ * Atomically decrements count (resource) by 1.
+ * Thread blocks until there's resource available.
+ *
+ * @param s
+ *     The semaphore that'll be called.
+ */
 static inline void uk_semaphore_down(struct uk_semaphore *s)
 {
 	unsigned long irqf;
@@ -71,6 +78,15 @@ static inline void uk_semaphore_down(struct uk_semaphore *s)
 	ukplat_lcpu_restore_irqf(irqf);
 }
 
+/**
+ * Atomically decrements count (resource) by 1.
+ * Thread doesn't block, but returns immediately.
+ *
+ * @param s
+ *     The semaphore that'll be called.
+ * @return
+ *     1 if semaphore was successfully downed, 0 otherwise.
+ */
 static inline int uk_semaphore_down_try(struct uk_semaphore *s)
 {
 	unsigned long irqf;
@@ -91,7 +107,15 @@ static inline int uk_semaphore_down_try(struct uk_semaphore *s)
 	return ret;
 }
 
-/* Returns __NSEC_MAX on timeout, expired time when down was successful */
+/**
+ * Atomically decrements count (resource) by 1.
+ * Thread can only block upto timeout amount of ticks.
+ *
+ * @param s
+ *     The semaphore that'll be called.
+ * @return
+ *     __NSEC_MAX on timeout, expired time when down was successful.
+ */
 static inline __nsec uk_semaphore_down_to(struct uk_semaphore *s,
 					  __nsec timeout)
 {
@@ -128,6 +152,13 @@ static inline __nsec uk_semaphore_down_to(struct uk_semaphore *s,
 	return __NSEC_MAX;
 }
 
+/**
+ * Atomically increments count (resource) by 1.
+ * Then wakes up a thread waiting on the semaphore.
+ *
+ * @param s
+ *     The semaphore that'll be called.
+ */
 static inline void uk_semaphore_up(struct uk_semaphore *s)
 {
 	unsigned long irqf;

--- a/lib/uklock/mutex.c
+++ b/lib/uklock/mutex.c
@@ -8,6 +8,13 @@ struct uk_mutex_metrics _uk_mutex_metrics = { 0 };
 __spinlock              _uk_mutex_metrics_lock;
 #endif /* CONFIG_LIBUKLOCK_MUTEX_METRICS */
 
+/**
+ * Initializes a mutex and its wait queue.
+ * Increments active mutex count using the spinlock.
+ *
+ * @param m
+ *     The mutex to initialize.
+ */
 void uk_mutex_init(struct uk_mutex *m)
 {
 	m->lock_count = 0;
@@ -38,7 +45,9 @@ uk_lib_initcall_prio(mutex_metrics_ctor, 1);
 
 /**
  * Makes a copy of mutex metrics to avoid direct user access.
- * @dst : destination buffer (must have been already allocated)
+ *
+ * @param dst
+ *     Destination buffer (must have been already allocated)
  */
 void uk_mutex_get_metrics(struct uk_mutex_metrics *dst)
 {

--- a/lib/uklock/semaphore.c
+++ b/lib/uklock/semaphore.c
@@ -3,6 +3,15 @@
 #include <uk/process.h>
 #endif /* CONFIG_LIBPOSIX_PROCESS_CLONE */
 
+/**
+ * Initializes a semaphore with count resources.
+ * Initializes the wait queue, then prints debug message.
+ *
+ * @param s
+ *     The semaphore to initialize.
+ * @param count
+ *     Initial number of "resources" a thread can acquire.
+ */
 void uk_semaphore_init(struct uk_semaphore *s, long count)
 {
 	s->count = count;


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]

### Additional configuration
 - N/A
 
### Added Doxygen-style comments in lib/uklock

As part of #558, I've added Doxygen-style comments in lib/uklock.
I really enjoyed seeing how synchronization primitives are implemented in the internal library as I'm highly interested in the GSoC project on it.
Please let me know if there are any formatting issues!

 - lib/uklock/mutex.c
 - lib/uklock/semaphore.c
 - lib/uklock/include/uk/mutex.h
 - lib/uklock/include/uk/semaphore.h
 - lib/uklock/include/uk/spinlock.h
 - lib/uklock/include/arch/arm64/ticketlock.h
 - lib/uklock/include/isr/mutex.h
 - lib/uklock/include/isr/semaphore.h