### PR TITLE
lib/nolibc, lib/isrlib: Pointer comparison

### DIFF
--- a/lib/isrlib/string.c
+++ b/lib/isrlib/string.c
@@ -107,21 +107,27 @@ void *memrchr_isr(const void *m, int c, size_t n)
 
 void *memmove_isr(void *dst, const void *src, size_t len)
 {
-	uint8_t *d = dst;
-	const uint8_t *s = src;
+	uint8_t *d = dst; 
+    const uint8_t *s = src; 
 
-	if (src > dst) {
-		for (; len > 0; --len)
-			*(d++) = *(s++);
-	} else {
-		s += len;
-		d += len;
+    if ((intptr_t)src == (intptr_t)dst) {
+        return dst;
+    }
 
-		for (; len > 0; --len)
-			*(d--) = *(s--);
-	}
+    if ((intptr_t)src > (intptr_t)dst) {
+        for (; len > 0; --len) {
+            *(d++) = *(s++);
+        }
+    } else {
+        s += len;
+        d += len;
 
-	return dst;
+        for (; len > 0; --len) {
+            *(d--) = *(s--);
+        }
+    }
+
+    return dst;
 }
 
 int memcmp_isr(const void *ptr1, const void *ptr2, size_t len)

--- a/lib/isrlib/string.c
+++ b/lib/isrlib/string.c
@@ -109,11 +109,10 @@ void *memmove_isr(void *dst, const void *src, size_t len)
 {
 	uint8_t *d = dst;
     const uint8_t *s = src;
+    const uint8_t *s = src;
 
-    if ((intptr_t)src == (intptr_t)dst) {
-        return dst;
-    }
-
+    if ((intptr_t)src == (intptr_t)dst)
+		return dst;
     if ((intptr_t)src > (intptr_t)dst) {
         for (; len > 0; --len)
             *(d++) = *(s++);
@@ -121,6 +120,9 @@ void *memmove_isr(void *dst, const void *src, size_t len)
         s += len;
         d += len;
 
+        for (; len > 0; --len)
+            *(d--) = *(s--);
+    }
         for (; len > 0; --len)
             *(d--) = *(s--);
     }

