### PR TITLE
lib/vfscore: Fix create through broken symlink

### DIFF
--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -114,6 +114,7 @@ sys_open(char *path, int flags, mode_t mode, struct vfscore_file **fpp)
 	struct dentry *dp, *ddp;
 	struct vnode *vp;
 	char *filename;
+	char realpath[PATH_MAX];
 	int error;
 
 	DPRINTF(VFSDB_SYSCALL, ("sys_open: path=%s flags=%x mode=%x\n",
@@ -121,10 +122,10 @@ sys_open(char *path, int flags, mode_t mode, struct vfscore_file **fpp)
 
 	flags = vfscore_fflags(flags);
 	if (flags & O_CREAT) {
-		error = namei(path, &dp);
+		error = namei_resolve(path, &dp, realpath);
 		if (error == ENOENT) {
 			/* Create new struct vfscore_file. */
-			if ((error = lookup(path, &ddp, &filename)) != 0)
+			if ((error = lookup(realpath, &ddp, &filename)) != 0)
 				return error;
 
 			vn_lock(ddp->d_vnode);

--- a/lib/vfscore/vfs.h
+++ b/lib/vfscore/vfs.h
@@ -685,6 +685,21 @@ int sec_vnode_permission(char *path);
 int namei(const char *path, struct dentry **dpp);
 
 /**
+ * Resolve a pathname into a pointer to a dentry and a realpath.
+ *
+ * @param path
+ *	The full path name
+ * @param[out] dpp
+ *	Dentry to be returned
+ * @param[out] realpath
+ *	if not NULL, return path after resolving all symlinks
+ * @return
+ *	- (0):  Completed successfully
+ *	- (<0): Negative value with error code
+ */
+int namei_resolve(const char *path, struct dentry **dpp, char *realpath);
+
+/**
  * Converts the last component in the path to a pointer to a dentry.
  *
  * @param path


### PR DESCRIPTION
### Description of changes

Previously a vfs syscall on a broken symlink would fail with ENOENT instead of attempting the syscall on the symlink target. This would make open(O_CREAT) to fail instead of creating the missing target file. This change fixes this behavior, bringing it in line with expectations.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Test with:
```
symlink("nonexistent", "broken-link");
int f = open("broken-link", O_WRONLY|O_CREAT, 0644);
if (f < 0) perror("bug in open()");
```