### PR TITLE
build: Add minumum required compiler version and fix cpu model and erratas for arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -676,6 +676,14 @@ $(foreach E,$(EPLAT_DIR), \
 )
 $(eval $(call verbose_include,$(CONFIG_UK_BASE)/Makefile.uk)) # Unikraft base
 
+ifeq ($(call have_clang),y)
+$(call error_if_clang_version_lt,9,0)
+endif
+
+ifeq ($(call have_gcc),y)
+$(call error_if_gcc_version_lt,7,0)
+endif
+
 ifeq ($(call qstrip,$(UK_PLATS) $(UK_PLATS-y)),)
 $(warning You did not choose any target platform.)
 $(error Please choose at least one target platform in the configuration!)

--- a/arch/arm/arm/Makefile.uk
+++ b/arch/arm/arm/Makefile.uk
@@ -10,81 +10,76 @@ CXXINCLUDES += -I$(CONFIG_UK_BASE)/arch/arm/arm/include
 # Disable FPU for trap/exception/interrupt handlers
 ISR_ARCHFLAGS += -mfpu=none
 
-# Set GCC flags for MARCH_ARM32_GENERICV7. GCC supports -mtune=generic-armv7-a from 4.7
+# Set GCC flags for MARCH_ARM32_GENERICV7.
 ifeq ($(CONFIG_MARCH_ARM32_GENERICV7),y)
-$(call error_if_gcc_version_lt,4,7)
-ARCHFLAGS-$(call gcc_version_ge,4,7)     += -march=armv7-a -mtune=generic-armv7-a
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,7) += -march=armv7-a -mtune=generic-armv7-a
+ifeq ($(call have_clang),y)
+$(error Generic Cortex A7 CPU model only supported with GCC)
+endif
+ARCHFLAGS     += -march=armv7-a -mtune=generic-armv7-a
+ISR_ARCHFLAGS += -march=armv7-a -mtune=generic-armv7-a
 endif
 
-# Set GCC flags for MARCH_ARM32_CORTEXA5. GCC supports -mcpu=cortex-a5 from 4.5
+# Set flags for MARCH_ARM32_CORTEXA5.
 ifeq ($(CONFIG_MARCH_ARM32_CORTEXA5),y)
-$(call error_if_gcc_version_lt,4,5)
-ARCHFLAGS-$(call gcc_version_ge,4,5)     += -mcpu=cortex-a5 -mtune=cortex-a5
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,5) += -mcpu=cortex-a5 -mtune=cortex-a5
+ARCHFLAGS     += -mcpu=cortex-a5 -mtune=cortex-a5
+ISR_ARCHFLAGS += -mcpu=cortex-a5 -mtune=cortex-a5
 endif
 
-# Set GCC flags for MARCH_ARM32_CORTEXA7. GCC supports -mcpu=cortex-a7 from 4.7
+# Set flags for MARCH_ARM32_CORTEXA7.
 ifeq ($(CONFIG_MARCH_ARM32_CORTEXA7),y)
-$(call error_if_gcc_version_lt,4,7)
-ARCHFLAGS-$(call gcc_version_ge,4,7)     += -mcpu=cortex-a7 -mtune=cortex-a7
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,7) += -mcpu=cortex-a7 -mtune=cortex-a7
+ARCHFLAGS     += -mcpu=cortex-a7 -mtune=cortex-a7
+ISR_ARCHFLAGS += -mcpu=cortex-a7 -mtune=cortex-a7
 endif
 
-# Set GCC flags for MARCH_ARM32_CORTEXA8. GCC supports -mcpu=cortex-a8 from 4.3
+# Set flags for MARCH_ARM32_CORTEXA8.
 ifeq ($(CONFIG_MARCH_ARM32_CORTEXA8),y)
-$(call error_if_gcc_version_lt,4,3)
-ARCHFLAGS-$(call gcc_version_ge,4,3)     += -mcpu=cortex-a8 -mtune=cortex-a8
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,3) += -mcpu=cortex-a8 -mtune=cortex-a8
+ARCHFLAGS     += -mcpu=cortex-a8 -mtune=cortex-a8
+ISR_ARCHFLAGS += -mcpu=cortex-a8 -mtune=cortex-a8
 endif
 
