### PR TITLE
.github/workflows: Fix missing dependency to `LIBCOMPILER_RT`

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -86,6 +86,8 @@ jobs:
               kconfig:
                 CONFIG_MUSL: "y"
                 CONFIG_LIBMUSL_COMPLEX: "y"
+            compiler-rt:
+              version: staging
           targets:
           - platform: ${{ matrix.plat }}
             architecture: ${{ matrix.arch }}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [all]
 - Platform(s): [all]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Following the merge of [0], the use of complex numbers requires the
external microlibrary `compiler-rt`[1].  Without this inclusion, builds
that set `CONFIG_LIBMUSL_COMPLEX` will fail.

[0]: https://github.com/unikraft/lib-musl/pull/64
[1]: https://github.com/unikraft/lib-compiler-rt

