### PR TITLE
Dynamically allocate `struct mount` paths

### DIFF
--- a/lib/posix-event/epoll.c
+++ b/lib/posix-event/epoll.c
@@ -41,10 +41,13 @@
 #include <uk/alloc.h>
 #include <uk/syscall.h>
 #include <uk/config.h>
+#include <uk/init.h>
 
 #include <inttypes.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <string.h>
+#include <stdlib.h>
 
 static uint64_t e_inode;
 
@@ -371,3 +374,28 @@ int epoll_pwait(int epfd, struct epoll_event *events, int maxevents,
 	return ret;
 }
 #endif /* UK_LIBC_SYSCALLS */
+
+static int epoll_mount_init(void)
+{
+	int ret;
+
+	epoll_mount.m_path = strdup("");
+	if (!epoll_mount.m_path) {
+		ret = -ENOMEM;
+		goto err_out;
+	}
+
+	epoll_mount.m_special = strdup("");
+	if (!epoll_mount.m_special) {
+		ret = -ENOMEM;
+		goto err_free_m_path;
+	}
+
+	return 0;
+
+err_free_m_path:
+	free(epoll_mount.m_path);
+err_out:
+	return ret;
+}
+uk_lib_initcall(epoll_mount_init);

--- a/lib/posix-event/eventfd.c
+++ b/lib/posix-event/eventfd.c
@@ -45,10 +45,13 @@
 #include <uk/mutex.h>
 #include <uk/list.h>
 #include <uk/config.h>
+#include <uk/init.h>
 
 #include <sys/eventfd.h>
 #include <inttypes.h>
 #include <errno.h>
+#include <string.h>
+#include <stdlib.h>
 
 struct eventfd {
 	/** Current value of this eventfd */
@@ -438,3 +441,28 @@ int eventfd(unsigned int initval, int flags)
 	return ret;
 }
 #endif /* UK_LIBC_SYSCALLS */
+
+static int eventfd_mount_init(void)
+{
+	int ret;
+
+	eventfd_mount.m_path = strdup("");
+	if (!eventfd_mount.m_path) {
+		ret = -ENOMEM;
+		goto err_out;
+	}
+
+	eventfd_mount.m_special = strdup("");
+	if (!eventfd_mount.m_special) {
+		ret = -ENOMEM;
+		goto err_free_m_path;
+	}
+
+	return 0;
+
+err_free_m_path:
+	free(eventfd_mount.m_path);
+err_out:
+	return ret;
+}
+uk_lib_initcall(eventfd_mount_init);

--- a/lib/posix-socket/socket_vnops.c
+++ b/lib/posix-socket/socket_vnops.c
@@ -43,8 +43,11 @@
 #include <vfscore/mount.h>
 #include <vfscore/fs.h>
 #include <uk/errptr.h>
+#include <uk/init.h>
 #include <inttypes.h>
 #include <errno.h>
+#include <string.h>
+#include <stdlib.h>
 
 static struct mount posix_socket_mount;
 
@@ -342,3 +345,28 @@ static struct vfsops posix_socket_vfsops = {
 static struct mount posix_socket_mount = {
 	.m_op = &posix_socket_vfsops
 };
+
+static int posix_socket_mount_init(void)
+{
+	int ret;
+
+	posix_socket_mount.m_path = strdup("");
+	if (!posix_socket_mount.m_path) {
+		ret = -ENOMEM;
+		goto err_out;
+	}
+
+	posix_socket_mount.m_special = strdup("");
+	if (!posix_socket_mount.m_special) {
+		ret = -ENOMEM;
+		goto err_free_m_path;
+	}
+
+	return 0;
+
+err_free_m_path:
+	free(posix_socket_mount.m_path);
+err_out:
+	return ret;
+}
+uk_lib_initcall(posix_socket_mount_init);

--- a/lib/vfscore/include/vfscore/mount.h
+++ b/lib/vfscore/include/vfscore/mount.h
@@ -45,8 +45,8 @@ struct mount {
 	struct vfsops	*m_op;		/* pointer to vfs operation */
 	int		m_flags;	/* mount flag */
 	int		m_count;	/* reference count */
-	char            m_path[PATH_MAX]; /* mounted path */
-	char            m_special[PATH_MAX]; /* resource */
+	char            *m_path;	/* mounted path */
+	char            *m_special;	/* resource */
 	struct device	*m_dev;		/* mounted device */
 	struct dentry	*m_root;	/* root vnode */
 	struct dentry	*m_covered;	/* vnode covered on parent fs */

--- a/lib/vfscore/pipe.c
+++ b/lib/vfscore/pipe.c
@@ -37,6 +37,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <vfscore/file.h>
 #include <vfscore/fs.h>
 #include <vfscore/mount.h>
@@ -46,6 +47,7 @@
 #include <uk/syscall.h>
 #include <sys/ioctl.h>
 #include <uk/syscall.h>
+#include <uk/init.h>
 
 /* We use the default size in Linux kernel */
 #define PIPE_MAX_SIZE	(1 << CONFIG_LIBVFSCORE_PIPE_SIZE_ORDER)
@@ -718,3 +720,28 @@ int mkfifo(const char *path __unused, mode_t mode __unused)
 	return -1;
 }
 #endif /* UK_LIBC_SYSCALLS */
+
+static int pipe_mount_init(void)
+{
+	int ret;
+
+	p_mount.m_path = strdup("");
+	if (!p_mount.m_path) {
+		ret = -ENOMEM;
+		goto err_out;
+	}
+
+	p_mount.m_special = strdup("");
+	if (!p_mount.m_special) {
+		ret = -ENOMEM;
+		goto err_free_m_path;
+	}
+
+	return 0;
+
+err_free_m_path:
+	free(p_mount.m_path);
+err_out:
+	return ret;
+}
+uk_lib_initcall(pipe_mount_init);


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Description of changes

Currently `m_path` and `m_special` are statically-allocated arrays, meaning their storage spaces are wasted in `static struct mount` variables.

Dynamically allocate these variables instead to save on binary size.

This PR saves ~8K of uncompressed binary size per `static struct mount` object.