### PR TITLE
arch/arm/arm64: Fix `stxr`'s used in `spinlock`s register size

### DIFF
--- a/arch/arm/arm64/include/uk/asm/spinlock.h
+++ b/arch/arm/arm64/include/uk/asm/spinlock.h
@@ -58,7 +58,7 @@ static inline void ukarch_spin_lock(struct __spinlock *lock)
 		"1:	wfe\n"			/* wait for event */
 		"2:	ldaxr	%w0, [%1]\n"	/* exclusive load lock value */
 		"	cbnz	%w0, 1b\n"	/* check if already locked */
-		"	stxr	%w0, %2, [%1]\n"/* try to lock it */
+		"	stxr	%w0, %w2, [%1]\n"/* try to lock it */
 		"	cbnz	%w0, 2b\n"	/* jump to l2 if we failed */
 		: "=&r" (r)
 		: "r" (&lock->lock), "r" (locked));
@@ -80,7 +80,7 @@ static inline int ukarch_spin_trylock(struct __spinlock *lock)
 	__asm__ __volatile__(
 		"	ldaxr	%w0, [%1]\n"	/* exclusive load lock value */
 		"	cbnz	%w0, 1f\n"	/* bail out if locked */
-		"	stxr	%w0, %2, [%1]\n"/* try to lock it */
+		"	stxr	%w0, %w2, [%1]\n"/* try to lock it */
 		"1:\n"
 		: "=&r" (r)
 		: "r" (&lock->lock), "r" (locked));


### PR DESCRIPTION
Our `spinlock`s have a size of 4-bytes and an alignment of 8, which, in our `semaphore` implementation, causes a padding of 4 bytes. This is fine, but it is an inconsistency.

With `QEMU` direct kernel boot, all of our free memory is zeroed out. However, when using a previous boot phase such as `UEFI`, this inconsistency shows itself through an always locked `spinlock`. `UEFI` firmware "poisons" all of its free memory with `0xaf` bytes which leads to our `stxr`, whose second register argument is 64-bit instead of 32-bit, also atomically storing the `poisoned` padding.

Thus, make sure that our `stxr` uses 32-bit register for the to be transferred register.


GitHub-Fixes: #289

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
