### PR TITLE
plat/common: Add BIOS system memory in legacy high memory region

### DIFF
--- a/plat/common/include/uk/plat/common/memory.h
+++ b/plat/common/include/uk/plat/common/memory.h
@@ -115,7 +115,7 @@ ukplat_memregion_list_insert(struct ukplat_memregion_list *list,
 
 #if defined(__X86_64__)
 #define	X86_HI_MEM_START		0xA0000
-#define X86_HI_MEM_LEN			0x50000
+#define X86_HI_MEM_LEN			0x60000
 
 static inline int
 ukplat_memregion_list_insert_legacy_hi_mem(struct ukplat_memregion_list *list)


### PR DESCRIPTION
Previously, `ukplat_memregion_list_insert_legacy_hi_mem` did not include the `0xf0000 -> 0x100000` memory regions that would usually contain the legacy BIOS system memory below the first 1MiB. This would lead to x86 platforms that do not yet have any form of ACPI (RSDP from BDA or UEFI System Tables) such as Firecracker to crash when looking for the `RSDP` in that specific region.

Therefore, make sure that this region is also included so that it can be mapped accordingly by the paging initialization phase.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
