### PR TITLE
plat/kvm/arm: Do not enable interrupts before `wfi`

### DIFF
--- a/include/uk/plat/lcpu.h
+++ b/include/uk/plat/lcpu.h
@@ -96,6 +96,9 @@ void ukplat_lcpu_halt_irq_until(__nsec until);
 /**
  * Halts the current logical CPU. Execution is resumed when an interrupt/signal
  * arrives.
+ *
+ * NOTE: This must be called with IRQ's disabled. On return, IRQ's are not
+ *        re-enabled.
  */
 void ukplat_lcpu_halt_irq(void);
 

--- a/plat/kvm/arm/lcpu.c
+++ b/plat/kvm/arm/lcpu.c
@@ -46,6 +46,8 @@ void ukplat_lcpu_disable_irq(void)
 
 void ukplat_lcpu_halt_irq(void)
 {
+	UK_ASSERT(ukplat_lcpu_irqs_disabled());
+
 	ukplat_lcpu_enable_irq();
 	halt();
 	ukplat_lcpu_disable_irq();

--- a/plat/kvm/arm/lcpu.c
+++ b/plat/kvm/arm/lcpu.c
@@ -48,9 +48,12 @@ void ukplat_lcpu_halt_irq(void)
 {
 	UK_ASSERT(ukplat_lcpu_irqs_disabled());
 
-	ukplat_lcpu_enable_irq();
+	/* Note: If priority masking is enabled
+	 * interrupts need to be unmasked in the GIC.
+	 *
+	 * See Linux `cpu_do_idle(void)` implementation
+	 */
 	halt();
-	ukplat_lcpu_disable_irq();
 }
 
 unsigned long ukplat_lcpu_save_irqf(void)

--- a/plat/kvm/x86/lcpu.c
+++ b/plat/kvm/x86/lcpu.c
@@ -47,6 +47,8 @@ void ukplat_lcpu_disable_irq(void)
 
 void ukplat_lcpu_halt_irq(void)
 {
+	UK_ASSERT(ukplat_lcpu_irqs_disabled());
+
 	/*
 	 * We have to be careful when enabling interrupts before entering a
 	 * halt state. If we want to wait for an interrupt (e.g., a timer)

--- a/plat/linuxu/irq.c
+++ b/plat/linuxu/irq.c
@@ -103,6 +103,8 @@ void ukplat_lcpu_disable_irq(void)
 
 void ukplat_lcpu_halt_irq(void)
 {
+	UK_ASSERT(ukplat_lcpu_irqs_disabled());
+
 	ukplat_lcpu_enable_irq();
 	halt();
 	ukplat_lcpu_disable_irq();

--- a/plat/xen/lcpu.c
+++ b/plat/xen/lcpu.c
@@ -55,6 +55,8 @@ void ukplat_lcpu_disable_irq(void)
 
 void ukplat_lcpu_halt_irq(void)
 {
+	UK_ASSERT(ukplat_lcpu_irqs_disabled());
+
 	ukplat_lcpu_enable_irq();
 	halt();
 	ukplat_lcpu_disable_irq();


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

None

### Description of changes

There is the opportunity to miss an IRQ on the path to `wfi` from the idle thread after deciding to sleep:
The interrupts are enable just before exuting `wfi`. If the interrupt already arrived before that, it will be executed before `wfi`, and `wfi` will go to sleep afterward, not being woken up by the interrupt.

This patch removes calls to enable/disable interrupts around `wfi`. `wfi` will be woken up by interrupts regardless of the state of the CPSR register.

### Feedback needed 

- It is probably a good idea to assert IRQ disabled in `ukplat_lcpu_halt_irq` similar to #941, however, it is not completely clear if this will work with the other platforms.