### PR TITLE
plat/kvm/arm: Use length when clean/invalidating cache in `KVM` entry

### DIFF
--- a/plat/kvm/arm/efi_post.c
+++ b/plat/kvm/arm/efi_post.c
@@ -25,7 +25,7 @@ void __noreturn uk_efi_jmp_to_kern(void)
 	ukplat_lcpu_disable_irq();
 
 	/* Invalidate the image from the data cache */
-	clean_and_invalidate_dcache_range(__BASE_ADDR, __END);
+	clean_and_invalidate_dcache_range(__BASE_ADDR, __END - __BASE_ADDR);
 
 	SYSREG_WRITE64(sctlr_el1, SCTLR_SET_BITS);
 	SYSREG_WRITE64(contextidr_el1, 0);

--- a/plat/kvm/arm/entry64.S
+++ b/plat/kvm/arm/entry64.S
@@ -83,6 +83,7 @@ ENTRY(_libkvmplat_entry)
 
 	ur_ldr	x0, _start_ram_addr
 	ur_ldr	x1, _end
+	sub	x1, x1, x0
 	bl	clean_and_invalidate_dcache_range
 
 	/* Disable the MMU and D-Cache. */
@@ -97,6 +98,7 @@ ENTRY(_libkvmplat_entry)
 0:
 	ur_ldr	x0, _start_ram_addr
 	ur_ldr	x1, _end
+	sub	x1, x1, x0
 	bl	invalidate_dcache_range
 #endif /* CONFIG_LIBUKRELOC */
 1:


### PR DESCRIPTION
Fix second argument of [clean_and_]invalidate_dcache_range in `KVM` entry to use the length of the range instead of the address of the end of the range.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [`kvm`]
 - Application(s): [all]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
