### PR TITLE
`lib/vfscore`: Add semicolon to `DPRINTF` macro

### DIFF
--- a/lib/vfscore/vfs.h
+++ b/lib/vfscore/vfs.h
@@ -68,7 +68,7 @@ extern int vfs_debug;
  *	Format string, followed by a variable-length list of arguments,
  *	similar to arguments passed to printf().
  */
-#define DPRINTF(_m, X)	do {if (vfs_debug & (_m)) uk_pr_debug X} while (0)
+#define DPRINTF(_m, X)	do { if (vfs_debug & (_m)) uk_pr_debug X; } while (0)
 #else
 #define DPRINTF(_m, X)
 #endif


### PR DESCRIPTION
The `DPRINTF()` macro in `vfscore` requires a semicolon (`;`). If this
is not present (once `DEBUG_VFS` is enabled), a build issue occurs.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

You can test it by enabling `DEBUG_VFS`:

```c
#define DEBUG_VFS
```

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
