### PR TITLE
plat/kvm/x86: Fix register names for clang

### DIFF
--- a/plat/kvm/x86/cpu_vectors_x86_64.S
+++ b/plat/kvm/x86/cpu_vectors_x86_64.S
@@ -80,7 +80,15 @@ ENTRY(ASM_TRAP_SYM(\trapname))
 	.cfi_offset rip, -8
 	/* Description of the stack with active IST */
 	.cfi_offset cs, 0
+
+#ifdef __clang__
+	.cfi_offset flags, 8
+#elif __GNUC__
 	.cfi_offset rflags, 8
+#else
+#error "Unsupported Compiler"
+#endif
+
 	.cfi_offset rsp, 16
 	.cfi_offset ss, 24
 	cld
@@ -115,7 +123,15 @@ ENTRY(cpu_irq_\irqno)
 
 	/* Description of the stack with active IST */
 	.cfi_offset cs, 0
+
+#ifdef __clang__
+	.cfi_offset flags, 8
+#elif __GNUC__
 	.cfi_offset rflags, 8
+#else
+#error "Unsupported Compiler"
+#endif
+
 	.cfi_offset rsp, 16
 	.cfi_offset ss, 24
 	cld


### PR DESCRIPTION
`clang` does not understand the `rflags` register name, so the build will fail. On the other hand, `gcc` does not understand `flags`, so the register naming needs to be placed inside `#ifdef` guards.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
