### PR TITLE
lib/posix-process: Fix build warnings

### DIFF
--- a/lib/posix-process/deprecated.c
+++ b/lib/posix-process/deprecated.c
@@ -239,7 +239,7 @@ int tcsetpgrp(int fd __unused, pid_t pgrp)
 #endif /* UK_LIBC_SYSCALLS */
 
 #if UK_LIBC_SYSCALLS
-pid_t tcgetpgrp(int fd)
+pid_t tcgetpgrp(int fd __unused)
 {
 	/* We have a single "process group" */
 	return UNIKRAFT_PGID;
@@ -247,7 +247,7 @@ pid_t tcgetpgrp(int fd)
 #endif /* UK_LIBC_SYSCALLS */
 
 #if UK_LIBC_SYSCALLS
-int nice(int inc)
+int nice(int inc __unused)
 {
 	/* We don't support priority updates at the moment */
 	errno = EPERM;
@@ -405,7 +405,7 @@ UK_SYSCALL_R_DEFINE(int, getrusage, int, who,
 }
 
 #if UK_LIBC_SYSCALLS
-int prlimit(pid_t pid, int resource, const struct rlimit *new_limit,
+int prlimit(pid_t pid __unused, int resource, const struct rlimit *new_limit,
 	    struct rlimit *old_limit)
 {
 	return uk_syscall_e_prlimit64(0, (long) resource,


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [X] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Fixed build warnings about unused arguments.

GitHub-Fixes: #818