### PR TITLE
lib/vfscore: Fix dup, utimensat, and futimens

### DIFF
--- a/lib/vfscore/include/vfscore/vnode.h
+++ b/lib/vfscore/include/vfscore/vnode.h
@@ -137,7 +137,6 @@ struct vattr {
 /*
  *  Modes.
  */
-#define VAPPEND 00010
 #define	VREAD	00004		/* read, write, execute permissions */
 #define	VWRITE	00002
 #define	VEXEC	00001

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1937,7 +1937,7 @@ UK_TRACEPOINT(trace_vfs_dup3_err, "%d", int);
  */
 UK_SYSCALL_R_DEFINE(int, dup3, int, oldfd, int, newfd, int, flags)
 {
-	struct vfscore_file *fp, *fp_new;
+	struct vfscore_file *fp;
 	int error;
 
 	trace_vfs_dup3(oldfd, newfd, flags);
@@ -1959,33 +1959,27 @@ UK_SYSCALL_R_DEFINE(int, dup3, int, oldfd, int, newfd, int, flags)
 	if (error)
 		goto out_error;
 
-	error = fget(newfd, &fp_new);
-	if (error == 0) {
-		/* if newfd is open, then close it */
-		error = close(newfd);
-		if (error)
-			goto out_error;
-	}
+	/* BUG: The close and reserve operation must be atomic */
+	error = uk_syscall_r_close(newfd);
+	if (error && error != -EBADF)
+		goto out_error_drop;
 
 	error = vfscore_reserve_fd(newfd);
 	if (error)
-		goto out_error;
+		goto out_error_drop;
 
 	error = vfscore_install_fd(newfd, fp);
-	if (error) {
-		fdrop(fp);
-		goto out_error;
-	}
+	if (error)
+		goto out_error_drop;
 
-	fdrop(fp);
 	trace_vfs_dup3_ret(newfd);
 	return newfd;
 
-	out_error:
+out_error_drop:
+	fdrop(fp);
+out_error:
 	trace_vfs_dup3_err(error);
-	if(error > 0)
-		return -error;
-	return error;
+	return (error > 0) ? -error : error;
 }
 
 UK_SYSCALL_R_DEFINE(int, dup2, int, oldfd, int, newfd)

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1984,8 +1984,17 @@ out_error:
 
 UK_SYSCALL_R_DEFINE(int, dup2, int, oldfd, int, newfd)
 {
-	if (oldfd == newfd)
+	struct vfscore_file *fp;
+	int error;
+
+	if (unlikely(oldfd == newfd)) {
+		error = fget(oldfd, &fp);
+		if (unlikely(error))
+			return -error;
+
+		fdrop(fp);
 		return newfd;
+	}
 
 	return uk_syscall_r_dup3(oldfd, newfd, 0);
 }

--- a/lib/vfscore/stdio.c
+++ b/lib/vfscore/stdio.c
@@ -209,6 +209,7 @@ static struct vnode stdio_vnode = {
 
 static struct dentry stdio_dentry = {
 	.d_vnode = &stdio_vnode,
+	.d_refcnt = 1,
 };
 
 static struct vfscore_file  stdio_file = {

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1351,27 +1351,27 @@ sys_utimes(char *path, const struct timeval *times, int flags)
 /*
  * Check the validity of members of a struct timespec
  */
-static int is_timespec_valid(const struct timespec *time)
+static int timespec_is_valid(const struct timespec *time)
 {
 	return (time->tv_sec >= 0) &&
-	   ((time->tv_nsec >= 0 && time->tv_nsec <= 999999999) ||
-	    time->tv_nsec == UTIME_NOW ||
-	    time->tv_nsec == UTIME_OMIT);
+	       ((time->tv_nsec >= 0 && time->tv_nsec <= 999999999) ||
+		time->tv_nsec == UTIME_NOW ||
+		time->tv_nsec == UTIME_OMIT);
 }
 
-void init_timespec(struct timespec *_times, const struct timespec *times)
+static void timespec_init(struct timespec *out, const struct timespec *in)
 {
-	if (times == NULL || times->tv_nsec == UTIME_NOW) {
-		clock_gettime(CLOCK_REALTIME, _times);
+	if (in == NULL || in->tv_nsec == UTIME_NOW) {
+		clock_gettime(CLOCK_REALTIME, out);
 	} else {
-		_times->tv_sec = times->tv_sec;
-		_times->tv_nsec = times->tv_nsec;
+		out->tv_sec = in->tv_sec;
+		out->tv_nsec = in->tv_nsec;
 	}
-	return;
 }
 
 int
-sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], int flags)
+sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2],
+	      int flags)
 {
 	int error;
 	char *ap;
@@ -1386,15 +1386,15 @@ sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], i
 			     times[1].tv_nsec == UTIME_OMIT))
 			return 0;
 
-		if (unlikely(!is_timespec_valid(&times[0]) ||
-			     !is_timespec_valid(&times[1])))
+		if (unlikely(!timespec_is_valid(&times[0]) ||
+			     !timespec_is_valid(&times[1])))
 			return EINVAL;
 
-		init_timespec(&timespec_times[0], times + 0);
-		init_timespec(&timespec_times[1], times + 1);
+		timespec_init(&timespec_times[0], times + 0);
+		timespec_init(&timespec_times[1], times + 1);
 	} else {
-		init_timespec(&timespec_times[0], NULL);
-		init_timespec(&timespec_times[1], NULL);
+		timespec_init(&timespec_times[0], NULL);
+		timespec_init(&timespec_times[1], NULL);
 	}
 
 	/* utimensat should return ENOENT when pathname is empty */

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1481,20 +1481,7 @@ exit_rel:
 int
 sys_futimens(int fd, const struct timespec times[2])
 {
-	int error;
-	struct vfscore_file *fp;
-	char *pathname;
-
-	fp = vfscore_get_file(fd);
-	if (!fp)
-		return EBADF;
-
-	if (!fp->f_dentry)
-		return EBADF;
-
-	pathname = fp->f_dentry->d_path;
-	error = sys_utimensat(AT_FDCWD, pathname, times, 0);
-	return error;
+	return sys_utimensat(fd, NULL, times, 0);
 }
 
 int

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1398,30 +1398,31 @@ sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], i
 	}
 
 	/* utimensat should return ENOENT when pathname is empty */
-	if(pathname && pathname[0] == 0)
+	if (unlikely(pathname && pathname[0] == 0))
 		return ENOENT;
 
 	/* Only the AT_SYMLINK_NOFOLLOW is allowed */
-	if (flags && !(flags & AT_SYMLINK_NOFOLLOW))
+	if (unlikely(flags & ~AT_SYMLINK_NOFOLLOW))
 		return EINVAL;
 
 	if (pathname && pathname[0] == '/') {
 		ap = strdup(pathname);
-		if (!ap)
+		if (unlikely(!ap))
 			return ENOMEM;
 
 	} else if (dirfd == AT_FDCWD) {
-		if (!pathname)
+		if (unlikely(!pathname))
 			return EFAULT;
+
 		error = asprintf(&ap, "%s/%s", main_task->t_cwd, pathname);
 		if (unlikely(error == -1))
 			return ENOMEM;
 	} else {
 		fp = vfscore_get_file(dirfd);
-		if (!fp)
+		if (unlikely(!fp))
 			return EBADF;
 
-		if (!fp->f_dentry)
+		if (unlikely(!fp->f_dentry))
 			return EBADF;
 
 		if (pathname) {

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1450,14 +1450,11 @@ sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], i
 		UK_ASSERT(dp);
 	}
 
-	if (dp->d_mount->m_flags & MNT_RDONLY) {
-		error = EROFS;
-	} else {
-		if (vn_access(dp->d_vnode, VWRITE)) {
-			return EACCES;
-		}
-		error = vn_settimes(dp->d_vnode, timespec_times);
-	}
+	error = vn_access(dp->d_vnode, VWRITE);
+	if (unlikely(error))
+		goto exit_rel;
+
+	error = vn_settimes(dp->d_vnode, timespec_times);
 
 exit_rel:
 	if (fp)

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1441,11 +1441,6 @@ sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], i
 		if (vn_access(dp->d_vnode, VWRITE)) {
 			return EACCES;
 		}
-		if (times &&
-			(times[0].tv_nsec != UTIME_NOW || times[1].tv_nsec != UTIME_NOW) &&
-			(times[0].tv_nsec != UTIME_OMIT || times[1].tv_nsec != UTIME_OMIT) &&
-			(!(dp->d_vnode->v_mode & ~VAPPEND)))
-			return EPERM;
 		error = vn_settimes(dp->d_vnode, timespec_times);
 	}
 

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1377,7 +1377,8 @@ sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], i
 	char *ap;
 	struct timespec timespec_times[2];
 	extern struct task *main_task;
-	struct dentry *dp;
+	struct dentry *dp = NULL;
+	struct vfscore_file *fp = NULL;
 
 	/* utimensat should return ENOENT when pathname is empty */
 	if(pathname && pathname[0] == 0)
