### PR TITLE
Add the ability to build `EFI` `ISO` and `DISK` images.

### DIFF
--- a/support/scripts/mkgrubimg
+++ b/support/scripts/mkgrubimg
@@ -17,13 +17,44 @@ usage()
 # default options
 OPTFORMAT="iso"
 OPTCMDLINE=""
+OPTOUTPUT=${1}
 
 # cleanup
 BUILDDIR=
 sighandler_exit()
 {
-	if [ ! -z "${BUILDDIR}" -a -d "${BUILDDIR}" ]; then
+	if [ -n "${BUILDDIR}" ] && [ -d "${BUILDDIR}" ]; then
 		rm -rf "${BUILDDIR}"
+	fi
+}
+
+mkgrubiso()
+{
+	# configure grub
+	mkdir -p "${BUILDDIR}/boot/grub"
+
+	if [ -n "${OPTINITRD}" ]; then
+		GRUB_CFG_INITRD="module /boot/${OPTINITRDNAME}"
+		cp "${OPTINITRD}" "${BUILDDIR}/boot/${OPTINITRDNAME}" || exit 1
+	fi
+	cp "${OPTKERNELIMG}" "${BUILDDIR}/boot/" || exit 1
+
+	cat >"${BUILDDIR}/boot/grub/grub.cfg" <<EOF
+set default=0
+set timeout=0
+
+menuentry "${OPTKERNELNAME}" {
+	multiboot /boot/${OPTKERNELNAME} /${OPTKERNELNAME} ${OPTCMDLINE}
+	${GRUB_CFG_INITRD}
+	boot
+}
+EOF
+
+	# build grub image
+	GRUB_INSTALL_MSGS=$( grub-mkrescue -o "${OPTOUTPUT}" --install-modules="multiboot" --fonts="" --themes="" --locales="" "${BUILDDIR}/" 2>&1 )
+	if [ ${?} != 0 ]; then
+		printf '%s\n' "${GRUB_INSTALL_MSGS}" 1>&2
+		exit 1
 	fi
 }
 
@@ -57,7 +88,7 @@ if [[ -z "${OPTKERNELIMG}" ]]; then
 	echo "Missing path to kernel image ('-k')" 1>&2
 	usage
 fi
-if [[ -z "${1}" ]]; then
+if [[ -z "${OPTOUTPUT}" ]]; then
 	echo "Missing path to output image" 1>&2
 	usage
 fi
@@ -65,7 +96,7 @@ if [ ! -f "${OPTKERNELIMG}" ]; then
 	echo "${OPTKERNELIMG} does not exist or is not a file" 1>&2
 	exit 1
 fi
-if [ ! -z "${OPTINITRD}" -a ! -f "${OPTINITRD}" ]; then
+if [ -n "${OPTINITRD}" ] && [ ! -f "${OPTINITRD}" ]; then
 	echo "${OPTINITRD} does not exist or is not a file" 1>&2
 	exit 1
 fi
@@ -73,7 +104,7 @@ fi
 # Register exit handler and create BUILDDIR
 trap sighandler_exit exit
 BUILDDIR="$( mktemp -d )"
-if [ $? -ne 0 -o -z "${BUILDDIR}" -o ! -d "${BUILDDIR}" ]; then
+if [ ${?} -ne 0 ] || [ -z "${BUILDDIR}" ] || [ ! -d "${BUILDDIR}" ]; then
 	echo "Failed to create temporary directory" 1>&2
 	exit 1
 fi
@@ -84,32 +115,7 @@ OPTINITRDNAME="${OPTINITRD##*/}"
 case "${OPTFORMAT}" in
 	# generate grub iso image
 	iso)
