### PR TITLE
build/Makefile: Force update UK_CONFIG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,8 @@ override C := $(realpath $(dir $(C)))/$(notdir $(C))
 endif
 UK_CONFIG  := $(C)
 CONFIG_DIR := $(dir $(C))
+# As UK_CONFIG could be different files, always assume it has a newer version
+.PHONY: $(UK_CONFIG)
 
 # EPLAT_DIR (list of external platform libraries)
 # Retrieved from P variable from the command line (paths separated by colon)


### PR DESCRIPTION

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Description of changes

The builder uses UK_CONFIG to generate files such as KCONFIG_AUTOHEADER in the build directory. When UK_CONFIG changes, these newly generated files will also be regenerated.

However, UK_CONFIG may not remain consistent across multiple builds, for example, in the following command sequence:
```
make C=.config_kvm-x86_64
make C=.config_linuxu-x86_64
make C=.config_kvm-x86_64
```

During the first two builds, the configuration files in the build directory will be regenerated. But when using the same configuration file as the first time in the third build, because .config_kvm-x86_64 is not a new version, the configuration files in the build directory will remain the version of linuxu, which will cause the build to fail.

When using kraftkit, similar issues can also be reproduced. Executing "kraft build --arch x86_64" twice, each time is in the order of linuxu, kvm, and xen. When building linuxu for the second time, the configuration files in the build directory are still the configuration of xen, which also causes the build to fail.

This patch forces UK_CONFIG to be recognized as updated, so that the configuration files in the build directory are always updated. It has been tested and can fix this issue.
