### PR TITLE
uk/arch: Add `ukarch_fetch_sub`

### DIFF
--- a/include/uk/arch/atomic.h
+++ b/include/uk/arch/atomic.h
@@ -39,25 +39,27 @@ extern "C" {
 #include <uk/asm/atomic.h>
 
 /**
- * Perform a atomic load operation.
+ * Perform an atomic load operation.
  */
 #define ukarch_load_n(src) \
 	__atomic_load_n(src, __ATOMIC_SEQ_CST)
 
 /**
- * Perform a atomic store operation.
+ * Perform an atomic store operation.
  */
 #define ukarch_store_n(src, value) \
 	__atomic_store_n(src, value, __ATOMIC_SEQ_CST)
 
 /**
- * Perform a atomic fetch and add operation.
+ * Perform an atomic fetch and add/sub operation.
  */
 #define ukarch_fetch_add(src, value) \
 	__atomic_fetch_add(src, value, __ATOMIC_SEQ_CST)
+#define ukarch_fetch_sub(src, value) \
+	__atomic_fetch_sub(src, value, __ATOMIC_SEQ_CST)
 
 /**
- * Perform a atomic increment/decrement operation and return the
+ * Perform an atomic increment/decrement operation and return the
  * previous value.
  */
 #define ukarch_inc(src) \

--- a/include/uk/arch/atomic.h
+++ b/include/uk/arch/atomic.h
@@ -65,7 +65,7 @@ extern "C" {
 #define ukarch_inc(src) \
 	ukarch_fetch_add(src, 1)
 #define ukarch_dec(src) \
-	__atomic_fetch_sub(src, 1, __ATOMIC_SEQ_CST)
+	ukarch_fetch_sub(src, 1)
 /**
  * Writes *src into *dst, and returns the previous contents of *dst.
  */


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`, arm64]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

### Description of changes

Since we are using wrappers over the GNU atomic builtins (see [this header](https://github.com/unikraft/unikraft/blob/staging/include/uk/arch/atomic.h), we need to complete them with a wraper for `__atomic_fetch_sub `. For instance, this is required in [this PR](https://github.com/unikraft/unikraft/pull/801).
