### PR TITLE
lib/uksignal: Use correct kernel struct sigaction

### DIFF
--- a/lib/uksignal/ksigaction.h
+++ b/lib/uksignal/ksigaction.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+
+#ifndef __UK_KSIGACTION_H__
+#define __UK_KSIGACTION_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Imported from musl 1.2.3 */
+/* In line with the Linux kernel struct for x86_64 and aarch64. */
+
+struct k_sigaction {
+        void (*handler)(int);
+        unsigned long flags;
+        void (*restorer)(void);
+        unsigned mask[2];
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __UK_KSIGACTION_H__ */

--- a/lib/uksignal/signal.c
+++ b/lib/uksignal/signal.c
@@ -46,6 +46,7 @@
 #endif
 #include <sys/types.h>
 #include "sigset.h"
+#include "ksigaction.h"
 
 UK_SYSCALL_R_DEFINE(int, sigaltstack, const stack_t *, ss,
 		    stack_t *, old_ss)
@@ -54,37 +55,47 @@ UK_SYSCALL_R_DEFINE(int, sigaltstack, const stack_t *, ss,
 }
 
 UK_SYSCALL_R_DEFINE(int, rt_sigaction, int, signum,
-		    const struct sigaction *__unused, act,
-		    struct sigaction *, oldact,
+		    const struct k_sigaction *__unused, act,
+		    struct k_sigaction *, oldact,
 		    size_t __unused, sigsetsize)
 {
 	if (unlikely(signum == SIGKILL || signum == SIGSTOP))
 		return -EINVAL;
 
 	if (oldact)
-		*oldact = (struct sigaction){0};
+		*oldact = (struct k_sigaction){0};
 
 	return 0;
 }
 
 #if UK_LIBC_SYSCALLS
-int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
+int sigaction(int signum, const struct sigaction __unused *act,
+              struct sigaction *oldact)
 {
-	return rt_sigaction(signum, act, oldact, sizeof(sigset_t));
+	/* Not actually an implementation of sigaction.
+	 * Do minimal argument matching for the stub syscall. */
+	int r;
+	struct k_sigaction kold;
+	r = rt_sigaction(signum, NULL, oldact ? &kold : NULL, sizeof(sigset_t));
+	if (oldact && !r) {
+		oldact->sa_handler = kold.handler;
+		oldact->sa_flags = kold.flags;
+	}
+	return r;
 }
 
 sighandler_t signal(int signum, sighandler_t handler)
 {
-	struct sigaction old;
-	struct sigaction act = {
-		.sa_handler = handler,
-		.sa_flags = SA_RESTART, /* BSD signal semantics */
+	struct k_sigaction old;
+	struct k_sigaction act = {
+		.handler = handler,
+		.flags = SA_RESTART, /* BSD signal semantics */
 	};
 
 	if (unlikely(rt_sigaction(signum, &act, &old, sizeof(sigset_t)) < 0))
 		return SIG_ERR;
 
-	return (old.sa_flags & SA_SIGINFO) ? NULL : old.sa_handler;
+	return (old.flags & SA_SIGINFO) ? NULL : old.handler;
 }
 #endif /* UK_LIBC_SYSCALLS */
 


### PR DESCRIPTION
### Description of changes

The structs passed to the `sigaction` library call and the `rt_sigaction` Linux syscall have different sizes and layouts; uksignal previously used the incorrect library struct in the syscall, leading to possible memory corruptions when called from a real libc (musl, newlib). This change corrects this behavior by using the kernel struct.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): X86_64, aarch64
 - Platform(s): N/A
 - Application(s): N/A

### Additional configuration

Application which uses sigaction through a real libc (musl, newlib).
