### PR TITLE
lib/9pfs: Fix create call for 9p.2000L

### DIFF
--- a/lib/9pfs/9pfs_vnops.c
+++ b/lib/9pfs/9pfs_vnops.c
@@ -394,8 +394,8 @@ static int uk_9pfs_create(struct vnode *dvp, const char *name, mode_t mode)
 	if (md->proto == UK_9P_PROTO_2000L) {
 		struct uk_9pfid *fid =
 		    uk_9p_walk(md->dev, UK_9PFS_VFID(dvp), NULL);
-		return -uk_9p_lcreate(md->dev, fid, name, O_WRONLY | O_TRUNC,
-				      mode, 0);
+		return -uk_9p_lcreate(md->dev, fid, name,
+				UK_9P_DOTL_WRONLY | UK_9P_DOTL_APPEND, mode, 0);
 
 	} else if (md->proto == UK_9P_PROTO_2000U) {
 		return uk_9pfs_create_generic(dvp, name, mode);

--- a/lib/uk9p/include/uk/9p_core.h
+++ b/lib/uk9p/include/uk/9p_core.h
@@ -205,6 +205,31 @@ enum uk_9p_type {
 #define UK_9P_SETATTR_MTIME_SET   0x00000100UL
 
 /**
+ * 9p2000.L open flags
+ *
+ * Source: https://lxr.missinglinkelectronics.com/qemu/hw/9pfs/9p.h#L368
+ */
+#define UK_9P_DOTL_RDONLY        00000000
+#define UK_9P_DOTL_WRONLY        00000001
+#define UK_9P_DOTL_RDWR          00000002
+#define UK_9P_DOTL_NOACCESS      00000003
+#define UK_9P_DOTL_CREATE        00000100
+#define UK_9P_DOTL_EXCL          00000200
+#define UK_9P_DOTL_NOCTTY        00000400
+#define UK_9P_DOTL_TRUNC         00001000
+#define UK_9P_DOTL_APPEND        00002000
+#define UK_9P_DOTL_NONBLOCK      00004000
+#define UK_9P_DOTL_DSYNC         00010000
+#define UK_9P_DOTL_FASYNC        00020000
+#define UK_9P_DOTL_DIRECT        00040000
+#define UK_9P_DOTL_LARGEFILE     00100000
+#define UK_9P_DOTL_DIRECTORY     00200000
+#define UK_9P_DOTL_NOFOLLOW      00400000
+#define UK_9P_DOTL_NOATIME       01000000
+#define UK_9P_DOTL_CLOEXEC       02000000
+#define UK_9P_DOTL_SYNC          04000000
+
+/**
  * 9P qid.
  *
  * Source: https://9fans.github.io/plan9port/man/man9/intro.html.


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


The `uk_9pfs_create` call for `9p.2000L` uses posix flags for open file
permissions. The 9P server however will expect specific 9p2000.L flags.

9p2000.L flags declaration are taken from the 9p protocol manual and
QEMU implementation:

* http://9p.io/magic/man2html/5/intro
* https://lxr.missinglinkelectronics.com/qemu/hw/9pfs/9p.h#L368

Most of the flags are identical, so using posix flags did not cause any troubles just yet, but
we should use the proper ones.
Discovered while investigating https://github.com/unikraft/run-app-elfloader/issues/16