### PR TITLE
lib/ukalloc: Fix underallocation bug in malloc

### DIFF
--- a/lib/ukalloc/alloc.c
+++ b/lib/ukalloc/alloc.c
@@ -149,7 +149,7 @@ void *uk_malloc_ifpages(struct uk_alloc *a, __sz size)
 #ifdef CONFIG_HAVE_MEMTAG
 	size = MEMTAG_ALIGN(size);
 #endif /* CONFIG_HAVE_MEMTAG */
-	__sz realsize = sizeof(*metadata) + size;
+	__sz realsize = METADATA_IFPAGES_SIZE_POW2 + size;
 
 	UK_ASSERT(a);
 	/* check for invalid size and overflow */


### PR DESCRIPTION
### Description of changes

This change fixes a logic error that allocates less memory than necessary in specific cases, risking the memory corruption of internal data structures, leading to unpredictable behavior and crashes.

The bug manifests when requesting exactly 24 bytes less than an integer number of pages (4072, 8168, etc.) because our malloc code reserves 24 bytes of extra space for bookkeeping metadata. However, the same malloc implementation returns buffers _32 bytes_ above an allocated page boundary, leading to 8 bytes being inadvertently underallocated. Any code that rightfully uses the entire buffer returned by malloc risks corrupting the following page, with dire consequences.
This fix reserves the correct amount of space when computing how many pages to allocate.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Minimal snippet to reproduce the issue:
```
{
    long *p = malloc(4072);
    p[508] = -1;
    free(p);
}
```
