### PR TITLE
build: Use -nostdinc for clang

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -5,8 +5,8 @@
 ################################################################################
 
 COMPFLAGS    += -nostdlib
-COMPFLAGS    += -U __linux__ -U __FreeBSD__ -U __sun__
-COMPFLAGS-$(call have_gcc)	+= -fno-tree-sra -fno-split-stack -nostdinc
+COMPFLAGS    += -U __linux__ -U __FreeBSD__ -U __sun__ -nostdinc
+COMPFLAGS-$(call have_gcc)	+= -fno-tree-sra -fno-split-stack
 
 ifneq ($(HAVE_STACKPROTECTOR),y)
 COMPFLAGS    += -fno-stack-protector


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A 

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
This flag ensures that no system header directories are used by the compiler. If this flag is not used, the compiler could silently fall back to system headers instead of complaining about not finding a header. Currently, the flag is only used when GCC is used, but clang also supports this flag.

