### PR TITLE
lib/9pfs: Stub uk_9pfs_ioctl

### DIFF
--- a/lib/9pfs/9pfs_vnops.c
+++ b/lib/9pfs/9pfs_vnops.c
@@ -1012,7 +1012,7 @@ static int uk_9pfs_symlink(struct vnode *dvp, const char *op, const char *np)
 }
 
 #define uk_9pfs_seek		((vnop_seek_t)vfscore_vop_nullop)
-#define uk_9pfs_ioctl		((vnop_ioctl_t)vfscore_vop_einval)
+#define uk_9pfs_ioctl		((vnop_ioctl_t)vfscore_vop_nullop)
 #define uk_9pfs_cache		((vnop_cache_t)NULL)
 #define uk_9pfs_fallocate	((vnop_fallocate_t)vfscore_vop_nullop)
 #define uk_9pfs_poll		((vnop_poll_t)vfscore_vop_einval)


### PR DESCRIPTION
Change `uk_9pfs_ioctl` from `vfscore_vop_einval` to `vfscore_vop_nullop`, effectively stubbing it. This means a call to `uk_9pfs_ioctl` will no longer return `-EINVAL`, but it will return `0`, tricking the caller into thinking `ioctl()` functionality is available.

This is useful in binary-compatibility mode, where certain `ioctl()` calls may cause the application to end, if an error code (such as `-EINVAL` is returned). This is the case of Ruby interpreter running in binary-compatibility mode.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64`]
 - Platform(s): [e.g. `kvm`]
 - Application(s): [e.g. `app-elfloader`, Ruby in binary-compatibility mode]