### PR TITLE
lib/posix-sysinfo: Provide _SC_GETPW_R_SIZE_MAX

### DIFF
--- a/lib/nolibc/include/unistd.h
+++ b/lib/nolibc/include/unistd.h
@@ -53,6 +53,7 @@ extern "C" {
 #define _SC_OPEN_MAX          4
 #define _SC_PAGE_SIZE        30
 #define _SC_PAGESIZE         _SC_PAGE_SIZE
+#define _SC_GETPW_R_SIZE_MAX 70
 #define _SC_PHYS_PAGES       85
 #define _SC_AVPHYS_PAGES     86
 #define _SC_NPROCESSORS_CONF 83

--- a/lib/nolibc/include/unistd.h
+++ b/lib/nolibc/include/unistd.h
@@ -58,6 +58,8 @@ extern "C" {
 #define _SC_AVPHYS_PAGES     86
 #define _SC_NPROCESSORS_CONF 83
 #define _SC_NPROCESSORS_ONLN 84
+
+long sysconf(int);
 #endif
 
 #include <nolibc-internal/shareddefs.h>

--- a/lib/posix-sysinfo/sysinfo.c
+++ b/lib/posix-sysinfo/sysinfo.c
@@ -120,6 +120,11 @@ long sysconf(int name)
 	if (name == _SC_PAGESIZE)
 		return __PAGE_SIZE;
 
+#ifdef CONFIG_LIBPOSIX_USER
+	if (name == _SC_GETPW_R_SIZE_MAX)
+		return -1;
+#endif /* CONFIG_LIBPOSIX_USER */
+
 #ifdef CONFIG_HAVE_PAGING
 	if (name == _SC_PHYS_PAGES) {
 		struct uk_pagetable *pt;


### PR DESCRIPTION
### Description of changes

Calling code expects `sysconf(_SC_GETPW_R_SIZE_MAX)` to be either -1 or a non-zero value for an initial buffer size. The previous default value of 0 is outside of specifications and can cause unintended behavior. This change makes `sysconf(_SC_GETPW_R_SIZE_MAX)` return -1.

See `man 3 getpwuid` for the specifications for `sysconf(_SC_GETPW_R_SIZE_MAX)`.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Additional configuration

`CONFIG_LIBPOSIX_USER=y` and `CONFIG_LIBPOSIX_SYSINFO=y`.
