### PR TITLE
lib/vfscore: Fix for #821

### DIFF
--- a/lib/9pfs/9pfs_vfsops.c
+++ b/lib/9pfs/9pfs_vfsops.c
@@ -30,6 +30,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _BSD_SOURCE
+
 #include <uk/config.h>
 #include <uk/errptr.h>
 #include <uk/9p.h>

--- a/lib/posix-event/epoll.c
+++ b/lib/posix-event/epoll.c
@@ -30,6 +30,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _BSD_SOURCE
+
 #include <vfscore/eventpoll.h>
 #include <vfscore/fs.h>
 #include <vfscore/file.h>

--- a/lib/posix-event/eventfd.c
+++ b/lib/posix-event/eventfd.c
@@ -30,6 +30,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _BSD_SOURCE
+
 #include <vfscore/eventpoll.h>
 #include <vfscore/fs.h>
 #include <vfscore/file.h>

--- a/lib/posix-socket/socket_vnops.c
+++ b/lib/posix-socket/socket_vnops.c
@@ -34,6 +34,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _BSD_SOURCE
+
 #include <uk/socket_driver.h>
 #include <uk/socket_vnops.h>
 #include <uk/socket.h>

--- a/lib/vfscore/include/vfscore/mount.h
+++ b/lib/vfscore/include/vfscore/mount.h
@@ -32,8 +32,6 @@
 #ifndef _VFSCORE_SYS_MOUNT_H_
 #define _VFSCORE_SYS_MOUNT_H_
 
-#define _BSD_SOURCE
-
 #include <sys/mount.h>
 #include <sys/statfs.h>
 #include <limits.h>

--- a/lib/vfscore/pipe.c
+++ b/lib/vfscore/pipe.c
@@ -31,6 +31,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _BSD_SOURCE
+
 #include <uk/config.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/lib/vfscore/stdio.c
+++ b/lib/vfscore/stdio.c
@@ -31,6 +31,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _BSD_SOURCE
+
 #include <vfscore/file.h>
 #include <vfscore/fs.h>
 #include <uk/plat/console.h>


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): `app-sqlite`


### Additional configuration

### Description of changes

The issue was caused by defining the feature macro `_BSD_SOURCE` in a header file `include/vfscore/mount.h`.
This commit removes the macro from the header, resolving the issue.

Github-Fixes: #821