### PR TITLE
plat/kvm: Fix guest hang on `UKPLAT_HALT` during shutdown request

### DIFF
--- a/plat/kvm/shutdown.c
+++ b/plat/kvm/shutdown.c
@@ -59,10 +59,6 @@ void ukplat_terminate(enum ukplat_gstate request)
 	uk_pr_info("Unikraft halted\n");
 
 	switch (request) {
-	case UKPLAT_HALT:
-		cpu_halt();
-
-		break;
 	case UKPLAT_RESTART:
 		uk_efi_rs_reset_system(UK_EFI_RESET_COLD);
 


### PR DESCRIPTION
As soon as
commit 170a8a4fb242 ("plat/kvm/shutdown.c: If on a `UEFI` system, rely on Runtime Services") got merged guests would not finish on successful runs by exiting, but instead by halting.

Although confusing, the intention was to use `UKPLAT_HALT` for a graceful shutdown instead of a `cpu_halt` as it acts now.

Therefore, fix this by deleting the `UKPLAT_HALT` `case` from the `switch` statement.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
