### PR TITLE
lib/ukboot: Zero out main thread TLS

### DIFF
--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -303,6 +303,7 @@ void ukplat_entry(int argc, char *argv[])
 	if (!tls)
 		UK_CRASH("Failed to allocate and initialize TLS\n");
 
+	memset(tls, 0, ukarch_tls_area_size());
 	/* Copy from TLS master template */
 	ukarch_tls_area_init(tls);
 	/* Activate TLS */


### PR DESCRIPTION
The main thread TLS is allocated but not cleaned, what leads to undefined behavior.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): any
 - Platform(s): any
 - Application(s): any with musl-libc

### Additional configuration

 - `CONFIG_LIBMUSL=y`

### Description of changes

The allocation sequence for tls memory is:

uk_memalign => uk_do_memalign => a->memalign => uk_memalign_compat => uk_posix_memalign_ifpages => uk_palloc => bbuddy_palloc

it seems there is no memory cleaning in the call chain (the posix memalign also doesn't give such guarantees). Also memory is not cleaned manually after tls have been allocated. If memset memory with some pattern, the pthread_t tls related fields end up with this pattern value, what means no further initialization of pthread_t structure is performed.

**Actual issue with pthread_t fields corruption we encountered**

Arch: arm64 (but could be reproduced on x86 also)
How bug looks like from the perspective of observer: sometimes randomly main thread called pthread_exit() & was terminated.

To understand the actual issue we need to know, that during posix calls canceled pthread could terminate. For example, here is sem_wait call, which we invoked

```
9 int sem_timedwait(sem_t *restrict sem, const struct timespec *restrict at)      
 10 {                                                                               
 11 >---pthread_testcancel();                                                       
 12                                                                                 
 13 >---if (!sem_trywait(sem)) return 0;                                            
 14                                                                                 
 15 >---int spins = 100;                                                            
 16 >---while (spins-- && sem->__val[0] <= 0 && 
...
```
at the beginning it is checked whether we have pending cancellation request.

the cancellation flag is located together with canceldisable in pthread_t structure which is located in TLS. Both flags are checked before the thread is canceled.

```
 76 void __testcancel()                                                             
 77 {                                                                               
 78                                                                                 
 79 >---pthread_t self = __pthread_self();                                          
 82 >---if (self->cancel && !self->canceldisable)                                   
 83 >--->---__cancel();                                                             
 84 }
```

The main thread TLS is allocated using unikraft memalign call
```

275 >---/* Allocate a TLS for this execution context */                             
276 >---tls = uk_memalign(a,                                                        
277 >--->--->---  ukarch_tls_area_align(),                                          
278 >--->--->---  ukarch_tls_area_size());                                          
279 >---if (!tls)                                                                   
280 >--->---UK_CRASH("Failed to allocate and initialize TLS\n"); 
```

just after the memalign I have printed the buffer, the printing shows, that memory returned is not zeroed.
```
[    0.000000] ERR:  [libukboot] <boot.c @  287> 910328810d40a680 449088a8c6b900b1 30bdbb08b8020d9b 2209880dcc010c80   <---- here we have value which ends up in pthread->cancel flags
```

there is a chance, that the memory is initialized somewhere further, however when I put print in __testcancel it could be clearly seen that some of this uninitialized data (showed above) end up in pthread_t fields (cancel, canceldisable and others of course). Also if I memset tls memory with some pattern, I can clearly see this pattern in self->cancel and self->canceldisable

```
__pthread_testcancel:11
__testcancel:80 tid = 0 cancel 30bdbb08 canceldisable 1 self 0x409de028
```

You can use this example to reproduce/verify on your side.
To reproduce it you need:
1) musl
2) app-helloworld which calls sem_wait in main function
3) mem buf returned by uk_memalign for tls could be zeroed, but there is no guarantee, to emulate garbage fill it via pattern.
4) print cancel flag from __testcancel, you will see pattern there