### PR TITLE
lib/ramfs: Support setting file mode on creation

### DIFF
--- a/lib/ramfs/ramfs.h
+++ b/lib/ramfs/ramfs.h
@@ -82,10 +82,12 @@ struct ramfs_node {
  * @param type
  *   The entry type (regular file - VREG, symbolic link - VLNK,
  *   or directory - VDIR)
+ * @param mode
+ *   The mode bits of the newly created node
  * @return
  *   Pointer to the new ramfs_node
  */
-struct ramfs_node *ramfs_allocate_node(const char *name, int type);
+struct ramfs_node *ramfs_allocate_node(const char *name, int type, mode_t mode);
 
 /**
  * Frees a ramfs node.

--- a/lib/ramfs/ramfs_vfsops.c
+++ b/lib/ramfs/ramfs_vfsops.c
@@ -82,7 +82,7 @@ ramfs_mount(struct mount *mp, const char *dev __unused,
 	uk_pr_debug("%s: dev=%s\n", __func__, dev);
 
 	/* Create a root node */
-	np = ramfs_allocate_node("/", VDIR);
+	np = ramfs_allocate_node("/", VDIR, 0777);
 	if (np == NULL)
 		return ENOMEM;
 	mp->m_root->d_vnode->v_data = np;


### PR DESCRIPTION
### Description of changes

Previously any file created on ramfs would have the mode bits set to 0777, regardless of the mode bits supplied to open/creat/mkdir, which can break software that explicitly checks these bits. This change corrects this oversight, having new files be created with the requested mode bits set.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Test on a ramfs root with:
```
f = open("file", O_WRONLY|O_CREAT, 0640);
fstat(f, &st);
printf("%o\n", st.st_mode);
```
