### PR TITLE
plat/common: Add support for pvpanic devices for x86

### DIFF
--- a/plat/common/x86/cpu_native.c
+++ b/plat/common/x86/cpu_native.c
@@ -55,6 +55,13 @@ unsigned long read_cr2(void)
 /* This corresponds to an 85 (42 << 1 | 1) return value from QEMU */
 #define QEMU_ISA_DEBUG_EXIT_CRASH	42
 
+/* The port used by QEMU by default for the pvpanic device */
+#define QEMU_PVPANIC_EXIT_PORT		0x505
+/* This corresponds to a GUEST_PANICKED event for QEMU */
+#define QEMU_PVPANIC_GUEST_PANICKED	(1 << 0)
+/* This corresponds to a GUEST_CRASHLOADED event for QEMU */
+#define QEMU_PVPANIC_GUEST_CRASHLOADED	(1 << 1)
+
 /**
  * Trigger an exit() in QEMU with the code `value << 1 | 1`.
  * @param value the value used in the calculation of the exit code
@@ -79,9 +86,13 @@ void system_off(enum ukplat_gstate request __maybe_unused)
 	 * device.
 	 * Should be harmless if it is not present. This is used to enable
 	 * automated tests on virtio.
+	 * Also send a panic request to the pvpanic device.
+	 * Should be also harmless and helps with automated tests.
 	 */
-	if (request == UKPLAT_CRASH)
+	if (request == UKPLAT_CRASH) {
 		qemu_debug_exit(QEMU_ISA_DEBUG_EXIT_CRASH);
+		outb(QEMU_PVPANIC_EXIT_PORT, QEMU_PVPANIC_GUEST_PANICKED);
+	}
 #endif /* CONFIG_KVM_VMM_QEMU */
 
 	/*


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

Use `-device pvpanic` when testing with `qemu-system-x86_64`.

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Unikraft already offers exit codes through the ISA device, but these
are only a convention and are not understood by QEMU itself.

When using `-device pvpanic`, a GUEST_PANICKED event[1] is sent to QEMU
when the unikernel crashes.
This event can be seen when using QMP[1] for example.
The bits corresponding to each even are set as per the documentation[2].

The main usage of this is in kraftkit where unikernels are detached
and exit codes are lost.
Using this can signal when the unikernel crashes.

[1] https://qemu-project.gitlab.io/qemu/interop/qemu-qmp-ref.html#qapidoc-152
[2] https://github.com/qemu/qemu/blob/master/docs/specs/pvpanic.txt