### PR TITLE
arch/x86: Fix interrupts on qemu-microvm/qboot

### DIFF
--- a/arch/x86/x86_64/include/uk/asm/lcpu.h
+++ b/arch/x86/x86_64/include/uk/asm/lcpu.h
@@ -114,9 +114,75 @@ struct __regs {
 #ifndef nop
 #define nop()   __asm__ __volatile__ ("nop" : : : "memory")
 #endif
-#endif /* !__ASSEMBLY__ */
 
-#ifndef __ASSEMBLY__
+static inline __u8 ioreg_read8(const volatile __u8 *address)
+{
+	__u8 value;
+
+	__asm__ __volatile__("movb %1, %0"
+		: "=q" (value) : "m" (*address) : "memory");
+
+	return value;
+}
+
+static inline __u16 ioreg_read16(const volatile __u16 *address)
+{
+	__u16 value;
+
+	__asm__ __volatile__("movw %1, %0"
+		: "=r" (value) : "m" (*address) : "memory");
+
+	return value;
+}
+
+static inline __u32 ioreg_read32(const volatile __u32 *address)
+{
+	__u32 value;
+
+	__asm__ __volatile__("movl %1, %0"
+		: "=r" (value) : "m" (*address) : "memory");
+
+	return value;
+}
+
+static inline __u64 ioreg_read64(const volatile __u64 *address)
+{
+	__u64 value;
+
+	__asm__ __volatile__("movq %1, %0"
+		: "=r" (value) : "m" (*address) : "memory");
+
+	return value;
+}
+
+static inline void ioreg_write8(const volatile __u8 *address,
+				__u8 value)
+{
+	__asm__ __volatile__("movb %0, %1"
+		: : "q" (value), "m" (*address) : "memory");
+}
+
+static inline void ioreg_write16(const volatile __u16 *address,
+				 __u16 value)
+{
+	__asm__ __volatile__("movw %0, %1"
+		: : "r" (value), "m" (*address) : "memory");
+}
+
+static inline void ioreg_write32(const volatile __u32 *address,
+				 __u32 value)
+{
+	__asm__ __volatile__("movl %0, %1"
+		: : "r" (value), "m" (*address) : "memory");
+}
+
+static inline void ioreg_write64(const volatile __u64 *address,
+				 __u64 value)
+{
+	__asm__ __volatile__("movq %0, %1"
+		: : "r" (value), "m" (*address) : "memory");
+}
+
 static inline unsigned long ukarch_read_sp(void)
 {
 	unsigned long sp;

--- a/plat/common/include/x86/apic_defs.h
+++ b/plat/common/include/x86/apic_defs.h
@@ -40,6 +40,11 @@
 /* APIC MSR registers */
 #define APIC_MSR_BASE			0x01b
 
+/* The following MMIO registers are only accessible in xAPIC mode */
+#define APIC_MMIO_SVR			((void *)0xfee000f0)
+#define APIC_MMIO_LINT0			((void *)0xfee00350)
+#define APIC_MMIO_LINT1			((void *)0xfee00360)
+
 /* The following MSRs are only accessible in x2APIC mode */
 #define APIC_MSR_ID			0x802
 #define APIC_MSR_VER			0x803
@@ -76,6 +81,15 @@
 #define APIC_SVR_EN			(1 << 8)
 #define APIC_SVR_VECTOR_MASK		0x00000000000000ffUL
 #define APIC_SVR_EOI_BROADCAST		(1 << 12)
+
+/* APIC local vector table registers (LVT) */
+#define APIC_LVT_DELIVERY_MODE_FIXED	0x0000
+#define APIC_LVT_DELIVERY_MODE_SMI	0x0200
+#define APIC_LVT_DELIVERY_MODE_NMI	0x0400
+#define APIC_LVT_DELIVERY_MODE_INIT	0x0500
+#define APIC_LVT_DELIVERY_MODE_EXTINT	0x0700
+
+#define APIC_LVT_TRIGGER_MODE_LEVEL	0x8000
 
 /* APIC error status registers (ESR) */
 #define APIC_ESR_SEND_CHECKSUM		(1 << 0) /* only Pentium and P6 */

--- a/plat/common/x86/lcpu.c
+++ b/plat/common/x86/lcpu.c
@@ -60,13 +60,16 @@ __lcpuid lcpu_arch_id(void)
 
 int lcpu_arch_init(struct lcpu *this_lcpu)
 {
-#ifdef CONFIG_HAVE_SMP
 	int rc;
 
-	rc = apic_enable();
+	/*
+	 * Configure local APIC to receive interrupts from the PIC.
+	 * For SMP this also enables x2APIC mode and will fail with
+	 * ENOTSUP if that is not possible.
+	 */
+	rc = apic_enable(this_lcpu);
 	if (unlikely(rc))
 		return rc;
-#endif /* CONFIG_HAVE_SMP */
 
 	traps_lcpu_init(this_lcpu);
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Most firmware will put the APIC in "virtual wire mode" before starting the OS, which will raise interrupts received from the legacy PIC on LINT0 to the BSP. This is well explained [here (section 3.6.2.2)](https://web.archive.org/web/20121002210153/http://download.intel.com/design/archives/processors/pro/docs/24201606.pdf).
The relevant part where this is set up in SeaBIOS can be found [here](https://github.com/coreboot/seabios/blob/cd933454b5e3e1f86379a44b5ae1852c2a01a485/src/fw/smp.c#L128).

[qboot](https://github.com/bonzini/qboot) which is the default bios for QEMU's microvm machine type does not do this, so if we want to boot with qboot we need to do this setup ourselves.

I believe it is save to assume that we will boot in xAPIC mode (?), in which case we can do the necessary configuration while still in that mode, before switching to x2APIC mode for smp boot.

2e370e526ee9458fb77e512bd8628dd66dd54ec2 adds some MMIO read/write functions similar to the ones that already exist for arm64 to simplify interacting with the xAPIC MMIO interface.

fixes #516 

Booting on qemu-microvm works with the following command

```
qemu-system-x86_64 \
  -M microvm,rtc=on,pit=on,pic=on \
  -kernel "build/app-helloworld_qemu-x86_64" \
  -nographic
```

Booting on normal QEMU with qboot

```
qemu-system-x86_64 \
  -kernel "build/app-helloworld_qemu-x86_64" \
  -bios "/usr/share/qemu/qboot.rom" \
  -cpu host \
  -enable-kvm \
  -nographic
```