-		# configure grub
-		mkdir -p "${BUILDDIR}/boot/grub"
-
-		if [ ! -z "${OPTINITRD}" ]; then
-			GRUB_CFG_INITRD="module /boot/${OPTINITRDNAME}"
-			cp "${OPTINITRD}" "${BUILDDIR}/boot/${OPTINITRDNAME}" || exit 1
-		fi
-		cp "${OPTKERNELIMG}" "${BUILDDIR}/boot/" || exit 1
-
-		cat >"${BUILDDIR}/boot/grub/grub.cfg" <<EOF
-set default=0
-set timeout=0
-
-menuentry "${OPTKERNELNAME}" {
-	multiboot /boot/${OPTKERNELNAME} /${OPTKERNELNAME} ${OPTCMDLINE}
-	${GRUB_CFG_INITRD}
-	boot
-}
-EOF
-
-		# build grub image
-		GRUB_INSTALL_MSGS=$( grub-mkrescue -o "$1" --install-modules="multiboot" --fonts="" --themes="" --locales="" "${BUILDDIR}/" 2>&1 )
-		if [ $? != 0 ]; then
-			printf '%s\n' "$GRUB_INSTALL_MSGS" 1>&2
-			exit 1
-		fi
+		mkgrubiso
 		;;
 	*)
 		echo -e "\"${OPTFORMAT}\" not a supported format." 1>&2

--- a/support/scripts/mkgrubimg
+++ b/support/scripts/mkgrubimg
@@ -9,7 +9,7 @@ usage()
 	echo "  -h                         Display help and exit"
 	echo "  -f                         Output format (supported: iso)"
 	echo "  -k                         Path to the Unikraft kernel image"
-	echo "  -a                         Kernel command-line parameters (optional)"
+	echo "  -c                         Kernel command-line parameters file (optional)"
 	echo "  -i                         Path to initrd cpio file (optional)"
 	exit 1
 }
@@ -39,12 +39,17 @@ mkgrubiso()
 	fi
 	cp "${OPTKERNELIMG}" "${BUILDDIR}/boot/" || exit 1
 
+	MBCMDL=
+	if [ -n "${OPTCMDLINE}" ]; then
+		MBCMDL=$(tr '\n' ' ' < "${OPTCMDLINE}")
+	fi
+
 	cat >"${BUILDDIR}/boot/grub/grub.cfg" <<EOF
 set default=0
 set timeout=0
 
 menuentry "${OPTKERNELNAME}" {
-	multiboot /boot/${OPTKERNELNAME} /${OPTKERNELNAME} ${OPTCMDLINE}
+	multiboot /boot/${OPTKERNELNAME} /${OPTKERNELNAME} ${MBCMDL}
 	${GRUB_CFG_INITRD}
 	boot
 }
@@ -59,7 +64,7 @@ EOF
 }
 
 # process options
-while getopts "hk:i:f:a:" OPT; do
+while getopts "hk:c:i:f:" OPT; do
 	case "${OPT}" in
 		h)
 			usage
@@ -70,7 +75,7 @@ while getopts "hk:i:f:a:" OPT; do
 		k)
 			OPTKERNELIMG="${OPTARG}"
 			;;
-		a)
+		c)
 			OPTCMDLINE="${OPTARG}"
 			;;
 		i)

--- a/support/scripts/mkukimg
+++ b/support/scripts/mkukimg
@@ -3,7 +3,7 @@
 # help menu
 usage()
 {
-	echo "Usage: $0 [options] [output file]"
+	echo "Usage: $0 [options]"
 	echo "Creates bootable images from Unikraft kernel images."
 	echo ""
 	echo "  -h                         Display help and exit"
@@ -14,13 +14,14 @@ usage()
 	echo "  -b                         Bootloader: grub (GRUB), ukefi (Unikraft EFI stub)"
 	echo "  -a                         Architecture: X64 (x86_64), AA64 (Aarch64)"
 	echo "  -d                         Path to Devicetree Blob (optional, for ukefi only!)"
+	echo "  -o                         Path to output file"
 	exit 1
 }
 
 # default options
 OPTFORMAT="iso"
 OPTCMDLINE=""
-OPTOUTPUT=${1}
+OPTOUTPUT=
 OPTARCH=
 OPTDTB=
 
@@ -105,7 +106,7 @@ mkukefiiso()
 }
 
 # process options
-while getopts "hk:c:i:f:a:b:d" OPT; do
+while getopts "hk:c:i:f:a:b:d:o:" OPT; do
 	case "${OPT}" in
 		h)
 			usage
