### PR TITLE
lib/nolibc: scanf and fscanf functions

### DIFF
--- a/lib/nolibc/Makefile.uk
+++ b/lib/nolibc/Makefile.uk
@@ -44,6 +44,7 @@ LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/musl-imported/src/network/ntohs.c
 LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/h_errno.c
 LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/getopt.c
 LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/sscanf.c
+LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/scanf.c
 LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/asprintf.c
 LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/random.c
 

--- a/lib/nolibc/exportsyms.uk
+++ b/lib/nolibc/exportsyms.uk
@@ -22,8 +22,9 @@ free
 
 # sscanf
 vsscanf
-scanf
 sscanf
+scanf
+fscanf
 
 # stdio
 stdin

--- a/lib/nolibc/include/stdio.h
+++ b/lib/nolibc/include/stdio.h
@@ -78,6 +78,9 @@ int  printf(const char *fmt, ...)                           __printf(1, 2);
 int vsscanf(const char *str, const char *fmt, va_list ap);
 int  sscanf(const char *str, const char *fmt, ...)          __scanf(2, 3);
 
+int scanf(const char *fmt, ...);                            __scanf(1, 2);
+int fscanf(FILE *fp, const char *fmt, ...);                 __scanf(2, 3); 
+
 int vasprintf(char **str, const char *fmt, va_list ap);
 int  asprintf(char **str, const char *fmt, ...)             __printf(2, 3);
 

--- a/lib/nolibc/scanf.c
+++ b/lib/nolibc/scanf.c
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+#include <uk/plat/console.h>
+
+static int
+uk_scanf(void *buffer,  size_t *cnt)
+{
+	int bytes_read;
+	size_t bytes_total = 0, count;
+	char *buf = buffer;
+
+	count = *cnt;
+
+	do {
+		while ((bytes_read = ukplat_cink(buf,
+			count - bytes_total)) <= 0)
+			;
+
+		buf = buf + bytes_read;
+		*(buf - 1) = *(buf - 1) == '\r' ?
+					'\n' : *(buf - 1);
+
+		/* Echo the input */
+		if (*(buf - 1) == '\177') {
+			/* DELETE control character */
+			if (buf - 1 != buffer) {
+				/* If this is not the first byte */
+				ukplat_coutk("\b \b", 3);
+				buf -= 1;
+				if (bytes_total > 0)
+					bytes_total--;
+			}
+			buf -= 1;
+		} else {
+			ukplat_coutk(buf - bytes_read, bytes_read);
+			bytes_total += bytes_read;
+		}
+
+	} while (bytes_total < count &&
+	((bytes_total == 0) || (*(buf - 1) != '\n' && *(buf - 1) != '\0')));
+
+	*cnt = bytes_total;
+
+	return 0;
+}
+
+int
+vfscanf(FILE *fp, const char *fmt, va_list ap)
+{
+	int ret = 0;
+	char buf[1024];
+	size_t size = sizeof(buf);
+
+	if (fp == stdin)
+		ret = uk_scanf(buf, &size);
+	else
+		return 0;
+
+	if (ret < 0)
+		return ret;
+
+	ret = vsscanf(buf, fmt, ap);
+	return ret;
+}
+
+int
+vscanf(const char *fmt, va_list ap)
+{
+	return vfscanf(stdin, fmt, ap);
+}
+
+int
+fscanf(FILE *fp, const char *fmt, ...)
+{
+	int ret;
+	va_list ap;
+
+	va_start(ap, fmt);
+	ret = vfscanf(fp, fmt, ap);
+	va_end(ap);
+
+	return ret;
+}
+
+int
+scanf(const char *fmt, ...)
+{
+	int ret;
+	va_list ap;
+
+	va_start(ap, fmt);
+	ret = vscanf(fmt, ap);
+	va_end(ap);
+	return ret;
+}


### PR DESCRIPTION
Adding scanf and fscanf function to nolibc, since their symbols were exported, but no implementation was provided.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`  and `aarch64`
 - Platform(s): [e.g. `kvm`, `xen` and `linuxu`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Added a proper implementation for the `scanf` and `fscanf` functions. The idea behind from reading from the serial port was highly inspired from [here](https://github.com/unikraft/unikraft/blob/staging/lib/vfscore/stdio.c#L86)


You can test the PR by trying to call the `scanf` and `fscanf` functions with various parameters. For example,

```c
#include <stdio.h>

int main()
{
  int x;
  short y;

  fscanf(stdin, "%d%hu", &x, &y);
  printf("x = %d and y = %hu\n", x, y);

  return 0;
}
```


