### PR TITLE
arch/arm64: Support AArch64 binary syscalls

### DIFF
--- a/arch/arm/arm64/include/uk/asm/traps.h
+++ b/arch/arm/arm64/include/uk/asm/traps.h
@@ -64,3 +64,5 @@ struct ukarch_trap_ctx {
 #define UKARCH_TRAP_MATH		trap_math
 
 #define UKARCH_TRAP_SECURITY		trap_security
+
+#define UKARCH_TRAP_SYSCALL		trap_syscall

--- a/lib/syscall_shim/Config.uk
+++ b/lib/syscall_shim/Config.uk
@@ -28,7 +28,7 @@ if LIBSYSCALL_SHIM
 	config LIBSYSCALL_SHIM_HANDLER
 		bool "Binary system call handler (Linux ABI)"
 		default n
-		depends on ARCH_X86_64
+		depends on (ARCH_X86_64 || ARCH_ARM_64)
 		select HAVE_SYSCALL
 		help
 			Enables a system call handler for binary system call

--- a/lib/syscall_shim/arch/regmap_linuxabi.h
+++ b/lib/syscall_shim/arch/regmap_linuxabi.h
@@ -25,8 +25,8 @@
 #define rret0		rax
 #define rret1		rdx
 
-#elif (defined __ARM64__)
-#define rip		x[15] /* TODO: Is this correct? */
+#elif (defined __ARM_64__)
+#define rip		elr_el1
 #define rsyscall	x[8]
 #define rarg0		x[0]
 #define rarg1		x[1]

--- a/plat/common/arm/traps_arm64.c
+++ b/plat/common/arm/traps_arm64.c
@@ -50,6 +50,7 @@ enum aarch64_trap {
 	AARCH64_TRAP_BUS_ERROR,
 	AARCH64_TRAP_MATH,
 	AARCH64_TRAP_SECURITY,
+	AARCH64_TRAP_SYSCALL,
 
 	AARCH64_TRAP_MAX
 };
@@ -99,6 +100,7 @@ DECLARE_TRAP_EVENT(UKARCH_TRAP_PAGE_FAULT);
 DECLARE_TRAP_EVENT(UKARCH_TRAP_BUS_ERROR);
 DECLARE_TRAP_EVENT(UKARCH_TRAP_MATH);
 DECLARE_TRAP_EVENT(UKARCH_TRAP_SECURITY);
+DECLARE_TRAP_EVENT(UKARCH_TRAP_SYSCALL);
 
 static const struct {
 	struct uk_event *event;
@@ -109,7 +111,8 @@ static const struct {
 	{ UK_EVENT_PTR(UKARCH_TRAP_PAGE_FAULT), "page fault"     },
 	{ UK_EVENT_PTR(UKARCH_TRAP_BUS_ERROR),  "bus error"      },
 	{ UK_EVENT_PTR(UKARCH_TRAP_MATH),       "floating point" },
-	{ UK_EVENT_PTR(UKARCH_TRAP_SECURITY),   "security"       }
+	{ UK_EVENT_PTR(UKARCH_TRAP_SECURITY),   "security"       },
+	{ UK_EVENT_PTR(UKARCH_TRAP_SYSCALL),    "system call"    }
 };
 
 static enum aarch64_trap esr_to_trap(__u64 esr)
@@ -118,6 +121,9 @@ static enum aarch64_trap esr_to_trap(__u64 esr)
 
 	/* We expect Unikraft to run in EL1. So do not catch traps from EL0. */
 	switch (ESR_EC_FROM(esr)) {
+	case ESR_EL1_EC_SVC64:
+		return AARCH64_TRAP_SYSCALL;
+
 	case ESR_EL1_EC_MMU_IABRT_EL1:
 	case ESR_EL1_EC_MMU_DABRT_EL1:
 		fsc = ESR_ISS_ABRT_FSC_FROM(ESR_ISS_FROM(esr));
@@ -215,3 +221,19 @@ void trap_el1_irq(struct __regs *regs)
 
 	gic->ops.handle_irq(regs);
 }
+
+#ifdef CONFIG_LIBSYSCALL_SHIM
+
+extern void ukplat_syscall_handler(struct __regs *r);
+
+static int arm64_syscall_adapter(void *data)
+{
+	struct ukarch_trap_ctx *ctx = (struct ukarch_trap_ctx *)data;
+
+	ukplat_syscall_handler(ctx->regs);
+	return 1; /* Success */
+}
+
+UK_EVENT_HANDLER(UKARCH_TRAP_SYSCALL, arm64_syscall_adapter);
+
+#endif /* CONFIG_LIBSYSCALL_SHIM */

--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -1,7 +1,7 @@
 menuconfig PLAT_KVM
 	bool "KVM guest"
 	default n
-	depends on (ARCH_X86_64 || (ARCH_ARM_64 && !HAVE_SYSCALL))
+	depends on (ARCH_X86_64 || ARCH_ARM_64)
 	select LIBUKDEBUG
 	select LIBUKALLOC
 	select LIBUKTIMECONV


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `AArch64`
 - Platform(s): `kvm`

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

A interrupt handler is provided to redirect the interrupts generated by syscalls to the `syscall-shim` layer.