@@ -130,6 +131,9 @@ while getopts "hk:c:i:f:a:b:d" OPT; do
 			;;
 		d)
 			OPTDTB="${OPTARG}"
+			;;
+		o)
+			OPTOUTPUT="${OPTARG}"
 			;;
 		*)
 			usage

--- a/support/scripts/mkukimg
+++ b/support/scripts/mkukimg
@@ -4,13 +4,15 @@
 usage()
 {
 	echo "Usage: $0 [options] [output file]"
-	echo "Creates bootable GRUB images from Unikraft kernel images."
+	echo "Creates bootable images from Unikraft kernel images."
 	echo ""
 	echo "  -h                         Display help and exit"
 	echo "  -f                         Output format (supported: iso)"
 	echo "  -k                         Path to the Unikraft kernel image"
 	echo "  -c                         Kernel command-line parameters file (optional)"
 	echo "  -i                         Path to initrd cpio file (optional)"
+	echo "  -b                         Bootloader: grub (GRUB), ukefi (Unikraft EFI stub)"
+	echo "  -a                         Architecture: X64 (x86_64), AA64 (Aarch64)"
 	exit 1
 }
 
@@ -18,6 +20,7 @@ usage()
 OPTFORMAT="iso"
 OPTCMDLINE=""
 OPTOUTPUT=${1}
+OPTARCH=
 
 # cleanup
 BUILDDIR=
@@ -63,8 +66,39 @@ EOF
 	fi
 }
 
+mkukefiiso()
+{
+	# create initial empty image we will format as FAT32
+	# ESP must be at least 100MB
+	dd if=/dev/zero of=${BUILDDIR}/fs.img bs=1M count=100
+
+	mkfs.vfat -F 32 ${BUILDDIR}/fs.img
+
+	LOOPDEV=$(sudo losetup --find --show ${BUILDDIR}/fs.img)
+	mkdir ${BUILDDIR}/mnt
+	sudo mount ${LOOPDEV} ${BUILDDIR}/mnt
+	sudo mkdir -p ${BUILDDIR}/mnt/EFI/BOOT/
+
+	if [ ! -z ${OPTINITRD} ]; then
+		sudo cp ${OPTINITRD} ${BUILDDIR}/mnt/EFI/BOOT/
+	fi
+
+	if [ ! -z ${OPTCMDLINE} ]; then
+		sudo cp ${OPTCMDLINE} ${BUILDDIR}/mnt/EFI/BOOT/
+	fi
+
+	sudo cp ${OPTKERNELIMG} ${BUILDDIR}/mnt/EFI/BOOT/BOOT${OPTARCH}.EFI
+
+	sudo umount ${BUILDDIR}/mnt
+	sudo losetup -d ${LOOPDEV}
+
+	mkdir ${BUILDDIR}/iso_dir
+	cp ${BUILDDIR}/fs.img ${BUILDDIR}/iso_dir
+	xorriso -as mkisofs -R -f -e fs.img -no-emul-boot -o ${OPTOUTPUT} ${BUILDDIR}/iso_dir
+}
+
 # process options
-while getopts "hk:c:i:f:" OPT; do
+while getopts "hk:c:i:f:a:b:" OPT; do
 	case "${OPT}" in
 		h)
 			usage
@@ -80,6 +114,12 @@ while getopts "hk:c:i:f:" OPT; do
 			;;
 		i)
 			OPTINITRD="${OPTARG}"
+			;;
+		b)
+			OPTBOOTLOADER="${OPTARG}"
+			;;
+		a)
+			OPTARCH="${OPTARG}"
 			;;
 		*)
 			usage
@@ -105,6 +145,10 @@ if [ -n "${OPTINITRD}" ] && [ ! -f "${OPTINITRD}" ]; then
 	echo "${OPTINITRD} does not exist or is not a file" 1>&2
 	exit 1
 fi
+if [ "${OPTARCH}" != "AA64" ] && [ "${OPTARCH}" != "X64" ]; then
+	echo "Invalid architecture" 1>&2
+	usage
+fi
 
 # Register exit handler and create BUILDDIR
 trap sighandler_exit exit
