### PR TITLE
Add support for setting up `SMP` on `ARM64` through `ACPI`

### DIFF
--- a/plat/common/arm/lcpu.c
+++ b/plat/common/arm/lcpu.c
@@ -30,6 +30,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#include <uk/plat/common/bootinfo.h>
+#include <uk/plat/common/acpi.h>
 #include <uk/plat/lcpu.h>
 #include <uk/plat/io.h>
 #include <arm/smccc.h>
@@ -73,7 +75,6 @@ void __noreturn lcpu_arch_jump_to(void *sp, ukplat_lcpu_entry_t entry)
 #define FDT_SIZE_CELLS_DEFAULT 0
 #define FDT_ADDR_CELLS_DEFAULT 2
 
-static void *dtb;
 void lcpu_start(struct lcpu *cpu);
 static __paddr_t lcpu_start_paddr;
 extern struct _gic_dev *gic;
@@ -92,7 +93,59 @@ int lcpu_arch_init(struct lcpu *this_lcpu)
 	return ret;
 }
 
-int lcpu_arch_mp_init(void *arg)
+#ifdef CONFIG_UKPLAT_ACPI
+static int do_arch_mp_init(void *arg __unused)
+{
+	__lcpuid bsp_cpu_id = lcpu_get(0)->id;
+	int bsp_found __maybe_unused = 0;
+	union {
+		struct acpi_madt_gicc *gicc;
+		struct acpi_subsdt_hdr *h;
+	} m;
+	struct lcpu *lcpu;
+	struct acpi_madt *madt;
+	__lcpuid cpu_id;
+	__sz off, len;
+
+	uk_pr_info("Bootstrapping processor has the ID %ld\n", bsp_cpu_id);
+
+	/* Enumerate all other CPUs */
+	madt = acpi_get_madt();
+	UK_ASSERT(madt);
+
+	len = madt->hdr.tab_len - sizeof(*madt);
+	for (off = 0; off < len; off += m.h->len) {
+		m.h = (struct acpi_subsdt_hdr *)(madt->entries + off);
+
+		if (m.h->type != ACPI_MADT_GICC ||
+		    !(m.gicc->flags & ACPI_MADT_GICC_FLAGS_EN))
+			continue;
+
+		cpu_id = m.gicc->mpidr & CPU_ID_MASK;
+
+		if (bsp_cpu_id == cpu_id) {
+			UK_ASSERT(!bsp_found);
+
+			bsp_found = 1;
+			continue;
+		}
+
+		lcpu = lcpu_alloc(cpu_id);
+		if (unlikely(!lcpu)) {
+			/* If we cannot allocate another LCPU, we probably have
+			 * reached the maximum number of supported CPUs. So
+			 * just stop here.
+			 */
+			uk_pr_warn("Maximum number of cores exceeded.\n");
+			return 0;
+		}
+	}
+	UK_ASSERT(bsp_found);
+
+	return 0;
+}
+#else
+static int do_arch_mp_init(void *arg)
 {
 	int fdt_cpu;
 	const fdt32_t *naddr_prop, *nsize_prop, *id_reg;
@@ -103,17 +156,12 @@ int lcpu_arch_mp_init(void *arg)
 	__lcpuid bsp_cpu_id;
 	char bsp_found __maybe_unused = 0;
 	struct lcpu *lcpu;
+	void *dtb;
 
 	/* MP support is dependent on an initialized GIC */
 	UK_ASSERT(gic);
 
 	dtb = arg;
-	/**
-	 * We have to provide the physical address of the start routine when
-	 * starting secondary CPUs. We thus do the translation here once and
-	 * cache the result.
-	 */
-	lcpu_start_paddr = ukplat_virt_to_phys(lcpu_start);
 
 	bsp_cpu_id = lcpu_arch_id();
 	uk_pr_info("Bootstrapping processor has the ID %ld\n",
@@ -215,6 +263,19 @@ int lcpu_arch_mp_init(void *arg)
 	UK_ASSERT(bsp_found);
 
 	return 0;
+}
+#endif
+
+int lcpu_arch_mp_init(void *arg)
+{
+	/**
+	 * We have to provide the physical address of the start routine when
+	 * starting secondary CPUs. We thus do the translation here once and
+	 * cache the result.
+	 */
+	lcpu_start_paddr = ukplat_virt_to_phys(lcpu_start);
+
+	return do_arch_mp_init(arg);
 }
 
 int lcpu_arch_start(struct lcpu *lcpu, unsigned long flags __unused)

--- a/plat/common/include/uk/plat/common/madt.h
+++ b/plat/common/include/uk/plat/common/madt.h
@@ -191,6 +191,11 @@ struct acpi_madt_gicc {
 } __packed;
 
 /* GIC Distributor (GICD) Structure */
+#define ACPI_MADT_GICD_VERSION_NONE				0x0
+#define ACPI_MADT_GICD_VERSION_1				0x1
+#define ACPI_MADT_GICD_VERSION_2				0x2
+#define ACPI_MADT_GICD_VERSION_3				0x3
+#define ACPI_MADT_GICD_VERSION_4				0x4
 struct acpi_madt_gicd {
 	struct acpi_subsdt_hdr hdr;
 	__u16 reserved;

--- a/plat/common/include/uk/plat/common/madt.h
+++ b/plat/common/include/uk/plat/common/madt.h
@@ -167,6 +167,9 @@ struct acpi_madt_x2apic_nmi {
 } __packed;
 
 /* GIC CPU Interface (GICC) Structure */
+#define ACPI_MADT_GICC_FLAGS_EN					0x01
+#define ACPI_MADT_GICC_FLAGS_PERF_IRQ_MODE			0x02
+#define ACPI_MADT_GICC_FLAGS_VGIC_IRQ_MODE			0x03
 struct acpi_madt_gicc {
 	struct acpi_subsdt_hdr hdr;
 	__u16 reserved;

--- a/plat/drivers/gic/gic-common.c
+++ b/plat/drivers/gic/gic-common.c
@@ -41,7 +41,7 @@
 #error At least one GIC driver should be selected!
 #endif
 
-int _dtb_init_gic(const void *fdt, struct _gic_dev **dev)
+int init_gic(struct _gic_dev **dev)
 {
 	int rc;
 

--- a/plat/drivers/gic/gic-common.c
+++ b/plat/drivers/gic/gic-common.c
@@ -54,7 +54,7 @@ int _dtb_init_gic(const void *fdt, struct _gic_dev **dev)
 
 #ifdef CONFIG_LIBGICV3
 	/* GICv2 is not present, try GICv3 */
-	rc = gicv3_probe(fdt, dev);
+	rc = gicv3_probe(dev);
 	if (rc == 0)
 		return 0;
 #endif /* CONFIG_LIBGICV3 */

--- a/plat/drivers/gic/gic-common.c
+++ b/plat/drivers/gic/gic-common.c
@@ -47,7 +47,7 @@ int _dtb_init_gic(const void *fdt, struct _gic_dev **dev)
 
 #ifdef CONFIG_LIBGICV2
 	/* First, try GICv2 */
-	rc = gicv2_probe(fdt, dev);
+	rc = gicv2_probe(dev);
 	if (rc == 0)
 		return 0;
 #endif /* CONFIG_LIBGICV2 */

--- a/plat/drivers/gic/gic-v3.c
+++ b/plat/drivers/gic/gic-v3.c
@@ -44,6 +44,10 @@
 #include <uk/bitops.h>
 #include <uk/asm.h>
 #include <uk/plat/lcpu.h>
+#ifdef CONFIG_UKPLAT_ACPI
+#include <uk/plat/common/acpi.h>
+#endif /* CONFIG_UKPLAT_ACPI */
+#include <uk/plat/common/bootinfo.h>
 #include <uk/plat/common/irq.h>
 #include <uk/plat/spinlock.h>
 #include <arm/cpu.h>
@@ -78,7 +82,7 @@ struct _gic_dev gicv3_drv = {
 #endif /* CONFIG_HAVE_SMP */
 };
 
-static const char * const gic_device_list[] = {
+static const char * const gic_device_list[] __maybe_unused = {
 	"arm,gic-v3",
 	NULL
 };
@@ -561,9 +565,8 @@ static int gicv3_initialize(void)
 	return 0;
 }
 
-static int gicv3_do_probe(const void *fdt)
+static inline void gicv3_set_ops(void)
 {
-	int fdt_gic, r;
 	struct _gic_operations drv_ops = {
 		.initialize        = gicv3_initialize,
 		.ack_irq           = gicv3_ack_irq,
@@ -580,6 +583,71 @@ static int gicv3_do_probe(const void *fdt)
 
 	/* Set driver functions */
 	gicv3_drv.ops = drv_ops;
+}
+
+#if defined(CONFIG_UKPLAT_ACPI)
+static int acpi_get_gicr(struct _gic_dev *g)
+{
+	union {
+		struct acpi_madt_gicr *gicr;
+		struct acpi_subsdt_hdr *h;
+	} m;
+	struct acpi_madt *madt;
+	__sz off, len;
+
+	madt = acpi_get_madt();
+	UK_ASSERT(madt);
+
+	/* We do not count the Redistributor regions, instead we rely on
+	 * having the GICv3 in an always-on power domain so that we are
+	 * aligned with the current state of the driver, which only supports
+	 * contiguous GIC Redistributors...
+	 */
+	len = madt->hdr.tab_len - sizeof(*madt);
+	for (off = 0; off < len; off += m.h->len) {
+		m.h = (struct acpi_subsdt_hdr *)(madt->entries + off);
+
+		if (m.h->type != ACPI_MADT_GICR)
+			continue;
+
+		g->rdist_mem_addr = m.gicr->paddr;
+		g->rdist_mem_size = m.gicr->len;
+
+		/* We assume we only have one redistributor region */
+		return 0;
+	}
+
+	return -ENOENT;
+}
+
+static int gicv3_do_probe(void)
+{
+	int rc;
+
+	rc = acpi_get_gicd(&gicv3_drv);
+	if (unlikely(rc < 0))
+		return rc;
+
+	/* Normally we should check first if there exists a Redistributor.
+	 * If there is none then we must get its address from the GICC
+	 * structure, since that means that the Redistributors are not in an
+	 * always-on power domain. Otherwise there could be a GICR for each
+	 * Redistributor region and the DT probe version does not accommodate
+	 * anyway for multiple regions. So, until there is need for that (not
+	 * the case for QEMU Virt), align ACPI probe with DT probe and assume
+	 * we only have one Redistributor region.
+	 */
+	return acpi_get_gicr(&gicv3_drv);
+}
+#else /* CONFIG_UKPLAT_ACPI */
+static int gicv3_do_probe(void)
+{
+	struct ukplat_bootinfo *bi = ukplat_bootinfo_get();
+	int fdt_gic, r;
+	void *fdt;
+
+	UK_ASSERT(bi);
+	fdt = (void *)bi->dtb;
 
 	/* Currently, we only support 1 GIC per system */
 	fdt_gic = fdt_node_offset_by_compatible_list(fdt, -1, gic_device_list);
@@ -589,42 +657,42 @@ static int gicv3_do_probe(const void *fdt)
 	/* Get address and size of the GIC's register regions */
 	r = fdt_get_address(fdt, fdt_gic, 0, &gicv3_drv.dist_mem_addr,
 				&gicv3_drv.dist_mem_size);
-	if (r < 0) {
+	if (unlikely(r < 0)) {
 		uk_pr_err("Could not find GICv3 distributor region!\n");
 		return r;
 	}
 
+	/* TODO: Redistributors may be spread out in different regions.
+	 * Make sure we get the count of such regions and enumerate properly
+	 * using the `#redistributor-regions"` DT property. Furthermore,
+	 * we should also check for the `redistributor-stride` property,
+	 * since there are `Devicetree`'s that have `GICv4` nodes that use the
+	 * `GICv3` compatible (there is also mixed `GICv3/4`, see Chapter 9.7
+	 * from `GICv3 and GICv4 Software Overview`). The main difference
+	 * between `GICv3/4` is the support for `vLPI`'s which basically
+	 * doubles the address space range (with some exceptions):
+	 * RD + SGI + vLPI + reserved.
+	 */
 	r = fdt_get_address(fdt, fdt_gic, 1, &gicv3_drv.rdist_mem_addr,
 				&gicv3_drv.rdist_mem_size);
-	if (r < 0) {
+	if (unlikely(r < 0)) {
 		uk_pr_err("Could not find GICv3 redistributor region!\n");
 		return r;
 	}
 
-	uk_pr_info("Found GICv3 on:\n");
-	uk_pr_info("\tDistributor  : 0x%lx - 0x%lx\n",
-		gicv3_drv.dist_mem_addr,
-		gicv3_drv.dist_mem_addr + gicv3_drv.dist_mem_size - 1);
-	uk_pr_info("\tRedistributor: 0x%lx - 0x%lx\n",
-		gicv3_drv.rdist_mem_addr,
-		gicv3_drv.rdist_mem_addr + gicv3_drv.rdist_mem_size - 1);
-
-	/* GICv3 is present */
-	gicv3_drv.is_present = 1;
-
 	return 0;
 }
+#endif /* !CONFIG_UKPLAT_ACPI */
 
 /**
  * Probe device tree for GICv3
  * NOTE: First time must not be called from multiple CPUs in parallel
  *
- * @param [in] fdt pointer to device tree
  * @param [out] dev receives pointer to GICv3 if available, NULL otherwise
  *
  * @return 0 if device is available, an FDT (FDT_ERR_*) error otherwise
  */
-int gicv3_probe(const void *fdt, struct _gic_dev **dev)
+int gicv3_probe(struct _gic_dev **dev)
 {
 	int rc;
 
@@ -643,11 +711,21 @@ int gicv3_probe(const void *fdt, struct _gic_dev **dev)
 
 	gicv3_drv.is_probed = 1;
 
-	rc = gicv3_do_probe(fdt);
+	rc = gicv3_do_probe();
 	if (rc) {
 		*dev = NULL;
 		return rc;
 	}
+
+	uk_pr_info("Found GICv3 on:\n");
+	uk_pr_info("\tDistributor  : 0x%lx - 0x%lx\n",	gicv3_drv.dist_mem_addr,
+		   gicv3_drv.dist_mem_addr + gicv3_drv.dist_mem_size - 1);
+	uk_pr_info("\tRedistributor: 0x%lx - 0x%lx\n", gicv3_drv.rdist_mem_addr,
+		   gicv3_drv.rdist_mem_addr + gicv3_drv.rdist_mem_size - 1);
+
+	/* GICv3 is present */
+	gicv3_drv.is_present = 1;
+	gicv3_set_ops();
 
 	*dev = &gicv3_drv;
 	return 0;

--- a/plat/drivers/include/gic/gic-v2.h
+++ b/plat/drivers/include/gic/gic-v2.h
@@ -251,6 +251,11 @@ enum sgi_filter {
  * so we just describe non-secure registers.
  */
 
+/* Default page-aligned up size for GICv2 CPU interface according to
+ * ARM Generic Interrupt Controller Architecture version 2.0 Issue B.b.
+ */
+#define GICC_MEM_SZ	0x2000
+
 /* CPU Interface Control Register */
 #define GICC_CTLR		0x0000
 #define GICC_CTLR_ENABLE	0x1
@@ -311,13 +316,12 @@ void gicv2_sgi_gen_to_others(uint32_t sgintid);
 void gicv2_sgi_gen_to_self(uint32_t sgintid);
 
 /**
- * Probe device tree for GICv2
+ * Probe device tree or ACPI for GICv2
  * NOTE: First time must not be called from multiple CPUs in parallel
  *
- * @param [in] fdt pointer to device tree
  * @param [out] dev receives pointer to GICv2 if available, NULL otherwise
- * @return 0 if device is available, an FDT (FDT_ERR_*) error otherwise
+ * @return 0 if device is available, < 0 otherwise
  */
-int gicv2_probe(const void *fdt, struct _gic_dev **dev);
+int gicv2_probe(struct _gic_dev **dev);
 
 #endif /* __PLAT_DRV_ARM_GICV2_H__ */

--- a/plat/drivers/include/gic/gic-v2.h
+++ b/plat/drivers/include/gic/gic-v2.h
@@ -35,6 +35,11 @@
 
 #include <gic/gic.h>
 
+/* GICv2 GICD register map size page aligned up according to
+ * ARM Generic Interrupt Controller Architecture version 2.0 Issue B.b.
+ */
+#define GICD_V2_MEM_SZ					0x01000
+
 /*
  * Distributor registers. Unikraft only supports running on non-secure
  * so we just describe non-secure registers.

--- a/plat/drivers/include/gic/gic-v3.h
+++ b/plat/drivers/include/gic/gic-v3.h
@@ -371,13 +371,12 @@
 #define GICC_IAR_INTID_SPURIOUS	1023
 
 /**
- * Probe device tree for GICv3
+ * Probe device tree or ACPI for GICv3
  * NOTE: First time must not be called from multiple CPUs in parallel
  *
- * @param [in] fdt pointer to device tree
  * @param [out] dev receives pointer to GICv3 if available, NULL otherwise
- * @return 0 if device is available, an FDT (FDT_ERR_*) error otherwise
+ * @return 0 if device is available, < 0 otherwise
  */
-int gicv3_probe(const void *fdt, struct _gic_dev **dev);
+int gicv3_probe(struct _gic_dev **dev);
 
 #endif /* __PLAT_DRV_ARM_GICV3_H__ */

--- a/plat/drivers/include/gic/gic-v3.h
+++ b/plat/drivers/include/gic/gic-v3.h
@@ -67,6 +67,11 @@
  */
 #define GICC_CTLR_EL1_EOImode_drop	(1U << 1)
 
+/* Default size according to ARM Generic Interrupt Controller Architecture
+ * Specification GIC Architecture version 3 and version 4 Issue H.
+ */
+#define GICD_V3_MEM_SZ			0x10000
+
 #define GICD_STATUSR			(0x010)
 #define GICD_SETSPI_NSR			(0x040)
 #define GICD_CLRSPI_NSR			(0x048)

--- a/plat/drivers/include/gic/gic.h
+++ b/plat/drivers/include/gic/gic.h
@@ -166,4 +166,15 @@ int _dtb_init_gic(const void *fdt, struct _gic_dev **dev);
  */
 uint32_t gic_irq_translate(uint32_t type, uint32_t irq);
 
+/**
+ * Fetch data from an existing MADT's GICD table.
+ *
+ * @param _gic_dev The driver whose memory base and size to fill in
+ *
+ * @return 0 on success, < 0 otherwise
+ */
+#if defined(CONFIG_UKPLAT_ACPI)
+int acpi_get_gicd(struct _gic_dev *g);
+#endif /* CONFIG_UKPLAT_ACPI */
+
 #endif /* __PLAT_DRV_ARM_GIC_COMMON_H__ */

--- a/plat/drivers/include/gic/gic.h
+++ b/plat/drivers/include/gic/gic.h
@@ -143,15 +143,14 @@ struct _gic_dev {
 };
 
 /**
- * Initialize GIC driver from device tree
+ * Initialize GIC driver from device tree or ACPI
  *
- * @param [in] fdt Pointer to fdt structure
  * @param [out] dev receives pointer to GIC device driver on success, NULL
  *    otherwise
  *
  * @return 0 on success, a non-zero error code otherwise
  */
-int _dtb_init_gic(const void *fdt, struct _gic_dev **dev);
+int init_gic(struct _gic_dev **dev);
 
 /**
  * Translate a type-relative interrupt number to the corresponding absolute

--- a/plat/kvm/arm/intctrl.c
+++ b/plat/kvm/arm/intctrl.c
@@ -42,13 +42,10 @@ struct _gic_dev *gic;
 
 void intctrl_init(void)
 {
-	void *dtb;
 	int rc;
 
-	dtb = (void *)ukplat_bootinfo_get()->dtb;
-
 	/* Initialize GIC from DTB */
-	rc = _dtb_init_gic(dtb, &gic);
+	rc = init_gic(&gic);
 	if (unlikely(rc))
 		goto EXIT_ERR;
 

--- a/plat/kvm/arm/setup.c
+++ b/plat/kvm/arm/setup.c
@@ -24,6 +24,7 @@
 #include <libfdt.h>
 #include <uk/plat/common/sections.h>
 #include <uk/plat/common/bootinfo.h>
+#include <uk/plat/common/acpi.h>
 #include <uk/plat/lcpu.h>
 #include <uk/plat/common/lcpu.h>
 #include <uart/pl011.h>
@@ -180,6 +181,12 @@ void __no_pauth _ukplat_entry(struct ukplat_bootinfo *bi)
 	/* Initialize RTC */
 	pl031_init_rtc(fdt);
 #endif /* CONFIG_RTC_PL031 */
+
+#if defined(CONFIG_UKPLAT_ACPI)
+	rc = acpi_init();
+	if (unlikely(rc < 0))
+		uk_pr_err("ACPI init failed: %d\n", rc);
+#endif /* CONFIG_UKPLAT_ACPI */
 
 	/* Initialize interrupt controller */
 	intctrl_init();


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Add support for setting up `SMP` on `ARM64` through `ACPI`. 

This PR depends on #772 #848 #908 #909 #910 and #911, therefore it includes.
### NOTE
This is part of a larger set of Pull Requests. To make things easier and to ensure that things build as expected, it is recommended that testing is done based on #912, which includes everything. The splitting has been done to ease the review process.

To make testing easier, use the script from #910 to build the Unikraft images. You will need an `OVMF BIOS` image first.