### PR TITLE
lib/vfscore: fix potential free(NULL)

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1054,10 +1054,11 @@ int scandir(const char *path, struct dirent ***res,
 	closedir(d);
 
 	if (errno) {
-		if (names)
+		if (names) {
 			while (cnt-->0)
 				free(names[cnt]);
-		free(names);
+			free(names);
+		}
 		return -1;
 	}
 	errno = old_errno;


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): N/A
 - Platform(s): N?A
 - Application(s): N/A

### Description of changes

Very clearly this code is not correct. If `names` is always non-NULL then the `if` is useless. Otherwise `names` should be freed in the `if`. Since I'm not sure I am just playing it safe and freeing `names` in the `if`.

This bug was found by Coccinelle with the following spatch:

    @@
    expression E;
    @@

    if(E) {...}
    -free(E);

NOTE: I only minimally tested this. Please carefully double check it.