### PR TITLE
lib/*: Use correct allocator for vfscore_file

### DIFF
--- a/lib/posix-event/epoll.c
+++ b/lib/posix-event/epoll.c
@@ -130,7 +130,7 @@ static int do_epoll_create(struct uk_alloc *a, int flags)
 		goto ERR_MALLOC_FILE;
 	}
 
-	vfs_file = uk_malloc(a, sizeof(struct vfscore_file));
+	vfs_file = malloc(sizeof(struct vfscore_file));
 	if (unlikely(!vfs_file)) {
 		ret = -ENOMEM;
 		goto ERR_MALLOC_VFS_FILE;
@@ -185,7 +185,7 @@ ERR_VFS_INSTALL:
 ERR_ALLOC_DENTRY:
 	vput(vfs_vnode);
 ERR_ALLOC_VNODE:
-	uk_free(a, vfs_file);
+	free(vfs_file);
 ERR_MALLOC_VFS_FILE:
 	uk_free(a, ep);
 ERR_MALLOC_FILE:

--- a/lib/posix-event/eventfd.c
+++ b/lib/posix-event/eventfd.c
@@ -343,7 +343,7 @@ static int do_eventfd(struct uk_alloc *a, unsigned int initval, int flags)
 		goto ERR_MALLOC_FILE;
 	}
 
-	vfs_file = uk_malloc(a, sizeof(struct vfscore_file));
+	vfs_file = malloc(sizeof(struct vfscore_file));
 	if (unlikely(!vfs_file)) {
 		ret = -ENOMEM;
 		goto ERR_MALLOC_VFS_FILE;
@@ -404,7 +404,7 @@ ERR_VFS_INSTALL:
 ERR_ALLOC_DENTRY:
 	vput(vfs_vnode);
 ERR_ALLOC_VNODE:
-	uk_free(a, vfs_file);
+	free(vfs_file);
 ERR_MALLOC_VFS_FILE:
 	uk_free(a, efd);
 ERR_MALLOC_FILE:

--- a/lib/posix-socket/socket_vnops.c
+++ b/lib/posix-socket/socket_vnops.c
@@ -96,7 +96,7 @@ posix_socket_alloc_fd(struct posix_socket_driver *d, int type, void *sock_data)
 		goto ERR_MALLOC_FILE;
 	}
 
-	vfs_file = uk_calloc(d->allocator, 1, sizeof(*vfs_file));
+	vfs_file = calloc(1, sizeof(*vfs_file));
 	if (unlikely(!vfs_file)) {
 		ret = -ENOMEM;
 		goto ERR_MALLOC_VFS_FILE;
@@ -155,7 +155,7 @@ ERR_VFS_INSTALL:
 ERR_ALLOC_DENTRY:
 	vput(vfs_vnode);
 ERR_ALLOC_VNODE:
-	uk_free(d->allocator, vfs_file);
+	free(vfs_file);
 ERR_MALLOC_VFS_FILE:
 	uk_free(d->allocator, sock);
 ERR_MALLOC_FILE:


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

vfscore will always use the default system allocator to free the
structure. This ensures a matching allocate for that.