### PR TITLE
lib/ukschedcoop: Check run queue before halting the CPU

### DIFF
--- a/lib/ukschedcoop/schedcoop.c
+++ b/lib/ukschedcoop/schedcoop.c
@@ -214,15 +214,17 @@ static __noreturn void idle_thread_fn(void *argp)
 		now = ukplat_monotonic_clock();
 
 		if (!wake_up_time || wake_up_time > now) {
-			if (wake_up_time) {
-				ukplat_lcpu_halt_to(wake_up_time);
-			} else {
-				ukplat_lcpu_halt_irq();
-				ukplat_lcpu_enable_irq();
-			}
+			ukplat_lcpu_disable_irq();
+			if (!UK_TAILQ_FIRST(&c->run_queue)) {
+				if (wake_up_time)
+					ukplat_lcpu_halt_to(wake_up_time);
+				else
+					ukplat_lcpu_halt_irq();
 
-			/* handle pending events if any */
-			ukplat_lcpu_irqs_handle_pending();
+				/* handle pending events if any */
+				ukplat_lcpu_irqs_handle_pending();
+			}
+			ukplat_lcpu_enable_irq();
 		}
 
 		/* try to schedule a thread that might now be available */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

### Description of changes

An interrupt received after the decision to halt the CPU has been taken could wake up a thread, but the CPU would still halt, possibly indefinitely. A check on the run queue with irqs disabled before halting prevents this situation.