### PR TITLE
lib/ukallocbbuddy: Allocate physical memory in the buddy allocator 

### DIFF
--- a/lib/ukallocbbuddy/Config.uk
+++ b/lib/ukallocbbuddy/Config.uk
@@ -5,3 +5,15 @@ menuconfig LIBUKALLOCBBUDDY
 	select LIBUKDEBUG
 	select LIBUKALLOC
 
+if LIBUKALLOCBBUDDY
+
+config UKLIBALLOCBUDDY_THRESHOLD
+	int "Maximum level for chunk physical allocation"
+	range 1 52
+	default 26
+	help
+		Maximum level of a chunk for which we allocate physical memory even
+		if the chunk will be split.
+
+endif
+

--- a/lib/ukallocbbuddy/Config.uk
+++ b/lib/ukallocbbuddy/Config.uk
@@ -1,6 +1,7 @@
-config LIBUKALLOCBBUDDY
+menuconfig LIBUKALLOCBBUDDY
 	bool "ukallocbbuddy: Binary buddy page allocator"
 	default n
 	select LIBNOLIBC if !HAVE_LIBC
 	select LIBUKDEBUG
 	select LIBUKALLOC
+


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [X] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [`kvm`]


### Additional configuration

Tweak this threshold in the buddy allocator configuration menu:
 - `CONFIG_UKLIBALLOCBUDDY_THRESHOLD`


### Description of changes
Currently, the buddy allocator only handles virtual memory reservation in a huge memory area that is mapped at boot time, whereas physical memory is handled with demand paging.
    
This commit introduces physical memory allocation for the blocks that are provided by the buddy allocator, minimizing the number of page faults generated by subsequent accesses.

This is created on the top of the buddy allocator synchronization PR (that is why it is still in draft). For testing, please use [this branch](https://github.com/razvanvirtan/unikraft/tree/buddy_ukvmem) that removes some problematic commits (see the conversations from [here](https://discord.com/channels/762976922531528725/883603425076584448))
