### PR TITLE
lib/vfscore: Change vnops to take constant strings

### DIFF
--- a/lib/9pfs/9pfs_vnops.c
+++ b/lib/9pfs/9pfs_vnops.c
@@ -246,7 +246,8 @@ static int uk_9pfs_close(struct vnode *vn __unused, struct vfscore_file *file)
 	return 0;
 }
 
-static int uk_9pfs_lookup(struct vnode *dvp, char *name, struct vnode **vpp)
+static int uk_9pfs_lookup(struct vnode *dvp, const char *name,
+			  struct vnode **vpp)
 {
 	struct uk_9pfs_mount_data *md = UK_9PFS_MD(dvp->v_mount);
 	struct uk_9pdev *dev = md->dev;
@@ -363,7 +364,8 @@ static int uk_9pfs_inactive(struct vnode *vp)
 	return 0;
 }
 
-static int uk_9pfs_create_generic(struct vnode *dvp, char *name, mode_t mode)
+static int uk_9pfs_create_generic(struct vnode *dvp, const char *name,
+				  mode_t mode)
 {
 	struct uk_9pdev *dev = UK_9PFS_MD(dvp->v_mount)->dev;
 	struct uk_9pfid *fid;
@@ -382,7 +384,7 @@ static int uk_9pfs_create_generic(struct vnode *dvp, char *name, mode_t mode)
 	return -rc;
 }
 
-static int uk_9pfs_create(struct vnode *dvp, char *name, mode_t mode)
+static int uk_9pfs_create(struct vnode *dvp, const char *name, mode_t mode)
 {
 	struct uk_9pfs_mount_data *md = UK_9PFS_MD(dvp->v_mount);
 
@@ -412,7 +414,7 @@ static int uk_9pfs_remove_generic(struct vnode *dvp, struct vnode *vp)
 }
 
 static int uk_9pfs_remove(struct vnode *dvp, struct vnode *vp,
-		char *name __unused)
+			  const char *name __unused)
 {
 	struct uk_9pfs_node_data *nd = UK_9PFS_ND(vp);
 	int rc = 0;
@@ -425,7 +427,7 @@ static int uk_9pfs_remove(struct vnode *dvp, struct vnode *vp,
 	return rc;
 }
 
-static int uk_9pfs_mkdir(struct vnode *dvp, char *name, mode_t mode)
+static int uk_9pfs_mkdir(struct vnode *dvp, const char *name, mode_t mode)
 {
 	if (!S_ISDIR(mode))
 		return EINVAL;
@@ -434,7 +436,7 @@ static int uk_9pfs_mkdir(struct vnode *dvp, char *name, mode_t mode)
 }
 
 static int uk_9pfs_rmdir(struct vnode *dvp, struct vnode *vp,
-		char *name __unused)
+			 const char *name __unused)
 {
 	return uk_9pfs_remove_generic(dvp, vp);
 }
@@ -867,9 +869,10 @@ static int uk_9pfs_truncate(struct vnode *vp, off_t off)
 	}
 }
 
