### PR TITLE
plat/drivers/virtio: Fix virtio read write

### DIFF
--- a/plat/drivers/virtio/virtio_9p.c
+++ b/plat/drivers/virtio/virtio_9p.c
@@ -356,7 +356,10 @@ static int virtio_9p_feature_negotiate(struct virtio_9p_device *d)
 		goto out;
 	}
 
-
+	/**
+	 * The tag field read may result in unaligned read.
+	 * Currently, unaligned read is supported in the underlying function.
+	 */
 	if (virtio_config_get(d->vdev,
 			  __offsetof(struct virtio_9p_config, tag),
 			  d->tag, tag_len, 1) < 0) {

--- a/plat/drivers/virtio/virtio_mmio.c
+++ b/plat/drivers/virtio/virtio_mmio.c
@@ -162,8 +162,8 @@ static int vm_get(struct virtio_dev *vdev, __u16 offset,
 		memcpy(buf + sizeof(l), &l, sizeof(l));
 		break;
 	default:
-		uk_pr_err("Not supported length(%d) for io read\n", len);
-		UK_BUG();
+		_virtio_cread_bytes(base, offset, buf, len, 1);
+		uk_pr_warn("Unaligned io read: %d bytes\n", len);
 	}
 
 	return len;
@@ -207,8 +207,8 @@ static int vm_set(struct virtio_dev *vdev, __u16 offset,
 		virtio_cwrite32(base, offset + sizeof(l), l);
 		break;
 	default:
-		uk_pr_err("Not supported length(%d) for io write\n", len);
-		UK_BUG();
+		_virtio_cwrite_bytes(base, offset, buf, len, 1);
+		uk_pr_warn("Unaligned io write: %d bytes\n", len);
 	}
 
 	return 0;

--- a/plat/drivers/virtio/virtio_net.c
+++ b/plat/drivers/virtio/virtio_net.c
@@ -934,6 +934,7 @@ static int virtio_netdev_feature_negotiate(struct uk_netdev *n)
 	 * reconsider providing generic read/write function for all these
 	 * virtio device in a separate header file which could be reused across
 	 * different virtio devices.
+	 * Currently, unaligned read is supported in the underlying function.
 	 */
 	virtio_config_get(vndev->vdev,
 				   __offsetof(struct virtio_net_config, mac),


### PR DESCRIPTION
Add support for variable length of virtio read and write.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): `kvm`
 - Application(s): N/A


### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The `vm_get` and `vm_set` in `virtio_mmio` can only handle reading/writing 1/2/4/8 bytes. However, there are several cases, such as in [virtio_net](https://github.com/unikraft/unikraft/blob/5eb820bdbd1dee81c48b1f98bb588edb16b252fa/plat/drivers/virtio/virtio_net.c#L938) and [virtio_9p](https://github.com/unikraft/unikraft/blob/5eb820bdbd1dee81c48b1f98bb588edb16b252fa/plat/drivers/virtio/virtio_9p.c#L360), that the length of bytes to read is not supported by this function. This PR adds support to this case by using `_virtio_cread_bytes` and `_virtio_cwrite_bytes` functions in the default case of  `vm_set` and `vm_get` functions correspondingly. This approach turns an `n`-byte read/write operation into `n` 1-byte read/write operations.
