### PR TITLE
arch/x86: Silence warning about incomplete switch

### DIFF
--- a/arch/x86/ectx.c
+++ b/arch/x86/ectx.c
@@ -131,6 +131,9 @@ void ukarch_ectx_sanitize(struct ukarch_ectx *state)
 		((__u64 *)state)[69] = 0;
 		((__u64 *)state)[70] = 0;
 		((__u64 *)state)[71] = 0;
+		break;
+	default: /* Nothing to be done in the general case. */
+		break;
 	}
 }
 


### PR DESCRIPTION
### Description of changes

Commit ffdbb486c4dd ("arch/*: Add sanitization function for ectx memory") added a function for sanitizing ECTX memory in cases where it is needed. It also triggers a warning about the switch not handling all values. This change silences this warning by adding a no-op default.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): x86_64
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A