### PR TITLE
lib/posix-process: Start tid numbering from one

### DIFF
--- a/lib/posix-process/Config.uk
+++ b/lib/posix-process/Config.uk
@@ -12,8 +12,8 @@ if LIBPOSIX_PROCESS
 if LIBPOSIX_PROCESS_PIDS
 		config LIBPOSIX_PROCESS_MAX_PID
 		int "Largest PID"
-		range 1 32768
-		default 32
+		range 1 32767
+		default 31
 
 		config LIBPOSIX_PROCESS_INIT_PIDS
 		bool "Assign PID during boot"

--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -83,9 +83,11 @@ struct posix_thread {
 
 /**
  * System global lists
+ * NOTE: We pre-allocate PID/TID 0 which is reserved by the kernel.
+ *       An application should never get PID/TID 0 assigned.
  */
 static struct posix_thread *tid_thread[TIDMAP_SIZE];
-static unsigned long tid_map[UK_BITS_TO_LONGS(TIDMAP_SIZE)];
+static unsigned long tid_map[UK_BITS_TO_LONGS(TIDMAP_SIZE)] = { [0] = 0x01UL };
 
 /**
  * Thread-local posix_thread reference


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): `N/A`


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
These commits make so that PID/TID 0 cannot be assigned to any thread. Some library calls can fail when using binary compatibility mode because they assume that this value is reserved by the kernel.