### PR TITLE
lib/ukschedcoop: Add early check for runnable thread in idle thread

### DIFF
--- a/include/uk/plat/lcpu.h
+++ b/include/uk/plat/lcpu.h
@@ -86,9 +86,12 @@ void __noreturn ukplat_lcpu_halt(void);
  * Halts the current logical CPU. Execution is resumed when an interrupt/signal
  * arrives or the specified deadline expires
  *
+ * NOTE: This must be called with IRQ's disabled. On return, IRQ's are not
+ *        re-enabled.
+ *
  * @param until deadline in nanoseconds
  */
-void ukplat_lcpu_halt_to(__nsec until);
+void ukplat_lcpu_halt_irq_until(__nsec until);
 
 /**
  * Halts the current logical CPU. Execution is resumed when an interrupt/signal

--- a/lib/posix-time/time.c
+++ b/lib/posix-time/time.c
@@ -56,9 +56,12 @@
 static void __spin_wait(__nsec nsec)
 {
 	__nsec until = ukplat_monotonic_clock() + nsec;
+	unsigned long flags;
 
+	flags = ukplat_lcpu_save_irqf();
 	while (until > ukplat_monotonic_clock())
-		ukplat_lcpu_halt_to(until);
+		ukplat_lcpu_halt_irq_until(until);
+	ukplat_lcpu_restore_irqf(flags);
 }
 #endif
 

--- a/lib/ukschedcoop/schedcoop.c
+++ b/lib/ukschedcoop/schedcoop.c
@@ -215,7 +215,7 @@ static __noreturn void idle_thread_fn(void *argp)
 
 		if (!wake_up_time || wake_up_time > now) {
 			if (wake_up_time) {
-				ukplat_lcpu_halt_to(wake_up_time);
+				ukplat_lcpu_halt_irq_until(wake_up_time);
 			} else {
 				ukplat_lcpu_halt_irq();
 				ukplat_lcpu_enable_irq();

--- a/plat/common/lcpu.c
+++ b/plat/common/lcpu.c
@@ -187,13 +187,11 @@ void __noreturn ukplat_lcpu_halt(void)
 	lcpu_halt(lcpu_get_current(), 0);
 }
 
-void ukplat_lcpu_halt_to(__nsec until)
+void ukplat_lcpu_halt_irq_until(__nsec until)
 {
-	unsigned long flags;
+	UK_ASSERT(ukplat_lcpu_irqs_disabled());
 
-	flags = ukplat_lcpu_save_irqf();
 	time_block_until(until);
-	ukplat_lcpu_restore_irqf(flags);
 }
 
 __lcpuid ukplat_lcpu_id(void)


### PR DESCRIPTION
lib/ukschedcoop: Add early check for runnable thread in idle thread
    
Since we enable IRQ's before context switching, there is a chance that
IRQ's may fire in the short time frame between the enabling of IRQ's
in the scheduler before context switching and disabling of IRQ's before
entering the idle thread's halting state.
    
To fix this, make sure we disable IRQ's at the beginning of the idle
thread's halting loop and do a quick early check for runnable threads
alongside the one for exited threads.
    
Co-authored-by: Stefan Jumarea <stefanjumarea02@gmail.com>
Signed-off-by: Sergiu Moga <sergiu@unikraft.io>
Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
