### PR TITLE
lib/nolibc: Fix compiler warning for `(f)scanf()` prototypes

### DIFF
--- a/lib/nolibc/include/stdio.h
+++ b/lib/nolibc/include/stdio.h
@@ -78,8 +78,8 @@ int  printf(const char *fmt, ...)                           __printf(1, 2);
 int vsscanf(const char *str, const char *fmt, va_list ap);
 int  sscanf(const char *str, const char *fmt, ...)          __scanf(2, 3);
 
-int scanf(const char *fmt, ...);                            __scanf(1, 2);
-int fscanf(FILE *fp, const char *fmt, ...);                 __scanf(2, 3); 
+int scanf(const char *fmt, ...)                             __scanf(1, 2);
+int fscanf(FILE *fp, const char *fmt, ...)                  __scanf(2, 3);
 
 int vasprintf(char **str, const char *fmt, va_list ap);
 int  asprintf(char **str, const char *fmt, ...)             __printf(2, 3);


### PR DESCRIPTION
This PR fixes a compiler warning about empty declarations introduced with commit e622c0043f50 ("lib/nolibc: scanf and fscanf functions").