### PR TITLE
plat/common: Pass pagetable base address to ukplat_lcpu_start()

### DIFF
--- a/include/uk/plat/lcpu.h
+++ b/include/uk/plat/lcpu.h
@@ -148,6 +148,9 @@ __u32 ukplat_lcpu_count(void);
  *   elements in lcpuidx, and [OUT] the number of successfully started CPUs in
  *   sequential order of lcpuidx. If the call succeeds, input and output values
  *   are equal. Must be NULL if lcpuidx is NULL
+ * @param pt_base array of pointers to the base of pagetables, on for each
+ *        logical CPU. If lcpuidx is NULL, must be ukplat_lcpu_count() - 1
+ *        pointers.
  * @param sp array of stack pointers, one for each logical CPU to start. If
  *   lcpuidx is NULL, must be ukplat_lcpu_count() - 1 stack pointers. The
  *   stacks may be specifically prepared to contain arguments for the entry
@@ -163,8 +166,9 @@ __u32 ukplat_lcpu_count(void);
  *
  * @return 0 on success, an errno-type error value otherwise
  */
-int ukplat_lcpu_start(const __lcpuidx lcpuidx[], unsigned int *num, void *sp[],
-		      const ukplat_lcpu_entry_t entry[], unsigned long flags);
+int ukplat_lcpu_start(const __lcpuidx lcpuidx[], unsigned int *num, void *pt_base[],
+		      void *sp[], const ukplat_lcpu_entry_t entry[],
+		      unsigned long flags);
 
 /**
  * Waits for the specified logical CPUs to enter idle state, or until the

--- a/plat/common/include/uk/plat/common/lcpu.h
+++ b/plat/common/include/uk/plat/common/lcpu.h
@@ -67,17 +67,20 @@ struct lcpu_arch { };
  */
 #define LCPU_SARGS_ENTRY_OFFSET		0x00
 #define LCPU_SARGS_STACKP_OFFSET	(LCPU_SARGS_ENTRY_OFFSET + 0x08)
+#define LCPU_SARGS_BPT_OFFSET		(LCPU_SARGS_ENTRY_OFFSET + 0x10)
 
-#define LCPU_SARGS_SIZE			0x10
+#define LCPU_SARGS_SIZE			0x18
 
 #ifndef __ASSEMBLY__
 struct lcpu_sargs {
 	ukplat_lcpu_entry_t entry;
 	void *stackp;
+	void *bpt;
 };
 
 UK_CTASSERT(__offsetof(struct lcpu_sargs, entry)  == LCPU_SARGS_ENTRY_OFFSET);
 UK_CTASSERT(__offsetof(struct lcpu_sargs, stackp) == LCPU_SARGS_STACKP_OFFSET);
+UK_CTASSERT(__offsetof(struct lcpu_sargs, bpt)    == LCPU_SARGS_BPT_OFFSET);
 
 UK_CTASSERT(sizeof(struct lcpu_sargs) == LCPU_SARGS_SIZE);
 #endif /* !__ASSEMBLY__ */
@@ -90,8 +93,9 @@ UK_CTASSERT(sizeof(struct lcpu_sargs) == LCPU_SARGS_SIZE);
 #define LCPU_ID_OFFSET			(LCPU_IDX_OFFSET   + 0x04)
 #define LCPU_ENTRY_OFFSET		(LCPU_ID_OFFSET    + 0x08)
 #define LCPU_STACKP_OFFSET		(LCPU_ENTRY_OFFSET + 0x08)
+#define LCPU_BPT_OFFSET			(LCPU_ENTRY_OFFSET + 0x10)
 #define LCPU_ERR_OFFSET			(LCPU_ENTRY_OFFSET + 0x00)
-#define LCPU_ARCH_OFFSET		(LCPU_ENTRY_OFFSET + 0x10)
+#define LCPU_ARCH_OFFSET		(LCPU_ENTRY_OFFSET + 0x18)
 
 #ifdef CONFIG_HAVE_SMP
 #define LCPU_FUNC_SIZE			0x10

--- a/plat/common/lcpu.c
+++ b/plat/common/lcpu.c
@@ -404,8 +404,9 @@ void __weak __noreturn lcpu_entry_default(struct lcpu *this_lcpu)
 	}
 }
 
