### PR TITLE
plat/kvm/x86: Ensure that lxboot initrd/cmdl regions are aligned

### DIFF
--- a/plat/kvm/x86/lxboot.c
+++ b/plat/kvm/x86/lxboot.c
@@ -41,7 +41,7 @@ lxboot_init_cmdline(struct ukplat_bootinfo *bi, struct lxboot_params *bp)
 
 	mrd.pbase = cmdline_addr;
 	mrd.vbase = cmdline_addr;
-	mrd.len   = cmdline_size;
+	mrd.len   = PAGE_ALIGN_UP(cmdline_size);
 	mrd.type  = UKPLAT_MEMRT_CMDLINE;
 	mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 #ifdef CONFIG_UKPLAT_MEMRNAME
@@ -79,7 +79,7 @@ lxboot_init_initrd(struct ukplat_bootinfo *bi, struct lxboot_params *bp)
 	mrd.flags = UKPLAT_MEMRF_MAP | UKPLAT_MEMRF_READ;
 	mrd.vbase = initrd_addr;
 	mrd.pbase = initrd_addr;
-	mrd.len   = initrd_size;
+	mrd.len   = PAGE_ALIGN_UP(initrd_size);
 #ifdef CONFIG_UKPLAT_MEMRNAME
 	memcpy(mrd.name, "initrd", sizeof("initrd"));
 #endif /* CONFIG_UKPLAT_MEMRNAME */


### PR DESCRIPTION
All memory region descriptors must be aligned. Therefore, ensure that the initrd and command-line related memory regions inserted when booting through the Linux Boot Protocol are also aligned.

Note: If these two are aligned, all the other memory regions reported through the boot protocol should be already aligned. Thus, we do not do this explicit alignment on the free memory regions, as they must have been already aligned by the previous boot phase. If this is not the case, then the issue lies in the entity that booted us.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [`kvm`]
 - Application(s): [all]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
