### PR TITLE
CI: Add lib-libc-test for pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: libc functional test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - staging
+
+jobs:
+  lib-libc-test:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run tests
+        uses: unikraft/test-workflows@unikraft_libc-test


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Added `lib-libc-test` as a regression test. In each pull request, it will check if the PR would break existing libc compatibility, and if so, it will prevent the merge.

This PR is just a trigger; for the specific implementation, please refer to [1].

[1] https://github.com/unikraft/test-workflows/tree/unikraft_libc-test
