### PR TITLE
lib/ramfs: Ensure stability of inode numbers

### DIFF
--- a/lib/ramfs/ramfs.h
+++ b/lib/ramfs/ramfs.h
@@ -47,6 +47,8 @@ struct ramfs_node {
 	 * else NULL
 	 */
 	struct ramfs_node *rn_child;
+	/* Inode number of this node, should be unique and stable */
+	uint64_t rn_ino;
 	/*
 	 * Entry type: regular file - VREG, symbolic link - VLNK,
 	 * or directory - VDIR

--- a/lib/ramfs/ramfs_vnops.c
+++ b/lib/ramfs/ramfs_vnops.c
@@ -92,6 +92,7 @@ ramfs_allocate_node(const char *name, int type)
 	}
 	strlcpy(np->rn_name, name, np->rn_namelen + 1);
 	np->rn_type = type;
+	np->rn_ino = inode_count++;
 
 	if (type == VDIR)
 		np->rn_mode = S_IFDIR|0777;
@@ -230,7 +231,7 @@ ramfs_lookup(struct vnode *dvp, const char *name, struct vnode **vpp)
 		uk_mutex_unlock(&ramfs_lock);
 		return ENOENT;
 	}
-	if (vfscore_vget(dvp->v_mount, inode_count++, &vp)) {
+	if (vfscore_vget(dvp->v_mount, np->rn_ino, &vp)) {
 		/* found in cache */
 		*vpp = vp;
 		uk_mutex_unlock(&ramfs_lock);


### PR DESCRIPTION
### Description of changes

Previously ramfs would assign a new unique inode number to a file on every successful filesystem lookup. This can lead to the same file being allocated multiple different inodes, breaking code that (correctly) uses inodes as reliable indicators of file identity.
This change makes inode numbers persistent, allocated along with the filesystem node, and stable across multiple lookups of the same file.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Test with:
```
int f = open("file", O_RDONLY);
fstat(f, &st1);
stat("file", &st2);
printf("Should be same: %ld %ld\n", st1.st_ino, st2.st_ino);
```