### PR TITLE
arch/x86: Introduce NMI event for x86

### DIFF
--- a/arch/x86/x86_64/include/uk/asm/traps.h
+++ b/arch/x86/x86_64/include/uk/asm/traps.h
@@ -56,6 +56,7 @@ struct ukarch_trap_ctx {
  */
 #define UKARCH_TRAP_INVALID_OP		trap_invalid_op
 #define UKARCH_TRAP_DEBUG		trap_debug
+#define UKARCH_TRAP_NMI			trap_nmi
 
 #define UKARCH_TRAP_PAGE_FAULT		trap_page_fault
 #define UKARCH_TRAP_BUS_ERROR		trap_bus_error

--- a/plat/kvm/x86/traps.c
+++ b/plat/kvm/x86/traps.c
@@ -137,7 +137,9 @@ static void tss_init(__lcpuidx idx)
 }
 
 /* Declare the traps used only by this platform: */
-DECLARE_TRAP_EC(nmi,           "NMI",                  NULL)
+DECLARE_TRAP_EVENT(UKARCH_TRAP_NMI);
+
+DECLARE_TRAP_EC(nmi,           "NMI",                  UKARCH_TRAP_NMI)
 DECLARE_TRAP_EC(double_fault,  "double fault",         NULL)
 DECLARE_TRAP_EC(virt_error,    "virtualization error", NULL)
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

This allows libraries to handle NMI interrupts.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