-# Set GCC flags for MARCH_ARM32_CORTEXA9. GCC supports -mcpu=cortex-a9 from 4.4
+# Set flags for MARCH_ARM32_CORTEXA9.
 ifeq ($(CONFIG_MARCH_ARM32_CORTEXA9),y)
-$(call error_if_gcc_version_lt,4,4)
-ARCHFLAGS-$(call gcc_version_ge,4,4)     += -mcpu=cortex-a9 -mtune=cortex-a9
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,4) += -mcpu=cortex-a9 -mtune=cortex-a9
+ARCHFLAGS     += -mcpu=cortex-a9 -mtune=cortex-a9
+ISR_ARCHFLAGS += -mcpu=cortex-a9 -mtune=cortex-a9
 endif
 
-# Set GCC flags for MARCH_ARM32_CORTEXA12. GCC supports -mcpu=cortex-a12 from 4.9
+# Set flags for MARCH_ARM32_CORTEXA12.
 ifeq ($(CONFIG_MARCH_ARM32_CORTEXA12),y)
-$(call error_if_gcc_version_lt,4,9)
-ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mcpu=cortex-a12 -mtune=cortex-a12
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mcpu=cortex-a12 -mtune=cortex-a12
+ARCHFLAGS     += -mcpu=cortex-a12 -mtune=cortex-a12
+ISR_ARCHFLAGS += -mcpu=cortex-a12 -mtune=cortex-a12
 endif
 
-# Set GCC flags for MARCH_ARM32_CORTEXA15. GCC supports -mcpu=cortex-a15 from 4.6
+# Set flags for MARCH_ARM32_CORTEXA15.
 ifeq ($(CONFIG_MARCH_ARM32_CORTEXA15),y)
-$(call error_if_gcc_version_lt,4,6)
-ARCHFLAGS-$(call gcc_version_ge,4,6)     += -mcpu=cortex-a15 -mtune=cortex-a15
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,6) += -mcpu=cortex-a15 -mtune=cortex-a15
+ARCHFLAGS     += -mcpu=cortex-a15 -mtune=cortex-a15
+ISR_ARCHFLAGS += -mcpu=cortex-a15 -mtune=cortex-a15
 endif
 
-# Set GCC flags for MARCH_ARM32_CORTEXA17. GCC supports -mcpu=cortex-a17 from 6.1
+# Set flags for MARCH_ARM32_CORTEXA17.
 ifeq ($(CONFIG_MARCH_ARM32_CORTEXA17),y)
-$(call error_if_gcc_version_lt,6,1)
-ARCHFLAGS-$(call gcc_version_ge,6,1)     += -mcpu=cortex-a17 -mtune=cortex-a17
-ISR_ARCHFLAGS-$(call gcc_version_ge,6,1) += -mcpu=cortex-a17 -mtune=cortex-a17
+ARCHFLAGS     += -mcpu=cortex-a17 -mtune=cortex-a17
+ISR_ARCHFLAGS += -mcpu=cortex-a17 -mtune=cortex-a17
 endif
 
-# Set GCC flags for MARCH_ARM32_CORTEXA32. GCC supports -mcpu=cortex-a32 from 6.1
+# Set flags for MARCH_ARM32_CORTEXA32.
 ifeq ($(CONFIG_MARCH_ARM32_CORTEXA32),y)
-$(call error_if_gcc_version_lt,6,1)
-ARCHFLAGS-$(call gcc_version_ge,6,1)     += -mcpu=cortex-a32 -mtune=cortex-a32
-ISR_ARCHFLAGS-$(call gcc_version_ge,6,1) += -mcpu=cortex-a32 -mtune=cortex-a32
+ARCHFLAGS     += -mcpu=cortex-a32 -mtune=cortex-a32
+ISR_ARCHFLAGS += -mcpu=cortex-a32 -mtune=cortex-a32
 endif
 
