### PR TITLE
plat/{linuxu,xen}: Do not enable interrupts before halt

### DIFF
--- a/plat/linuxu/irq.c
+++ b/plat/linuxu/irq.c
@@ -93,9 +93,7 @@ void ukplat_lcpu_halt_irq(void)
 {
 	UK_ASSERT(ukplat_lcpu_irqs_disabled());
 
-	ukplat_lcpu_enable_irq();
 	halt();
-	ukplat_lcpu_disable_irq();
 }
 
 int ukplat_lcpu_irqs_disabled(void)

--- a/plat/xen/lcpu.c
+++ b/plat/xen/lcpu.c
@@ -58,9 +58,7 @@ void ukplat_lcpu_halt_irq(void)
 {
 	UK_ASSERT(ukplat_lcpu_irqs_disabled());
 
-	ukplat_lcpu_enable_irq();
 	halt();
-	ukplat_lcpu_disable_irq();
 }
 
 unsigned long ukplat_lcpu_save_irqf(void)


### PR DESCRIPTION
### Prerequisite checklist


 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`, `arm64`
 - Platform(s): `xen`, `linuxu`
 - Application(s): N/A


### Additional configuration

None.

### Description of changes

Based on #980. While working on #980, I noticed both `linuxu` and `xen` also enable the interrupts before the halt, which will most likely lead to the same problem as on arm64.
