### PR TITLE
lib/ramfs: Implement new file timestamps

### DIFF
--- a/lib/ramfs/ramfs_vnops.c
+++ b/lib/ramfs/ramfs_vnops.c
@@ -62,10 +62,9 @@ static void
 set_times_to_now(struct timespec *time1, struct timespec *time2,
 		 struct timespec *time3)
 {
-	struct timespec now = {0, 0};
+	struct timespec now;
 
-	/* TODO: implement the real clock_gettime */
-	/* clock_gettime(CLOCK_REALTIME, &now); */
+	clock_gettime(CLOCK_REALTIME, &now);
 	if (time1)
 		memcpy(time1, &now, sizeof(struct timespec));
 	if (time2)


### PR DESCRIPTION
### Description of changes

This change implements setting the file times of newly created files to the current time, filling in a placeholder that previously would set the times to the epoch (i.e., 1970-01-01 00:00 UTC).

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Test with:
```
int f = open("file", O_WRONLY|O_CREAT, 0777);
fstat(f, &st);
printf("%ld %ld\n", st.st_atime, st.st_mtime);
```
