### PR TITLE
lib/9pfs: Provide `TIOCGWINSZ`-aware `ioctl` stub

### DIFF
--- a/lib/9pfs/9pfs_vnops.c
+++ b/lib/9pfs/9pfs_vnops.c
@@ -35,6 +35,7 @@
 #include <fcntl.h>
 #include <dirent.h>
 #include <stdlib.h>
+#include <sys/ioctl.h>
 #include <uk/config.h>
 #include <uk/9p.h>
 #include <uk/errptr.h>
@@ -1011,8 +1012,18 @@ static int uk_9pfs_symlink(struct vnode *dvp, const char *op, const char *np)
 	return 0;
 }
 
+static int uk_9pfs_ioctl(struct vnode *dvp, struct vfscore_file *fp,
+			 unsigned long com, void *data)
+{
+	switch (com) {
+	case TIOCGWINSZ:
+		return ENOTTY;
+	default:
+		return 0;
+	}
+}
+
 #define uk_9pfs_seek		((vnop_seek_t)vfscore_vop_nullop)
-#define uk_9pfs_ioctl		((vnop_ioctl_t)vfscore_vop_nullop)
 #define uk_9pfs_cache		((vnop_cache_t)NULL)
 #define uk_9pfs_fallocate	((vnop_fallocate_t)vfscore_vop_nullop)
 #define uk_9pfs_poll		((vnop_poll_t)vfscore_vop_einval)


### PR DESCRIPTION
`python3` uses `isatty()`, which does an `ioctl()` with `TIOCGWINSZ` as an argument for checking whether it should invoke the interactive interpretor or just start interpreting a given file.

Since `9pfs` is not a pseudo filesystem, it should be able to respond to such `ioctl` accordingly for scripts defined in its filesystem with a `ENOTTY`.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
