### PR TITLE
Makefile: Allow external Makefile.build and Provide GO 1.18 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -582,7 +582,7 @@ LD		:= $(CONFIG_CROSS_COMPILE)$(CONFIG_COMPILER)
 CC		:= $(CONFIG_CROSS_COMPILE)$(CONFIG_COMPILER)
 CPP		:= $(CC)
 CXX		:= $(CPP)
-GOC		:= $(CONFIG_CROSS_COMPILE)gccgo-7
+GOC		:= $(CONFIG_CROSS_COMPILE)gccgo
 # We use rustc because the gcc frontend is experimental and missing features such
 # as borrowing checking
 ifneq ("$(origin LLVM_TARGET_ARCH)","undefined")

--- a/lib/posix-mmap/Config.uk
+++ b/lib/posix-mmap/Config.uk
@@ -2,7 +2,6 @@ menuconfig LIBPOSIX_MMAP
 	bool "posix-mmap: Memory mapping related functions"
 	default n
 	depends on LIBUKVMEM
-	depends on !LIBUKMMAP
 	help
 		This library implements memory mapping related functions such
 		as mmap() and munmap().

--- a/lib/ukmmap/Config.uk
+++ b/lib/ukmmap/Config.uk
@@ -3,6 +3,7 @@ menuconfig LIBUKMMAP
 	default n
 	select LIBNOLIBC if !HAVE_LIBC
 	select LIBUKALLOC
+	depends on !LIBPOSIX_MMAP
 
 if LIBUKMMAP
 

--- a/support/build/Makefile.build
+++ b/support/build/Makefile.build
@@ -38,6 +38,11 @@ $(call verbose_info,Warning: '$(L)' has no sources or object files$(comma) ignor
 )
 endif
 
+$(foreach _M,$(wildcard $(addsuffix Makefile.build,\
+	   $(CONFIG_UK_BASE)/lib/*/ $(CONFIG_UK_BASE)/plat/*/ \
+	   $(addsuffix /,$(ELIB_DIR)) $(APP_DIR)/)), \
+		$(eval $(call verbose_include,$(_M))) \
+)
 
 #################################################
 #


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR is part of a series of PRs that work in conjunction for the update of Go support to 1.18:

- https://github.com/unikraft/lib-libgo/pull/7
- https://github.com/unikraft/unikraft/pull/1005
- https://github.com/unikraft/lib-musl/pull/67
- https://github.com/unikraft/app-helloworld-go/pull/9
- https://github.com/unikraft/lib-compiler-rt/pull/16
- https://github.com/unikraft/lib-musl/pull/52

For testing, make sure to pass to QEMU the `-cpu host` argument (this is necessary because the paging API and ukvmem are required by `libgo` as part of Virtual Address space management, and somehow the default CPU just won't handle 1GB pages).

Only GCC12 and x86 is supported for the moment.