### PR TITLE
ukalloc: remove unreachable NULL checks

### DIFF
--- a/lib/ukalloc/alloc.c
+++ b/lib/ukalloc/alloc.c
@@ -203,7 +203,7 @@ void *uk_realloc_ifpages(struct uk_alloc *a, void *ptr, __sz size)
 	if (!ptr)
 		return uk_malloc_ifpages(a, size);
 
-	if (ptr && !size) {
+	if (!size) {
 		uk_free_ifpages(a, ptr);
 		return __NULL;
 	}
@@ -414,7 +414,7 @@ void *uk_realloc_ifmalloc(struct uk_alloc *a, void *ptr, __sz size)
 	if (!ptr)
 		return uk_malloc_ifmalloc(a, size);
 
-	if (ptr && !size) {
+	if (!size) {
 		uk_free_ifmalloc(a, ptr);
 		return __NULL;
 	}
@@ -520,7 +520,7 @@ void *uk_realloc_compat(struct uk_alloc *a, void *ptr, __sz size)
 	if (!ptr)
 		return uk_malloc(a, size);
 
-	if (ptr && !size) {
+	if (!size) {
 		uk_free(a, ptr);
 		return __NULL;
 	}


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Description of changes

These `if (ptr && ...)` will always turn out true due to the preceding `if (!ptr)`.

This was found by the following Coccinelle spatch: https://coccinelle.gitlabpages.inria.fr/website/rules/notnull.cocci