### PR TITLE
Fix file flags for O_NONBLOCK and O_ASYNC

### DIFF
--- a/lib/nolibc/musl-imported/include/sys/ioctl.h
+++ b/lib/nolibc/musl-imported/include/sys/ioctl.h
@@ -116,7 +116,7 @@ struct winsize {
 #define SIOCDEVPRIVATE     0x89F0
 #define SIOCPROTOPRIVATE   0x89E0
 
-int ioctl (int, int, ...);
+int ioctl (int, unsigned long, ...);
 
 #ifdef __cplusplus
 }

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -34,6 +34,7 @@
 
 #include <sys/statvfs.h>
 #include <sys/stat.h>
+#include <sys/ioctl.h>
 #include <limits.h>
 #include <string.h>
 #include <stdlib.h>
@@ -2008,9 +2009,7 @@ UK_LLSYSCALL_R_DEFINE(int, fcntl, int, fd, unsigned int, cmd, int, arg)
 {
 	struct vfscore_file *fp;
 	int ret = 0, error;
-#if defined(FIONBIO) && defined(FIOASYNC)
-	int tmp;
-#endif
+	int tmp, oldf;
 
 	trace_vfs_fcntl(fd, cmd, arg);
 	error = fget(fd, &fp);
@@ -2047,17 +2046,44 @@ UK_LLSYSCALL_R_DEFINE(int, fcntl, int, fd, unsigned int, cmd, int, arg)
 		break;
 	case F_SETFL:
 		FD_LOCK(fp);
-		fp->f_flags = vfscore_fflags((vfscore_oflags(fp->f_flags) & ~SETFL) |
-				(arg & SETFL));
-		FD_UNLOCK(fp);
+		oldf = fp->f_flags;
+		tmp  = vfscore_oflags(fp->f_flags) & ~SETFL;
+		fp->f_flags = vfscore_fflags(tmp | (arg & SETFL));
 
-#if defined(FIONBIO) && defined(FIOASYNC)
-		/* Sync nonblocking/async state with file flags */
+		/* Sync nonblocking/async state with file flags
+		 * To make sure that the actual state of the underlying file
+		 * is in sync with the configured flag, we need to perform the
+		 * ioctl while holding the lock. This is not optimal since we
+		 * hold the lock for the duration of potentially expensive
+		 * operations. It would be better to just set the flag here and
+		 * make sure that all components directly consume this flag
+		 * instead of synching it to other places.
+		 */
 		tmp = fp->f_flags & FNONBLOCK;
-		vfs_ioctl(fp, FIONBIO, &tmp);
+		if ((tmp ^ oldf) & FNONBLOCK) {
+			error = vfs_ioctl(fp, FIONBIO, &tmp);
+			if (unlikely(error)) {
+				fp->f_flags = oldf;
+				FD_UNLOCK(fp);
+				break;
+			}
+		}
+
 		tmp = fp->f_flags & FASYNC;
-		vfs_ioctl(fp, FIOASYNC, &tmp);
-#endif
+		if ((tmp ^ oldf) & FASYNC) {
+			error = vfs_ioctl(fp, FIOASYNC, &tmp);
+			if (unlikely(error)) {
+				tmp = oldf & FNONBLOCK;
+				if ((tmp ^ fp->f_flags) & FNONBLOCK)
+					(void)vfs_ioctl(fp, FIONBIO, &tmp);
+
+				fp->f_flags = oldf;
+				FD_UNLOCK(fp);
+				break;
+			}
+		}
+
+		FD_UNLOCK(fp);
 		break;
 	case F_DUPFD_CLOEXEC:
 		error = fdalloc(fp, &ret);

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -382,23 +382,45 @@ int
 sys_ioctl(struct vfscore_file *fp, unsigned long request, void *buf)
 {
 	int error = 0;
+	int oldf;
 
 	DPRINTF(VFSDB_SYSCALL, ("sys_ioctl: fp=%p request=%lux\n", fp, request));
 
 	if ((fp->f_flags & (UK_FREAD | UK_FWRITE)) == 0)
 		return EBADF;
 
+	FD_LOCK(fp);
+	oldf = fp->f_flags;
+
 	switch (request) {
 	case FIOCLEX:
 		fp->f_flags |= O_CLOEXEC;
-		break;
+		goto exit;
 	case FIONCLEX:
 		fp->f_flags &= ~O_CLOEXEC;
+		goto exit;
+	case FIONBIO:
+		UK_ASSERT(buf);
+		if (*(int *)buf)
+			fp->f_flags |= FNONBLOCK;
+		else
+			fp->f_flags &= ~FNONBLOCK;
 		break;
-	default:
-		error = vfs_ioctl(fp, request, buf);
+	case FIOASYNC:
+		UK_ASSERT(buf);
+		if (*(int *)buf)
+			fp->f_flags |= FASYNC;
+		else
+			fp->f_flags &= ~FASYNC;
 		break;
 	}
+
+	error = vfs_ioctl(fp, request, buf);
+	if (unlikely(error))
+		fp->f_flags = oldf;
+
+exit:
+	FD_UNLOCK(fp);
 
 	DPRINTF(VFSDB_SYSCALL, ("sys_ioctl: comp error=%d\n", error));
 	return error;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

This fix makes sure that `O_NONBLOCK` and `O_ASYNC` are applied to file descriptions via a call to `fcntl(fd, F_SETFL, ...)` and that these flags and the state of the file implementation stay in sync. This includes calls to `ioctl(fd, FIONBIO, ...)` and `ioctl(fd, FIOASYNC, ...)`. The commits also improve error handling by resetting the old flags in case of an error.

This PR needs to be merged together with:
- https://github.com/unikraft/lib-musl/pull/42