### PR TITLE
plat/kvm: Check return code of all memory region inserting methods

### DIFF
--- a/plat/kvm/efi.c
+++ b/plat/kvm/efi.c
@@ -335,10 +335,14 @@ static void uk_efi_setup_bootinfo_mrds(struct ukplat_bootinfo *bi)
 			uk_efi_crash("Failed to insert mrd\n");
 	}
 
-	ukplat_memregion_list_coalesce(&bi->mrds);
+	rc = ukplat_memregion_list_coalesce(&bi->mrds);
+	if (unlikely(rc))
+		uk_efi_crash("Failed to coalesce memory regions\n");
 
 #if defined(__X86_64__)
-	ukplat_memregion_alloc_sipi_vect();
+	rc = ukplat_memregion_alloc_sipi_vect();
+	if (unlikely(rc))
+		uk_efi_crash("Failed to insert SIPI vector region\n");
 #endif
 }
 

--- a/plat/kvm/x86/lxboot.c
+++ b/plat/kvm/x86/lxboot.c
@@ -145,6 +145,7 @@ lxboot_init_mem(struct ukplat_bootinfo *bi, struct lxboot_params *bp)
 void lxboot_entry(struct lcpu *lcpu, struct lxboot_params *bp)
 {
 	struct ukplat_bootinfo *bi;
+	int rc;
 
 	bi = ukplat_bootinfo_get();
 	if (unlikely(!bi))
@@ -156,7 +157,9 @@ void lxboot_entry(struct lcpu *lcpu, struct lxboot_params *bp)
 	lxboot_init_cmdline(bi, bp);
 	lxboot_init_initrd(bi, bp);
 	lxboot_init_mem(bi, bp);
-	ukplat_memregion_list_coalesce(&bi->mrds);
+	rc = ukplat_memregion_list_coalesce(&bi->mrds);
+	if (unlikely(rc))
+		lxboot_crash(rc, "Could not coalesce memory regions");
 
 	memcpy(bi->bootprotocol, "lxboot", sizeof("lxboot"));
 


### PR DESCRIPTION
Make sure that we do check the return codes of all of the memory region inserting methods so that we can crash in case of failure, instead of letting the system run with a corrupted state.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
