### PR TITLE
9pfs: Change default 9p version to `9P 2000L`

### DIFF
--- a/lib/9pfs/9pfs.h
+++ b/lib/9pfs/9pfs.h
@@ -40,8 +40,9 @@
 #include <vfscore/prex.h>
 
 /**
- * Protocol version; currently only the `9P2000.u`
- * variant of the protocol is supported
+ * Protocol version; the default version is `9P2000.L`,
+ * it can be changed via the `CONFIG_LIBVFSCORE_ROOTOPTS`
+ * config option.
  */
 enum uk_9pfs_proto {
 	/*

--- a/lib/9pfs/9pfs_vfsops.c
+++ b/lib/9pfs/9pfs_vfsops.c
@@ -125,7 +125,7 @@ static int uk_9pfs_parse_options(struct uk_9pfs_mount_data *md,
 	 */
 	options = options_tok = strdup(data);
 
-	md->proto = UK_9P_PROTO_2000U;
+	md->proto = UK_9P_PROTO_2000L;
 	md->uname = strdup("");
 	md->aname = strdup("");
 

--- a/lib/9pfs/Config.uk
+++ b/lib/9pfs/Config.uk
@@ -8,7 +8,7 @@ config LIB9PFS
 		The following mount options are supported:
 		version={"9P2000.u"|"9P2000.L"}
 			9P protocol version (case sensitive).
-			Defaults to "9P2000.u".
+			Defaults to "9P2000.L".
 		uname=
 			The user name to use.
 		aname=


### PR DESCRIPTION
Using the `9p 2000U` version as the default leads to problems, especially when using Unikraft in binary compatibility mode, since it has a lot of limitation. There is no actual reason to use it as the default 9P protocol version, so we just change it to `2000L`.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


