### PR TITLE
Fix exporting of ntohs and also include the long versions

### DIFF
--- a/lib/nolibc/exportsyms.uk
+++ b/lib/nolibc/exportsyms.uk
@@ -103,6 +103,8 @@ errno
 # network
 htons
 ntohs
+htonl
+ntohl
 h_errno
 
 # syslog

--- a/lib/nolibc/exportsyms.uk
+++ b/lib/nolibc/exportsyms.uk
@@ -102,7 +102,7 @@ errno
 
 # network
 htons
-nthos
+ntohs
 h_errno
 
 # syslog

--- a/lib/nolibc/musl-imported/src/network/htonl.c
+++ b/lib/nolibc/musl-imported/src/network/htonl.c
@@ -1,0 +1,8 @@
+#include <netinet/in.h>
+#include <byteswap.h>
+
+uint32_t htonl(uint32_t n)
+{
+	union { int i; char c; } u = { 1 };
+	return u.c ? bswap_32(n) : n;
+}

--- a/lib/nolibc/musl-imported/src/network/ntohl.c
+++ b/lib/nolibc/musl-imported/src/network/ntohl.c
@@ -1,0 +1,8 @@
+#include <netinet/in.h>
+#include <byteswap.h>
+
+uint32_t ntohl(uint32_t n)
+{
+	union { int i; char c; } u = { 1 };
+	return u.c ? bswap_32(n) : n;
+}


### PR DESCRIPTION
### Description of changes

This is split into two commits:
1 - ntohs(3) had a typo in the exported symbol manifest, fix that.
2 - include ntohl(3) and htonl(3) as well

I'd wage that the long versions are more used/common than the short ones (think of an ip).