### PR TITLE
lib/nolibc,lib/isrlib: Fix strncpy

### DIFF
--- a/lib/isrlib/string.c
+++ b/lib/isrlib/string.c
@@ -152,17 +152,21 @@ size_t strnlen_isr(const char *str, size_t len)
 
 char *strncpy_isr(char *dst, const char *src, size_t len)
 {
-	size_t clen;
+	if (len != 0) {
+		char *d = dst;
+		const char *s = src;
 
-	clen = strnlen_isr(src, len);
-	memcpy_isr(dst, src, clen);
+		do {
+			if ((*d++ = *s++) == 0) {
+				/* NUL pad the remaining n-1 bytes */
+				while (--len != 0)
+					*d++ = 0;
+				break;
+			}
+		} while (--len != 0);
+	}
 
-	/* instead of filling up the rest of left space with zeros,
-	 * append a termination character if we did not copy one
-	 */
-	if (clen < len && dst[clen - 1] != '\0')
-		dst[clen] = '\0';
-	return dst;
+	return (dst);
 }
 
 char *strcpy_isr(char *dst, const char *src)

--- a/lib/nolibc/string.c
+++ b/lib/nolibc/string.c
@@ -152,17 +152,21 @@ size_t strnlen(const char *str, size_t len)
 
 char *strncpy(char *dst, const char *src, size_t len)
 {
-	size_t clen;
+	if (len != 0) {
+		char *d = dst;
+		const char *s = src;
 
-	clen = strnlen(src, len);
-	memcpy(dst, src, clen);
+		do {
+			if ((*d++ = *s++) == 0) {
+				/* NUL pad the remaining n-1 bytes */
+				while (--len != 0)
+					*d++ = 0;
+				break;
+			}
+		} while (--len != 0);
+	}
 
-	/* instead of filling up the rest of left space with zeros,
-	 * append a termination character if we did not copy one
-	 */
-	if (clen < len && dst[clen - 1] != '\0')
-		dst[clen] = '\0';
-	return dst;
+	return (dst);
 }
 
 char *strcpy(char *dst, const char *src)


### PR DESCRIPTION
strncpy will produce different results for an empty string depending on the preceding value of dst:

char buf[4];

bzero(buf, sizeof(buf));
buf[0] = 0;
buf[1] = 9;
strncpy(&buf[1], "", 3);

"clen" will be 0 since strnlen("") is 0, which will then look into dst[-1] (buf[0]) to decide if it terminates dst or not.

Instead of working around, replace strncpy for a conformant version, taken from OpenBSD libkern, as a bonus we zero out the remaining buffer.

Easier to test by renaming strncpy to something else otherwise the compiler will inline it most of the small cases.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.