### PR TITLE
plat/kvm: Align the bootstack base address

### DIFF
--- a/plat/kvm/arm/entry64.S
+++ b/plat/kvm/arm/entry64.S
@@ -79,8 +79,9 @@ ENTRY(_libkvmplat_entry)
 	isb
 
 	/* Set the boot stack */
-	ur_ldr x26, lcpu_bootstack
-	mov sp, x26
+	ur_ldr	x26, lcpu_bootstack
+	and	x26, x26, ~(__STACK_ALIGN_SIZE - 1)
+	mov	sp, x26
 
 	/* Set the context id */
 	msr contextidr_el1, xzr


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`,`x86_64`]
 - Platform(s): [`kvm`]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The base address of the stack must be 16-byte aligned on both arm64 and x86_64. Fix the alignent where this is currently missing.