### PR TITLE
plat/drivers/virtio-ring: Downgrade saturated descriptors error

### DIFF
--- a/plat/drivers/virtio/virtio_ring.c
+++ b/plat/drivers/virtio/virtio_ring.c
@@ -344,7 +344,7 @@ int virtqueue_buffer_enqueue(struct virtqueue *vq, void *cookie,
 			  total_desc);
 		return -EINVAL;
 	} else if (vrq->desc_avail < total_desc) {
-		uk_pr_err("Available descriptor:%"__PRIu16", Requested descriptor:%"__PRIu32"\n",
+		uk_pr_debug("Available descriptor:%"__PRIu16", Requested descriptor:%"__PRIu32"\n",
 			  vrq->desc_avail, total_desc);
 		return -ENOSPC;
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->


Real-world applications may run into https://github.com/unikraft/unikraft/issues/853 many times per second.
I posted a simple reproduction into the issue.
According to @mschlumpp, this just means that Unikraft is filling up the virtio descriptors faster than the host consumes them.
This commit downgrades the error to a debug message to avoid scaring and to spend less time printing errors instead of doing work.