@@ -118,9 +162,19 @@ OPTKERNELNAME="${OPTKERNELIMG##*/}"
 OPTINITRDNAME="${OPTINITRD##*/}"
 
 case "${OPTFORMAT}" in
-	# generate grub iso image
 	iso)
-		mkgrubiso
+		case "${OPTBOOTLOADER}" in
+		grub)
+			mkgrubiso
+			;;
+		ukefi)
+			mkukefiiso
+			;;
+		*)
+			echo -e "\"${OPTBOOTLOADER}\" not a supported bootloader." 1>&2
+			usage
+			;;
+		esac
 		;;
 	*)
 		echo -e "\"${OPTFORMAT}\" not a supported format." 1>&2

--- a/support/scripts/mkukimg
+++ b/support/scripts/mkukimg
@@ -13,6 +13,7 @@ usage()
 	echo "  -i                         Path to initrd cpio file (optional)"
 	echo "  -b                         Bootloader: grub (GRUB), ukefi (Unikraft EFI stub)"
 	echo "  -a                         Architecture: X64 (x86_64), AA64 (Aarch64)"
+	echo "  -d                         Path to Devicetree Blob (optional, for ukefi only!)"
 	exit 1
 }
 
@@ -21,6 +22,7 @@ OPTFORMAT="iso"
 OPTCMDLINE=""
 OPTOUTPUT=${1}
 OPTARCH=
+OPTDTB=
 
 # cleanup
 BUILDDIR=
@@ -87,6 +89,10 @@ mkukefiiso()
 		sudo cp ${OPTCMDLINE} ${BUILDDIR}/mnt/EFI/BOOT/
 	fi
 
+	if [ ! -z ${OPTDTB} ]; then
+		sudo cp ${OPTDTB} ${BUILDDIR}/mnt/EFI/BOOT/
+	fi
+
 	sudo cp ${OPTKERNELIMG} ${BUILDDIR}/mnt/EFI/BOOT/BOOT${OPTARCH}.EFI
 
 	sudo umount ${BUILDDIR}/mnt
@@ -94,11 +100,12 @@ mkukefiiso()
 
 	mkdir ${BUILDDIR}/iso_dir
 	cp ${BUILDDIR}/fs.img ${BUILDDIR}/iso_dir
+	echo ${OPTOUTPUT}
 	xorriso -as mkisofs -R -f -e fs.img -no-emul-boot -o ${OPTOUTPUT} ${BUILDDIR}/iso_dir
 }
 
 # process options
-while getopts "hk:c:i:f:a:b:" OPT; do
+while getopts "hk:c:i:f:a:b:d" OPT; do
 	case "${OPT}" in
 		h)
 			usage
@@ -120,6 +127,9 @@ while getopts "hk:c:i:f:a:b:" OPT; do
 			;;
 		a)
 			OPTARCH="${OPTARG}"
+			;;
+		d)
+			OPTDTB="${OPTARG}"
 			;;
 		*)
 			usage

--- a/support/scripts/mkukimg
+++ b/support/scripts/mkukimg
@@ -7,7 +7,7 @@ usage()
 	echo "Creates bootable images from Unikraft kernel images."
 	echo ""
 	echo "  -h                         Display help and exit"
-	echo "  -f                         Output format (supported: iso)"
+	echo "  -f                         Output format: iso, disk (ukefi only)"
 	echo "  -k                         Path to the Unikraft kernel image"
 	echo "  -c                         Kernel command-line parameters file (optional)"
 	echo "  -i                         Path to initrd cpio file (optional)"
@@ -69,40 +69,95 @@ EOF
 	fi
 }
 
