### PR TITLE
plat/kvm/arm: Fix default choice in arm64 VMM menu

### DIFF
--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -16,6 +16,7 @@ if (PLAT_KVM)
 
 choice
 	prompt "Boot protocol"
+	default KVM_BOOT_PROTO_LXBOOT
 
 config KVM_BOOT_PROTO_MULTIBOOT
 	bool "Multiboot"
@@ -25,7 +26,6 @@ config KVM_BOOT_PROTO_MULTIBOOT
 
 config KVM_BOOT_PROTO_LXBOOT
 	bool "Lxboot"
-	default y
 	depends on KVM_VMM_FIRECRACKER || (KVM_VMM_QEMU && ARCH_ARM_64)
 	help
 		Linux 64-bit Boot Protocol


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Fix the default selection of the VMM in Config.uk. Kconfig requires that the default is defined as an attribute of the `choice` option rather than the contained item.
