### PR TITLE
lib/ukboot: Allow disabling weak main using KConfig

### DIFF
--- a/lib/ukboot/Config.uk
+++ b/lib/ukboot/Config.uk
@@ -77,6 +77,10 @@ if LIBUKBOOT
 	int "Maximum number of arguments (max. size of argv)"
 	default 60
 
+	config LIBUKBOOT_DISABLE_WEAK_MAIN
+	bool
+	default n
+
 	choice LIBUKBOOT_INITALLOC
 	prompt "Initialize memory allocator"
 	default LIBUKBOOT_INITBBUDDY

--- a/lib/ukboot/Makefile.uk
+++ b/lib/ukboot/Makefile.uk
@@ -19,4 +19,6 @@ endif
 # incremental linking (ld -r). This possibly will be fixed in gcc
 # v9. But we have to deal with it now.
 $(eval $(call addlib_s,libukboot_main,$(CONFIG_LIBUKBOOT)))
+ifneq ($(CONFIG_LIBUKBOOT_DISABLE_WEAK_MAIN),y)
 LIBUKBOOT_MAIN_SRCS-y += $(LIBUKBOOT_BASE)/weak_main.c
+endif


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

-->

 - `CONFIG_LIBUKBOOT_DISABLE_WEAK_MAIN=y`

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This allows other modules to disable the weak main function. This is useful in situations where the main is in a static library and the weak symbol causes a premature end of search in the linker.