### PR TITLE
plat/common/x86: Copy AP bootcode when num cores is exceeded

### DIFF
--- a/plat/common/x86/lcpu.c
+++ b/plat/common/x86/lcpu.c
@@ -172,7 +172,7 @@ int lcpu_arch_mp_init(void *arg __unused)
 			 * just stop here.
 			 */
 			uk_pr_warn("Maximum number of cores exceeded.\n");
-			return 0;
+			break;
 		}
 	}
 	UK_ASSERT(bsp_found);


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `common`
 - Application(s): N/A

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Copy the AP bootcode when a higher number of cores than the one specified in CONFIG_UKPLAT_LCPU_MAXCOUNT is detected, to allow existing cores to boot up.
