### PR TITLE
lib/vfscore: Fix double-lock bug in symlink

### DIFF
--- a/lib/vfscore/lookup.c
+++ b/lib/vfscore/lookup.c
@@ -240,6 +240,36 @@ namei(const char *path, struct dentry **dpp)
 	return 0;
 }
 
+static int
+_namei_prep_path(const char *path, struct mount **mp, char *node, char **fname)
+{
+	if (path[0] != '/') {
+		return (ENOTDIR);
+	}
+
+	char *name = strrchr(path, '/');
+	if (name == NULL) {
+		return (ENOENT);
+	}
+	*fname = name + 1;
+
+	char *p;
+	int error = vfs_findroot(path, mp, &p);
+	if (error != 0) {
+		return (ENOTDIR);
+	}
+
+	strlcpy(node, "/", PATH_MAX);
+	strlcat(node, p, PATH_MAX);
+	// We want to treat things like /tmp/ the same as /tmp. Best way to do that
+	// is to ignore the last character, except when we're stating the root.
+	int l = strlen(node) - 1;
+	if (l && node[l] == '/') {
+		node[l] = '\0';
+	}
+	return 0;
+}
+
 /*
  * Convert last component in the path to pointer to dentry
  *
@@ -253,39 +283,14 @@ namei_last_nofollow(char *path, struct dentry *ddp, struct dentry **dpp)
 	char          *name;
 	int           error;
 	struct mount  *mp;
-	char          *p;
 	struct dentry *dp;
 	struct vnode  *dvp;
 	struct vnode  *vp;
 	char node[PATH_MAX];
 
-	dvp  = NULL;
-
-	if (path[0] != '/') {
-		return (ENOTDIR);
+	if ((error = _namei_prep_path(path, &mp, node, &name))) {
+		return error;
 	}
-
-	name = strrchr(path, '/');
-	if (name == NULL) {
-		return (ENOENT);
-	}
-	name++;
-
-	error = vfs_findroot(path, &mp, &p);
-	if (error != 0) {
-		return (ENOTDIR);
-	}
-
-	strlcpy(node, "/", PATH_MAX);
-	strlcat(node, p, PATH_MAX);
-
-	// We want to treat things like /tmp/ the same as /tmp. Best way to do that
-	// is to ignore the last character, except when we're stating the root.
-	int l = strlen(node) - 1;
-	if (l && node[l] == '/') {
-		node[l] = '\0';
-	}
-
 	dvp = ddp->d_vnode;
 	vn_lock(dvp);
 	dp = dentry_lookup(mp, node);
@@ -307,9 +312,51 @@ namei_last_nofollow(char *path, struct dentry *ddp, struct dentry **dpp)
 	*dpp  = dp;
 	error = 0;
 out:
-	if (dvp != NULL) {
-		vn_unlock(dvp);
+	vn_unlock(dvp);
+	return (error);
+}
+
+/*
+ * Same as namei_last_nofollow but does not lock ddp->d_vnode.
+ *
+ * @path: full path name
+ * @ddp : pointer to dentry of parent
+ * @dpp : dentry to be returned
+ */
+int
+namei_last_nofollow_locked(char *path, struct dentry *ddp, struct dentry **dpp)
+{
+	char          *name;
+	int           error;
+	struct mount  *mp;
+	struct dentry *dp;
+	struct vnode  *dvp;
+	struct vnode  *vp;
+	char node[PATH_MAX];
+
+	if ((error = _namei_prep_path(path, &mp, node, &name))) {
+		return error;
 	}
+	dvp = ddp->d_vnode;
+	dp = dentry_lookup(mp, node);
+	if (dp == NULL) {
+		error = VOP_LOOKUP(dvp, name, &vp);
+		if (error != 0) {
+			goto out;
+		}
+
+		dp = dentry_alloc(ddp, vp, node);
+		vput(vp);
+
+		if (dp == NULL) {
+			error = ENOMEM;
+			goto out;
+		}
+	}
+
+	*dpp  = dp;
+	error = 0;
+out:
 	return (error);
 }
 

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -907,7 +907,7 @@ sys_symlink(const char *oldpath, const char *newpath)
 	vn_lock(newdirdp->d_vnode);
 
 	/* newpath should not already exist */
-	if (unlikely(namei_last_nofollow(np, newdirdp, &newdp) == 0)) {
+	if (unlikely(namei_last_nofollow_locked(np, newdirdp, &newdp) == 0)) {
 		drele(newdp);
 		error = EEXIST;
 		goto out_unlock;

--- a/lib/vfscore/vfs.h
+++ b/lib/vfscore/vfs.h
@@ -700,6 +700,22 @@ int namei(const char *path, struct dentry **dpp);
 int namei_last_nofollow(char *path, struct dentry *ddp, struct dentry **dp);
 
 /**
+ * Same as namei_last_nofollow, to be called with the ddp->d_vnode lock held.
+ *
+ * @param path
+ *	The full path name
+ * @param ddp
+ *	Pointer to dentry of parent
+ * @param[out] dp
+ *	Dentry to be returned
+ * @return
+ *	- (0):  Completed successfully
+ *	- (<0): Negative value with error code
+ */
+int
+namei_last_nofollow_locked(char *path, struct dentry *ddp, struct dentry **dp);
+
+/**
  * Searches a pathname.
  * This routine returns a locked directory vnode and file name.
  *


### PR DESCRIPTION
### Description of changes

This change fixes an issue where the lock of the destination parent directory was being taken more than once in the  symlink syscall by using a locked variant of namei_last_nofollow, which this PR also adds. In implementing the locked version of the latter function there's also some factoring out of common code.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

`checkpatch.uk` complains, but I've purposely kept the style consistent within the file.

### Base target

 - Architecture(s): all
 - Platform(s): all
 - Application(s): all


### Additional configuration

Test by issuing a symlink syscall; staging fails with a lock assert, fixed code behaves as expected.
