### PR TITLE
lib/{nolibc,isrlib}: Modify pointer comparison

### DIFF
--- a/lib/isrlib/string.c
+++ b/lib/isrlib/string.c
@@ -110,7 +110,9 @@ void *memmove_isr(void *dst, const void *src, size_t len)
 	uint8_t *d = dst;
 	const uint8_t *s = src;
 
-	if (src > dst) {
+	if ((intptr_t)src == (intptr_t)dst) {
+		return dst;
+	} else if ((intptr_t)src > (intptr_t)dst) {
 		for (; len > 0; --len)
 			*(d++) = *(s++);
 	} else {

--- a/lib/nolibc/string.c
+++ b/lib/nolibc/string.c
@@ -110,7 +110,9 @@ void *memmove(void *dst, const void *src, size_t len)
 	uint8_t *d = dst;
 	const uint8_t *s = src;
 
-	if (src > dst) {
+	if ((intptr_t)src == (intptr_t)dst) {
+		return dst;
+	} else if ((intptr_t)src > (intptr_t)dst) {
 		for (; len > 0; --len)
 			*(d++) = *(s++);
 	} else {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR typecasts `src` and `dst` strings from `string.h:memmove()` to ensure that their values are treated as pointers.

It also modifies the function implementation to handle overlapping.
