### PR TITLE
plat/drivers: Add two configurations to ns16550

### DIFF
--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -178,6 +178,20 @@ config EARLY_UART_NS16550_BASE
 	depends on EARLY_UART_NS16550
 	help
 		NS16550 serial address used by early debug console.
+
+config UART_NS16550_REG_SHIFT
+	int "NS16550 serial register shift"
+	depends on UART_NS16550
+	default 0
+	help
+		NS16550 serial register shift.
+
+config UART_NS16550_REG_WIDTH
+	int "NS165500 serial register width"
+	depends on UART_NS16550
+	default 1
+	help
+		NS16550 serial register width.
 endmenu
 endif
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `ARM64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The register shift of ns16550 is hard-coded in the driver, but it does not match the hardware on some platforms. The device-tree specification has a property "reg-shift" to describe the register shift of a device.
To match the specification, the register shift of ns16550 is retrieved from the device tree instead. If no such property is found, the default value 0 is used.

The register width of ns16550 varies on different platforms. u-boot uses a reg-io-width property in the device tree to determine it. If no such property is found, the default value 1 is used. The read and write macros are replaced by functions with the same name.

These two configurations break the compatibility of the driver. To keep the compatibility, the device tree should contain these properties.
