### PR TITLE
Fix schedcoop idling and x86 timer interrupts

### DIFF
--- a/lib/ukschedcoop/schedcoop.c
+++ b/lib/ukschedcoop/schedcoop.c
@@ -213,11 +213,13 @@ static __noreturn void idle_thread_fn(void *argp)
 		wake_up_time = (volatile __nsec) c->idle_return_time;
 		now = ukplat_monotonic_clock();
 
-		if (wake_up_time > now) {
-			if (wake_up_time)
+		if (!wake_up_time || wake_up_time > now) {
+			if (wake_up_time) {
 				ukplat_lcpu_halt_to(wake_up_time);
-			else
+			} else {
 				ukplat_lcpu_halt_irq();
+				ukplat_lcpu_enable_irq();
+			}
 
 			/* handle pending events if any */
 			ukplat_lcpu_irqs_handle_pending();

--- a/plat/kvm/x86/tscclock.c
+++ b/plat/kvm/x86/tscclock.c
@@ -292,6 +292,8 @@ int tscclock_init(void)
 	 * Initialise i8254 timer channel 0 to mode 4 (one shot).
 	 */
 	outb(TIMER_MODE, TIMER_SEL0 | TIMER_ONESHOT | TIMER_16BIT);
+	outb(TIMER_CNTR, 0);
+	outb(TIMER_CNTR, 0);
 
 	return 0;
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): x86_64
 - Platform(s): kvm
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

880f27c020ecfbd70fae8c1bd7efecb3cce9f170 fixes a problem in ukschedcoop in which the idle thread keeps busy looping instead of halting the cpu when no wakeup time is set (i.e., wake_up_time == 0). To test the problem simply apply [app-helloworld-diff.txt](https://github.com/unikraft/unikraft/files/11619568/app-helloworld-diff.txt) to the helloworld application (the diff causes the main thread to block) and run it. You will see the CPU usage at 100%.

655ea17d3c46904578dac921348a267234502855 fixes a problem in which the i8254 timer doesn't switch completely to software-triggered strobe in the init function.  To switch the i8254 to sw-triggered strobe mode a value must be written into the counter. Previously the timer remained in rate generator mode and kept generating interrupts until the counter was written (e.g., for a sleep()). To test add some debug message in the timer interrupt ISR and run the previous modified helloworld, you will see a lot of interrupts are triggered. E.g., [time-diff.txt](https://github.com/unikraft/unikraft/files/11619569/time-diff.txt).