### PR TITLE
lib/nolibc: Introduce 'FILE' object APIs

### DIFF
--- a/lib/nolibc/exportsyms.uk
+++ b/lib/nolibc/exportsyms.uk
@@ -44,6 +44,17 @@ putchar
 fputs
 puts
 
+# file
+clearerr
+feof
+ferror
+fseek
+fopen
+fclose
+fdopen
+fread
+fwrite
+
 # stdlib
 abort
 exit

--- a/lib/nolibc/include/nolibc-internal/shareddefs.h
+++ b/lib/nolibc/include/nolibc-internal/shareddefs.h
@@ -88,6 +88,11 @@ typedef struct {
 #define __DEFINED_max_align_t
 #endif
 
+#if (defined __NEED_FILE && !defined __DEFINED_FILE)
+typedef struct _nolibc_file FILE;
+#define __DEFINED_FILE
+#endif
+
 #if defined(__NEED_useconds_t) && !defined(__DEFINED_useconds_t)
 typedef unsigned useconds_t;
 #define __DEFINED_useconds_t

--- a/lib/nolibc/include/stdio.h
+++ b/lib/nolibc/include/stdio.h
@@ -36,6 +36,11 @@
 
 #include <uk/essentials.h>
 
+
+#if CONFIG_LIBVFSCORE
+#include <vfscore/file.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -43,10 +48,8 @@ extern "C" {
 #define __NEED_NULL
 #define __NEED_size_t
 #define __NEED_ssize_t
+#define __NEED_FILE
 #include <nolibc-internal/shareddefs.h>
-
-struct _nolibc_fd;
-typedef struct _nolibc_fd FILE;
 
 extern FILE *stdin;
 extern FILE *stdout;
@@ -92,8 +95,17 @@ int fputs(const char *restrict s, FILE *restrict stream);
 int puts(const char *s);
 
 #if CONFIG_LIBVFSCORE
+void clearerr(FILE *stream);
 int rename(const char *oldpath, const char *newpath);
-#endif
+int feof(FILE *stream);
+int ferror(FILE *stream);
+int fseek(FILE *stream, long offset, int whence);
+int fclose(FILE *stream);
+FILE *fopen(const char *pathname, const char *mode);
+FILE *fdopen(int fd, const char *mode);
+size_t fread(void *ptr, size_t size, size_t nmemb, FILE *stream);
+size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
+#endif /* CONFIG_LIBVFSCORE */
 
 #ifdef __STDIO_H_DEFINED_va_list
 #undef va_list


### PR DESCRIPTION
If `vfscore` is enabled, then add a small set of minimally implemented file handling functions like `fopen`, `fclose`, `fwrite` that are useful at link time for `gcc` objects such as the ones from `gcov`

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

- CONFIG_LIBVFSCORE=y

### Description of changes

Useful and simple file operations functions using `libvfscore`

<!--
Please provide a detailed description of the changes made in this new PR.
-->
