### PR TITLE
lib/ukargparse: Support escaping of quotes

### DIFF
--- a/lib/ukargparse/tests/test_ukargparse_parse.c
+++ b/lib/ukargparse/tests/test_ukargparse_parse.c
@@ -103,4 +103,43 @@ UK_TESTCASE(ukargparse, parse_quotes)
 		UK_TEST_EXPECT_SNUM_EQ(strcmp(arg_ex[i], arg_out[i]), 0);
 }
 
+UK_TESTCASE(ukargparse, parse_quotes_escaped)
+{
+	int argc, i;
+	char *arg_vec[0x10] = { NULL };
+	char arg_str[] =
+		"\\'"
+		" \\\""
+		" \"arg0\\\"\""
+		" \"\\\"arg1 '-'\\\"\"-\" \\\\ arg2\\\"\""
+		" '\" \\\\ \\\" \\''\"'"
+		" \\a\\b\\\"\\c\\\""
+		" \"\\a\\b\\\"\\c\\\"\""
+		" '\\a\\b\\\"\\c\\\"'"
+		" '\\'a\\'"
+		" a\\ b"
+		" \\";
+	static const char * const arg_exp[] = {
+		"'",
+		"\"",
+		"arg0\"",
+		"\"arg1 '-'\"- \\ arg2\"",
+		"\" \\\\ \\\" \\\"",
+		"ab\"c\"",
+		"\\a\\b\"\\c\"",
+		"\\a\\b\\\"\\c\\\"",
+		"\\a'",
+		"a b",
+		"\\"
+	};
+
+	argc = uk_argparse(arg_str, arg_vec, ARRAY_SIZE(arg_vec) - 1);
+	UK_TEST_EXPECT_SNUM_EQ(argc, ARRAY_SIZE(arg_exp));
+	if (argc != ARRAY_SIZE(arg_exp))
+		return;
+
+	for (i = 0; i < (int) ARRAY_SIZE(arg_exp); ++i)
+		UK_TEST_EXPECT_SNUM_EQ(strcmp(arg_exp[i], arg_vec[i]), 0);
+}
+
 uk_testsuite_register(ukargparse, NULL);


### PR DESCRIPTION
### Base target

 - Architecture(s): [all]
 - Platform(s): [all]
 - Application(s): [N/A]


### Additional configuration

 - `CONFIG_LIBUKARGPARSE=y`

### Description of changes

This PR introduces the support of escaping single (`'`) and double quotes (`"`) with the escape character `\`. The behavior is similar to what one expects from Unix shells, like `sh` or `bash`.

Single-quoted characters and character sequences preserve each character. Double-quoted characters and character sequences preserve each character except the backslash `\`. The backslash can be used to switch of the special meaning of a character, like the double quote (`\"`) or a backslash (`\\`).

This enables handing over of strings with nested quotes, like:
`"\"my string\""` --`uk_argparse()`--> `"my string"`
This can be especially useful for setting c-string values through `lib/uklibparam`.