### PR TITLE
lib/vfscore: Reorder locks in *at syscalls

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -204,10 +204,10 @@ UK_LLSYSCALL_R_DEFINE(int, openat, int, dirfd, const char *, pathname,
 	strlcat(p, "/", PATH_MAX);
 	strlcat(p, pathname, PATH_MAX);
 
-	error = uk_syscall_r_open((long int)p, flags, mode);
-
 	vn_unlock(vp);
 	fdrop(fp);
+
+	error = uk_syscall_r_open((long int)p, flags, mode);
 
 	return error;
 }
@@ -1294,10 +1294,10 @@ UK_SYSCALL_R_DEFINE(int, mkdirat, int, dirfd,
 	strlcat(p, "/", PATH_MAX);
 	strlcat(p, pathname, PATH_MAX);
 
-	error = uk_syscall_r_mkdir((long) p, (long) mode);
-
 	vn_unlock(vp);
 	fdrop(fp);
+
+	error = uk_syscall_r_mkdir((long) p, (long) mode);
 
 	return error;
 }
@@ -1711,13 +1711,13 @@ static int __fxstatat_helper(int ver __unused, int dirfd, const char *pathname,
 	strlcat(p, "/", PATH_MAX);
 	strlcat(p, pathname, PATH_MAX);
 
+	vn_unlock(vp);
+	fdrop(fp);
+
 	if (flags & AT_SYMLINK_NOFOLLOW)
 		error = uk_syscall_r_lstat((long) p, (long) st);
 	else
 		error = uk_syscall_r_stat((long) p, (long) st);
-
-	vn_unlock(vp);
-	fdrop(fp);
 
 	return error;
 }
@@ -2201,10 +2201,10 @@ UK_SYSCALL_R_DEFINE(int, faccessat, int, dirfd, const char*, pathname, int, mode
 	strlcat(p, "/", PATH_MAX);
 	strlcat(p, pathname, PATH_MAX);
 
-	error = uk_syscall_r_access((long) p, (long) mode);
-
 	vn_unlock(vp);
 	fdrop(fp);
+
+	error = uk_syscall_r_access((long) p, (long) mode);
 
 	out_error:
 	return error;


### PR DESCRIPTION
### Description of changes

*at syscalls are implemented in Unikraft in two stages: (1) build the full target path relative to the supplied dirfd, and (2) delegate to the regular syscall. Previously these syscalls held the lock on the dirfd vnode throughout steps (1) and (2); however, the sub-syscalls often need to acquire the same lock (along with perhaps others), causing double-lock asserts to trigger.
This commit changes this logic to only hold the vnode lock during step (1) and release it immediately before (2). While this relaxes the previous atomicity guarantees somewhat, holding the vnode lock on dirfd only prevented concurrent changes to first-generation descendents, and unorthogonal and arguably unexpected behavior. The useful purpose of holding the dirfd lock is to ensure we build a full path that was (at one point in time) valid, with the sub-syscalls implementing their own atomicity guarantees as per usual.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): all
 - Platform(s): all
 - Application(s): all


### Additional configuration

Test with using any of the `openat`, `mkdirat`, `fstatat`, `faccessat` syscalls; staging fails with a lock assertion, fixed code should behave as expected.