### PR TITLE
plat/drivers/virtio: Fix missing lcpu.h include

### DIFF
--- a/plat/drivers/virtio/virtio_blk.c
+++ b/plat/drivers/virtio/virtio_blk.c
@@ -31,6 +31,7 @@
 #include <virtio/virtio_blk.h>
 #include <uk/sglist.h>
 #include <uk/blkdev_driver.h>
+#include <uk/plat/lcpu.h>
 
 #define DRIVER_NAME		"virtio-blk"
 #define DEFAULT_SECTOR_SIZE	512


### PR DESCRIPTION
### Description of changes

This change adds an #include of <uk/plat/lcpu.h> which provides `ukplat_lcpu_disable_irq()` and `ukplat_lcpu_enable_irq()`, that are used by `virtio_blkdev_queue_cleanup_requests()`.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Additional configuration

N/A