### PR TITLE
plat/kvm: Add vmm option for arm64

### DIFF
--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -12,8 +12,6 @@ menuconfig PLAT_KVM
 
 if (PLAT_KVM)
 
-if (ARCH_X86_64)
-
 config KVM_BOOT_PROTO_MULTIBOOT
 	bool
 
@@ -31,9 +29,9 @@ config KVM_VMM_QEMU
 config KVM_VMM_FIRECRACKER
 	bool "Firecracker"
 	select KVM_BOOT_PROTO_LXBOOT
+	depends on ARCH_X86_64
 
 endchoice
-endif
 
 menu "Console Options"
 


### PR DESCRIPTION
Add the option to choose a VMM when building for arm64. There are build options that depend on the chosen VMM (i.e. PCI support), so the VMM should be selected no matter what the chosen architecture is.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`
 - Platform(s): `kvm`


### Additional configuration

To test it you can use an `arm64` build that requires a `9pfs` filesystem attached.
