### PR TITLE
plat/common: Introduce ukplat_pt_init_clone

### DIFF
--- a/include/uk/plat/paging.h
+++ b/include/uk/plat/paging.h
@@ -85,7 +85,8 @@ struct uk_pagetable {
 	(((flag) >> PAGE_FLAG_SIZE_SHIFT) & PAGE_FLAG_SIZE_MASK)
 
 /* Page table clone flags */
-#define PAGE_FLAG_CLONE_NEW	0x01 /* Create an empty page table */
+#define PAGE_FLAG_CLONE_NEW		0x01 /* Create an empty page table */
+#define PAGE_FLAG_CLONE_INITIALIZED	0x02 /* PT is already initialized */
 
 /**
  * Returns the active page table (the one that defines the virtual address
@@ -166,6 +167,30 @@ int ukplat_pt_add_mem(struct uk_pagetable *pt, __paddr_t start, __sz len);
  */
 int ukplat_pt_clone(struct uk_pagetable *pt, struct uk_pagetable *pt_src,
 		    unsigned long flags);
+
+/**
+ * Initializes a new page table as a clone of an existing pagetable. The
+ * new pagetable is assigned physical address range for allocations and
+ * mappings.
+ *
+ * @param pt_dst
+ *   An uninitialized page table that will receive a clone of the source page
+ *   table
+ * @param pt_src
+ *   The source page table that will be cloned
+ * @param start
+ *   Start of the physical address range that will be available
+ *   for allocations of physical memory (e.g., mapping with __PADDR_ANY).
+ *   The function may reserve some memory in this area for own purposes. The
+ *   range must not be assigned to other page tables.
+ * @param len
+ *   The length (in bytes) of the physical address range
+ *
+ * @return
+ *   0 on success, a non-zero value otherwise
+ */
+int ukplat_pt_init_clone(struct uk_pagetable *pt_dst, struct uk_pagetable *pt_src,
+			 __paddr_t start, __sz len);
 
 /**
  * Frees the given page table by recursively releasing the page table hierarchy

--- a/plat/common/paging.c
+++ b/plat/common/paging.c
@@ -122,11 +122,13 @@ static int pg_pt_clone(struct uk_pagetable *pt_dst, struct uk_pagetable *pt_src,
 	UK_ASSERT(pt_src->pt_vbase != __VADDR_INV);
 	UK_ASSERT(pt_src->pt_pbase != __PADDR_INV);
 
-	if (pt_dst != pt_src)
-		memset(pt_dst, 0, sizeof(struct uk_pagetable));
+	if (!(flags & PAGE_FLAG_CLONE_INITIALIZED)) {
+		/* Use the same frame allocator for the new page table */
+		if (pt_dst != pt_src)
+			memset(pt_dst, 0, sizeof(struct uk_pagetable));
 
-	/* Use the same frame allocator for the new page table */
-	pt_dst->fa = pt_src->fa;
+		pt_dst->fa = pt_src->fa;
+	}
 
 	pt_vaddr_scache[lvl] = pt_svaddr = pt_src->pt_vbase;
 
@@ -237,6 +239,20 @@ EXIT_FREE:
 	pg_pt_free(pt_dst, pt_vaddr_dcache[PT_LEVELS - 1], PT_LEVELS - 1);
 
 	return rc;
+}
+
+int ukplat_pt_init_clone(struct uk_pagetable *pt_dst, struct uk_pagetable *pt_src,
+			 __paddr_t start, __sz len)
+{
+	int rc;
+
+	memset(pt_dst, 0, sizeof(struct uk_pagetable));
+
+	rc = pgarch_pt_init(pt_dst, start, len);
+	if (unlikely(rc))
+		return rc;
+
+	return pg_pt_clone(pt_dst, pt_src, PAGE_FLAG_CLONE_INITIALIZED);
 }
 
 int ukplat_pt_init(struct uk_pagetable *pt, __paddr_t start, __sz len)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The existing ukplat_pt_clone function allows cloning an existing pagetable, with both pagetables using the same frame allocator.
    
Introduce ukplat_pt_init_clone to allow initializing a new pagetable with a dedicated allocator, as a clone of an existing one.
