### PR TITLE
lib/ukdebug: Handle a full tracing buffer correctly

### DIFF
--- a/lib/ukdebug/include/uk/trace.h
+++ b/lib/ukdebug/include/uk/trace.h
@@ -218,6 +218,20 @@ static inline void __uk_trace_finalize_buff(char *new_buff_pos, void *cookie)
 	struct uk_tracepoint_header *head =
 		(struct uk_tracepoint_header *) uk_trace_buffer_writep;
 
+	if (uk_trace_buffer_free == 0) {
+		/**
+		 * This means that the buffer was large enough for the header.
+		 * (__uk_trace_get_buff would have return NULL and the
+		 * tracepoint would have short-circuited), but the tracepoint
+		 * wanted to write some data which did not fit into the
+		 * remaining space. Therefore, the free variable was also set to
+		 * zero.
+		 * This implies that the event is incomplete and we must not
+		 * mark it as usable via the magic variable.
+		 */
+		return;
+	}
+
 	size = new_buff_pos - uk_trace_buffer_writep;
 	uk_trace_buffer_writep += size;
 	uk_trace_buffer_free -= size;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:
-->

 - `CONFIG_LIBUKDEBUG=y`
 - `CONFIG_LIBUKDEBUG_TRACEPOINTS=y`


### Description of changes

The `__uk_trace_save_arg` function sets the `uk_trace_buffer_free` to zero. The code previously subtracted the size from the `uk_trace_buffer_free` variable even in this case causing an integer underflow. Further trace-point emissions would then happily write past the tracing buffer.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