@@ -1404,8 +1405,6 @@ sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], i
 		if (unlikely(error == -1))
 			return ENOMEM;
 	} else {
-		struct vfscore_file *fp;
-
 		fp = vfscore_get_file(dirfd);
 		if (!fp)
 			return EBADF;
@@ -1413,26 +1412,43 @@ sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], i
 		if (!fp->f_dentry)
 			return EBADF;
 
-		if (!(fp->f_dentry->d_vnode->v_type & VDIR))
-			return ENOTDIR;
+		if (pathname) {
+			if (unlikely(!(fp->f_dentry->d_vnode->v_type & VDIR))) {
+				fdrop(fp);
+				return ENOTDIR;
+			}
 
-		if (pathname)
-			error = asprintf(&ap, "%s/%s/%s", fp->f_dentry->d_mount->m_path,
-					fp->f_dentry->d_path, pathname);
-		else
-			error = asprintf(&ap, "%s/%s", fp->f_dentry->d_mount->m_path,
-					fp->f_dentry->d_path);
-		if (unlikely(error == -1))
-			return ENOMEM;
+			error = asprintf(&ap, "%s/%s/%s",
+					 fp->f_dentry->d_mount->m_path,
+					 fp->f_dentry->d_path, pathname);
+
+			fdrop(fp);
+			fp = NULL;
+
+			if (unlikely(error == -1))
+				return ENOMEM;
+		} else {
+			/* On Linux, if pathname is NULL dirfd does not need to
+			 * be a directory. The change is applied to whatever
+			 * file dirfd refers to.
+			 */
+			dp = fp->f_dentry;
+		}
 	}
 
-	/* FIXME: Add support for AT_SYMLINK_NOFOLLOW */
+	if (!dp) {
+		UK_ASSERT(!fp);
+		UK_ASSERT(ap);
 
-	error = namei(ap, &dp);
-	free(ap);
+		/* FIXME: Add support for AT_SYMLINK_NOFOLLOW */
+		error = namei(ap, &dp);
+		free(ap);
 
-	if (error)
-		return error;
+		if (unlikely(error))
+			return error;
+
+		UK_ASSERT(dp);
+	}
 
 	if (dp->d_mount->m_flags & MNT_RDONLY) {
 		error = EROFS;
@@ -1443,7 +1459,12 @@ sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], i
 		error = vn_settimes(dp->d_vnode, timespec_times);
 	}
 
-	drele(dp);
+exit_rel:
+	if (fp)
+		fdrop(fp);
+	else
+		drele(dp);
+
 	return error;
 }
 

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1380,18 +1380,30 @@ sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], i
 	struct dentry *dp = NULL;
 	struct vfscore_file *fp = NULL;
 
+	if (times) {
+		/* Make the behavior compatible with Linux */
+		if (unlikely(times[0].tv_nsec == UTIME_OMIT &&
+			     times[1].tv_nsec == UTIME_OMIT))
+			return 0;
+
+		if (unlikely(!is_timespec_valid(&times[0]) ||
+			     !is_timespec_valid(&times[1])))
+			return EINVAL;
+
+		init_timespec(&timespec_times[0], times + 0);
+		init_timespec(&timespec_times[1], times + 1);
+	} else {
+		init_timespec(&timespec_times[0], NULL);
+		init_timespec(&timespec_times[1], NULL);
+	}
+
 	/* utimensat should return ENOENT when pathname is empty */
 	if(pathname && pathname[0] == 0)
 		return ENOENT;
 
+	/* Only the AT_SYMLINK_NOFOLLOW is allowed */
 	if (flags && !(flags & AT_SYMLINK_NOFOLLOW))
 		return EINVAL;
-
-	if (times && (!is_timespec_valid(&times[0]) || !is_timespec_valid(&times[1])))
-		return EINVAL;
-
-	init_timespec(&timespec_times[0], times ? times + 0 : NULL);
-	init_timespec(&timespec_times[1], times ? times + 1 : NULL);
 
 	if (pathname && pathname[0] == '/') {
 		ap = strdup(pathname);

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1401,9 +1401,8 @@ sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], i
 		if (!pathname)
 			return EFAULT;
 		error = asprintf(&ap, "%s/%s", main_task->t_cwd, pathname);
-		if (error || !ap)
+		if (unlikely(error == -1))
 			return ENOMEM;
-
 	} else {
 		struct vfscore_file *fp;
 
@@ -1423,7 +1422,7 @@ sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], i
 		else
 			error = asprintf(&ap, "%s/%s", fp->f_dentry->d_mount->m_path,
 					fp->f_dentry->d_path);
-		if (error || !ap)
+		if (unlikely(error == -1))
 			return ENOMEM;
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

This PR fixes a series of leaks and bugs in the `dup3`, `utimensat`, and `futimens` syscalls and makes them more compatible with Linux behavior.

Closes: #858 
