### PR TITLE
plat/common/x86: Use FSGSBASE for TLS if available

### DIFF
--- a/plat/common/include/x86/cpu.h
+++ b/plat/common/include/x86/cpu.h
@@ -97,6 +97,21 @@ static inline __u64 rdtsc(void)
 	return (h << 32) | l;
 }
 
+#ifdef __FSGSBASE__
+static inline __u64 rdfsbase(void)
+{
+	__u64 ret;
+
+	__asm__ __volatile__ ("rdfsbase %%rax" : "=a" (ret));
+	return ret;
+}
+
+static inline void wrfsbase(__u64 fsbase)
+{
+	__asm__ __volatile__ ("wrfsbase %0" : : "r" (fsbase));
+}
+#endif /* __FSGSBASE__ */
+
 
 /* accessing devices via port space */
 static inline __u8 inb(__u16 port)

--- a/plat/common/include/x86/tls.h
+++ b/plat/common/include/x86/tls.h
@@ -30,16 +30,22 @@
 #ifndef __PLAT_CMN_X86_TLS_H__
 #define __PLAT_CMN_X86_TLS_H__
 
-#include <x86/cpu.h> /* rdmsrl, wrmsrl */
+#include <x86/cpu.h> /* rdmsrl, wrmsrl, rdfsbase, wrfsbase */
 #include <x86/cpu_defs.h>
 
-/* TODO: On latest CPUs a faster instruction can be used:
- * https://www.kernel.org/doc/html/latest/x86/x86_64/fsgs.html
- *  #accessing-fs-gs-base-with-the-fsgsbase-instructions
- */
+
+#ifdef __FSGSBASE__
+
+#define get_tls_pointer() rdfsbase()
+
+#define set_tls_pointer(ptr) wrfsbase(ptr)
+
+#else /* !__FSGSBASE__ */
 
 #define get_tls_pointer() rdmsrl(X86_MSR_FS_BASE)
 
 #define set_tls_pointer(ptr) wrmsrl(X86_MSR_FS_BASE, ptr)
+
+#endif /* __FSGSBASE__ */
 
 #endif /* __PLAT_CMN_X86_TLS_H__ */


### PR DESCRIPTION
FSGSBASE is an ISA extension that provides a way to access the FS and GS registers directly, without a need for an MSR read/write. This change adds support for using the `rdfsbase` and `wrfsbase` instructions to manipulate the TLS pointer, increasing performance on context switch.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): x86_64
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

 - `CONFIG_MARCH_X86_64_COREI7AVXI=y` or any other x86 arch that has FSGSBASE