### PR TITLE
build: Add `-mno-outline-atomics` flag for clang

### DIFF
--- a/arch/arm/arm64/Makefile.uk
+++ b/arch/arm/arm64/Makefile.uk
@@ -9,10 +9,12 @@ else
 ARCHFLAGS     += -D__ARM_64__ -mgeneral-regs-only
 endif
 ARCHFLAGS-$(call gcc_version_ge,9,4) += -mno-outline-atomics
+ARCHFLAGS-$(call have_clang) += -mno-outline-atomics
 
 # Disable FPU for trap/exception/interrupt handlers
 ISR_ARCHFLAGS += -D__ARM_64__ -mgeneral-regs-only
 ISR_ARCHFLAGS-$(call gcc_version_ge,9,4) += -mno-outline-atomics
+ISR_ARCHFLAGS-$(call have_clang) += -mno-outline-atomics
 
 CINCLUDES   += -I$(CONFIG_UK_BASE)/arch/arm/arm64/include
 ASINCLUDES  += -I$(CONFIG_UK_BASE)/arch/arm/arm64/include


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->
The `-mno-outline-atomics` flags is necessary when building with clang,
not using it causes a crash when running `helloworld-cpp` when calling
the `init_have_lse_atomics` constructor.

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [ `kvm`]
 - Application(s): [`app-helloworld-cpp`]


### Additional configuration

You can replicate the crash by using the [`c++-17` PRs](https://github.com/unikraft/lib-libunwind/pull/7) (along with #900 and #902) and building `helloworld-cpp` for `arm64` with `clang`. Running it will fail with the following trap:

```
Powered by
o.   .o       _ _               __ _
Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
oOo oOO| | | | |   (| | | (_) |  _) :_
 OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
                  Atlas 0.13.0~12cb6bab
[    0.025664] CRIT: [libkvmplat] <traps_arm64.c @  202> EL1 sync trap caught
[    0.026384] CRIT: [libkvmplat] <traps_arm64.c @  163>         SP       : 0x0000000047fffe70
[    0.026519] CRIT: [libkvmplat] <traps_arm64.c @  164>         ESR_EL1  : 0x0000000096000006
[    0.026653] CRIT: [libkvmplat] <traps_arm64.c @  165>         ELR_EL1  : 0x000000004017fb54
[    0.026823] CRIT: [libkvmplat] <traps_arm64.c @  166>         LR (x30) : 0x0000000040216668
[    0.026973] CRIT: [libkvmplat] <traps_arm64.c @  167>         PSTATE   : 0x0000000080000345
[    0.027097] CRIT: [libkvmplat] <traps_arm64.c @  168>         FAR_EL1  : 0x0000000000000000
[    0.027296] CRIT: [libkvmplat] <traps_arm64.c @  173>         x00 ~ x03: 0x0000000000000010 0x00000000402bc928 0x00000000402bc918 0x000000004011e9f4
[    0.027550] CRIT: [libkvmplat] <traps_arm64.c @  173>         x04 ~ x07: 0x0000000047ffdb78 0x0000000047fffe3c 0x00000000402544cd 0x0000000000000000
[    0.027755] CRIT: [libkvmplat] <traps_arm64.c @  173>         x08 ~ x11: 0x0000000000000000 0x00000000402e5ac0 0x0000000000000000 0x00000000000000f0
[    0.028192] CRIT: [libkvmplat] <traps_arm64.c @  173>         x12 ~ x15: 0x00000000402e3371 0x0000000007800000 0x0000000000000f90 0x0000000000000000
[    0.028405] CRIT: [libkvmplat] <traps_arm64.c @  173>         x16 ~ x19: 0x00000000ffffffff 0x0000000000000004 0x000000000000003a 0x00000000402de5e0
[    0.028604] CRIT: [libkvmplat] <traps_arm64.c @  173>         x20 ~ x23: 0x0000000000000001 0x00000000402b30a0 0x00000000402b3098 0x00000000402be000
[    0.028826] CRIT: [libkvmplat] <traps_arm64.c @  173>         x24 ~ x27: 0x0000000000000000 0x0000000040000000 0x00000000402e7000 0x00000000402b6000
[    0.029036] CRIT: [libkvmplat] <traps_arm64.c @  176>         x28 ~ x29: 0x0000000000000000 0x0000000047ffff90
```
with the backtrace below
```
#0  0x0000000040216664 in init_have_lse_atomics ()                                                       
#1  0x000000004011fcc8 in ukplat_entry (argc=argc@entry=1, argv=0x402de5e0 <ukplat_entry_argp.argv>) at workdir/unikraft/lib/ukboot/boot.c:387
#2  0x000000004011fadc in ukplat_entry_argp (arg0=<optimised out>, argb=<optimised out>, argb@entry=0x402be0c0 <cmdline> "", argb_len=<optimised out>) at workdir/unikraft/
lib/ukboot/boot.c:224                                                                                    
#3  0x0000000040102a64 in _libkvmplat_start (dtb_pointer=<optimised out>) at workdir/unikraft/plat/kvm/arm/setup.c:365
```

The error goes away when adding the `-mno-outline-atomics` flag.
