### PR TITLE
build: Add tree builds

### DIFF
--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -82,17 +82,18 @@ endef
 #
 ################################################################################
 
+# Returns the fully-qualified path for a subfolder under the build output
+# directory
+sub_build_dir = $(addprefix $(BUILD_DIR)/,$(if $($(call uc,$(1))__BUILDTREE),\
+	$(notdir $(1))/build,$(notdir $(1))))
+
 # Creates a subfolder under the build output directory
 # mk_sub_build_dir $1:subfoldername
 define mk_sub_build_dir =
-$(if $(shell $(MKDIR) -p "$(BUILD_DIR)/$(notdir $(1))" && cd "$(BUILD_DIR)/$(notdir $(1))" >/dev/null && pwd),,\
-     $(error could not create directory "$(BUILD_DIR)/$(notdir $(1))"))
+$(eval _d := $(call sub_build_dir,$(1)))\
+$(if $(shell $(MKDIR) -p "$(_d)" && cd "$(_d)" >/dev/null && pwd),,\
+     $(error could not create directory "$(_d)"))
 endef
-
-# Returns the fully-qualified path for a subfolder under the build output
-# directory
-# sub_build_dir $1:subfoldername
-sub_build_dir = $(addprefix $(BUILD_DIR)/,$(notdir $(1)))
 
 # Returns the file extension
 fileext = $(subst .,,$(suffix $(1)))
@@ -269,14 +270,15 @@ define addplatlib_s =
 $(if $(filter y,$(3)),$(call addplatlib,$(1),$(2)),)
 endef
 
+sub_libbuild_dir = $(call sub_build_dir,$(1))/$(strip $(2))
+
 # creates a sub build directory for a library
 # mk_sub_libbuild_dir $1:libname,$2:subdir
 define mk_sub_libbuild_dir =
-$(if $(shell $(MKDIR) -p "$(BUILD_DIR)/$(notdir $(1))/$(strip $(2))" && cd "$(BUILD_DIR)/$(notdir $(1))/$(strip $(2))" >/dev/null && pwd),,\
-     $(error could not create directory "$(BUILD_DIR)/$(notdir $(1))/$(strip $(2))"))
+$(eval _d := $(call sub_libbuild_dir,$(1),$(2)))\
+$(if $(shell $(MKDIR) -p "$(_d)" && cd "$(_d)" >/dev/null && pwd),,\
+     $(error could not create directory "$(_d)"))
 endef
-
-sub_libbuild_dir = $(BUILD_DIR)/$(notdir $(1))/$(strip $(2))
 
 ################################################################################
 #
@@ -432,7 +434,7 @@ $(error $(2): missing extraction rule for archive type)\
 ))))
 UK_FETCH-y += $(BUILD_DIR)/$(1)/.origin \
 $(eval $(call vprefix_lib,$(1),ORIGIN) = $(BUILD_DIR)/$(1)/origin)
-$(call mk_sub_libbuild_dir,$(1),origin)
+$(shell $(MKDIR) -p $(BUILD_DIR)/$(1)/origin)
 
 .PRECIOUS: $(BUILD_DIR)/$(1)/origin
 

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -271,10 +271,23 @@ $(eval $(call uc,$(1))_EXPORTS += $(wildcard $(IMPORT_BASE)/exportsyms.uk))
 $(eval $(call uc,$(1))_LOCALS  += $(wildcard $(IMPORT_BASE)/localsyms.uk))
 endef
 
+# addlib_tree $1:libname
+define addlib_tree =
+$(eval $(call uc,$(1))__BUILDTREE := y)
+$(call addlib,$(1))
+endef
+
 # addlib_s $1:libname,$2:switch
 define addlib_s =
 ifeq ($(2),y)
 $(call addlib,$(1))
+endif
+endef
+
+# addlib_tree_s $1:libname,$2:switch
+define addlib_tree_s =
+ifeq ($(2),y)
+$(call addlib_tree,$(1))
 endif
 endef
 

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -104,17 +104,41 @@ libname2olib = $(addprefix $(BUILD_DIR)/,$(addsuffix .o,$(1)))
 
 libname2preolib = $(addprefix $(BUILD_DIR)/,$(addsuffix .ld.o,$(1)))
 
