### PR TITLE
posix-process: Add glibc compatible rusage structure

### DIFF
--- a/lib/posix-process/musl-imported/include/sys/resource.h
+++ b/lib/posix-process/musl-imported/include/sys/resource.h
@@ -41,8 +41,6 @@ struct rusage {
 	long	ru_nsignals;
 	long	ru_nvcsw;
 	long	ru_nivcsw;
-	/* room for more... */
-	long    __reserved[16];
 };
 
 int getrlimit (int, struct rlimit *);


### PR DESCRIPTION
The musl imported rusage structure keeps an extra buffer in the rusage.
This can lead to errors if running applications in binary compatibility, due
to buffer overflows.

GitHub-Fixes: #915

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


