### PR TITLE
use page alignment macros everywhere

### DIFF
--- a/lib/ukalloc/alloc.c
+++ b/lib/ukalloc/alloc.c
@@ -40,13 +40,14 @@
 #include <uk/assert.h>
 #include <uk/arch/limits.h>
 #include <uk/arch/lcpu.h>
+#include <uk/arch/paging.h>
 
 #if CONFIG_HAVE_MEMTAG
 #include <uk/arch/memtag.h>
 #endif
 
 #define size_to_num_pages(size) \
-	(ALIGN_UP((unsigned long)(size), __PAGE_SIZE) / __PAGE_SIZE)
+	(PAGE_ALIGN_UP((unsigned long)(size)) / __PAGE_SIZE)
 #define page_off(x) ((unsigned long)(x) & (__PAGE_SIZE - 1))
 
 struct uk_alloc *_uk_alloc_head;
@@ -102,7 +103,7 @@ static struct metadata_ifpages *uk_get_metadata(const void *ptr)
 	UK_ASSERT((__uptr) ptr >= __PAGE_SIZE +
 		  sizeof(struct metadata_ifpages));
 
-	metadata = ALIGN_DOWN((__uptr) ptr, (__uptr) __PAGE_SIZE);
+	metadata = PAGE_ALIGN_DOWN((__uptr)ptr);
 	if (metadata == (__uptr) ptr) {
 		/* special case: the memory was page-aligned.
 		 * In this case the metadata lies at the start of the

--- a/plat/kvm/arm/setup.c
+++ b/plat/kvm/arm/setup.c
@@ -32,6 +32,7 @@
 #include <arm/arm64/cpu.h>
 #include <arm/smccc.h>
 #include <uk/arch/limits.h>
+#include <uk/arch/paging.h>
 
 #ifdef CONFIG_ARM64_FEAT_PAUTH
 #include <arm/arm64/pauth.h>
@@ -175,7 +176,7 @@ static void _init_dtb_mem(void)
 	_libkvmplat_cfg.bstack.start = _libkvmplat_cfg.bstack.end
 				       - _libkvmplat_cfg.bstack.len;
 
-	_libkvmplat_cfg.heap.start = ALIGN_DOWN((uintptr_t)__END, __PAGE_SIZE);
+	_libkvmplat_cfg.heap.start = PAGE_ALIGN_DOWN((uintptr_t)__END);
 	_libkvmplat_cfg.heap.end   = _libkvmplat_cfg.bstack.start;
 	_libkvmplat_cfg.heap.len   = _libkvmplat_cfg.heap.end
 				     - _libkvmplat_cfg.heap.start;

--- a/plat/xen/x86/mm.c
+++ b/plat/xen/x86/mm.c
@@ -537,7 +537,7 @@ extern struct shared_info _libxenplat_shared_info;
 void _init_mem_set_readonly(void *text, void *etext)
 {
     unsigned long start_address =
-        ((unsigned long) text + PAGE_SIZE - 1) & PAGE_MASK;
+        PAGE_ALIGN((unsigned long)text);
     unsigned long end_address = (unsigned long) etext;
     pgentry_t *tab = pt_base, page;
     unsigned long mfn;


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): ARM64, x86
 - Platform(s): Xen, KVM
 - Application(s): N/A

### Description of changes

We have PAGE_ALIGN_DOWN, PAGE_ALIGN_UP, and PAGE_ALIGN macros, but don't use them consistently. At places we still have code that does custom ALIGN_DOWN, ALIGN_UP, and masks. Use appropriate macros everywhere.

This patch was generated by the following Coccinelle rule:

    @@
    expression E;
    @@

    - ALIGN_DOWN(E, __PAGE_SIZE)
    + PAGE_ALIGN_DOWN(E)

    @@
    expression E;
    type T;
    @@

    - ALIGN_DOWN(E, (T) __PAGE_SIZE)
    + PAGE_ALIGN_DOWN(E)

    @@
    expression E;
    @@

    - ALIGN_UP(E, __PAGE_SIZE)
    + PAGE_ALIGN_UP(E)

    @@
    expression E;
    type T;
    @@

    - ALIGN_UP(E, (T) __PAGE_SIZE)
    + PAGE_ALIGN_UP(E)

    @@
    expression E;
    @@

    - (E + PAGE_SIZE - 1) & PAGE_MASK
    + PAGE_ALIGN(E)

Note: this was only tested on x86 KVM, so the bit for ARM KVM and x86 Xen hasn't been tested. Please review carefully, I might have overlooked something.