+# check if $1 is a prefix of $2; expands to $2 if true
+isprefix = $(findstring $(1)$(subst $(1),,$(2)),$(2))
+
+# convert a full path to a source file into a relative path
+# result is relative to $(libname)_SRC, if defined and a prefix of $source
+# otherwise it is the filename of $source
+# srcrelpath $libname,$source
+define srcrelpath =
+$(eval _libsrc := $(if $($(call uc,$(1))__BUILDTREE),$($(call uc,$(1))_SRC)))\
+$(if $(and $(_libsrc),$(call isprefix,$(_libsrc),$(2))),\
+	$(2:$(_libsrc)/%=%),$(notdir $(2)))
+endef
+
+# convert a full path to a build target into a path relative to
+# the build dir of $libname if it is prefix of $target
+# otherwise return the filename of $target
+# targrelpath $libname,$target
+define targrelpath =
+$(eval _libbuild := $(if $($(call uc,$(1))__BUILDTREE),\
+	$(call sub_build_dir,$(1))))\
+$(if $(and $(_libbuild),$(call isprefix,$(_libbuild),$(2))),\
+	$(2:$(_libbuild)/%=%),$(notdir $(2)))
+endef
+
 # converts a list of sources to paths pointing to their corresponding destination files
 # src2dst $1:libname,$2:source(s),$3:destsuffix,$4:variant(optional),$5:subbuild(optional)
 define src2dst =
 $(if $(5),\
 $(if $(4),\
-$(addprefix $(call sub_libbuild_dir,$(1),$(5))/,$(addsuffix .$(4)$(3),$(basename $(notdir $(2))))),\
-$(addprefix $(call sub_libbuild_dir,$(1),$(5))/,$(addsuffix $(3),$(basename $(notdir $(2)))))\
+$(addprefix $(call sub_libbuild_dir,$(1),$(5))/,$(addsuffix .$(4)$(3),$(basename $(call srcrelpath,$(1),$(2))))),\
+$(addprefix $(call sub_libbuild_dir,$(1),$(5))/,$(addsuffix $(3),$(basename $(call srcrelpath,$(1),$(2)))))\
 ),\
 $(if $(4),\
-$(addprefix $(call sub_build_dir,$(strip $(1)))/,$(addsuffix .$(4)$(3),$(basename $(notdir $(2))))),\
-$(addprefix $(call sub_build_dir,$(strip $(1)))/,$(addsuffix $(3),$(basename $(notdir $(2)))))\
+$(addprefix $(call sub_build_dir,$(strip $(1)))/,$(addsuffix .$(4)$(3),$(basename $(call srcrelpath,$(1),$(2))))),\
+$(addprefix $(call sub_build_dir,$(strip $(1)))/,$(addsuffix $(3),$(basename $(call srcrelpath,$(1),$(2)))))\
 ))
 endef
 
@@ -139,12 +163,12 @@ src2dep = $(call out2dep,$(call src2obj,$(1),$(2),$(3),$(4)))
 define src2lds =
 $(if $(4),\
 $(if $(3),\
-$(addprefix $(call sub_libbuild_dir,$(1),$(4))/,$(addsuffix .$(3).lds,$(basename $(basename $(notdir $(2)))))),\
-$(addprefix $(call sub_libbuild_dir,$(1),$(4))/,$(addsuffix .lds,$(basename $(basename $(notdir $(2))))))\
+$(addprefix $(call sub_libbuild_dir,$(1),$(4))/,$(addsuffix .$(3).lds,$(basename $(basename $(call srcrelpath,$(1),$(2)))))),\
+$(addprefix $(call sub_libbuild_dir,$(1),$(4))/,$(addsuffix .lds,$(basename $(basename $(call srcrelpath,$(1),$(2))))))\
 ),\
 $(if $(3),\
-$(addprefix $(call sub_build_dir,$(1))/,$(addsuffix .$(3).lds,$(basename $(basename $(notdir $(2)))))),\
-$(addprefix $(call sub_build_dir,$(1))/,$(addsuffix .lds,$(basename $(basename $(notdir $(2))))))\
+$(addprefix $(call sub_build_dir,$(1))/,$(addsuffix .$(3).lds,$(basename $(basename $(call srcrelpath,$(1),$(2)))))),\
+$(addprefix $(call sub_build_dir,$(1))/,$(addsuffix .lds,$(basename $(basename $(call srcrelpath,$(1),$(2))))))\
 ))
 endef
 
