### PR TITLE
plat/kvm/x86: Enable relocation for `Firecracker` `PIE` builds

### DIFF
--- a/plat/kvm/x86/lxboot.S
+++ b/plat/kvm/x86/lxboot.S
@@ -35,6 +35,23 @@ ENTRY(_lxboot_entry)
 	cmpl	$LXBOOT_HDR_HEADER_MAGIC, LXBOOT_HDR_HEADER_OFFSET(%rsi)
 	jne	no_lxboot
 
+#if CONFIG_LIBUKRELOC
+	/* We are going to taint the early lcpu_bootstack but we do not care.
+	 * Since it's a stack, it does not need to not be tainted anyway.
+	 */
+	leaq	lcpu_bootstack(%rip), %rsp
+	/* Make sure it is aligned */
+	andq	$~0xf, %rsp
+	pushq	%rsi
+	xorl	%esi, %esi
+	xorl	%edi, %edi
+	call	do_uk_reloc
+	popq	%rsi
+	/* We do not restore the previous %rsp. At this time it does not seem to
+	 * be needed.
+	 */
+#endif /* CONFIG_LIBUKRELOC */
+
 	/* startup args for boot CPU */
 	leaq	lcpu_boot_startup_args(%rip), %rdi
 	leaq	lxboot_entry(%rip), %rax
@@ -44,7 +61,6 @@ ENTRY(_lxboot_entry)
 
 	leaq	x86_bpt_pml4(%rip), %rax
 	movq	%rax, %cr3
-
 	jmp	lcpu_start64
 
 no_lxboot:


### PR DESCRIPTION
Previously, `PIE` builds for `Firecracker VMM` would fail at runtime due to the fact that the static boot page tables would not be relocated.

Therefore, enable `Firecracker` builds to run as `PIE` by employing the early self relocator from `libukreloc`. Since an early bootstack is also required to backup `rsi` holding the Linux Boot Protocol structure as well as to provide room to `do_uk_reloc`'s local variables, add a new `.bss` symbol `lxboot_reloc_bstack` corresponding to a stack small enough for the previously mentioned data.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
