### PR TITLE
arch/x86: Add sanitization function for ECTX memory & use it in the syscall shim handler

### DIFF
--- a/arch/arm/ectx.c
+++ b/arch/arm/ectx.c
@@ -60,6 +60,12 @@ __sz ukarch_ectx_align(void)
 	return ECTX_ALIGN;
 }
 
+void ukarch_ectx_sanitize(struct ukarch_ectx *state __maybe_unused)
+{
+	UK_ASSERT(state);
+	UK_ASSERT(IS_ALIGNED((__uptr) state, ECTX_ALIGN));
+}
+
 void ukarch_ectx_init(struct ukarch_ectx *state)
 {
 	UK_ASSERT(state);

--- a/arch/x86/ectx.c
+++ b/arch/x86/ectx.c
@@ -110,6 +110,30 @@ __sz ukarch_ectx_align(void)
 	return ectx_align;
 }
 
+void ukarch_ectx_sanitize(struct ukarch_ectx *state)
+{
+	UK_ASSERT(ectx_align); /* Do not call when not yet initialized */
+	UK_ASSERT(state);
+	UK_ASSERT(IS_ALIGNED((__uptr) state, ectx_align));
+
+	switch (ectx_method) {
+	case X86_SAVE_XSAVE:
+	case X86_SAVE_XSAVEOPT:
+		/* XSAVE* & XRSTOR rely on sane values in the XSAVE header
+		 * (64 bytes starting at offset 512 from the base address)
+		 * and will raise #GP on garbage data. We must zero them out.
+		 */
+		((__u64 *)state)[64] = 0;
+		((__u64 *)state)[65] = 0;
+		((__u64 *)state)[66] = 0;
+		((__u64 *)state)[67] = 0;
+		((__u64 *)state)[68] = 0;
+		((__u64 *)state)[69] = 0;
+		((__u64 *)state)[70] = 0;
+		((__u64 *)state)[71] = 0;
+	}
+}
+
 void ukarch_ectx_init(struct ukarch_ectx *state)
 {
 	UK_ASSERT(ectx_align); /* Do not call when not yet initialized */

--- a/include/uk/arch/ctx.h
+++ b/include/uk/arch/ctx.h
@@ -206,6 +206,15 @@ __sz ukarch_ectx_size(void);
 __sz ukarch_ectx_align(void);
 
 /**
+ * Perform the minimum necessary to ensure the memory at `state`
+ * is appropriate for passing to `ukarch_ectx_save()`.
+ *
+ * @param state
+ *   Reference to extended context
+ */
+void ukarch_ectx_sanitize(struct ukarch_ectx *state);
+
+/**
  * Initializes an extended context so that it can be loaded
  * into a logical CPU with `ukarch_ectx_load()`.
  *

--- a/lib/syscall_shim/uk_syscall_binary.c
+++ b/lib/syscall_shim/uk_syscall_binary.c
@@ -70,6 +70,7 @@ void ukplat_syscall_handler(struct __regs *r)
 	UK_ASSERT(r);
 
 	/* Save extended register state */
+	ukarch_ectx_sanitize(ectx);
 	ukarch_ectx_store(ectx);
 
 #if CONFIG_LIBSYSCALL_SHIM_HANDLER_ULTLS


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): x86_64
 - Platform(s): N/A
 - Application(s): app-elfloader


### Additional configuration

 - `CONFIG_MARCH_X86_64_COREI7AVX=y` or any x86 arch that supports AVX

### Description of changes

Most context saving instructions/routines overwrite the target area with a valid representation that can be loaded back. x86 XSAVE/XSAVEOPT are an exception, as garbage data can remain in the context area causing the following XRSTOR to fault.
Thus any potentially dirty memory passed to XSAVE* must be (minimally) sanitized before its first use.
This change introduces `ukarch_ectx_sanitize` as a function to perform this sanitization if needed.
It differs from `ukarch_ectx_init` in that it does only the minimum work necessary to make memory ready for `ukarch_ectx_store`, instead of preparing a valid argument for `ukarch_ectx_load`.

`ukplat_syscall_handler` is changed to add this sanitization call before storing ECTX, as the memory area is allocated uninitialized on the stack. Another option would be to zero out the entire area, but that would add unacceptable overhead to the syscall hot path, especially for ectx methods which do not require it (x86 FSAVE & FXSAVE, arm & arm64).