-# Set GCC flags for MARCH_ARM32_CORTEXA35. GCC supports -mcpu=cortex-a35 from 6.1
+# Set flags for MARCH_ARM32_CORTEXA35.
 ifeq ($(CONFIG_MARCH_ARM32_CORTEXA35),y)
-$(call error_if_gcc_version_lt,6,1)
-ARCHFLAGS-$(call gcc_version_ge,6,1)     += -mcpu=cortex-a35 -mtune=cortex-a35
-ISR_ARCHFLAGS-$(call gcc_version_ge,6,1) += -mcpu=cortex-a35 -mtune=cortex-a35
+ARCHFLAGS     += -mcpu=cortex-a35 -mtune=cortex-a35
+ISR_ARCHFLAGS += -mcpu=cortex-a35 -mtune=cortex-a35
 endif
 
-# Set GCC flags for MARCH_ARM32_A20NEON. GCC supports -mcpu=cortex-a7 from 4.7
+# Set GCC flags for MARCH_ARM32_A20NEON.
 ifeq ($(CONFIG_MARCH_ARM32_A20NEON),y)
-$(call error_if_gcc_version_lt,4,7)
-ARCHFLAGS-$(call gcc_version_ge,4,7)     += -mcpu=cortex-a7 -mtune=cortex-a7 -mfpu=vfpv4-d16 -mfpu=neon-vfpv4 -funsafe-math-optimizations
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,7) += -mcpu=cortex-a7 -mtune=cortex-a7 -funsafe-math-optimizations
+ifeq ($(call have_clang),y)
+$(error Cortex AllWinner A20 CPU model only supported with GCC)
+endif
+ARCHFLAGS     += -mcpu=cortex-a7 -mtune=cortex-a7 -mfpu=vfpv4-d16 -mfpu=neon-vfpv4 -funsafe-math-optimizations
+ISR_ARCHFLAGS += -mcpu=cortex-a7 -mtune=cortex-a7 -funsafe-math-optimizations
 endif
 
 $(eval $(call addlib,libarmmath))

--- a/arch/arm/arm64/Makefile.uk
+++ b/arch/arm/arm64/Makefile.uk
@@ -67,205 +67,246 @@ ARCHFLAGS-y += -mbranch-protection=$(BRANCH_PROTECTION)
 ISR_ARCHFLAGS-y += -mbranch-protection=$(BRANCH_PROTECTION)
 endif
 
-# GCC support -mcpu=native for arm64 from 6.0
 ifeq ($(CONFIG_MCPU_ARM64_NATIVE),y)
-$(call error_if_gcc_version_lt,6,0)
-ARCHFLAGS-$(call gcc_version_ge,6,0)     += -mcpu=native
-ISR_ARCHFLAGS-$(call gcc_version_ge,6,0) += -mcpu=native
+ARCHFLAGS     += -mcpu=native
+ISR_ARCHFLAGS += -mcpu=native
 endif
 
-# GCC support -mcpu=generic for arm64 from 4.8
 ifeq ($(CONFIG_MCPU_ARM64_GENERIC),y)
-$(call error_if_gcc_version_lt,4,8)
-ARCHFLAGS-$(call gcc_version_ge,4,8)     += -mcpu=generic -mtune=generic
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,8) += -mcpu=generic -mtune=generic
+ARCHFLAGS     += -mcpu=generic -mtune=generic
+ISR_ARCHFLAGS += -mcpu=generic -mtune=generic
 endif
 
-# GCC support -mcpu=cortex-a53 for arm64 from 4.9
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A53),y)
-$(call error_if_gcc_version_lt,4,9)
-ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mcpu=cortex-a53 -mtune=cortex-a53
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mcpu=cortex-a53 -mtune=cortex-a53
+ARCHFLAGS     += -mcpu=cortex-a53 -mtune=cortex-a53
+ISR_ARCHFLAGS += -mcpu=cortex-a53 -mtune=cortex-a53
 endif
 
 # For erratum 835769
 ifeq ($(CONFIG_ARM64_ERRATUM_835769),y)
