### PR TITLE
lib/vfscore: Accept negative timestamps

### DIFF
--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1296,8 +1296,7 @@ sys_readlink(char *path, char *buf, size_t bufsize, ssize_t *size)
  */
 static int is_timeval_valid(const struct timeval *time)
 {
-	return (time->tv_sec >= 0) &&
-		   (time->tv_usec >= 0 && time->tv_usec < 1000000);
+	return (time->tv_usec >= 0 && time->tv_usec < 1000000);
 }
 
 /*
@@ -1364,8 +1363,7 @@ sys_utimes(char *path, const struct timeval *times, int flags)
  */
 static int timespec_is_valid(const struct timespec *time)
 {
-	return (time->tv_sec >= 0) &&
-	       ((time->tv_nsec >= 0 && time->tv_nsec <= 999999999) ||
+	return ((time->tv_nsec >= 0 && time->tv_nsec <= 999999999) ||
 		time->tv_nsec == UTIME_NOW ||
 		time->tv_nsec == UTIME_OMIT);
 }


### PR DESCRIPTION
### Description of changes

Previously vfs code would reject timestamps that are more than 1 second before the epoch as invalid. This is wrong; unix time is defined as a signed offset and as such can and must support dates before the epoch. This change relaxes the overly-strict validity check, allowing the full range of valid file timestamps to be used.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Additional configuration

Test with:
```
struct utimbuf t = {-1, -1};
int r = utime("file", &t);
if (r) perror("Bug in utime");
```