+# Helper function for mkukefi{iso,disk}
+# Given a directory, creates an EFI System Partition layout
+mkukefiesp()
+{
+	ESP=${1}
+	if [ -z "${ESP}" ]; then
+		echo "mkukefiesp() must receive the directory where the ESP is mounted"
+		exit 1
+	fi
+
+	sudo mkdir -p "${ESP}"/EFI/BOOT/
+
+	if [ -n "${OPTINITRD}" ]; then
+		sudo cp "${OPTINITRD}" "${ESP}/EFI/BOOT/"
+	fi
+
+	if [ -n "${OPTCMDLINE}" ]; then
+		sudo cp "${OPTCMDLINE}" "${ESP}/EFI/BOOT/"
+	fi
+
+	if [ -n "${OPTDTB}" ]; then
+		sudo cp "${OPTDTB}" "${ESP}/EFI/BOOT/"
+	fi
+
+	sudo cp "${OPTKERNELIMG}" "${ESP}/EFI/BOOT/BOOT${OPTARCH}.EFI"
+}
+
 mkukefiiso()
 {
 	# create initial empty image we will format as FAT32
 	# ESP must be at least 100MB
-	dd if=/dev/zero of=${BUILDDIR}/fs.img bs=1M count=100
+	dd if=/dev/zero of="${BUILDDIR}/fs.img" bs=1M count=100
 
-	mkfs.vfat -F 32 ${BUILDDIR}/fs.img
+	mkfs.vfat -F 32 "${BUILDDIR}/fs.img"
 
-	LOOPDEV=$(sudo losetup --find --show ${BUILDDIR}/fs.img)
-	mkdir ${BUILDDIR}/mnt
-	sudo mount ${LOOPDEV} ${BUILDDIR}/mnt
-	sudo mkdir -p ${BUILDDIR}/mnt/EFI/BOOT/
+	LOOPDEV=$(sudo losetup --find --show "${BUILDDIR}/fs.img")
+	mkdir "${BUILDDIR}/mnt"
+	sudo mount "${LOOPDEV}" "${BUILDDIR}/mnt"
 
-	if [ ! -z ${OPTINITRD} ]; then
-		sudo cp ${OPTINITRD} ${BUILDDIR}/mnt/EFI/BOOT/
-	fi
+	mkukefiesp "${BUILDDIR}/mnt"
 
-	if [ ! -z ${OPTCMDLINE} ]; then
-		sudo cp ${OPTCMDLINE} ${BUILDDIR}/mnt/EFI/BOOT/
-	fi
+	sudo umount "${BUILDDIR}/mnt"
+	sudo losetup -d "${LOOPDEV}"
 
-	if [ ! -z ${OPTDTB} ]; then
-		sudo cp ${OPTDTB} ${BUILDDIR}/mnt/EFI/BOOT/
-	fi
+	mkdir "${BUILDDIR}/iso_dir"
+	cp "${BUILDDIR}/fs.img" "${BUILDDIR}/iso_dir"
+	echo "${OPTOUTPUT}"
+	xorriso -as mkisofs -R -f -e fs.img -no-emul-boot -o "${OPTOUTPUT}" "${BUILDDIR}/iso_dir"
+}
 
-	sudo cp ${OPTKERNELIMG} ${BUILDDIR}/mnt/EFI/BOOT/BOOT${OPTARCH}.EFI
+mkukefidisk()
+{
+	# create initial empty image we will format as GPT
+	# ESP must be at least 100MB and must be FAT12/16/32, but leave some
+	# room for the GPT and the backup GPT as well as the PMBR (5MB is enough)
+	dd if=/dev/zero of="${OPTOUTPUT}" bs=1M count=105
 
-	sudo umount ${BUILDDIR}/mnt
-	sudo losetup -d ${LOOPDEV}
+	# Create the partition table
+	#	g\n	Create new GPT
+	#	n\n	Create new partition
+	#	1\n	Select partition number as 1
+	#	\n	Default first sector
+	#	\n	Default last sector
+	#	t\n	Change type of partition (default partition 1)
+	#	1\n	Mark partition 1 as EFI System Partition
+	#	w\n	Write the changes to the disk image
+	echo -e	"								\
+		g\n								\
+		n\n								\
+		1\n								\
+		\n								\
+		\n								\
+		t\n								\
+		1\n								\
+		w\n								\
+		" | fdisk -W always "${OPTOUTPUT}"	# Wipe filesystem, RAID	\
+							# and partition-table signatures
 
-	mkdir ${BUILDDIR}/iso_dir
-	cp ${BUILDDIR}/fs.img ${BUILDDIR}/iso_dir
-	echo ${OPTOUTPUT}
-	xorriso -as mkisofs -R -f -e fs.img -no-emul-boot -o ${OPTOUTPUT} ${BUILDDIR}/iso_dir
+	LOOPDEV=$(sudo losetup --find --show "${OPTOUTPUT}")
+	sudo partprobe "${LOOPDEV}"
+	sudo mkfs.vfat -F 32 "${LOOPDEV}p1"
+
+	mkdir "${BUILDDIR}/mnt"
+	sudo mount "${LOOPDEV}p1" "${BUILDDIR}/mnt"	# We only have one partition
+
+	mkukefiesp "${BUILDDIR}/mnt"
+
+	sudo umount "${BUILDDIR}/mnt"
+	sudo losetup -d "${LOOPDEV}"
 }
 
 # process options
