### PR TITLE
arch/x86: Add compiler flags for auto host CPU

### DIFF
--- a/arch/x86/x86_64/Makefile.uk
+++ b/arch/x86/x86_64/Makefile.uk
@@ -15,6 +15,8 @@ ISR_ARCHFLAGS += -mno-80387 -mno-mmx -mno-sse -mno-avx
 ISR_ARCHFLAGS-$(call have_gcc)	+= -mno-fp-ret-in-387
 ISR_ARCHFLAGS-$(call gcc_version_ge,7,1) += -mgeneral-regs-only
 
+ARCHFLAGS-$(CONFIG_MARCH_X86_64_NATIVE)         += -march=native
+ISR_ARCHFLAGS-$(CONFIG_MARCH_X86_64_NATIVE)     += -march=native
 ARCHFLAGS-$(CONFIG_MARCH_X86_64_GENERIC)        += -mtune=generic
 ISR_ARCHFLAGS-$(CONFIG_MARCH_X86_64_GENERIC)    += -mtune=generic
 ARCHFLAGS-$(CONFIG_MARCH_X86_64_NOCONA)         += -march=nocona


### PR DESCRIPTION
Previously the `CONFIG_MARCH_X86_64_NATIVE` variable did not add `-march=native` to CFLAGS, the compiler then defaulting to generic x86_64. This implements the expected functionality.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): x86_64
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

 - `CONFIG_MARCH_X86_64_NATIVE=y`
