### PR TITLE
  lib/uknetdev: Fix typo in `uk_netdev_tx_one` documentation

### DIFF
--- a/lib/uknetdev/include/uk/netdev.h
+++ b/lib/uknetdev/include/uk/netdev.h
@@ -490,7 +490,7 @@ static inline int uk_netdev_rx_one(struct uk_netdev *dev, uint16_t queue_id,
  * @param dev
  *   The Unikraft Network Device.
  * @param queue_id
- *   The index of the receive queue to receive from.
+ *   The index of the transmit queue to send to.
  *   The value must be in the range [0, nb_tx_queue - 1] previously supplied
  *   to uk_netdev_configure().
  * @param pkt


### PR DESCRIPTION
We now know RX was written first :).

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [X] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [X] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Just a typo in the function api
