### PR TITLE
plat/kvm: Add configuration hint for EFI

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -100,10 +100,14 @@ config OPTIMIZE_LTO
 		Unikraft binaries.
 
 config OPTIMIZE_PIE
-	bool "Build the Unikernel as a static PIE"
+	bool "Static-PIE - Position-independent binary"
 	select LIBUKRELOC
+	default n
 	help
-		Build the Unikernel as a static PIE.
+		Creates a position independent binary. Such a Unikernel binary does
+		not have to be placed at a fixed location in the virtual address
+		space by a loader. Some loaders even assume that kernel entrance is
+		relocatable (e.g., EFI).
 
 choice
 	prompt "Debug information level"

--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -15,7 +15,7 @@ menuconfig PLAT_KVM
 if (PLAT_KVM)
 
 choice
-	prompt "Booting environment"
+	prompt "Boot protocol"
 
 config KVM_BOOT_PROTO_MULTIBOOT
 	bool "Multiboot"
@@ -43,6 +43,8 @@ config KVM_BOOT_EFI_STUB
 	help
 		Make Unikraft bootable by UEFI firmware
 
+comment "Hint: EFI stub depends on OPTIMIZE_PIE"
+	depends on !OPTIMIZE_PIE && !KVM_VMM_FIRECRACKER
 endchoice
 
 if KVM_BOOT_EFI_STUB


### PR DESCRIPTION
This PR adds a configuration hint for EFI to inform that `OPTIMIZE_PIE` needs to be enabled.
Additionally, this PR adds a description of the `OPTIMIZE_PIE` configuration option.
This is done for improving the user experience.