### PR TITLE
`lib/uklibparam`: Fixes for review PR #867

### DIFF
--- a/lib/uklibparam/Config.uk
+++ b/lib/uklibparam/Config.uk
@@ -1,5 +1,10 @@
 config LIBUKLIBPARAM
-       bool "uklibparam: Library arguments"
-       default n
-       select LIBUKDEBUG
-       select LIBNOLIBC if !HAVE_LIBC
+	bool "uklibparam: Library arguments"
+	default n
+	select LIBUKDEBUG
+	select LIBNOLIBC if !HAVE_LIBC
+	help
+		Parser for library arguments. Such arguments can be set with the
+		kernel command line at boot time and overwrites default values
+		(e.g., network interface IP addresses). A help summary with a
+		list of available arguments is printed with: "help --".

--- a/lib/uklibparam/include/uk/libparam.h
+++ b/lib/uklibparam/include/uk/libparam.h
@@ -62,7 +62,7 @@ extern C {
 /*
  * Name (prefixes) used for a per-library section that stores all references
  * to parameters (struct uk_libparam_param) available for one library. This
- * section is basically compiles into an array of pointers.
+ * section is basically compiled into an array of pointers.
  * A library parameter descriptor (struct uk_libparam_desc) is referencing to
  * the section's base address for iteration.
  */
@@ -78,7 +78,7 @@ extern C {
 
 #ifndef __ASSEMBLY__
 #ifdef CONFIG_LIBUKLIBPARAM
-/* The following symbols are provided by ther per-library linker script. They
+/* The following symbols are provided by the per-library linker script.
  * They define the start and the end of the library parameters reference array
  */
 extern struct uk_libparam_param * const UK_LIBPARAM_PARAMSECTION_STARTSYM[];
@@ -118,7 +118,7 @@ struct uk_libparam_param {
 	/* Reference to corresponding variable */
 	void * const addr;
 
-	/* Internally use by parser for array parameters */
+	/* Internally used by parser for array parameters */
 	__sz __widx;
 };
 
@@ -146,7 +146,7 @@ struct uk_libparam_libdesc {
  *        library. A solution could be to create a file in uklibparam that
  *        declares an array of structs, one struct per library. Ideally the
  *        fields are filled out at compile/link time. This can be done as soon
- *        as a library is available that can export the the list of included
+ *        as a library is available that can export the list of included
  *        libraries of a build.
  * NOTE: Double declaration within one source file is avoided by the header's
  *       include guards.

--- a/lib/uklibparam/parser.c
+++ b/lib/uklibparam/parser.c
@@ -133,7 +133,7 @@ static void uk_usage(void)
 	uk_pr_info("Valid boolean values for 'true' are: \"true\", \"on\", \"yes\", a non-zero number.\n"
 		   "Valid boolean values for 'false' are: \"false\", \"off\", \"no\", a zero number (e.g., \"0\").\n");
 	uk_pr_info("Boolean parameters that are passed without a value will be set to 'true'.\n");
-	uk_pr_info("Array parameters can be passed with multiple 'LIBRARY%cPARAMETER%cVALUE' tokens,\n",
+	uk_pr_info("Array parameters can be passed with multiple 'PREFIX%cPARAMETER%cVALUE' tokens,\n",
 		   PARSE_PARAM_SEP, PARSE_VALUE_SEP);
 	uk_pr_info("using a list: 'PREFIX%cPARAMETER%c%c VALUE0 VALUE1 ... %c', or a combination of both.\n",
 		   PARSE_PARAM_SEP, PARSE_VALUE_SEP, PARSE_LIST_START,
@@ -535,7 +535,7 @@ static int parse_arg(struct parse_arg_ctx *ctx, char *strbuf, int scan_only)
 	switch (ctx->state) {
 	case PAS_PARAM:
 		/*
-		 * Catch stop sequence ('---') or usage command ('help')
+		 * Catch stop sequence ('--') or usage command ('help')
 		 */
 		if (strcmp(strbuf, PARSE_STOP) == 0) {
 			ctx->hit_stop = 1;


### PR DESCRIPTION
PR #867 got merged by mistake with PR #868 due to a dependency.
This PR addresses the comments provided with the review for PR #867.