### PR TITLE
lib/vfscore: Correct behavior of utime(NULL)

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -2527,21 +2527,16 @@ int lutimes(const char *pathname, const struct timeval *times)
 UK_SYSCALL_R_DEFINE(int, utime, const char *, pathname,
 		    const struct utimbuf *, t)
 {
-	struct timeval times[2];
-	times[0].tv_usec = 0;
-	times[1].tv_usec = 0;
-
-	if (!t) {
-		long int tsec = 0; /* FIXME: Use current time in seconds */
-		times[0].tv_sec = tsec;
-		times[1].tv_sec = tsec;
-	} else {
+	if (t) {
+		struct timeval times[2];
 		times[0].tv_sec = t->actime;
+		times[0].tv_usec = 0;
 		times[1].tv_sec = t->modtime;
+		times[1].tv_usec = 0;
+		return uk_syscall_r_utimes((long) pathname, (long) times);
+	} else {
+		return uk_syscall_r_utimes((long) pathname, (long) NULL);
 	}
-
-	return uk_syscall_r_utimes((long) pathname,
-				   (long) times);
 }
 
 UK_TRACEPOINT(trace_vfs_chmod, "\"%s\" 0%0o", const char*, mode_t);


### PR DESCRIPTION

### Description of changes

Previously, as a placeholder behavior, utime(NULL) would set the file times to the epoch (1970-01-01 00:00 -0000) instead of the current time. This change corrects this oversight, bringing the syscall in line with expected and documented behavior.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Test with:
```
utime("file", NULL);
stat("file", &st);
printf("%ld %ld\n", st.st_atime, st.st_mtime);
```