-$(call error_if_gcc_version_lt,4,9)
-ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mfix-cortex-a53-835769
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mfix-cortex-a53-835769
+ARCHFLAGS     += -mfix-cortex-a53-835769
+ISR_ARCHFLAGS += -mfix-cortex-a53-835769
 endif
 
 # For erratum 843419
 ifeq ($(CONFIG_ARM64_ERRATUM_843419),y)
-$(call error_if_gcc_version_lt,4,9)
-ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mfix-cortex-a53-843419
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mfix-cortex-a53-843419
+ifeq ($(call have_clang),y)
+$(error The workaround for erratum 843419 is only supported with GCC)
+endif
+ARCHFLAGS     += -mfix-cortex-a53-843419
+ISR_ARCHFLAGS += -mfix-cortex-a53-843419
 endif
 
-# GCC support -mcpu=cortex-a57 for arm64 from 4.9
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A57),y)
-$(call error_if_gcc_version_lt,4,9)
-ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mcpu=cortex-a57 -mtune=cortex-a57
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mcpu=cortex-a57 -mtune=cortex-a57
+ARCHFLAGS     += -mcpu=cortex-a57 -mtune=cortex-a57
+ISR_ARCHFLAGS += -mcpu=cortex-a57 -mtune=cortex-a57
 endif
 
-# GCC support -mcpu=cortex-a57.cortex-a53 for arm64 from 4.9
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A57_A53),y)
-$(call error_if_gcc_version_lt,4,9)
-ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mcpu=cortex-a57.cortex-a53
-ARCHFLAGS-$(call gcc_version_ge,4,9)     += -mtune=cortex-a57.cortex-a53
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mcpu=cortex-a57.cortex-a53
-ISR_ARCHFLAGS-$(call gcc_version_ge,4,9) += -mtune=cortex-a57.cortex-a53
+ifeq ($(call have_clang),y)
+$(error Cortex A57-A53 CPU model is only supported with GCC)
+endif
+ARCHFLAGS     += -mcpu=cortex-a57.cortex-a53
+ARCHFLAGS     += -mtune=cortex-a57.cortex-a53
+ISR_ARCHFLAGS += -mcpu=cortex-a57.cortex-a53
+ISR_ARCHFLAGS += -mtune=cortex-a57.cortex-a53
 endif
 
-# GCC support -mcpu=cortex-a72 for arm64 from 5.0
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A72),y)
-$(call error_if_gcc_version_lt,5,0)
-ARCHFLAGS-$(call gcc_version_ge,5,0)     += -mcpu=cortex-a72 -mtune=cortex-a72
-ISR_ARCHFLAGS-$(call gcc_version_ge,5,0) += -mcpu=cortex-a72 -mtune=cortex-a72
+ARCHFLAGS     += -mcpu=cortex-a72 -mtune=cortex-a72
+ISR_ARCHFLAGS += -mcpu=cortex-a72 -mtune=cortex-a72
 endif
 
-# GCC support -mcpu=cortex-a72.cortex-a53 for arm64 from 5.0
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A72_A53),y)
-$(call error_if_gcc_version_lt,5,0)
-ARCHFLAGS-$(call gcc_version_ge,5,0)     += -mcpu=cortex-a72.cortex-a53
-ARCHFLAGS-$(call gcc_version_ge,5,0)     += -mtune=cortex-a72.cortex-a53
-ISR_ARCHFLAGS-$(call gcc_version_ge,5,0) += -mcpu=cortex-a72.cortex-a53
-ISR_ARCHFLAGS-$(call gcc_version_ge,5,0) += -mtune=cortex-a72.cortex-a53
+ifeq ($(call have_clang),y)
+$(error Cortex A72-A53 CPU model is only supported with GCC)
+endif
+ARCHFLAGS     += -mcpu=cortex-a72.cortex-a53
+ARCHFLAGS     += -mtune=cortex-a72.cortex-a53
+ISR_ARCHFLAGS += -mcpu=cortex-a72.cortex-a53
+ISR_ARCHFLAGS += -mtune=cortex-a72.cortex-a53
 endif
 
