### PR TITLE
plat/kvm/x86: Fix build error due to missing `assert.h` header

### DIFF
--- a/plat/kvm/x86/lcpu.c
+++ b/plat/kvm/x86/lcpu.c
@@ -32,6 +32,7 @@
  */
 
 #include <stdint.h>
+#include <uk/assert.h>
 #include <uk/plat/lcpu.h>
 #include <x86/irq.h>
 


### PR DESCRIPTION
Once the commit
dbfb886b5312 ("plat: Ensure IRQ's disabled in `ukplat_lcpu_halt_irq`") got merged, a new build error appeared:
```
 E  /usr/bin/ld: /github/workspace/_helloworld/.unikraft/build/libkvmplat.o: in function `ukplat_lcpu_halt_irq':
 E  /github/workspace/plat/kvm/x86/lcpu.c:50: undefined reference to `UK_ASSERT'
 E  collect2: error: ld returned 1 exit status
```

This happened due to `uk/assert.h` not being included.

Github-Fixes: #980

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`,
 - Application(s):


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