-int ukplat_lcpu_start(const __lcpuidx lcpuidx[], unsigned int *num, void *sp[],
-		      const ukplat_lcpu_entry_t entry[], unsigned long flags)
+int ukplat_lcpu_start(const __lcpuidx lcpuidx[], unsigned int *num, void *pt_base[],
+		      void *sp[], const ukplat_lcpu_entry_t entry[],
+		      unsigned long flags)
 {
 	__lcpuid this_cpu_id = ukplat_lcpu_id();
 	struct lcpu *lcpu;
@@ -464,6 +465,7 @@ retry:
 		lcpu->s_args.entry = (entry && entry[argi]) ?
 			entry[argi] : lcpu_entry_default;
 		lcpu->s_args.stackp = sp[argi];
+		lcpu->s_args.bpt = pt_base[argi];
 
 		/* Ensure that the startup arguments have been written back
 		 * before issuing the startup call

--- a/plat/kvm/x86/lcpu_start.S
+++ b/plat/kvm/x86/lcpu_start.S
@@ -172,8 +172,35 @@ ENTRY(lcpu_start32)
 	movl	$X86_MSR_EFER, %ecx
 	wrmsr
 
+	/* Request basic CPU features and APIC ID
+	 * TODO: This APIC ID is limited to 256. Better get from leaf 0x1f
+	 */
+	movl	$1, %eax
+	cpuid
+	shrl	$24, %ebx
+
+	/* Use APIC_ID * LCPU_SIZE for indexing the cpu structure */
+	movl	$LCPU_SIZE, %eax
+	imul	%ebx, %eax
+
+	/* Compute pointer into CPU struct array and store it in EDX
+	 */
+	movl	$lcpus, %edx
+	add	%eax, %edx
+
+	/* Check if we have startup arguments supplied */
+	test	%edi, %edi
+	jz	no_args32
+
 	/* Set boot page table and enable paging */
 	movl	$x86_bpt_pml4, %eax
+	jmp	enable_paging
+
+no_args32:
+	/* Get pml4 from lcpu struct */
+	mov	LCPU_BPT_OFFSET(%edx), %eax
+
+enable_paging:
 	movl	%eax, %cr3
 
 	movl	$CR0_BOOT32_SETTINGS, %eax
@@ -220,26 +247,10 @@ END(lcpu_start32)
 ENTRY(lcpu_start64)
 	/* Save the startup args pointer */
 	movq	%rdi, %r8
-
-	/* Request basic CPU features and APIC ID
-	 * TODO: This APIC ID is limited to 256. Better get from leaf 0x1f
-	 */
-	movl	$1, %eax
-	cpuid
-	shrl	$24, %ebx
-
-	/* Use APIC_ID * LCPU_SIZE for indexing the cpu structure */
-	movl	$LCPU_SIZE, %eax
-	imul	%ebx, %eax
-
-	/* Compute pointer into CPU struct array and store it in RBP
-	 * We do not use the frame pointer, yet
-	 */
-	leaq	lcpus(%rip), %rbp
-	addq	%rax, %rbp
+	movq	%rdx, %r9
 
 	/* Put CPU into init state */
-	movl	$LCPU_STATE_INIT, LCPU_STATE_OFFSET(%rbp)
+	movl	$LCPU_STATE_INIT, LCPU_STATE_OFFSET(%r9)
 
 	/* Enable FPU and SSE */
 	LCPU_ENABLE_FPU_SSE
@@ -279,8 +290,8 @@ no_pku:
 
 no_args:
 	/* Load the stack pointer and the entry address from the CPU struct */
-	movq	LCPU_ENTRY_OFFSET(%rbp), %rax
-	movq	LCPU_STACKP_OFFSET(%rbp), %rsp
+	movq	LCPU_ENTRY_OFFSET(%r9), %rax
+	movq	LCPU_STACKP_OFFSET(%r9), %rsp
 
 jump_to_entry:
 	/* According to System V AMD64 the stack pointer must be aligned to
@@ -292,7 +303,7 @@ jump_to_entry:
 	andq	$~0xf, %rsp
 	subq	$0x8, %rsp
 
-	movq	%rbp, %rdi
+	movq	%r9, %rdi
 #if !__OMIT_FRAMEPOINTER__
 	/* Reset frame pointer */
 	xorq	%rbp, %rbp
@@ -304,7 +315,7 @@ jump_to_entry:
 	jmp	*%rax
 
 fail:
-	movl	$LCPU_STATE_HALTED, LCPU_STATE_OFFSET(%rbp)
+	movl	$LCPU_STATE_HALTED, LCPU_STATE_OFFSET(%r9)
 
 fail_loop:
 	cli


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Update the parameters of ukplat_lcpu_start() to include the pagetable base address of each core. This provides additional flexibility when each cpu needs to use its own pagetables.

Update lcpu_start to fetch ptbase from s_args.