-# GCC support -mcpu=cortex-a35 for arm64 from 6.0
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A35),y)
-$(call error_if_gcc_version_lt,6,0)
-ARCHFLAGS-$(call gcc_version_ge,6,0)     += -mcpu=cortex-a35 -mtune=cortex-a35
-ISR_ARCHFLAGS-$(call gcc_version_ge,6,0) += -mcpu=cortex-a35 -mtune=cortex-a35
+ARCHFLAGS     += -mcpu=cortex-a35 -mtune=cortex-a35
+ISR_ARCHFLAGS += -mcpu=cortex-a35 -mtune=cortex-a35
 endif
 
-# GCC support -mcpu=cortex-a73 for arm64 from 7.0
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A73),y)
-$(call error_if_gcc_version_lt,7,0)
-ARCHFLAGS-$(call gcc_version_ge,7,0)     += -mcpu=cortex-a73 -mtune=cortex-a73
-ISR_ARCHFLAGS-$(call gcc_version_ge,7,0) += -mcpu=cortex-a73 -mtune=cortex-a73
+ARCHFLAGS     += -mcpu=cortex-a73 -mtune=cortex-a73
+ISR_ARCHFLAGS += -mcpu=cortex-a73 -mtune=cortex-a73
 endif
 
-# GCC support -mcpu=cortex-a73.cortex-a35 for arm64 from 7.0
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A73_A35),y)
-$(call error_if_gcc_version_lt,7,0)
-ARCHFLAGS-$(call gcc_version_ge,7,0)     += -mcpu=cortex-a73.cortex-a35
-ARCHFLAGS-$(call gcc_version_ge,7,0)     += -mtune=cortex-a73.cortex-a35
-ISR_ARCHFLAGS-$(call gcc_version_ge,7,0) += -mcpu=cortex-a73.cortex-a35
-ISR_ARCHFLAGS-$(call gcc_version_ge,7,0) += -mtune=cortex-a73.cortex-a35
+ifeq ($(call have_clang),y)
+$(error Cortex A73-A35 CPU model is only supported with GCC)
+endif
+ARCHFLAGS     += -mcpu=cortex-a73.cortex-a35
+ARCHFLAGS     += -mtune=cortex-a73.cortex-a35
+ISR_ARCHFLAGS += -mcpu=cortex-a73.cortex-a35
+ISR_ARCHFLAGS += -mtune=cortex-a73.cortex-a35
 endif
 
-# GCC support -mcpu=cortex-a73.cortex-a53 for arm64 from 7.0
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A73_A53),y)
-$(call error_if_gcc_version_lt,7,0)
-ARCHFLAGS-$(call gcc_version_ge,7,0)     += -mcpu=cortex-a73.cortex-a53
-ARCHFLAGS-$(call gcc_version_ge,7,0)     += -mtune=cortex-a73.cortex-a53
-ISR_ARCHFLAGS-$(call gcc_version_ge,7,0) += -mcpu=cortex-a73.cortex-a53
-ISR_ARCHFLAGS-$(call gcc_version_ge,7,0) += -mtune=cortex-a73.cortex-a53
+ifeq ($(call have_clang),y)
+$(error Cortex A73-A53 CPU model is only supported with GCC)
+endif
+ARCHFLAGS     += -mcpu=cortex-a73.cortex-a53
+ARCHFLAGS     += -mtune=cortex-a73.cortex-a53
+ISR_ARCHFLAGS += -mcpu=cortex-a73.cortex-a53
+ISR_ARCHFLAGS += -mtune=cortex-a73.cortex-a53
 endif
 
-# GCC support -mcpu=cortex-a55 for arm64 from 8.0
+# GCC supports -mcpu=cortex-a55 for arm64 from 8.0
+# Clang supports it from 9.0, the minimum required version
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A55),y)
+ifeq ($(call have_gcc),y)
 $(call error_if_gcc_version_lt,8,0)
