### PR TITLE
lib/uk9p, lib/9pfs: Fix I/O error on fsync with 9P2000.u

### DIFF
--- a/lib/uk9p/9preq.c
+++ b/lib/uk9p/9preq.c
@@ -145,8 +145,15 @@ int uk_9preq_receive_cb(struct uk_9preq *req, uint32_t recv_size)
 	/* Check state and the existence of the header. */
 	if (UK_READ_ONCE(req->state) != UK_9PREQ_SENT)
 		return -EIO;
-	if (recv_size < UK_9P_HEADER_SIZE)
+
+	if (recv_size < UK_9P_HEADER_SIZE) {
+#ifdef CONFIG_LIBUK9P_ERRATUM_WSTAT_FSYNC_ZERO
+		if (req->xmit.type == UK_9P_TWSTAT && recv_size == 0)
+			recv_size = UK_9P_HEADER_SIZE;
+		else
+#endif /* CONFIG_LIBUK9P_ERRATUM_WSTAT_FSYNC_ZERO */
 		return -EIO;
+	}
 
 	/* Deserialize the header into request fields. */
 	req->recv.offset = 0;

--- a/lib/uk9p/Config.uk
+++ b/lib/uk9p/Config.uk
@@ -1,6 +1,19 @@
-config LIBUK9P
+menuconfig LIBUK9P
 	bool "uk9p: 9p client"
 	default n
 	select LIBUKALLOC
 	select LIBNOLIBC if !HAVE_LIBC
 	select LIBUKDEBUG
+
+if LIBUK9P
+
+config LIBUK9P_ERRATUM_WSTAT_FSYNC_ZERO
+	bool "Workaround for WSTAT bug in QEMU"
+	depends on KVM_VMM_QEMU
+	default y
+	help
+		QEMU has a bug where a successful call of WSTAT to perform
+		an fsync will lead to a zero-sized response. This option
+		enables a workaround where the length of the response is fixed.
+
+endif


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [QEMU]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

With commit 6d07017e38fdbdec6037ba6f58daa6670ca7ab74, I introduced support for `fsync` with 9P2000.u. However, a bug in the implementation causes applications to receive an I/O error, whereas the stubbed version would let them continue to run. This issue has been discovered by @StefanJum.

This PR fixes the issue by
1) using the correct `fid` in the 9P request, which is the actual bug
2) introduces a workaround for a bug in QEMU, where QEMU returns a zero-length response for a successful `fsync`.

The bug fix can be tested by running `app-sqlite`. Trying to create a new table with `CREATE TABLE tab (d1 int);` will fail with an I/O error. The operation should complete with the PR applied. This can also by tested by simply calling `fsync` on a file in a simple `main`.