### PR TITLE
lib/vfscore: Fix wrong application of umask

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -140,6 +140,7 @@ UK_LLSYSCALL_R_DEFINE(int, open, const char*, pathname, int, flags,
 	if (error)
 		goto out_error;
 
+	mode = apply_umask(mode);
 	error = sys_open(path, flags, mode, &fp);
 	if (error)
 		goto out_error;
@@ -167,7 +168,7 @@ int open(const char *pathname, int flags, ...)
 		va_list ap;
 
 		va_start(ap, flags);
-		mode = apply_umask(va_arg(ap, mode_t));
+		mode = va_arg(ap, mode_t);
 		va_end(ap);
 	}
 
@@ -221,7 +222,7 @@ int openat(int dirfd, const char *pathname, int flags, ...)
 		va_list ap;
 
 		va_start(ap, flags);
-		mode = apply_umask(va_arg(ap, mode_t));
+		mode = va_arg(ap, mode_t);
 		va_end(ap);
 	}
 


### PR DESCRIPTION
### Description of changes

Previously vfscore would apply the umask to the mode bits in the emulated libc functions `open` and `openat`, instead of within the open/openat syscall implementation where it would be correct to do so. This lead to the umask being ignored when a real libc was in use. This change fixes this bug, restoring expected behavior with or without a libc.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Test with:
```
umask(0027);
f = open("file", O_WRONLY|O_CREAT, 0775);
fstat(f, &st);
printf("Should be: %o, is %o\n", 0775 & (~0027), st.st_mode);
```
