### PR TITLE
plat/common/x86: Fix `libukreloc` error for non-`PIE` `SMP` builds

### DIFF
--- a/plat/common/x86/lcpu.c
+++ b/plat/common/x86/lcpu.c
@@ -51,9 +51,7 @@
 #include <string.h>
 #include <errno.h>
 
-#if CONFIG_LIBUKRELOC
 #include "start16_helpers.h"
-#endif /* CONFIG_LIBUKRELOC */
 
 __lcpuid lcpu_arch_id(void)
 {

--- a/plat/common/x86/start16_helpers.h
+++ b/plat/common/x86/start16_helpers.h
@@ -14,6 +14,7 @@ extern void *x86_start16_end[];
 #define X86_START16_SIZE						\
 	((__uptr)x86_start16_end - (__uptr)x86_start16_begin)
 
+#if CONFIG_LIBUKRELOC
 #define START16_UKRELOC_MOV_SYM(sym, sz)				\
 	sym##_uk_reloc_imm##sz##_start16
 
@@ -36,5 +37,6 @@ extern void *x86_start16_end[];
 	UKRELOC_ENTRY(START16_UKRELOC_##type##_OFF(sym, sz),		\
 		       (void *)sym - (void *)x86_start16_begin,		\
 		       sz, UKRELOC_FLAGS_PHYS_REL)
+#endif /* CONFIG_LIBUKRELOC */
 
 #endif  /* __START16_HELPERS_H__ */


### PR DESCRIPTION
After the merge of
commit cf8cc65cb0ae ("plat/kvm/x86: Make SMP init code resolve its own `start16` relocations") SMP builds that were not built with `libukreloc` would fail due to external references to `x86_start16_*` symbols no longer being declared.

Thus, fix this by making their declaration present regardless of `CONFIG_LIBUKRELOC` being enabled or not. Furthermore, guard the no longer necessary `START16_UKRELOC_*` macro's, as they are not needed if the previously mentioned configuration is not enabled.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
