### PR TITLE
lib/nolibc: Add `__errno_location` implementation

### DIFF
--- a/lib/nolibc/Makefile.uk
+++ b/lib/nolibc/Makefile.uk
@@ -52,6 +52,3 @@ LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/random.c
 LIBNOLIBC_SRCS-$(CONFIG_LIBNOLIBC_SYSLOG) += $(LIBNOLIBC_BASE)/syslog.c
 
 LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/qsort.c
-
-# Localize internal symbols (starting with __*)
-LIBNOLIBC_OBJCFLAGS-y += -w -L __*

--- a/lib/nolibc/errno.c
+++ b/lib/nolibc/errno.c
@@ -32,9 +32,15 @@
  */
 
 #include <errno.h>
+#include <stddef.h>
 
 #if CONFIG_HAVE_SCHED
 __thread int errno;
 #else
 int errno;
 #endif /* !CONFIG_HAVE_SCHED */
+
+int *__errno_location(void)
+{
+	return &errno;
+}

--- a/lib/nolibc/exportsyms.uk
+++ b/lib/nolibc/exportsyms.uk
@@ -100,6 +100,7 @@ _nolibc_ctype
 
 # errno
 errno
+__errno_location
 
 # network
 htons

--- a/lib/nolibc/include/errno.h
+++ b/lib/nolibc/include/errno.h
@@ -190,4 +190,6 @@ extern int errno;
 }
 #endif
 
+int *__errno_location(void);
+
 #endif /* __ERRNO_H__ */


### PR DESCRIPTION
At link time, objects such as the ones derived from `gcov` which comes with `gcc-13` require this symbol in order to build.
There was also the need to remove the internalisation of symbols starting with `_`. This is still a work in progress and requires feedback.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
