### PR TITLE
support/scripts: Fix Python ascii codec can't decode byte

### DIFF
--- a/support/scripts/mkbootinfo.py
+++ b/support/scripts/mkbootinfo.py
@@ -64,7 +64,7 @@ def main():
     # to create a binary blob that has exactly this size so we can replace it
     # in the binary.
     out = subprocess.check_output(["objdump", "-h", opt.kernel])
-    match = re.findall(SECINFO_EXP, out.decode('ASCII'), re.MULTILINE)
+    match = re.findall(SECINFO_EXP, out.decode('utf-8'), re.MULTILINE)
 
     if len(match) != 1:
         raise Exception(".uk_bootinfo section not found")
@@ -73,7 +73,7 @@ def main():
 
     # Retrieve info about ELF segments in unikernel
     out = subprocess.check_output(["objdump", "-p", opt.kernel])
-    phdrs = re.findall(PHDRS_EXP, out.decode('ASCII'), re.MULTILINE)
+    phdrs = re.findall(PHDRS_EXP, out.decode('utf-8'), re.MULTILINE)
 
     # The boot info is a struct ukplat_bootinfo
     # (see plat/common/include/uk/plat/common/bootinfo.h) followed by a list of


### PR DESCRIPTION
The output of objdump can't be decoded using only the ASCII encoding on some system languages. Change it to utf-8 to be more permissive.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): `all`


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes
This is a copy of #782.
Closes #782.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
