### PR TITLE
lib/ukvmem: Allow non-writable shared file mappings

### DIFF
--- a/lib/ukvmem/include/uk/vmem.h
+++ b/lib/ukvmem/include/uk/vmem.h
@@ -225,6 +225,8 @@ struct uk_vma_ops {
 	 *   The length of the virtual memory area in bytes
 	 * @param data
 	 *   Pointer to VMA-type specific data supplied to the map function
+	 * @param attr
+	 *   Page attributes for the pages in the memory area
 	 * @param[in,out] flags
 	 *   The flags supplied to the map function. The handler may
 	 *   set/unset the following flags (besides VMA-type specific ones):
@@ -237,7 +239,8 @@ struct uk_vma_ops {
 	 *   0 on success, a negative errno error otherwise
 	 */
 	int (*new)(struct uk_vas *vas, __vaddr_t vaddr, __sz len, void *data,
-		   unsigned long *flags, struct uk_vma **vma);
+		   unsigned long attr, unsigned long *flags,
+		   struct uk_vma **vma);
 
 	/**
 	 * Frees any references that this VMA might hold. The memory for the

--- a/lib/ukvmem/vma_dma.c
+++ b/lib/ukvmem/vma_dma.c
@@ -29,8 +29,8 @@ static __vaddr_t vma_op_dma_get_base(struct uk_vas *vas __unused,
 #endif /* CONFIG_LIBUKVMEM_DMA_BASE */
 
 int vma_op_dma_new(struct uk_vas *vas, __vaddr_t vaddr __unused,
-		   __sz len __unused, void *data, unsigned long *flags __unused,
-		   struct uk_vma **vma)
+		   __sz len __unused, void *data, unsigned long attr __unused,
+		   unsigned long *flags __unused, struct uk_vma **vma)
 {
 	struct uk_vma_dma_args *args = (struct uk_vma_dma_args *)data;
 	struct uk_vma_dma *vma_dma;

--- a/lib/ukvmem/vmem.c
+++ b/lib/ukvmem/vmem.c
@@ -669,7 +669,7 @@ int uk_vma_map(struct uk_vas *vas, __vaddr_t *vaddr, __sz len,
 		/* Split also needs to allocate a new VMA */
 		UK_ASSERT(ops->split);
 
-		rc = ops->new(vas, va, len, args, &flags, &vma);
+		rc = ops->new(vas, va, len, args, attr, &flags, &vma);
 		if (unlikely(rc))
 			return rc;
 	} else {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Non-writable shared file mappings are now treated as anonymous read-only file mappings. Note that any writes made to the underlying file while the mapping is established will not be reflected in memory.