### PR TITLE
lib/vfscore: Fix error return on symlink syscall

### DIFF
--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -883,10 +883,9 @@ sys_symlink(const char *oldpath, const char *newpath)
 	}
 
 	/* parent directory for new path must exist */
-	if ((error = lookup(np, &newdirdp, &name)) != 0) {
-		error = ENOENT;
+	if ((error = lookup(np, &newdirdp, &name)) != 0)
 		goto out;
-	}
+
 	vn_lock(newdirdp->d_vnode);
 
 	/* newpath should not already exist */


### PR DESCRIPTION
The `sys_symlink()` function returns `ENOENT` if the lookup failed, instead of the actual error code `lookup()` exited with. This may not always be right, since `lookup()` can return other error codes (for example `ELOOP`).

Fix that by not setting the error code and just jump to the end of the function.

Note that for symlinks to work properly, @andraprs's PR #830 is also needed.

GitHub-Closes: #849

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`