@@ -152,8 +176,8 @@ endef
 # dts2dtb $1:libname,$2:dts,$subbuild(optional)
 define dts2dtb =
 $(if $(3),\
-$(addprefix $(call sub_libbuild_dir,$(1),$(3))/,$(addsuffix .dtb,$(basename $(notdir $(2))))),
-$(addprefix $(call sub_build_dir,$(1))/,$(addsuffix .dtb,$(basename $(notdir $(2)))))
+$(addprefix $(call sub_libbuild_dir,$(1),$(3))/,$(addsuffix .dtb,$(basename $(call srcrelpath,$(1),$(2))))),
+$(addprefix $(call sub_build_dir,$(1))/,$(addsuffix .dtb,$(basename $(call srcrelpath,$(1),$(2)))))
 )
 endef
 
@@ -300,7 +324,9 @@ endif
 # Writes to a file during deferred expansion
 #
 # write_file_deferred $1:filepath,$2:content
-write_file_deferred = $(if $(UK_DEFERRED_EXPANSION),$(file > $(1),$(2)),$$(file > $(1),$(2)))
+write_file_deferred = $(if $(UK_DEFERRED_EXPANSION),\
+	$(shell $(MKDIR) -p $(dir $(1)))$(file > $(1),$(2)),\
+	$$(shell $(MKDIR) -p $(dir $(1)))$$(file > $(1),$(2)))
 
 # Calls a command that creates an object
 #
@@ -308,18 +334,18 @@ write_file_deferred = $(if $(UK_DEFERRED_EXPANSION),$(file > $(1),$(2)),$$(file 
 ifeq ($(CONFIG_RECORD_BUILDTIME_TIME),y)
 define build_cmd =
 $(call write_file_deferred,$(addsuffix .cmd,$(3)),$(strip $(4)))\
-$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)),$(TIME) $(TIMEFLAGS) -o $(addsuffix .time,$(3)) $(SHELL) $(addsuffix .cmd,$(3)))
+$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(strip $(call targrelpath,$(2),$(3))),$(TIME) $(TIMEFLAGS) -o $(addsuffix .time,$(3)) $(SHELL) $(addsuffix .cmd,$(3)))
 endef
 else
 ifeq ($(CONFIG_RECORD_BUILDTIME_LIFTOFF),y)
 define build_cmd =
 $(call write_file_deferred,$(addsuffix .cmd,$(3)),$(strip $(4)))\
-$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)),$(LIFTOFF) $(LITFOFFFLAGS) -o $(addsuffix .liftoff,$(3)) -- $(SHELL) $(addsuffix .cmd,$(3)))
+$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(strip $(call targrelpath,$(2),$(3))),$(LIFTOFF) $(LITFOFFFLAGS) -o $(addsuffix .liftoff,$(3)) -- $(SHELL) $(addsuffix .cmd,$(3)))
 endef
 else
 define build_cmd =
 $(call write_file_deferred,$(addsuffix .cmd,$(3)),$(strip $(4)))\
-$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(notdir $(3)), $(SHELL) $(addsuffix .cmd,$(3)))
+$(call verbose_cmd,$(1),$(if $(2),$(2)':' ,)$(strip $(call targrelpath,$(2),$(3))), $(SHELL) $(addsuffix .cmd,$(3)))
 endef
 endif
 endif


### PR DESCRIPTION
### Description of changes

This PR adds tree builds -- builds that plate the products in a directory tree mirroring the source files.
The root of this source tree relative to which source files are considered is taken from the `$(LIBNAME)_SRC` make variable, if present.
This feature is most useful in libraries with many files sharing the same basename (e.g. sources named after class names). 

It consists of 3 commits:
- Add a separate `build/` directory to place the build tree in (so source directories won't conflict with unikraft files); this feature is active if `$(LIBNAME)_BUILDTREE` is set to `y`.
- Adapt path processing functions to retain source hierarchy when `$(LIBNAME)_BUILDTREE` is set to `y`.
- Add make functions `addlib_tree` and `addlib_tree_s` that automate setting `$(LIBNAME)_BUILDTREE`.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Use addlib_tree[_s] to register a treebuild library.

