### PR TITLE
lib/nolibc: Provide symbols for `malloc`, `free`, `calloc`, `realloc`...

### DIFF
--- a/lib/nolibc/include/stdlib.h
+++ b/lib/nolibc/include/stdlib.h
@@ -63,58 +63,15 @@ int atoi(const char *s);
 long atol(const char *s);
 
 #if CONFIG_LIBUKALLOC
-/* Allocate size bytes of memory. Returns pointer to start of allocated memory,
- * or NULL on failure.
- */
-static inline void *malloc(size_t size)
-{
-	return uk_malloc(uk_alloc_get_default(), size);
-}
 
-/* Release memory previously allocated by malloc(). ptr must be a pointer
- * previously returned by malloc(), otherwise undefined behavior will occur.
- */
-static inline void free(void *ptr)
-{
-	return uk_free(uk_alloc_get_default(), ptr);
-}
+void *malloc(size_t size);
+void free(void *ptr);
+void *calloc(size_t nmemb, size_t size);
+void *realloc(void *ptr, size_t size);
+int posix_memalign(void **memptr, size_t align, size_t size);
+void *memalign(size_t align, size_t size);
 
-/* Allocate memory for an array of nmemb elements of size bytes. Returns
- * pointer to start of allocated memory, or NULL on failure.
- */
-static inline void *calloc(size_t nmemb, size_t size)
-{
-	return uk_calloc(uk_alloc_get_default(), nmemb, size);
-}
-
-/* Change the size of the memory block pointed to by ptr to size bytes.
- * Returns a pointer to the resized memory area. If the area pointed to was
- * moved, a free(ptr) is done.
- */
-static inline void *realloc(void *ptr, size_t size)
-{
-	return uk_realloc(uk_alloc_get_default(), ptr, size);
-}
-
-/* Allocate size bytes of memory, aligned to align bytes, and return the
- * pointer to that area in *memptr. Returns 0 on success, and a non-zero error
- * value on failure.
- */
-static inline int posix_memalign(void **memptr, size_t align, size_t size)
-{
-	return uk_posix_memalign(uk_alloc_get_default(),
-				 memptr, align, size);
-}
-
-/* Allocate size bytes of memory, aligned to align bytes. Returns pointer to
- * start of allocated memory, or NULL on failure.
- */
-static inline void *memalign(size_t align, size_t size)
-{
-	return uk_memalign(uk_alloc_get_default(), align, size);
-}
 #endif /* CONFIG_LIBUKALLOC */
-
 void abort(void) __noreturn;
 
 void exit(int status) __noreturn;

--- a/lib/nolibc/stdlib.c
+++ b/lib/nolibc/stdlib.c
@@ -61,6 +61,60 @@
 
 #define __DECONST(type, var) ((type)(uintptr_t)(const void *)(var))
 
+
+#if CONFIG_LIBUKALLOC
+/* Allocate size bytes of memory. Returns pointer to start of allocated memory,
+ * or NULL on failure.
+ */
+void *malloc(size_t size)
+{
+	return uk_malloc(uk_alloc_get_default(), size);
+}
+
+/* Release memory previously allocated by malloc(). ptr must be a pointer
+ * previously returned by malloc(), otherwise undefined behavior will occur.
+ */
+void free(void *ptr)
+{
+	return uk_free(uk_alloc_get_default(), ptr);
+}
+
+/* Allocate memory for an array of nmemb elements of size bytes. Returns
+ * pointer to start of allocated memory, or NULL on failure.
+ */
+void *calloc(size_t nmemb, size_t size)
+{
+	return uk_calloc(uk_alloc_get_default(), nmemb, size);
+}
+
+/* Change the size of the memory block pointed to by ptr to size bytes.
+ * Returns a pointer to the resized memory area. If the area pointed to was
+ * moved, a free(ptr) is done. If the call fails, the memory remains unchanged
+ */
+void *realloc(void *ptr, size_t size)
+{
+	return uk_realloc(uk_alloc_get_default(), ptr, size);
+}
+
+/* Allocate size bytes of memory, aligned to align bytes, and return the
+ * pointer to that area in *memptr. Returns 0 on success, and a non-zero error
+ * value on failure.
+ */
+int posix_memalign(void **memptr, size_t align, size_t size)
+{
+	return uk_posix_memalign(uk_alloc_get_default(),
+				 memptr, align, size);
+}
+
+/* Allocate size bytes of memory, aligned to align bytes. Returns pointer to
+ * start of allocated memory, or NULL on failure.
+ */
+void *memalign(size_t align, size_t size)
+{
+	return uk_memalign(uk_alloc_get_default(), align, size);
+}
+#endif /* CONFIG_LIBUKALLOC */
+
 /*
  * Convert a string to an unsigned long integer.
  *


### PR DESCRIPTION
To ensure that symbols such as malloc, calloc, and free are accessible during link time for internal gcc objects, such as those related to gcov, these functions must be designated as public.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

- CONFIG_LIBUKALLOC=y

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Remove `static inline` modifiers from memory management functions in `nolibc`

<!--
Please provide a detailed description of the changes made in this new PR.
-->