--- a/lib/isrlib/string.c
+++ b/lib/isrlib/string.c
@@ -107,24 +107,24 @@ void *memrchr_isr(const void *m, int c, size_t n)
 
 void *memmove_isr(void *dst, const void *src, size_t len)
 {
-	uint8_t *d = dst; 
-    const uint8_t *s = src; 
+	uint8_t *d = dst;
+    const uint8_t *s = src;
 
     if ((intptr_t)src == (intptr_t)dst) {
-        return dst;
+	return dst;
     }
 
     if ((intptr_t)src > (intptr_t)dst) {
-        for (; len > 0; --len) {
-            *(d++) = *(s++);
-        }
+	for (; len > 0; --len) {
+	    *(d++) = *(s++);
+	}
     } else {
-        s += len;
-        d += len;
+	s += len;
+	d += len;
 
-        for (; len > 0; --len) {
-            *(d--) = *(s--);
-        }
+	for (; len > 0; --len) {
+	    *(d--) = *(s--);
+	}
     }
 
     return dst;
@@ -151,6 +151,7 @@ size_t strlen_isr(const char *str)
 size_t strnlen_isr(const char *str, size_t len)
 {
 	const char *p = memchr_isr(str, 0, len);
+
 	return p ? (size_t) (p - str) : len;
 }
 
@@ -229,6 +230,7 @@ char *strchrnul_isr(const char *s, int c)
 char *strchr_isr(const char *str, int c)
 {
 	char *r = strchrnul_isr(str, c);
+
 	return *(unsigned char *)r == (unsigned char)c ? r : 0;
 }
 
@@ -325,6 +327,7 @@ finish:
 size_t strlcat_isr(char *d, const char *s, size_t n)
 {
 	size_t l = strnlen_isr(d, n);
+
 	if (l == n)
 		return l + strlen_isr(s);
 	return l + strlcpy_isr(d+l, s, n-l);

--- a/lib/isrlib/string.c
+++ b/lib/isrlib/string.c
@@ -110,24 +110,21 @@ void *memmove_isr(void *dst, const void *src, size_t len)
 	uint8_t *d = dst;
     const uint8_t *s = src;
 
-    if ((intptr_t)src == (intptr_t)dst) {
-	return dst;
-    }
+    if ((intptr_t)src == (intptr_t)dst)
+        return dst;
 
     if ((intptr_t)src > (intptr_t)dst) {
-	for (; len > 0; --len) {
-	    *(d++) = *(s++);
-	}
+        for (; len > 0; --len)
+            *(d++) = *(s++);
     } else {
-	s += len;
-	d += len;
+        s += len;
+        d += len;
 
-	for (; len > 0; --len) {
-	    *(d--) = *(s--);
-	}
+        for (; len > 0; --len)
+            *(d--) = *(s--);
     }
 
-    return dst;
+	return dst;
 }
 
 int memcmp_isr(const void *ptr1, const void *ptr2, size_t len)
@@ -151,7 +148,6 @@ size_t strlen_isr(const char *str)
 size_t strnlen_isr(const char *str, size_t len)
 {
 	const char *p = memchr_isr(str, 0, len);
-
 	return p ? (size_t) (p - str) : len;
 }
 
@@ -230,7 +226,6 @@ char *strchrnul_isr(const char *s, int c)
 char *strchr_isr(const char *str, int c)
 {
 	char *r = strchrnul_isr(str, c);
-
 	return *(unsigned char *)r == (unsigned char)c ? r : 0;
 }
 
@@ -327,7 +322,6 @@ finish:
 size_t strlcat_isr(char *d, const char *s, size_t n)
 {
 	size_t l = strnlen_isr(d, n);
-
 	if (l == n)
 		return l + strlen_isr(s);
 	return l + strlcpy_isr(d+l, s, n-l);

--- a/lib/isrlib/string.c
+++ b/lib/isrlib/string.c
@@ -119,7 +119,6 @@ void *memmove_isr(void *dst, const void *src, size_t len)
     } else {
         s += len;
         d += len;
-
         for (; len > 0; --len)
             *(d--) = *(s--);
     }

--- a/lib/isrlib/string.c
+++ b/lib/isrlib/string.c
@@ -110,8 +110,9 @@ void *memmove_isr(void *dst, const void *src, size_t len)
 	uint8_t *d = dst;
     const uint8_t *s = src;
 
-    if ((intptr_t)src == (intptr_t)dst)
+    if ((intptr_t)src == (intptr_t)dst) {
         return dst;
+    }
 
     if ((intptr_t)src > (intptr_t)dst) {
         for (; len > 0; --len)

--- a/lib/nolibc/string.c
+++ b/lib/nolibc/string.c
@@ -109,10 +109,8 @@ void *memmove(void *dst, const void *src, size_t len)
 	uint8_t *d = dst;
 	const uint8_t *s = src;
 
-	if ((intptr_t)src == (intptr_t)dst) {
+	if ((intptr_t)src == (intptr_t)dst)
         return dst;
-    }
-	
 	if ((intptr_t)src > (intptr_t)dst) {
 		for (; len > 0; --len)
 			*(d++) = *(s++);

--- a/lib/nolibc/string.c
+++ b/lib/nolibc/string.c
@@ -109,7 +109,11 @@ void *memmove(void *dst, const void *src, size_t len)
 	uint8_t *d = dst;
 	const uint8_t *s = src;
 
-	if (src > dst) {
+	if ((intptr_t)src == (intptr_t)dst) {
+        return dst;
+    }
+	
+	if ((intptr_t)src > (intptr_t)dst) {
 		for (; len > 0; --len)
 			*(d++) = *(s++);
 	} else {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The memmove_isr function is used to copy a block of memory from a source address to a destination address. The function is used in interrupt service routines (ISRs) where it is important to copy the memory as quickly as possible.

In the previous implementation of memmove_isr, the function assumed that the source address is either greater than the destination address or less than it. If both the conditions were false, the function would not work as expected and may cause undefined behavior. This assumption could lead to issues where the memory blocks overlap.

The modified implementation of memmove_isr takes into account both overlapping and non-overlapping cases. The function typecasts the src and dst pointers to intptr_t to ensure that the values being compared are treated as pointers rather than integers. This can help prevent errors that might occur if the pointer values are interpreted as signed integers.  ( Issue [#447](https://github.com/unikraft/unikraft/issues/447) ).

The changes were implemented in both nolibc and isrlib libraries to ensure that the code is consistent across all libraries and to prevent any issues when switching between them.

Overall, the changes ensure that memmove_isr works correctly in all cases, including when the memory blocks overlap, and that the code is robust and less prone to errors.