### PR TITLE
build: Allow setting flags from the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1098,6 +1098,7 @@ help:
 	@echo '  UK_CXXFLAGS            - explicit Unikraft-specific additions to the C++ compiler flags (the CXXFLAGS variable is ignored)'
 	@echo '  UK_GOCFLAGS            - explicit Unikraft-specific additions to the GO compiler flags (the GOCFLAGS variable is ignored)'
 	@echo '  UK_LDFLAGS             - explicit Unikraft-specific additions to the linker flags (the LDFLAGS variable is ignored)'
+	@echo '  UK_LDEPS               - explicit, space-seperated link-time file dependencies (changes to these files will trigger relinking on subsequent builds)'
 	@echo ''
 	@echo 'Miscellaneous:'
 	@echo '  print-version          - print Unikraft version'

--- a/Makefile
+++ b/Makefile
@@ -639,6 +639,13 @@ CFLAGS		+= -DCC_VERSION=$(CC_VERSION)
 CXXFLAGS	+= -DCC_VERSION=$(CC_VERSION)
 GOCFLAGS	+= -DCC_VERSION=$(CC_VERSION)
 
+# Add user supplied flags as the last assignments
+ASFLAGS  += $(UK_ASFLAGS)
+CFLAGS   += $(UK_CFLAGS)
+CXXFLAGS += $(UK_CXXFLAGS)
+GOCFLAGS += $(UK_GOCFLAGS)
+LDFLAGS  += $(UK_LDFLAGS)
+
 # ensure $(BUILD_DIR)/kconfig, $(BUILD_DIR)/include and $(BUILD_DIR)/include/uk exists
 $(call mk_sub_build_dir,kconfig)
 $(call mk_sub_build_dir,include)
@@ -1084,6 +1091,13 @@ help:
 	@echo '                           (note: the name in the configuration file is not overwritten)'
 	@echo '  L=[PATH]:[PATH]:..     - colon-separated list of paths to external libraries'
 	@echo '  P=[PATH]:[PATH]:..     - colon-separated list of paths to external platforms'
+	@echo ''
+	@echo 'Environment variables:'
+	@echo '  UK_ASFLAGS             - explicit Unikraft-specific additions to the assembler flags (the ASFLAGS variable is ignored)'
+	@echo '  UK_CFLAGS              - explicit Unikraft-specific additions to the C compiler flags (the CFLAGS variable is ignored)'
+	@echo '  UK_CXXFLAGS            - explicit Unikraft-specific additions to the C++ compiler flags (the CXXFLAGS variable is ignored)'
+	@echo '  UK_GOCFLAGS            - explicit Unikraft-specific additions to the GO compiler flags (the GOCFLAGS variable is ignored)'
+	@echo '  UK_LDFLAGS             - explicit Unikraft-specific additions to the linker flags (the LDFLAGS variable is ignored)'
 	@echo ''
 	@echo 'Miscellaneous:'
 	@echo '  print-version          - print Unikraft version'

--- a/plat/kvm/Linker.uk
+++ b/plat/kvm/Linker.uk
@@ -44,7 +44,7 @@ endef
 $(KVM_DEBUG_IMAGE): $(KVM_ALIBS) $(KVM_ALIBS-y) $(KVM_OLIBS) $(KVM_OLIBS-y) \
 		    $(UK_ALIBS) $(UK_ALIBS-y) $(UK_OLIBS) $(UK_OLIBS-y) \
 		    $(KVM_LD_SCRIPT-y) $(EXTRA_LD_SCRIPT-y) \
-		    $(UK_PLAT_KVM_DEF_LDS)
+		    $(UK_PLAT_KVM_DEF_LDS) $(UK_LDEPS)
 	$(call build_cmd,LD,,$@,\
 	       $(LD) \
 			$(KVM_LDFLAGS) $(KVM_LDFLAGS-y) \

--- a/plat/linuxu/Linker.uk
+++ b/plat/linuxu/Linker.uk
@@ -11,7 +11,7 @@ LINUXU_LD_SCRIPT_FLAGS := $(addprefix -Wl$(comma)-T$(comma),\
 $(LINUXU_DEBUG_IMAGE): $(LINUXU_ALIBS) $(LINUXU_ALIBS-y) \
 		       $(LINUXU_OLIBS) $(LINUXU_OLIBS-y) \
 		       $(UK_ALIBS) $(UK_ALIBS-y) $(UK_OLIBS) $(UK_OLIBS-y) \
-		       $(LINUXU_LD_SCRIPT-y) $(EXTRA_LD_SCRIPT-y)
+		       $(LINUXU_LD_SCRIPT-y) $(EXTRA_LD_SCRIPT-y) $(UK_LDEPS)
 	$(call build_cmd,LD,,$@,\
 	       $(LD) $(LDFLAGS) $(LDFLAGS-y) \
 		     $(LINUXU_LDFLAGS) $(LINUXU_LDFLAGS-y) \

--- a/plat/xen/Linker.uk
+++ b/plat/xen/Linker.uk
@@ -21,7 +21,7 @@ XEN_LD_SCRIPT_FLAGS += $(addprefix -Wl$(comma)-T$(comma),\
 $(XEN_DEBUG_IMAGE): $(XEN_ALIBS) $(XEN_ALIBS-y) $(XEN_OLIBS) $(XEN_OLIBS-y) \
 		    $(UK_ALIBS) $(UK_ALIBS-y) $(UK_OLIBS) $(UK_OLIBS-y) \
 		    $(XEN_LD_SCRIPT-y) $(EXTRA_LD_SCRIPT-y) \
-		    $(UK_PLAT_XEN_DEF_LDS)
+		    $(UK_PLAT_XEN_DEF_LDS) $(UK_LDEPS)
 	$(call build_cmd,LD,,$(XEN_IMAGE).ld.o,\
 	       $(LD) -r $(LIBLDFLAGS) $(LIBLDFLAGS-y) \
 			$(XEN_LDFLAGS) $(XEN_LDFLAGS-y) \


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

 - N/A

### Description of changes

This adds `UK_ASFLAGS`, `UK_CFLAGS`, `UK_CXXFLAGS`, `UK_GOCFLAGS`, and
`UK_LDFLAGS` for explicitly setting these build flags for Unikraft.

For reference, see
- https://github.com/torvalds/linux/blob/v6.4/Documentation/kbuild/kbuild.rst#environment-variables
- https://github.com/torvalds/linux/blob/v6.4/Makefile#L1097-L1101

This also adds `UK_LDEPS` for manually relinking if user-specified files change. This has been separated to avoid tampering with the order of `LDFLAGS`.

Inspired by
- https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed