### PR TITLE
Makefile: Include Makefile.build from main Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -716,6 +716,11 @@ endif
 
 # Generate build rules
 $(eval $(call verbose_include,$(CONFIG_UK_BASE)/support/build/Makefile.build))
+$(foreach _M,$(wildcard $(addsuffix Makefile.build,\
+	   $(CONFIG_UK_BASE)/lib/*/ $(CONFIG_UK_BASE)/plat/*/ \
+	   $(addsuffix /,$(ELIB_DIR)) $(APP_DIR)/)), \
+		$(eval $(call verbose_include,$(_M))) \
+)
 
 # Include source dependencies
 ifneq ($(call qstrip,$(UK_DEPS) $(UK_DEPS-y)),)

--- a/support/build/Makefile.build
+++ b/support/build/Makefile.build
@@ -38,11 +38,6 @@ $(call verbose_info,Warning: '$(L)' has no sources or object files$(comma) ignor
 )
 endif
 
-$(foreach _M,$(wildcard $(addsuffix Makefile.build,\
-	   $(CONFIG_UK_BASE)/lib/*/ $(CONFIG_UK_BASE)/plat/*/ \
-	   $(addsuffix /,$(ELIB_DIR)) $(APP_DIR)/)), \
-		$(eval $(call verbose_include,$(_M))) \
-)
 
 #################################################
 #


### PR DESCRIPTION
This PR ensures that the inclusion of sub-'Makefile.build' is done with the main Makefile. This is done for consistency reasons. This basically adopts commit db20b80c47b2 ("Makefile: Allow external Makefile.build") from GitHub PR #1005.