### PR TITLE
build: Add proper compiler detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -624,19 +624,20 @@ DTC		:= dtc
 TIME		:= $(shell which time)
 LIFTOFF		:= liftoff -e -s
 override ARFLAGS:= rcs
-CC_VERSION	:= $(shell $(CC) --version | \
-		   sed -n -r 's/^.* ([0-9]*)\.([0-9]*)\.([0-9]*)[ ]*.*/\1.\2/p')
+
+CC_INFO := $(shell $(CONFIG_UK_BASE)/support/build/cc-version.sh $(CC))
+CC_NAME := $(word 1,$(CC_INFO))
+
 # Retrieve GCC major and minor number from CC_VERSION. They would be used
 # to select correct optimization parameters for target CPUs.
-CC_VER_MAJOR   := $(word 1,$(subst ., ,$(CC_VERSION)))
-CC_VER_MINOR   := $(word 2,$(subst ., ,$(CC_VERSION)))
+CC_VER_MAJOR   := $(word 2,$(subst ., ,$(CC_INFO)))
+CC_VER_MINOR   := $(word 3,$(subst ., ,$(CC_INFO)))
+CC_VERSION     := $(CC_VER_MAJOR).$(CC_VER_MINOR)
 
 ASFLAGS		+= -DCC_VERSION=$(CC_VERSION)
 CFLAGS		+= -DCC_VERSION=$(CC_VERSION)
 CXXFLAGS	+= -DCC_VERSION=$(CC_VERSION)
 GOCFLAGS	+= -DCC_VERSION=$(CC_VERSION)
-
-CC_NAME		:= $(shell $(CC) -v 2>&1 | grep -E "\\w+ version" | sed 's/\s.*$$//')
 
 # ensure $(BUILD_DIR)/kconfig, $(BUILD_DIR)/include and $(BUILD_DIR)/include/uk exists
 $(call mk_sub_build_dir,kconfig)

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -31,12 +31,12 @@ uc = $(subst a,A,$(subst b,B,$(subst c,C,$(subst d,D,$(subst e,E,$(subst f,F,$(s
 
 # test if GCC is set as a compiler
 define have_gcc =
-$(if $(filter gcc,$(CC_NAME)),y,n)
+$(if $(filter GCC,$(CC_NAME)),y,n)
 endef
 
 # test if CLANG is set as a compiler
 define have_clang =
-$(if $(filter clang,$(CC_NAME)),y,n)
+$(if $(filter Clang,$(CC_NAME)),y,n)
 endef
 
 # test whether GCC version is greater than or equal to the minimum requirement

--- a/support/build/cc-version.sh
+++ b/support/build/cc-version.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+#
+# Print the C compiler name and its version in a 5 or 6-digit form.
+# Also, perform the minimum version check.
+
+set -e
+
+# Print the C compiler name and some version components.
+get_c_compiler_info()
+{
+	cat <<- EOF | "$@" -E -P -x c - 2>/dev/null
+	#if defined(__clang__)
+	Clang	__clang_major__  __clang_minor__  __clang_patchlevel__
+	#elif defined(__GNUC__)
+	GCC	__GNUC__  __GNUC_MINOR__  __GNUC_PATCHLEVEL__
+	#else
+	unknown
+	#endif
+	EOF
+}
+
+# $@ instead of $1 because multiple words might be given, e.g. CC="ccache gcc".
+orig_args="$@"
+set -- $(get_c_compiler_info "$@")
+
+name=$1
+
+case "$name" in
+GCC)
+	version=$2.$3.$4
+	;;
+Clang)
+	version=$2.$3.$4
+	;;
+*)
+	echo "$orig_args: unknown C compiler" >&2
+	exit 1
+	;;
+esac
+
+echo $name $version


### PR DESCRIPTION
Use a preprocessor program to find the compiler name and version.

The `cc-version.sh` script is taken from the [linux kernel tree](https://github.com/torvalds/linux/blob/master/scripts/cc-version.sh), and will return a string containing the compiler name and version: `GCC|Clang MAJOR_V.MINOR_V`.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Additional configuration

You can test this by setting different compilers via the `CC=` variable.


