### PR TITLE
lib/nolibc: Fix wrong type for the `st_nlink` field inside `struct stat`

### DIFF
--- a/lib/nolibc/include/nolibc-internal/shareddefs.h
+++ b/lib/nolibc/include/nolibc-internal/shareddefs.h
@@ -105,7 +105,7 @@ typedef __u64 ino_t;
 #endif
 
 #if defined(__NEED_nlink_t) && !defined(__DEFINED_nlink_t)
-typedef __u32 nlink_t;
+typedef __u64 nlink_t;
 #define __DEFINED_nlink_t
 #endif
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): x86_64
 - Platform(s): N/A
 - Application(s): app-elfloader


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

`st_nlink` is defined as `unsigned long` inside the Linux kernel [1], however we define it as `unsigned int`, breaking the syscall interface.

Fixes #828 

[1] https://elixir.bootlin.com/linux/v6.2.10/source/arch/x86/include/uapi/asm/stat.h#L86
