### PR TITLE
lib/vfscore: Initialize stdio file lock

### DIFF
--- a/lib/vfscore/stdio.c
+++ b/lib/vfscore/stdio.c
@@ -221,6 +221,7 @@ static struct vfscore_file  stdio_file = {
 	.f_flags = UK_FWRITE | UK_FREAD,
 	.f_dentry = &stdio_dentry,
 	.f_vfs_flags = UK_VFSCORE_NOPOS,
+	.f_lock = UK_MUTEX_INITIALIZER(stdio_file.f_lock),
 	/* reference count is 2 because close(0) is a valid
 	 * operation. However it is not properly handled in the
 	 * current implementation. */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The code was previously relying on being able to zero initialize the lock structure.

