### PR TITLE
lib/ukdebug: Add `LVLC_THREAD` macro

### DIFF
--- a/lib/ukdebug/print.c
+++ b/lib/ukdebug/print.c
@@ -76,6 +76,7 @@
 #define LVLC_RESET	""
 #define LVLC_TS		""
 #define LVLC_CALLER	""
+#define LVLC_THREAD	""
 #define LVLC_LIBNAME	""
 #define LVLC_SRCNAME	""
 #define LVLC_DEBUG	""


### PR DESCRIPTION
If `LIBUKDEBUG_PRINT_THREAD` is selected in the configuration menu and `LIBUKDEBUG_ANSI_COLOR` is not, a build error is thrown because the `LVLC_THREAD` macro is not set.

Fix this by setting the macro to an empty string if `LIBUKDEBUG_ANSI_COLOR` is not set.

You can replicate the crash by enabling `ukdebug -> Show thread identifier` and making sure `ukdebug -> Colored output` is not selected in the `menuconfig`.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
