### PR TITLE
lib/vfscore: Fix file path resolution for 9pfs setup

### DIFF
--- a/lib/vfscore/lookup.c
+++ b/lib/vfscore/lookup.c
@@ -78,7 +78,7 @@ namei_follow_link(struct dentry *dp, char *node, char *name, char *fp, size_t mo
 	}
 	link[sz] = 0;
 
-	p = fp + mountpoint_len + strlen(node);
+	p = fp + mountpoint_len + strlen(node) - 1;
 	c = strlen(node) - strlen(name) - 1;
 	node[c] = 0;
 


### PR DESCRIPTION
The path resolution doesn't correctly work for a set of file cases (e.g. symlinks to binaries or shared libraries).

One setup example is using 9pfs and the entire root local filesystem, while running the "ls" binary and loading the shared libraries:

unikraft/support/scripts/qemu-guest -k build/app-elfloader_qemu-x86_64 -e / -a "/bin/ls /"

A "/" character is omitted from the last part of the path e.g. "/binls" instead of "/bin/ls". Update the logic to include the missing character.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): `app-elfloader` and `ls`

Add the changes from PR https://github.com/unikraft/app-elfloader/pull/17 on top of `app-elfloader` "staging" branch.

Use a 9pfs setup.

As an example, run the following command:

```
unikraft/support/scripts/qemu-guest -k build/app-elfloader_qemu-x86_64 -e / -a "/bin/ls /"
```

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
