### PR TITLE
lib/vfscore: Handle `FIONBIO` command in `pipe_ioctl()`

### DIFF
--- a/lib/vfscore/pipe.c
+++ b/lib/vfscore/pipe.c
@@ -462,6 +462,9 @@ static int pipe_ioctl(struct vnode *vnode,
 		*((int *) data) = pipe_buf_get_available(pipe_buf);
 		uk_mutex_unlock(&pipe_buf->rdlock);
 		return 0;
+	case FIONBIO:
+		/* sys_ioctl() already sets f_flags, no need to do anything */
+		return 0;
 	default:
 		return -EINVAL;
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The current `ioctl` implementation for pipes does not handle the `FIONBIO` command, which leads to a negative error value being returned. This PR introduces a simple case which sets the FNONBLOCK flag when such a command is passed.

Without this PR, `app-redis` won't respond to any PING requests, for example, since Redis relies on nonblocking pipes to properly work.