### PR TITLE
build: Disable compiler control flow protection

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -11,6 +11,8 @@ COMPFLAGS-$(call have_gcc)	+= -fno-tree-sra -fno-split-stack -nostdinc
 ifneq ($(HAVE_STACKPROTECTOR),y)
 COMPFLAGS    += -fno-stack-protector
 endif
+COMPFLAGS    += -fcf-protection=none
+
 COMPFLAGS    += -Wall -Wextra
 COMPFLAGS-$(call have_clang)	+= -Wdocumentation -Wdocumentation-pedantic
 


### PR DESCRIPTION
### Description of changes
Compiler flag -fcf-protection sets control-flow integrity measures that improve security, and sometimes defaults to enabled on distro compilers. Some aspects of this feature are implemented in the compiler header <cet.h> for e.g., stack unwinders. If this header is missing some programs fail to compile.
Since we don't (yet) support pulling compiler headers into unikraft build, this change disables cf-protection globally.

This change fixes missing <cet.h> errors for system compilers that default cf-protection to on.

This is part of a patch set consisting of:
 - [libcxx](https://github.com/unikraft/lib-libcxx/pull/28)
 - [libcxxabi](https://github.com/unikraft/lib-libcxxabi/pull/4)
 - [lib-compiler-rt](https://github.com/unikraft/lib-compiler-rt/pull/12)
 - [libunwind](https://github.com/unikraft/lib-libunwind/pull/7)
 - [musl](https://github.com/unikraft/lib-musl/pull/45)
 - [unikraft/build](https://github.com/unikraft/unikraft/pull/881)

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Additional configuration

System compiler that defaults cf-protection to on (check with `cc -E -dM - < /dev/null | grep CET`).