### PR TITLE
plat/kvm/arm: Rework early cache clean & invalidate

### DIFF
--- a/plat/common/arm/cache64.S
+++ b/plat/common/arm/cache64.S
@@ -60,7 +60,6 @@ ENTRY(clean_and_invalidate_dcache_range)
 1:
 	/* clean and invalidate D cache by D cache line size */
 	dc	civac, x0
-	dsb	nsh
 
 	/* Move to next line and reduce the size */
 	add	x0, x0, x3
@@ -68,9 +67,7 @@ ENTRY(clean_and_invalidate_dcache_range)
 
 	/* Check if all range has been invalidated */
 	b.hi	1b
-
-	isb
-
+	dsb	sy
 	ret
 END(clean_and_invalidate_dcache_range)
 
@@ -99,8 +96,6 @@ ENTRY(invalidate_dcache_range)
 
 	/* Check if all range has been invalidated */
 	b.hi	1b
-
-	isb
-
+	dsb	sy
 	ret
 END(invalidate_dcache_range)

--- a/plat/kvm/arm/entry64.S
+++ b/plat/kvm/arm/entry64.S
@@ -36,11 +36,13 @@
 #include <uk/config.h>
 #include <uk/reloc.h>
 
+#define BOOTSTACK_SIZE	4096
+
 /* Prefer using in-image stack, to avoid conflicts when unmapping is done by
  * paging_init (it invalidates our stack)
  */
 .section .bss
-.space 4096
+.space BOOTSTACK_SIZE
 lcpu_bootstack:
 
 .text
@@ -57,31 +59,58 @@ ENTRY(_libkvmplat_entry)
 	isb
 #endif /* CONFIG_FPSIMD */
 
-	/*
-	 * We will disable MMU and cache before the pagetables are ready.
-	 * This means we will change memory with cache disabled, so we need to
-	 * invalidate the cache to ensure there is no stale data in it.
-	 * But we don't know the size of the RAM either. And it would be
-	 * expensive to invalidate the whole cache. In this case, just
-	 * just need to invalidate what we are going to use:
-	 * DTB, TEXT, DATA, BSS, and bootstack.
+	/* If we boot via the linux boot protocol we expect that the MMU is
+	 * disabled and the cache for the region of the image is clean.
+	 * If we find that the MMU is enabled, we consider the cache state
+	 * unpredicatable. In that case we clean-invalidate the cache for
+	 * the entire image and disable the MMU.
+	 *
+	 * Notice: A clean cache would suffice as long as we invalidate any
+	 *         memory we touch while the MMU is disabled. But since PIE
+	 *         can write anywhere we also invalidate the entire image.
 	 */
+	mrs	x19, sctlr_el1
+	and	x19, x19, #SCTLR_EL1_M_BIT
+#if CONFIG_LIBUKRELOC
+	/* If PIE is enabled and the MMU is disabled we proceed to
+	 * invalidate the entire image region anyway, as libukreloc
+	 * right now does not invalidate the individual lines it touches.
+	 */
+	cbz	x19, 0f
+#else /* !CONFIG_LIBUKRELOC */
+	cbz	x19, 1f
+#endif /* !CONFIG_LIBUKRELOC */
+
 	ur_ldr	x0, _start_ram_addr
 	ur_ldr	x1, _end
-	bl clean_and_invalidate_dcache_range
+	bl	clean_and_invalidate_dcache_range
 
 	/* Disable the MMU and D-Cache. */
-	dsb sy
-	mrs x2, sctlr_el1
-	mov x3, #SCTLR_EL1_M_BIT|SCTLR_EL1_C_BIT
-	bic x2, x2, x3
-	msr sctlr_el1, x2
+	dsb	sy
+	mrs	x2, sctlr_el1
+	mov	x3, #SCTLR_EL1_M_BIT|SCTLR_EL1_C_BIT
+	bic	x2, x2, x3
+	msr	sctlr_el1, x2
 	isb
-
-	/* Set the boot stack */
+#if CONFIG_LIBUKRELOC
+	b	1f
+0:
+	ur_ldr	x0, _start_ram_addr
+	ur_ldr	x1, _end
+	bl	invalidate_dcache_range
+#endif /* CONFIG_LIBUKRELOC */
+1:
+	/* Set the boot stack.Invalidate the corresponding cache lines to
+	 * avoid stale cache contents shadowing our changes once the MMU
+	 * and D-cache are enabled.
+	 */
 	ur_ldr	x26, lcpu_bootstack
 	and	x26, x26, ~(__STACK_ALIGN_SIZE - 1)
 	mov	sp, x26
+	mov	x0, x26
+	mov	x1, #BOOTSTACK_SIZE
+	dmb	sy
+	bl	invalidate_dcache_range
 
 	/* Set the context id */
 	msr contextidr_el1, xzr

--- a/plat/kvm/arm/pagetable64.S
+++ b/plat/kvm/arm/pagetable64.S
@@ -95,18 +95,6 @@ setup_tcr_el1:
 	/* save lr */
 	mov x22, x30
 
-        /*
-	 * Invalidate the D-Cache to avoid using invalid data that existed
-	 * in D-Cache. Invalidate ranges that may have been modified:
-	 * DATA, BSS, PAGETABLE and BOOTSTACK.
-	 */
-	ur_ldr  x0, _data
-	ur_ldr  x1, _end
-
-	add x1, x1, #__STACK_SIZE
-	sub x1, x1, x0
-	bl clean_and_invalidate_dcache_range
-
 	/* Setup SCTLR */
 	ldr x2, =SCTLR_SET_BITS
 	ldr x3, =SCTLR_CLEAR_BITS


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [`kvm`]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

During boot the following cache operations are required:
- Clean the cache to the PoC to avoid evicted dirty cache lines to overwrite subsequent writes.
- With the MMU / caches off, perform any accesses necessary
- Invalidate any memory accessed to avoid clean cache lines to shadow what we previously wrote into memory.

The arm64 linux boot protocol provides the requirements for the system's state before jumping into the kernel [1[. Among these it is required that upon entry:

* The MMU is off
* The D-cache for the region corresponging to the loaded image must be cleaned to the point of coherence.

These conditions provide the opportunity of optimization the existing boot code. Specifically we can skip the extremely expensive clean & invalidating of the entire image on LXBOOT and QEMU virt, and futhermore limit further cache invalidation to the regions accessed before enabling the MMU.

Additionally to the above, optimize the existing cache and invalidate functionality by using a single barrier at the end of the operation.
