### PR TITLE
xen/x86/mm.c: fix unchecked uk_palloc value

### DIFF
--- a/plat/xen/x86/mm.c
+++ b/plat/xen/x86/mm.c
@@ -651,9 +651,13 @@ void _arch_init_p2m(struct uk_alloc *a)
 		UK_CRASH("Error: Too many pfns.\n");
 
 	l3_list = uk_palloc(a, 1);
+	if (l3_list == NULL)
+		UK_CRASH("Error: Cannot allocate l3_list.\n");
 	for (pfn = 0; pfn < max_pfn; pfn += P2M_ENTRIES) {
 		if (!(pfn % (P2M_ENTRIES * P2M_ENTRIES))) {
 			l2_list = uk_palloc(a, 1);
+			if (l2_list == NULL)
+				UK_CRASH("Error: Cannot allocate l2_list.\n");
 			l3_list[L3_P2M_IDX(pfn)] = virt_to_mfn(l2_list);
 			l2_list_pages[L3_P2M_IDX(pfn)] = l2_list;
 		}


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.
 
### Base target

 - Architecture(s): x86
 - Platform(s): xen
 - Application(s): N/A

### Description of changes

The return value of uk_palloc is not checked in _arch_init_p2m.

Allocation failure at that point should never happen, but it's not a reason not to check.

At this stage, in the even of a failure, we should probably abort the boot altogether.

This bug was detected using the following Coccinelle spatch:

    @call@
    expression ptr;
    position p;
    @@

    ptr@p = uk_palloc(...);

    @ok@
    expression ptr;
    position call.p;
    @@

    ptr@p = uk_palloc(...);
    ... when != ptr
    (
     (ptr == NULL || ...)
    |
     (ptr != NULL || ...)
    )

    @depends on !ok@
    expression ptr;
    position call.p;
    @@

    ptr@p = uk_palloc(...);
    + if (ptr == NULL) return;

Note: I did not test these changes because I do not have a Xen setup.