@@ -185,7 +240,18 @@ case "${OPTFORMAT}" in
 			mkukefiiso
 			;;
 		*)
-			echo -e "\"${OPTBOOTLOADER}\" not a supported bootloader." 1>&2
+			echo -e "\"${OPTBOOTLOADER}\" not a supported bootloader for ISO images." 1>&2
+			usage
+			;;
+		esac
+		;;
+	disk)
+		case "${OPTBOOTLOADER}" in
+		ukefi)
+			mkukefidisk
+			;;
+		*)
+			echo -e "\"${OPTBOOTLOADER}\" not a supported bootloader for DISK images." 1>&2
 			usage
 			;;
 		esac


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`, `arm64`
 - Platform(s): `kvm`
 - Application(s): N/A

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Add the ability to build `EFI` `ISO` and `DISK` images. Usage example:
- for `DISK`
```
support/scripts/mkukimg -k ${UK_IMG} -f disk -b ukefi -a ${ARCH} -c ${UK_CMDL} -i ${UK_INITRD} -d ${UK_DTB} -o ${OUTPUT_IMG}
```
```
sudo ${QEMU} \
			-fsdev local,id=myid,path=$(pwd)/fs0,security_model=none \
                        -device virtio-9p-pci,fsdev=myid,mount_tag=fs0,disable-modern=on,disable-legacy=off \
                        -netdev bridge,id=en0,br=virbr0 \
                        -device virtio-net-pci,netdev=en0 \
			-drive file=${OUTPUT_IMG},if=none,id=drive0,format=raw \
			-device virtio-blk,drive=drive0 \
			-drive if=pflash,format=raw,readonly=on,file=${OVMF_CODE} \
			-drive if=pflash,format=raw,file=${OVMF_VARS}
			-nographic \
			-m 8G \
			-enable-kvm \
			-cpu host -smp 4
```

- for `ISO`
```
support/scripts/mkukimg -k ${UK_IMG} -f iso -b ukefi -a ${ARCH} -c ${UK_CMDL} -i ${UK_INITRD} -d ${UK_DTB} -o ${OUTPUT_IMG}
```
```
sudo ${QEMU} \
			-fsdev local,id=myid,path=$(pwd)/fs0,security_model=none \
                        -device virtio-9p-pci,fsdev=myid,mount_tag=fs0,disable-modern=on,disable-legacy=off \
                        -netdev bridge,id=en0,br=virbr0 \
                        -device virtio-net-pci,netdev=en0 \
			-cdrom ${OUTPUT_IMG} \
			-drive if=pflash,format=raw,readonly=on,file=${OVMF_CODE} \
			-drive if=pflash,format=raw,file=${OVMF_VARS}
			-nographic \
			-m 8G \
			-enable-kvm \
			-cpu host -smp 4
```

This PR depends on #772 #848 #908 and #909, therefore it includes them but their commit messages have been marked with a DEP: , to know which commits to ignore.

### NOTE
This is part of a larger set of Pull Requests. To make things easier and to ensure that things build as expected, it is recommended that testing is done based on #912, which includes everything. The splitting has been done to ease the review process.