### PR TITLE
plat/common: Align TLS sections to PAGE_SIZE

### DIFF
--- a/plat/common/include/uk/plat/common/common.lds.h
+++ b/plat/common/include/uk/plat/common/common.lds.h
@@ -137,7 +137,7 @@
 	}
 
 #define TLS_SECTIONS							\
-	. = ALIGN(0x20);						\
+	. = ALIGN(__PAGE_SIZE);						\
 	_tls_start = .;							\
 	.tdata :							\
 	{								\


### PR DESCRIPTION
`mkbootinfo.py` takes each ELF segment and aligns it to PAGE_SIZE to convert it to a `struct ukplat_memregion_desc`. However, this ends up generating overlapping memregion descriptors in the case of the ELF segment corresponding to the TLS sections.

To solve this, simply ensure that the TLS sections are already aligned by PAGE_SIZE.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
