### PR TITLE
9p.c: fix cast to invalid type

### DIFF
--- a/lib/uk9p/9p.c
+++ b/lib/uk9p/9p.c
@@ -146,7 +146,7 @@ struct uk_9pfid *uk_9p_attach(struct uk_9pdev *dev, uint32_t afid,
 	req = request_create(dev, UK_9P_TATTACH);
 	if (PTRISERR(req)) {
 		uk_9pdev_fid_release(fid);
-		return (void *)req;
+		return (struct uk_9pfid *)req;
 	}
 
 	uk_pr_debug("TATTACH fid %u afid %u uname %s aname %s n_uname %u\n",
@@ -812,7 +812,7 @@ struct uk_9pfid *uk_9p_symlink(struct uk_9pdev *dev, struct uk_9pfid *sfid,
 	req = request_create(dev, UK_9P_TSYMLINK);
 	if (PTRISERR(req)) {
 		uk_9pdev_fid_release(fid);
-		return (void *)req;
+		return (struct uk_9pfid *)req;
 	}
 
 	uk_pr_debug("TSYMLINK fid %u\n", sfid->fid);


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Description of changes

This patch was generated by the following Coccinelle semantic patch:

```
@@
expression E;
type T;
type R;
function f;
@@

T* f(...) {
<... when any
- return (R*)E;
+ return (T*)E;
...>
}

@@
type T;
identifier X;
function f;
@@

f(...) {
...
T* X;
<... when any
- return (T*)X;
+ return X;
...>
}
```

I am not sure what concrete impact this issue has. Likely nothing. Anyways, it's easy to fix systematically with this rule.