-ARCHFLAGS-$(call gcc_version_ge,8,0)     += -mcpu=cortex-a55 -mtune=cortex-a55
-ISR_ARCHFLAGS-$(call gcc_version_ge,8,0) += -mcpu=cortex-a55 -mtune=cortex-a55
+endif
+ARCHFLAGS     += -mcpu=cortex-a55 -mtune=cortex-a55
+ISR_ARCHFLAGS += -mcpu=cortex-a55 -mtune=cortex-a55
 endif
 
 # GCC support -mcpu=cortex-a75 for arm64 from 8.0
+# Clang supports it from 9.0, the minimum required version
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A75),y)
+ifeq ($(call have_gcc),y)
 $(call error_if_gcc_version_lt,8,0)
-ARCHFLAGS-$(call gcc_version_ge,8,0)     += -mcpu=cortex-a75 -mtune=cortex-a75
-ISR_ARCHFLAGS-$(call gcc_version_ge,8,0) += -mcpu=cortex-a75 -mtune=cortex-a75
+endif
+ARCHFLAGS     += -mcpu=cortex-a75 -mtune=cortex-a75
+ISR_ARCHFLAGS += -mcpu=cortex-a75 -mtune=cortex-a75
 endif
 
 # GCC support -mcpu=cortex-a75.cortex-a55 for arm64 from 8.0
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A75_A55),y)
 $(call error_if_gcc_version_lt,8,0)
-ARCHFLAGS-$(call gcc_version_ge,8,0)     += -mcpu=cortex-a75.cortex-a55
-ARCHFLAGS-$(call gcc_version_ge,8,0)     += -mtune=cortex-a75.cortex-a55
-ISR_ARCHFLAGS-$(call gcc_version_ge,8,0) += -mcpu=cortex-a75.cortex-a55
-ISR_ARCHFLAGS-$(call gcc_version_ge,8,0) += -mtune=cortex-a75.cortex-a55
+ARCHFLAGS     += -mcpu=cortex-a75.cortex-a55
+ARCHFLAGS     += -mtune=cortex-a75.cortex-a55
+ISR_ARCHFLAGS += -mcpu=cortex-a75.cortex-a55
+ISR_ARCHFLAGS += -mtune=cortex-a75.cortex-a55
 endif
 
 # GCC support -mcpu=cortex-a76 for arm64 from 9.1
+# Clang supports it from 9.0, the minimum required version
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A76),y)
+ifeq ($(call have_gcc),y)
 $(call error_if_gcc_version_lt,9,1)
-ARCHFLAGS-$(call gcc_version_ge,9,1)     += -mcpu=cortex-a76 -mtune=cortex-a76
-ISR_ARCHFLAGS-$(call gcc_version_ge,9,1) += -mcpu=cortex-a76 -mtune=cortex-a76
+endif
+ARCHFLAGS     += -mcpu=cortex-a76 -mtune=cortex-a76
+ISR_ARCHFLAGS += -mcpu=cortex-a76 -mtune=cortex-a76
 endif
 
 # GCC support -mcpu=cortex-a76.cortex-a55 for arm64 from 9.1
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A76_A55),y)
 $(call error_if_gcc_version_lt,9,1)
-ARCHFLAGS-$(call gcc_version_ge,9,1)     += -mcpu=cortex-a76.cortex-a55
-ARCHFLAGS-$(call gcc_version_ge,9,1)     += -mtune=cortex-a76.cortex-a55
-ISR_ARCHFLAGS-$(call gcc_version_ge,9,1) += -mcpu=cortex-a76.cortex-a55
-ISR_ARCHFLAGS-$(call gcc_version_ge,9,1) += -mtune=cortex-a76.cortex-a55
+ARCHFLAGS     += -mcpu=cortex-a76.cortex-a55
+ARCHFLAGS     += -mtune=cortex-a76.cortex-a55
+ISR_ARCHFLAGS += -mcpu=cortex-a76.cortex-a55
+ISR_ARCHFLAGS += -mtune=cortex-a76.cortex-a55
 endif
 
