### PR TITLE
`lib/ukschedcoop`: Keep track of thread execution times

### DIFF
--- a/include/uk/arch/time.h
+++ b/include/uk/arch/time.h
@@ -55,12 +55,12 @@ typedef __s64 __snsec;
 #define __SNSEC_MAX (__S64_MAX)
 #define __SNSEC_MIN (__S64_MIN)
 
-#define UKARCH_NSEC_PER_SEC 1000000000ULL
+#define UKARCH_NSEC_PER_SEC ((__nsec)1000000000ULL)
 
 #define ukarch_time_nsec_to_sec(ns)      ((ns) / UKARCH_NSEC_PER_SEC)
-#define ukarch_time_nsec_to_msec(ns)     ((ns) / 1000000ULL)
+#define ukarch_time_nsec_to_msec(ns)     ((ns) / 1000000UL)
 #define ukarch_time_nsec_to_usec(ns)     ((ns) / 1000UL)
-#define ukarch_time_subsec(ns)           ((ns) % 1000000000ULL)
+#define ukarch_time_subsec(ns)           ((ns) % ((__nsec)1000000000ULL))
 
 #define ukarch_time_sec_to_nsec(sec)     ((sec)  * UKARCH_NSEC_PER_SEC)
 #define ukarch_time_msec_to_nsec(msec)   ((msec) * 1000000UL)

--- a/lib/uksched/include/uk/sched_impl.h
+++ b/lib/uksched/include/uk/sched_impl.h
@@ -55,7 +55,7 @@ int uk_sched_register(struct uk_sched *s);
 #define uk_sched_init(s, start_func, yield_func, \
 		thread_add_func, thread_remove_func, \
 		thread_blocked_func, thread_woken_func, \
-		def_allocator) \
+		idle_thread_func, def_allocator) \
 	do { \
 		(s)->sched_start     = start_func; \
 		(s)->yield           = yield_func; \
@@ -63,6 +63,7 @@ int uk_sched_register(struct uk_sched *s);
 		(s)->thread_remove   = thread_remove_func; \
 		(s)->thread_blocked  = thread_blocked_func; \
 		(s)->thread_woken    = thread_woken_func; \
+		(s)->idle_thread     = idle_thread_func; \
 		uk_sched_register((s)); \
 		\
 		(s)->a = (def_allocator); \

--- a/lib/uksched/include/uk/thread.h
+++ b/lib/uksched/include/uk/thread.h
@@ -78,6 +78,7 @@ struct uk_thread {
 	uk_thread_dtor_t dtor;		/**< User provided destructor */
 	void *priv;			/**< Private field, free for use */
 
+	__nsec exec_time;		/**< Time the thread was scheduled */
 	const char *name;		/**< Reference to thread name */
 	UK_TAILQ_ENTRY(struct uk_thread) thread_list;
 };

--- a/lib/uksched/thread.c
+++ b/lib/uksched/thread.c
@@ -241,6 +241,7 @@ static void _uk_thread_struct_init(struct uk_thread *t,
 	t->name = name;
 	t->priv = priv;
 	t->dtor = dtor;
+	t->exec_time = 0;
 
 	if (tlsp && is_uktls) {
 		t->flags |= UK_THREADF_UKTLS;

--- a/lib/ukschedcoop/schedcoop.c
+++ b/lib/ukschedcoop/schedcoop.c
@@ -273,6 +273,18 @@ static int schedcoop_start(struct uk_sched *s,
 	return 0;
 }
 
+static const struct uk_thread *schedcoop_idle_thread(struct uk_sched *s,
+						     unsigned int proc_id)
+{
+	struct schedcoop *c = uksched2schedcoop(s);
+
+	/* NOTE: We only support one processing LCPU (for now) */
+	if (proc_id > 0)
+		return NULL;
+
+	return &(c->idle);
+}
+
 struct uk_sched *uk_schedcoop_create(struct uk_alloc *a)
 {
 	struct schedcoop *c = NULL;
@@ -307,7 +319,7 @@ struct uk_sched *uk_schedcoop_create(struct uk_alloc *a)
 			schedcoop_thread_remove,
 			schedcoop_thread_blocked,
 			schedcoop_thread_woken,
-			NULL,
+			schedcoop_idle_thread,
 			a);
 
 	/* Add idle thread to the scheduler's thread list */

--- a/lib/ukschedcoop/schedcoop.c
+++ b/lib/ukschedcoop/schedcoop.c
@@ -307,6 +307,7 @@ struct uk_sched *uk_schedcoop_create(struct uk_alloc *a)
 			schedcoop_thread_remove,
 			schedcoop_thread_blocked,
 			schedcoop_thread_woken,
+			NULL,
 			a);
 
 	/* Add idle thread to the scheduler's thread list */


### PR DESCRIPTION
### Base target

 - Architecture(s): [all]
 - Platform(s): [all]
 - Application(s): [all]


### Additional configuration

 - `CONFIG_LIBUKSCHED=y`
 - `CONFIG_LIBUKSCHEDCOOP=y`

### Description of changes

This PR introduces keeping track of thread execution times with `lib/schedcoop` and is implemented with minimal overhead. An interface for returning the `idle` thread enables CPU utilization computations by putting thread execution times in relation over a time window.