### PR TITLE
lib/ukdebug: Add colorless `LVLC_THREAD` macro

### DIFF
--- a/lib/ukdebug/print.c
+++ b/lib/ukdebug/print.c
@@ -76,6 +76,7 @@
 #define LVLC_RESET	""
 #define LVLC_TS		""
 #define LVLC_CALLER	""
+#define LVLC_THREAD	""
 #define LVLC_LIBNAME	""
 #define LVLC_SRCNAME	""
 #define LVLC_DEBUG	""


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

- `CONFIG_LIBUKDEBUG=y`
- `CONFIG_LIBUKDEBUG_PRINT_THREAD=y`
- `CONFIG_LIBUKDEBUG_ANSI_COLOR=n`

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Choosing to print thread identifier fails at build time when the `CONFIG_LIBUKDEBUG_ANSI_COLOR` option is not selected. This is due to the fact that `LVLC_THREAD` is defined only with colored output:

```Makefile
/home/maria/arm/unikraft/lib/ukdebug/print.c:143:69: error: expected ‘)’ before ‘LVLC_THREAD’
  143 |                         len = __uk_snprintf(buf, BUFLEN, LVLC_RESET LVLC_THREAD
      |                                                                     ^~~~~~~~~~~
```
    
As a result, we define this macro with an empty string even when `CONFIG_LIBUKDEBUG_ANSI_COLOR` is not set.