-# GCC support -mcpu=neoverse-n1 for arm64 from 9.1
+# GCC supports -mcpu=neoverse-n1 for arm64 from 9.1
+# Clang supports -mcpu=neoverse-n1 for arm64 from 10.0
 ifeq ($(CONFIG_MCPU_ARM64_NEOVERSE_N1),y)
+ifeq ($(call have_gcc),y)
 $(call error_if_gcc_version_lt,9,1)
-ARCHFLAGS-$(call gcc_version_ge,9,1)     += -mcpu=neoverse-n1 -mtune=neoverse-n1
-ISR_ARCHFLAGS-$(call gcc_version_ge,9,1) += -mcpu=neoverse-n1 -mtune=neoverse-n1
+else
+$(call error_if_clang_version_lt,10,0)
+endif
+ARCHFLAGS     += -mcpu=neoverse-n1 -mtune=neoverse-n1
+ISR_ARCHFLAGS += -mcpu=neoverse-n1 -mtune=neoverse-n1
 endif
 
-# GCC support -mcpu=neoverse-e1 for arm64 from 9.1
+# GCC supports -mcpu=neoverse-e1 for arm64 from 9.1
+# Clang supports -mcpu=neoverse-e1 for arm64 from 10.0
 ifeq ($(CONFIG_MCPU_ARM64_NEOVERSE_E1),y)
+ifeq ($(call have_gcc),y)
 $(call error_if_gcc_version_lt,9,1)
-ARCHFLAGS-$(call gcc_version_ge,9,1)     += -mcpu=neoverse-e1 -mtune=neoverse-e1
-ISR_ARCHFLAGS-$(call gcc_version_ge,9,1) += -mcpu=neoverse-e1 -mtune=neoverse-e1
+else
+$(call error_if_clang_version_lt,10,0)
+endif
+ARCHFLAGS     += -mcpu=neoverse-e1 -mtune=neoverse-e1
+ISR_ARCHFLAGS += -mcpu=neoverse-e1 -mtune=neoverse-e1
 endif
 
-# GCC support -mcpu=cortex-a34 for arm64 from 10.1
+# GCC supports -mcpu=cortex-a34 for arm64 from 10.1
+# Clang supports -mcpu=cortex-a34 for arm64 from 11.0
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A34),y)
+ifeq ($(call have_gcc),y)
 $(call error_if_gcc_version_lt,10,1)
-ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=cortex-a34 -mtune=cortex-a34
-ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=cortex-a34 -mtune=cortex-a34
+else
+$(call error_if_clang_version_lt,11,0)
+endif
+ARCHFLAGS     += -mcpu=cortex-a34 -mtune=cortex-a34
+ISR_ARCHFLAGS += -mcpu=cortex-a34 -mtune=cortex-a34
 endif
 
-# GCC support -mcpu=cortex-a65 for arm64 from 10.1
+# GCC supports -mcpu=cortex-a65 for arm64 from 10.1
+# Clang supports -mcpu=cortex-a65 for arm64 from 10.0
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A65),y)
+ifeq ($(call have_gcc),y)
 $(call error_if_gcc_version_lt,10,1)
-ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=cortex-a65 -mtune=cortex-a65
-ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=cortex-a65 -mtune=cortex-a65
+else
+$(call error_if_clang_version_lt,10,0)
+endif
+ARCHFLAGS     += -mcpu=cortex-a65 -mtune=cortex-a65
+ISR_ARCHFLAGS += -mcpu=cortex-a65 -mtune=cortex-a65
 endif
 
-# GCC support -mcpu=cortex-a65ae for arm64 from 10.1
+# GCC supports -mcpu=cortex-a65ae for arm64 from 10.1
+# Clang supports -mcpu=cortex-a65ae for arm64 from 10.0
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A65AE),y)
+ifeq ($(call have_gcc),y)
 $(call error_if_gcc_version_lt,10,1)
-ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=cortex-a65ae -mtune=cortex-a65ae
-ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=cortex-a65ae -mtune=cortex-a65ae
+else
+$(call error_if_clang_version_lt,10,0)
+endif
+ARCHFLAGS     += -mcpu=cortex-a65ae -mtune=cortex-a65ae
+ISR_ARCHFLAGS += -mcpu=cortex-a65ae -mtune=cortex-a65ae
 endif
 
-# GCC support -mcpu=cortex-a76ae for arm64 from 10.1
+# GCC supports -mcpu=cortex-a76ae for arm64 from 10.1
+# Clang supports it from 9.0, the minimum required version
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A76AE),y)
+ifeq ($(call have_gcc),y)
 $(call error_if_gcc_version_lt,10,1)
-ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=cortex-a76ae -mtune=cortex-a76ae
-ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=cortex-a76ae -mtune=cortex-a76ae
+endif
+ARCHFLAGS     += -mcpu=cortex-a76ae -mtune=cortex-a76ae
+ISR_ARCHFLAGS += -mcpu=cortex-a76ae -mtune=cortex-a76ae
 endif
 
-# GCC support -mcpu=cortex-a77 for arm64 from 10.1
+# GCC supports -mcpu=cortex-a77 for arm64 from 10.1
+# Clang supports -mcpu=cortex-a77 for arm64 from 11.0
 ifeq ($(CONFIG_MCPU_ARM64_CORTEX_A77),y)
+ifeq ($(call have_gcc),y)
 $(call error_if_gcc_version_lt,10,1)
-ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=cortex-a77 -mtune=cortex-a77
-ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=cortex-a77 -mtune=cortex-a77
+else
+$(call error_if_clang_version_lt,11,0)
+endif
+ARCHFLAGS     += -mcpu=cortex-a77 -mtune=cortex-a77
+ISR_ARCHFLAGS += -mcpu=cortex-a77 -mtune=cortex-a77
 endif
 
-# GCC support -mcpu=neoverse-n2 for arm64 from 10.1
+# GCC supports -mcpu=neoverse-n2 for arm64 from 10.1
 ifeq ($(CONFIG_MCPU_ARM64_NEOVERSE_N2),y)
+ifeq ($(call have_gcc),y)
 $(call error_if_gcc_version_lt,10,1)
-ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=neoverse-n2 -mtune=neoverse-n2
-ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=neoverse-n2 -mtune=neoverse-n2
+else
+$(call error_if_clang_version_lt,12,0)
+endif
+ARCHFLAGS     += -mcpu=neoverse-n2 -mtune=neoverse-n2
+ISR_ARCHFLAGS += -mcpu=neoverse-n2 -mtune=neoverse-n2
 endif
 
 # GCC support -mcpu=neoverse-v1 for arm64 from 10.1
 ifeq ($(CONFIG_MCPU_ARM64_NEOVERSE_V1),y)
+ifeq ($(call have_gcc),y)
 $(call error_if_gcc_version_lt,10,1)
-ARCHFLAGS-$(call gcc_version_ge,10,1)     += -mcpu=neoverse-v1 -mtune=neoverse-v1
-ISR_ARCHFLAGS-$(call gcc_version_ge,10,1) += -mcpu=neoverse-v1 -mtune=neoverse-v1
+else
+$(call error_if_clang_version_lt,12,0)
+endif
+ARCHFLAGS     += -mcpu=neoverse-v1 -mtune=neoverse-v1
+ISR_ARCHFLAGS += -mcpu=neoverse-v1 -mtune=neoverse-v1
 endif
 
 $(eval $(call addlib,libarm64arch))


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.



### Description of changes

Since a lot of required features rely on some minimum compiler versions, we check the version for every build.
The required versions are:
* `GCC` >= 7.0
* `Clang` >= 9.0

After we set a minimum compiler version, a lot of unnecessary checks will be removed (like the ones for arm specific cpus).

Also fix arm cpu models and erratas for building with `clang`.
Previously, the checks were done only for the `gcc` version, which caused any build with `clang` to fail. This pr adds separate checks for `gcc` / `clang` versions.

The PR is rebased on top of #944 in order to have `error_clang_version_lt` available, will rebase after that is merged.

Part of #921 