### PR TITLE
`lib/vfscore`: Initialize lists for `stdio_vnode`

### DIFF
--- a/lib/vfscore/stdio.c
+++ b/lib/vfscore/stdio.c
@@ -206,6 +206,8 @@ static struct vnode stdio_vnode = {
 	.v_op = &stdio_vnops,
 	.v_lock = UK_MUTEX_INITIALIZER(stdio_vnode.v_lock),
 	.v_refcnt = 1,
+	.v_link = UK_LIST_HEAD_INIT(stdio_vnode.v_link),
+	.v_names = UK_LIST_HEAD_INIT(stdio_vnode.v_names),
 	.v_type = VCHR,
 };
 


### PR DESCRIPTION
The VFS `struct vnode` structure has two `uk_list_head` members: `v_link` and `v_names`. These need to be initialized by a dedicated macro / function, such as `UK_LIST_HEAD_INIT`.

The `stdio_vnode` variable (of type `struct vnode`) is not initializing these members (they are filled with zeros). This will cause crashes when using them.

This commit fixes that by properly initializing the `v_link` and `v_names` members of the `stdio_vnode` variable.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. N/A]
 - Platform(s): [e.g. N/A]
 - Application(s): [e.g. N/A]


### Additional configuration

If this commit is absent, then enabling `vfscore` debugging (by defining `DEBUG_VFS`) will cause a crash.

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
