### PR TITLE
plat/*: Signal shutdown cause on QEMU

### DIFF
--- a/plat/common/arm/cpu_native.c
+++ b/plat/common/arm/cpu_native.c
@@ -66,7 +66,7 @@ void reset(void)
 }
 
 /* Systems support PSCI >= 0.2 can do system off from PSCI */
-void system_off(void)
+void system_off(enum ukplat_gstate request __unused)
 {
 	struct smccc_args smccc_arguments = {0};
 

--- a/plat/common/include/arm/arm64/cpu.h
+++ b/plat/common/include/arm/arm64/cpu.h
@@ -35,6 +35,7 @@
 
 #include <inttypes.h>
 #include <uk/essentials.h>
+#include <uk/plat/bootstrap.h>
 #include <uk/alloc.h>
 #include <uk/assert.h>
 #include <arm/smccc.h>
@@ -57,7 +58,7 @@ extern smccc_conduit_fn_t smccc_psci_call;
 /* CPU native APIs */
 void halt(void);
 void reset(void);
-void system_off(void);
+void system_off(enum ukplat_gstate request);
 #ifdef CONFIG_HAVE_SMP
 int cpu_on(__lcpuid id, __paddr_t entry, void *arg);
 #endif /* CONFIG_HAVE_SMP */

--- a/plat/common/include/x86/cpu.h
+++ b/plat/common/include/x86/cpu.h
@@ -38,7 +38,7 @@
 #include <string.h>
 
 void halt(void);
-void system_off(void);
+void system_off(enum ukplat_gstate request);
 
 static inline void cpuid(__u32 fn, __u32 subfn,
 			 __u32 *eax, __u32 *ebx,

--- a/plat/common/x86/cpu_native.c
+++ b/plat/common/x86/cpu_native.c
@@ -46,7 +46,26 @@ unsigned long read_cr2(void)
 	return cr2;
 }
 
-void system_off(void)
+#ifdef CONFIG_KVM_VMM_QEMU
+
+/* The port used by QEMU by default for the isa-debug-exit device */
+#define QEMU_ISA_DEBUG_EXIT_PORT	0x501
+/* This corresponds to an 83 (41 << 1 | 1) return value from QEMU */
+#define QEMU_ISA_DEBUG_EXIT_NO_CRASH	41
+/* This corresponds to an 85 (42 << 1 | 1) return value from QEMU */
+#define QEMU_ISA_DEBUG_EXIT_CRASH	42
+
+/**
+ * Trigger an exit() in QEMU with the code `value << 1 | 1`.
+ * @param value the value used in the calculation of the exit code
+ */
+static void qemu_debug_exit(int value)
+{
+	outw(QEMU_ISA_DEBUG_EXIT_PORT, value);
+}
+#endif /* CONFIG_KVM_VMM_QEMU */
+
+void system_off(enum ukplat_gstate request __maybe_unused)
 {
 #ifdef CONFIG_KVM_VMM_FIRECRACKER
 	/* Trigger the reset line via the PS/2 controller. On firecracker
@@ -54,6 +73,16 @@ void system_off(void)
 	 */
 	outb(0x64, 0xFE);
 #endif /* CONFIG_KVM_VMM_FIRECRACKER */
+
+#ifdef CONFIG_KVM_VMM_QEMU
+	/* If we are crashing, then try to exit QEMU with the isa-debug-exit
+	 * device.
+	 * Should be harmless if it is not present. This is used to enable
+	 * automated tests on virtio.
+	 */
+	if (request == UKPLAT_CRASH)
+		qemu_debug_exit(QEMU_ISA_DEBUG_EXIT_CRASH);
+#endif /* CONFIG_KVM_VMM_QEMU */
 
 	/*
 	 * Perform an ACPI shutdown by writing (SLP_TYPa | SLP_EN) to PM1a_CNT.
@@ -64,11 +93,11 @@ void system_off(void)
 	 */
 	outw(0x604, 0x2000);
 
+#ifdef CONFIG_KVM_VMM_QEMU
 	/*
 	 * If that didn't work for whatever reason, try poking the QEMU
-	 * "isa-debug-exit" device to "shutdown". Should be harmless if it is
-	 * not present. This is used to enable automated tests on virtio.  Note
-	 * that the actual QEMU exit() status will be 83 ('S', 41 << 1 | 1).
+	 * "isa-debug-exit" device to "shutdown".
 	 */
-	outw(0x501, 41);
+	qemu_debug_exit(QEMU_ISA_DEBUG_EXIT_NO_CRASH);
+#endif /* CONFIG_KVM_VMM_QEMU */
 }

--- a/plat/kvm/shutdown.c
+++ b/plat/kvm/shutdown.c
@@ -30,12 +30,12 @@
 static void cpu_halt(void) __noreturn;
 
 /* TODO: implement CPU reset */
-void ukplat_terminate(enum ukplat_gstate request __unused)
+void ukplat_terminate(enum ukplat_gstate request)
 {
 	uk_pr_info("Unikraft halted\n");
 
 	/* Try to make system off */
-	system_off();
+	system_off(request);
 
 	/*
 	 * If we got here, there is no way to initiate "shutdown" on virtio


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
This uses the `isa-debug-exit` device to pass an exit code to QEMU. By default this device is not available but can be enabled using the `-device isa-debug-exit` switch on the QEMU command-line.

@craciunoiuc @nderjung 
