### PR TITLE
kvm/x86: Add pristine ECTX check

### DIFF
--- a/include/uk/arch/ctx.h
+++ b/include/uk/arch/ctx.h
@@ -231,5 +231,16 @@ void ukarch_ectx_store(struct ukarch_ectx *state);
  */
 void ukarch_ectx_load(struct ukarch_ectx *state);
 
+#ifdef CONFIG_ARCH_X86_64
+/**
+ * Compare the given extended context with the state of the currently executing
+ * CPU. If the state is different, crash the kernel.
+ *
+ * @param state
+ *   Reference to extended context to compare to
+ */
+void ukarch_ectx_assert_equal(struct ukarch_ectx *state);
+#endif
+
 #endif /* !__ASSEMBLY__ */
 #endif /* __UKARCH_CTX_H__ */

--- a/plat/Config.uk
+++ b/plat/Config.uk
@@ -41,6 +41,11 @@ config UKPLAT_LCPU_WAKEUP_IRQ
 
 endmenu
 
+config UKPLAT_ISR_ECTX_ASSERTIONS
+	bool "Check for unmodified ECTX in interrupt handlers"
+	default n
+	depends on (ARCH_X86_64 && PLAT_KVM)
+
 menuconfig PAGING
 	bool "Virtual memory API"
 	default n


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:
-->

 - `CONFIG_UKPLAT_ISR_ECTX_ASSERTIONS=y`


### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Currently, interrupt handlers could silently modify the values of extended context registers. More recent compilers are more likely to generate vectorized machine code that utilizes these registers. This happened in the past and usually caused hard to find bugs. 

This pull request implements a check on x86/kvm, but can be extended for other architectures/platforms.
