### PR TITLE
build: Use -fcf-protection for GCC >= 8 or Clang >= 7

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -11,7 +11,8 @@ COMPFLAGS-$(call have_gcc)	+= -fno-tree-sra -fno-split-stack -nostdinc
 ifneq ($(HAVE_STACKPROTECTOR),y)
 COMPFLAGS    += -fno-stack-protector
 endif
-COMPFLAGS    += -fcf-protection=none
+COMPFLAGS-$(call gcc_version_ge,8,0)	+= -fcf-protection=none
+COMPFLAGS-$(call have_clang)	+= -fcf-protection=none
 
 COMPFLAGS    += -Wall -Wextra
 COMPFLAGS-$(call have_clang)	+= -Wdocumentation -Wdocumentation-pedantic


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

The build fails on every app when gcc-8.0+ isn't used.

-fcf-protection was introduced in [gcc-8.0](https://gcc.gnu.org/gcc-8/changes.html) and in [clang-7.0](https://releases.llvm.org/7.0.0/tools/clang/docs/UsersManual.html).

The build still fails for clang-7.0, since `__asm__ goto` from `plat/kvm/x86/traps.c` was introduced in clang-9.0.

GitHub-Depends-On: https://github.com/unikraft/unikraft/pull/983