### PR TITLE
lib/nolibc: Prototypes for `pread` and `pwrite`

### DIFF
--- a/lib/nolibc/include/unistd.h
+++ b/lib/nolibc/include/unistd.h
@@ -83,7 +83,9 @@ int execve(const char *filename, char *const argv[],
 #if CONFIG_LIBVFSCORE
 int close(int fd);
 ssize_t write(int fd, const void *buf, size_t count);
+ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
 ssize_t read(int fd, void *buf, size_t count);
+ssize_t pread(int fd, void *buf, size_t count, off_t offset);
 void sync(void);
 int fsync(int fd);
 int dup(int oldfd);


### PR DESCRIPTION
### Base target

 - Architecture(s): any
 - Platform(s): any
 - Application(s): `app-elfloader`


### Additional configuration

 - `CONFIG_LIBNOLIBC=y`
 - `CONFIG_LIBVFSCORE=y`


### Description of changes

This PR introduces the prototypes for `pread` and `pwrite` with nolibc's `<unistd.h>` header. These functions are provided by `lib/vfscore`.
This PR is needed for executing ELF files form the VFS.