### PR TITLE
lib/vfscore: `fs0` for automounting 9pfs

### DIFF
--- a/lib/vfscore/Config.uk
+++ b/lib/vfscore/Config.uk
@@ -74,7 +74,7 @@ if LIBVFSCORE_AUTOMOUNT_ROOTFS
 	config LIBVFSCORE_ROOTDEV
 	string "Default root device"
 	depends on !LIBVFSCORE_ROOTFS_RAMFS && !LIBVFSCORE_ROOTFS_INITRD
-	default "rootfs" if LIBVFSCORE_ROOTFS_9PFS
+	default "fs0" if LIBVFSCORE_ROOTFS_9PFS
 	default ""
 	help
 		Device to mount the filesystem from (e.g., on 9PFS this


### PR DESCRIPTION
### Base target

 - Architecture(s): [all]
 - Platform(s): [all]
 - Application(s): [all]

### Additional configuration

 - `LIBVFSCORE_AUTOMOUNT_ROOTFS=y`
 - `LIBVFSCORE_ROOTFS_9PFS=y`

### Description of changes

This PR changes the default device/tag name for an automatically mounted 9pfs root volume from `rootfs` to `fs0`. This is done for convenience because `fs0` is the tag name that the `qemu-guest` support script uses to name the first 9pfs share.