-static int uk_9pfs_rename(struct vnode *dvp1, struct vnode *vp1, char *name1,
+static int uk_9pfs_rename(struct vnode *dvp1, struct vnode *vp1,
+			  const char *name1,
 			  struct vnode *dvp2, struct vnode *vp2 __unused,
-			  char *name2)
+			  const char *name2)
 {
 	struct uk_9pfs_mount_data *dmd1 = UK_9PFS_MD(dvp1->v_mount);
 	struct uk_9pfid *dfid1 = UK_9PFS_VFID(dvp1);
@@ -892,7 +895,7 @@ static int uk_9pfs_rename(struct vnode *dvp1, struct vnode *vp1, char *name1,
 	return -rc;
 }
 
-static int uk_9pfs_link(struct vnode *dvp, struct vnode *svp, char *name)
+static int uk_9pfs_link(struct vnode *dvp, struct vnode *svp, const char *name)
 {
 	struct uk_9pfs_mount_data *dmd = UK_9PFS_MD(dvp->v_mount);
 	struct uk_9pfid *dfid = UK_9PFS_VFID(dvp);
@@ -952,7 +955,7 @@ static int uk_9pfs_readlink(struct vnode *vp, struct uio *uio)
 	return 0;
 }
 
-static int uk_9pfs_symlink(struct vnode *dvp, char *op, char *np)
+static int uk_9pfs_symlink(struct vnode *dvp, const char *op, const char *np)
 {
 	struct uk_9pfs_mount_data *md = UK_9PFS_MD(dvp->v_mount);
 	struct uk_9pfid *dfid = UK_9PFS_VFID(dvp);

--- a/lib/devfs/devfs_vnops.c
+++ b/lib/devfs/devfs_vnops.c
@@ -133,7 +133,7 @@ devfs_ioctl(struct vnode *vp, struct vfscore_file *fp __unused,
 }
 
 static int
-devfs_lookup(struct vnode *dvp, char *name, struct vnode **vpp)
+devfs_lookup(struct vnode *dvp, const char *name, struct vnode **vpp)
 {
 	struct devinfo info;
 	struct vnode *vp;

--- a/lib/ramfs/ramfs_vnops.c
+++ b/lib/ramfs/ramfs_vnops.c
@@ -117,7 +117,7 @@ ramfs_free_node(struct ramfs_node *np)
 }
 
 static struct ramfs_node *
-ramfs_add_node(struct ramfs_node *dnp, char *name, int type)
+ramfs_add_node(struct ramfs_node *dnp, const char *name, int type)
 {
 	struct ramfs_node *np, *prev;
 
@@ -175,7 +175,7 @@ ramfs_remove_node(struct ramfs_node *dnp, struct ramfs_node *np)
 }
 
 static int
-ramfs_rename_node(struct ramfs_node *np, char *name)
+ramfs_rename_node(struct ramfs_node *np, const char *name)
 {
 	size_t len;
 	char *tmp;
@@ -202,7 +202,7 @@ ramfs_rename_node(struct ramfs_node *np, char *name)
 }
 
 static int
-ramfs_lookup(struct vnode *dvp, char *name, struct vnode **vpp)
+ramfs_lookup(struct vnode *dvp, const char *name, struct vnode **vpp)
 {
 	struct ramfs_node *np, *dnp;
 	struct vnode *vp;
@@ -253,7 +253,7 @@ ramfs_lookup(struct vnode *dvp, char *name, struct vnode **vpp)
 }
 
 static int
-ramfs_mkdir(struct vnode *dvp, char *name, mode_t mode)
+ramfs_mkdir(struct vnode *dvp, const char *name, mode_t mode)
 {
 	struct ramfs_node *np;
 
@@ -273,7 +273,7 @@ ramfs_mkdir(struct vnode *dvp, char *name, mode_t mode)
 }
 
 static int
-ramfs_symlink(struct vnode *dvp, char *name, char *link)
+ramfs_symlink(struct vnode *dvp, const char *name, const char *link)
 {
 	struct ramfs_node *np;
 	size_t len;
@@ -319,14 +319,15 @@ ramfs_readlink(struct vnode *vp, struct uio *uio)
 
 /* Remove a directory */
 static int
-ramfs_rmdir(struct vnode *dvp, struct vnode *vp, char *name __unused)
+ramfs_rmdir(struct vnode *dvp, struct vnode *vp, const char *name __unused)
 {
 	return ramfs_remove_node(dvp->v_data, vp->v_data);
 }
 
 /* Remove a file */
 static int
-ramfs_remove(struct vnode *dvp, struct vnode *vp, char *name __maybe_unused)
+ramfs_remove(struct vnode *dvp, struct vnode *vp,
+	     const char *name __maybe_unused)
 {
 	uk_pr_debug("remove %s in %s\n", name,
 		 RAMFS_NODE(dvp)->rn_name);
@@ -377,7 +378,7 @@ ramfs_truncate(struct vnode *vp, off_t length)
  * Create empty file.
  */
 static int
-ramfs_create(struct vnode *dvp, char *name, mode_t mode)
+ramfs_create(struct vnode *dvp, const char *name, mode_t mode)
 {
 	struct ramfs_node *np;
 
@@ -493,8 +494,9 @@ ramfs_write(struct vnode *vp, struct uio *uio, int ioflag)
 }
 
 static int
-ramfs_rename(struct vnode *dvp1, struct vnode *vp1, char *name1 __unused,
-			 struct vnode *dvp2, struct vnode *vp2, char *name2)
+ramfs_rename(struct vnode *dvp1, struct vnode *vp1, const char *name1 __unused,
+	     struct vnode *dvp2, struct vnode *vp2,
+	     const char *name2)
 {
 	struct ramfs_node *np, *old_np;
 	int error;

--- a/lib/vfscore/include/vfscore/vnode.h
+++ b/lib/vfscore/include/vfscore/vnode.h
@@ -164,22 +164,22 @@ typedef	int (*vnop_seek_t)	(struct vnode *, struct vfscore_file *,
 typedef	int (*vnop_ioctl_t)	(struct vnode *, struct vfscore_file *, unsigned long, void *);
 typedef	int (*vnop_fsync_t)	(struct vnode *, struct vfscore_file *);
 typedef	int (*vnop_readdir_t)	(struct vnode *, struct vfscore_file *, struct dirent *);
-typedef	int (*vnop_lookup_t)	(struct vnode *, char *, struct vnode **);
-typedef	int (*vnop_create_t)	(struct vnode *, char *, mode_t);
-typedef	int (*vnop_remove_t)	(struct vnode *, struct vnode *, char *);
-typedef	int (*vnop_rename_t)	(struct vnode *, struct vnode *, char *,
-				 struct vnode *, struct vnode *, char *);
-typedef	int (*vnop_mkdir_t)	(struct vnode *, char *, mode_t);
-typedef	int (*vnop_rmdir_t)	(struct vnode *, struct vnode *, char *);
+typedef	int (*vnop_lookup_t)	(struct vnode *, const char *, struct vnode **);
+typedef	int (*vnop_create_t)	(struct vnode *, const char *, mode_t);
+typedef	int (*vnop_remove_t)	(struct vnode *, struct vnode *, const char *);
+typedef	int (*vnop_rename_t)	(struct vnode *, struct vnode *, const char *,
+				 struct vnode *, struct vnode *, const char *);
+typedef	int (*vnop_mkdir_t)	(struct vnode *, const char *, mode_t);
+typedef	int (*vnop_rmdir_t)	(struct vnode *, struct vnode *, const char *);
 typedef	int (*vnop_getattr_t)	(struct vnode *, struct vattr *);
 typedef	int (*vnop_setattr_t)	(struct vnode *, struct vattr *);
 typedef	int (*vnop_inactive_t)	(struct vnode *);
 typedef	int (*vnop_truncate_t)	(struct vnode *, off_t);
-typedef	int (*vnop_link_t)      (struct vnode *, struct vnode *, char *);
+typedef	int (*vnop_link_t)      (struct vnode *, struct vnode *, const char *);
 typedef int (*vnop_cache_t) (struct vnode *, struct vfscore_file *, struct uio *);
 typedef int (*vnop_fallocate_t) (struct vnode *, int, off_t, off_t);
 typedef int (*vnop_readlink_t)  (struct vnode *, struct uio *);
-typedef int (*vnop_symlink_t)   (struct vnode *, char *, char *);
+typedef int (*vnop_symlink_t)   (struct vnode *, const char *, const char *);
 typedef int (*vnop_poll_t)	(struct vnode *, unsigned int *,
 				 struct eventpoll_cb *);
 

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -859,55 +859,48 @@ sys_rename(char *src, char *dest)
 int
 sys_symlink(const char *oldpath, const char *newpath)
 {
-	struct task	*t = main_task;
-	int		error;
-	char		np[PATH_MAX];
-	struct dentry	*newdp;
-	struct dentry	*newdirdp;
-	char		*name;
-
-	if (oldpath == NULL || newpath == NULL) {
-		return (EFAULT);
-	}
+	struct dentry *newdirdp = NULL;
+	struct dentry *newdp = NULL;
+	char np[PATH_MAX];
+	char *name;
+	int error;
 
 	DPRINTF(VFSDB_SYSCALL, ("sys_link: oldpath=%s newpath=%s\n",
 				oldpath, newpath));
 
-	newdp		= NULL;
-	newdirdp	= NULL;
+	error = task_conv(main_task, newpath, VWRITE, np);
+	if (unlikely(error))
+		goto out;
 
-	error = task_conv(t, newpath, VWRITE, np);
-	if (error != 0) {
-		return (error);
-	}
-
-	/* parent directory for new path must exist */
-	if ((error = lookup(np, &newdirdp, &name)) != 0)
+	/* parent directory for newpath must exist */
+	error = lookup(np, &newdirdp, &name);
+	if (unlikely(error))
 		goto out;
 
 	vn_lock(newdirdp->d_vnode);
 
 	/* newpath should not already exist */
-	if (namei_last_nofollow(np, newdirdp, &newdp) == 0) {
+	if (unlikely(namei_last_nofollow(np, newdirdp, &newdp) == 0)) {
 		drele(newdp);
 		error = EEXIST;
-		goto out;
+		goto out_unlock;
 	}
 
+	UK_ASSERT(!newdp);
+
 	/* check for write access at newpath */
-	if ((error = vn_access(newdirdp->d_vnode, VWRITE)) != 0) {
-		goto out;
-	}
+	error = vn_access(newdirdp->d_vnode, VWRITE);
+	if (unlikely(error))
+		goto out_unlock;
 
 	error = VOP_SYMLINK(newdirdp->d_vnode, name, oldpath);
 
-out:
-	if (newdirdp != NULL) {
-		vn_unlock(newdirdp->d_vnode);
-		drele(newdirdp);
-	}
+out_unlock:
+	vn_unlock(newdirdp->d_vnode);
+	drele(newdirdp);
 
-	return (error);
+out:
+	return error;
 }
 
 int

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -861,7 +861,6 @@ sys_symlink(const char *oldpath, const char *newpath)
 {
 	struct task	*t = main_task;
 	int		error;
-	char		op[PATH_MAX];
 	char		np[PATH_MAX];
 	struct dentry	*newdp;
 	struct dentry	*newdirdp;
@@ -900,14 +899,7 @@ sys_symlink(const char *oldpath, const char *newpath)
 		goto out;
 	}
 
-	/* oldpath may not be const char * to VOP_SYMLINK - need to copy */
-	size_t tocopy;
-	tocopy = strlcpy(op, oldpath, PATH_MAX);
-	if (tocopy >= PATH_MAX - 1) {
-		error = ENAMETOOLONG;
-		goto out;
-	}
-	error = VOP_SYMLINK(newdirdp->d_vnode, name, op);
+	error = VOP_SYMLINK(newdirdp->d_vnode, name, oldpath);
 
 out:
 	if (newdirdp != NULL) {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

The current vnode operations define strings as mutable, which makes it more difficult to do optimizations. Since no buffer size is supplied the strings can only be modified on a char-for-char basis anyways, which also limits the use-cases of their mutability. In addition, no implementation of the vnode operations makes use of the it.

This PR thus changes all vnode operations to take constant strings. The PR further cleans up `sys_symlink` and removes an unnecessary path copy.