### PR TITLE
build: Add compiler version checking for Clang

### DIFF
--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -39,10 +39,29 @@ define have_clang =
 $(if $(filter Clang,$(CC_NAME)),y,n)
 endef
 
-# test whether GCC version is greater than or equal to the minimum requirement
-# gcc_version_ge $gcc_major,$gcc_minor
+# test whether CC version is greater than or equal to the minimum requirement
+# cc_version_ge $cc_major,$cc_minor
+define cc_version_ge =
+$(shell if [ $(CC_VER_MAJOR) -gt $(1) ] || ([ $(CC_VER_MAJOR) -eq $(1) ] && [ $(CC_VER_MINOR) -ge $(2) ]) ; then echo -n y ; fi)
+endef
+# test whether CC version is less than the supplied version
+# cc_version_lt $cc_major,$cc_minor
+define cc_version_lt =
+$(shell if [ $(CC_VER_MAJOR) -lt $(1) ] || ([ $(CC_VER_MAJOR) -eq $(1) ] && [ $(CC_VER_MINOR) -lt $(2) ]) ; then echo -n y ; fi)
+endef
+
 define gcc_version_ge =
-$(shell if [ $(call have_gcc) = y ] ; then if [ $(CC_VER_MAJOR) -gt $(1) ] || ([ $(CC_VER_MAJOR) -eq $(1) ] && [ $(CC_VER_MINOR) -ge $(2) ]) ; then echo -n y ; fi ; fi)
+$(shell if [ $(call have_gcc) = y ] ; then echo -n "$(call cc_version_ge,$(1),$(2))" ; fi)
+endef
+define gcc_version_lt =
+$(shell if [ $(call have_gcc) = y ] ; then echo -n "$(call cc_version_lt,$(1),$(2))" ; fi)
+endef
+
+define clang_version_ge =
+$(shell if [ $(call have_clang) = y ] ; then echo -n "$(call cc_version_ge,$(1),$(2))" ; fi)
+endef
+define clang_version_lt =
+$(shell if [ $(call have_clang) = y ] ; then echo -n "$(call cc_version_gt,$(1),$(2))" ; fi)
 endef
 
 # print error and stop build when GCC version doesn't meet the minimum requirement
@@ -50,6 +69,11 @@ endef
 define error_if_gcc_version_lt =
 $(if $(call gcc_version_ge,$(1),$(2)),,\
      $(error Require GCC version >= $(1).$(2) found $(CC_VER_MAJOR).$(CC_VER_MINOR)))
+endef
+# error_if_clang_version_lt $clang_major,$clang_minor.
+define error_if_clang_version_lt =
+$(if $(call clang_version_ge,$(1),$(2)),,\
+     $(error Require Clang version >= $(1).$(2) found $(CC_VER_MAJOR).$(CC_VER_MINOR)))
 endef
 
 ################################################################################


### PR DESCRIPTION
### Description of changes

This change adds version checking make functions in line with what we have already for GCC.
Also added are `*_lt` functions that check for a maximum compiler version.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A

Edit: rebased & addressed comments.