### PR TITLE
9pfs, vfscore: Fix symlink support for 9pfs

### DIFF
--- a/lib/9pfs/9pfs_vnops.c
+++ b/lib/9pfs/9pfs_vnops.c
@@ -117,6 +117,10 @@ static int uk_9pfs_vtype_from_mode(int mode)
 {
 	if (mode & UK_9P_DMDIR)
 		return VDIR;
+
+	if (mode & UK_9P_DMSYMLINK)
+		return VLNK;
+
 	return VREG;
 }
 
@@ -913,9 +917,6 @@ static int uk_9pfs_readlink(struct vnode *vp, struct uio *uio)
 	struct iovec *iov;
 	struct uk_9preq *req;
 
-	if (md->proto != UK_9P_PROTO_2000L)
-		return EINVAL;
-
 	if (vp->v_type == VDIR)
 		return EISDIR;
 	if (vp->v_type != VLNK)
@@ -956,9 +957,6 @@ static int uk_9pfs_symlink(struct vnode *dvp, char *op, char *np)
 	struct uk_9pfs_mount_data *md = UK_9PFS_MD(dvp->v_mount);
 	struct uk_9pfid *dfid = UK_9PFS_VFID(dvp);
 	struct uk_9pfid *fid;
-
-	if (md->proto != UK_9P_PROTO_2000L)
-		return EPERM;
 
 	fid = uk_9p_symlink(md->dev, dfid, op, np, 0);
 	if (PTRISERR(fid))

--- a/lib/vfscore/lookup.c
+++ b/lib/vfscore/lookup.c
@@ -118,6 +118,8 @@ namei(const char *path, struct dentry **dpp)
 	DPRINTF(VFSDB_VNODE, ("namei: path=%s\n", path));
 
 	links_followed = 0;
+
+	memset(fp, 0, PATH_MAX);
 	strlcpy(fp, path, PATH_MAX);
 
 	do {

--- a/lib/vfscore/lookup.c
+++ b/lib/vfscore/lookup.c
@@ -129,7 +129,9 @@ namei(const char *path, struct dentry **dpp)
 		if (vfs_findroot(fp, &mp, &p)) {
 			return ENOTDIR;
 		}
-		int mountpoint_len = p - fp - 1;
+
+		size_t mountpoint_len = p - fp;
+
 		strlcpy(node, "/", sizeof(node));
 		strlcat(node, p, sizeof(node));
 		dp = dentry_lookup(mp, node);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s):  `kvm`
 - Application(s): `app-helloworld`

Checked out the fix using:
* app-helloworld built together with Unikraft.

```
unikraft/support/scripts/qemu-guest -k build/app-helloworld_kvm-x86_64 -e rootfs/
```

* dynamically linked helloworld example and the app-elfloader.

```
unikraft/support/scripts/qemu-guest -k build/app-elfloader_kvm-x86_64 -i /lib64/ld-linux-x86-64.so.2 -e rootfs/ -a "--library-path / /helloworld"
```

// Open a symlink file
```
open("<symlink-file-path>", O_RDONLY);
```
\<symlink-file> exists in the rootfs filesystem (9pfs type).

// Create a symlink file
```
symlink("symlink-target-file-path", "<symlink-file-path>");
```
\<symlink-target-file> exists in the rootfs filesystem (9pfs type).

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
