### PR TITLE
plat: Let coalescing method ensure memregion alignment

### DIFF
--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -86,6 +86,7 @@
 #ifdef CONFIG_LIBUKSP
 #include <uk/sp.h>
 #endif
+#include <uk/arch/paging.h>
 #include <uk/arch/tls.h>
 #include <uk/plat/tls.h>
 #include "banner.h"
@@ -186,6 +187,11 @@ static struct uk_alloc *heap_init()
 	 * add every subsequent region to it.
 	 */
 	ukplat_memregion_foreach(&md, UKPLAT_MEMRT_FREE, 0, 0) {
+		UK_ASSERT(md->vbase == md->pbase);
+		UK_ASSERT(!(md->pbase & ~PAGE_MASK));
+		UK_ASSERT(md->len);
+		UK_ASSERT(!(md->len & ~PAGE_MASK));
+
 		uk_pr_debug("Trying %p-%p 0x%02x %s\n",
 			    (void *)md->vbase, (void *)(md->vbase + md->len),
 			    md->flags,

--- a/plat/common/include/uk/plat/common/memory.h
+++ b/plat/common/include/uk/plat/common/memory.h
@@ -328,6 +328,55 @@ ukplat_memregion_list_delete(struct ukplat_memregion_list *list, __u32 idx)
 	list->count--;
 }
 
+#if CONFIG_LIBUKDEBUG_PRINTD
+static inline void
+ukplat_memregion_print_desc(struct ukplat_memregion_desc *mrd)
+{
+	const char *type;
+
+	switch (mrd->type) {
+	case UKPLAT_MEMRT_RESERVED:
+		type = "rsvd";
+		break;
+	case UKPLAT_MEMRT_KERNEL:
+		type = "krnl";
+		break;
+	case UKPLAT_MEMRT_INITRD:
+		type = "ramd";
+		break;
+	case UKPLAT_MEMRT_CMDLINE:
+		type = "cmdl";
+		break;
+	case UKPLAT_MEMRT_DEVICETREE:
+		type = "dtb ";
+		break;
+	case UKPLAT_MEMRT_STACK:
+		type = "stck";
+		break;
+	default:
+		type = "";
+		break;
+	}
+
+	uk_pr_debug(" %012lx-%012lx %012lx %c%c%c %016lx %s %s\n",
+		   mrd->pbase, mrd->pbase + mrd->len, mrd->len,
+		   (mrd->flags & UKPLAT_MEMRF_READ) ? 'r' : '-',
+		   (mrd->flags & UKPLAT_MEMRF_WRITE) ? 'w' : '-',
+		   (mrd->flags & UKPLAT_MEMRF_EXECUTE) ? 'x' : '-',
+		   mrd->vbase,
+		   type,
+#if CONFIG_UKPLAT_MEMRNAME
+		   mrd->name
+#else /* !CONFIG_UKPLAT_MEMRNAME */
+		   ""
+#endif /* !CONFIG_UKPLAT_MEMRNAME */
+		   );
+}
+#else  /* !CONFIG_LIBUKDEBUG_PRINTD */
+static inline void
+ukplat_memregion_print_desc(struct ukplat_memregion_desc *mrd __unused) { }
+#endif /* !CONFIG_LIBUKDEBUG_PRINTD */
+
 /**
  * Coalesces the memory regions of a given memory region descriptor list.
  *

--- a/plat/common/include/uk/plat/common/memory.h
+++ b/plat/common/include/uk/plat/common/memory.h
@@ -90,6 +90,9 @@ ukplat_memregion_list_insert(struct ukplat_memregion_list *list,
 	struct ukplat_memregion_desc *p;
 	__u32 i;
 
+	if (unlikely(!mrd->len))
+		return -EINVAL;
+
 	if (unlikely(list->count == list->capacity))
 		return -ENOMEM;
 
@@ -206,6 +209,9 @@ ukplat_memregion_list_insert_at_idx(struct ukplat_memregion_list *list,
 {
 	struct ukplat_memregion_desc *p;
 
+	if (unlikely(!mrd->len))
+		return -EINVAL;
+
 	if (unlikely(list->count == list->capacity))
 		return -ENOMEM;
 
@@ -246,6 +252,9 @@ ukplat_memregion_list_insert_split_phys(struct ukplat_memregion_list *list,
 	__vaddr_t voffset;
 	int i;
 	int rc;
+
+	if (unlikely(!mrd->len))
+		return -EINVAL;
 
 	voffset = mrd->vbase - mrd->pbase;
 	pstart = mrd->pbase;

--- a/plat/common/include/uk/plat/common/memory.h
+++ b/plat/common/include/uk/plat/common/memory.h
@@ -382,11 +382,8 @@ ukplat_memregion_print_desc(struct ukplat_memregion_desc *mrd __unused) { }
  *
  * @param list
  *   The list whose memory region descriptors to coalesce.
- *
- * @return
- *   0 on success, < 0 otherwise.
  */
-int ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list);
+void ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list);
 
 /**
  * Initializes the platform memory mappings which require an allocator. This

--- a/plat/common/memory.c
+++ b/plat/common/memory.c
@@ -154,19 +154,22 @@ void *ukplat_memregion_alloc(__sz size, int type, __u16 flags)
  * - the others are all allocated for Unikraft so they will have the same
  * priority
  */
+#define MRD_PRIO_FREE			0
+#define MRD_PRIO_KRNL_RSRC		1
+#define MRD_PRIO_RSVD			2
 static inline int get_mrd_prio(struct ukplat_memregion_desc *const m)
 {
 	switch (m->type) {
 	case UKPLAT_MEMRT_FREE:
-		return 0;
+		return MRD_PRIO_FREE;
 	case UKPLAT_MEMRT_INITRD:
 	case UKPLAT_MEMRT_CMDLINE:
 	case UKPLAT_MEMRT_STACK:
 	case UKPLAT_MEMRT_DEVICETREE:
 	case UKPLAT_MEMRT_KERNEL:
-		return 1;
+		return MRD_PRIO_KRNL_RSRC;
 	case UKPLAT_MEMRT_RESERVED:
-		return 2;
+		return MRD_PRIO_RSVD;
 	default:
 		return -1;
 	}
@@ -235,45 +238,120 @@ static inline void overlapping_mrd_fixup(struct ukplat_memregion_list *list,
 	}
 }
 
+/* During coalescing of two memory region descriptors, we first call this
+ * function which would overwrite the physical and length of a given memory
+ * region descriptor with its equivalent page-aligned physical base and length
+ * if the end address of the memory region would have also been page-aligned.
+ * The coalesce function then, at the end, calls ukplat_memregion_restore_mrd
+ * to undo this.
+ */
+static void ukplat_memregion_align_mrd(struct ukplat_memregion_desc *mrd,
+				       __paddr_t *opbase, __sz *olen)
+{
+	__sz pend;
+
+	/* Store the **original** physical base and length */
+	*opbase = mrd->pbase;
+	*olen = mrd->len;
+
+	/* Compute the page-aligned end address of the region */
+	pend = ALIGN_UP(mrd->pbase + mrd->len, __PAGE_SIZE);
+
+	/* Overwrite original pbase with its page-aligned value */
+	mrd->pbase = ALIGN_DOWN(mrd->pbase, __PAGE_SIZE);
+
+	/* Overwrite original len with the supposed size of end-to-end
+	 * page-aligned memory region.
+	 */
+	mrd->len = pend - mrd->pbase;
+}
+
+/* Called at the end of ukplat_memregion_list_coalesce to undo what
+ * ukplat_memregion_align_mrd has done.
+ */
+static void ukplat_memregion_restore_mrd(struct ukplat_memregion_desc *mrd,
+					 __paddr_t opbase, __sz olen)
+{
+	mrd->len = olen;
+	mrd->pbase = opbase;
+}
+
+/* Quick function to do potentially necessary swapping of two adjacent memory
+ * region descriptors. Here just to modularize code because
+ * ukplat_memregion_list_coalesce was quite large already.
+ */
+static void ukplat_memregion_swap_if_unordered(struct ukplat_memregion_list *l,
+					       __u32 l_idx, __u32 r_idx)
+{
+	struct ukplat_memregion_desc tmp, *m;
+
+	m = l->mrds;
+	if (m[l_idx].pbase > m[r_idx].pbase ||
+	    (m[l_idx].pbase == m[r_idx].pbase &&
+	     m[l_idx].pbase + m[l_idx].len > m[r_idx].pbase + m[r_idx].len)) {
+		tmp = m[l_idx];
+		m[l_idx] = m[r_idx];
+		m[r_idx] = tmp;
+	}
+}
+
 int ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 {
 	struct ukplat_memregion_desc *m, *ml, *mr;
+	__paddr_t ml_opbase, mr_opbase;
+	__sz ml_olen, mr_olen;
 	int ml_prio, mr_prio;
+	__u8 del; /* lets us know if a deletion happened */
 	__u32 i;
 
 	i = 0;
 	m = list->mrds;
 	while (i + 1 < list->count) {
-		/* Make sure first that they are ordered. If not, swap them */
-		if (m[i].pbase > m[i + 1].pbase ||
-		    (m[i].pbase == m[i + 1].pbase &&
-		     m[i].pbase + m[i].len > m[i + 1].pbase + m[i + 1].len)) {
-			struct ukplat_memregion_desc tmp;
+		del = 0;
 
-			tmp = m[i];
-			m[i] = m[i + 1];
-			m[i + 1] = tmp;
-		}
+		/* Make sure first that they are ordered. If not, swap them */
+		ukplat_memregion_swap_if_unordered(list, i, i + 1);
+
 		ml = &m[i];
 		mr = &m[i + 1];
-		ml_prio = get_mrd_prio(ml);
-		mr_prio = get_mrd_prio(mr);
 
-		/* If they overlap */
-		if (RANGE_OVERLAP(ml->pbase,  ml->len, mr->pbase, mr->len)) {
+		ml_prio = get_mrd_prio(ml);
+		if (unlikely(ml_prio < 0))
+			return -EINVAL;
+
+		mr_prio = get_mrd_prio(mr);
+		if (unlikely(mr_prio < 0))
+			return -EINVAL;
+
+		ukplat_memregion_align_mrd(ml, &ml_opbase, &ml_olen);
+		ukplat_memregion_align_mrd(mr, &mr_opbase, &mr_olen);
+
+		if (RANGE_OVERLAP(ml->pbase, ml->len, mr->pbase, mr->len)) {
 			/* If they are not of the same priority */
 			if (ml_prio != mr_prio) {
+				/* At least one of the overlapping regions must
+				 * be a free one. Otherwise, something wrong
+				 * happened.
+				 */
+				if (unlikely(!(mr_prio == MRD_PRIO_FREE ||
+					       ml_prio == MRD_PRIO_FREE)))
+					return -EINVAL;
+
 				overlapping_mrd_fixup(list, ml, mr, ml_prio,
 						      mr_prio, i, i + 1);
 
 				/* Remove dropped regions */
-				if (ml->len == 0)
+				del = 1;
+				if (ml->len == 0) {
 					ukplat_memregion_list_delete(list, i);
-				else if (mr->len == 0)
+
+				} else if (mr->len == 0) {
 					ukplat_memregion_list_delete(list,
 								     i + 1);
-				else
+				} else {
 					i++;
+					del = 0;  /* No deletions */
+				}
 
 			} else if (ml->flags != mr->flags) {
 				return -EINVAL;
@@ -289,8 +367,9 @@ int ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 				if (RANGE_CONTAIN(mr->pbase, mr->len,
 						  ml->pbase, ml->len)) {
 					ukplat_memregion_list_delete(list, i);
+					del = 1;
 
-					continue;
+					goto restore_mrds;
 
 				/* If the right region is contained within the
 				 * left region, drop it
@@ -299,8 +378,9 @@ int ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 							 mr->pbase, mr->len)) {
 					ukplat_memregion_list_delete(list,
 								     i + 1);
+					del = 1;
 
-					continue;
+					goto restore_mrds;
 				}
 
 				/* If they are not contained within each other,
@@ -317,6 +397,7 @@ int ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 				 * the previous region.
 				 */
 				ukplat_memregion_list_delete(list, i + 1);
+				del = 1;
 			}
 
 		/* If they do not overlap but they are contiguous and have the
@@ -326,10 +407,43 @@ int ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 			   ml_prio == mr_prio && ml->flags == mr->flags) {
 			ml->len += mr->len;
 			ukplat_memregion_list_delete(list, i + 1);
+			del = 1;
 		} else {
 			i++;
 		}
+
+restore_mrds:
+		if (!del) {
+			/* We assume only MRD_PRIO_FREE can be dropped. We want
+			 * to maintain !MRD_PRIO_FREE start addresses and
+			 * length so that the kernel may use them (e.g. initrd
+			 * start address).
+			 */
+			if (ml_prio != MRD_PRIO_FREE)
+				ukplat_memregion_restore_mrd(ml, ml_opbase,
+							     ml_olen);
+
+			/* This here can only happen if two adjacent
+			 * !MRD_PRIO_FREE regions are resolved without a
+			 * deletion. Preserve mr's original data as well.
+			 */
+			if (mr_prio != MRD_PRIO_FREE)
+				ukplat_memregion_restore_mrd(mr, mr_opbase,
+							     mr_olen);
+		}
+
+		/* Update ml's vbase, since it might not be equal to pbase
+		 * anymore. Whether we deleted ml or mr it does not matter,
+		 * as ml is now equal to the remaining one, because
+		 * ukplat_memregion_list_delete() removes by `memmove()`ing.
+		 */
+		ml->vbase = ml->pbase;
 	}
+
+	/* Make sure the last memory region always ends up being updated when
+	 * we exit this function
+	 */
+	m[i].vbase = m[i].pbase;
 
 	return 0;
 }

--- a/plat/kvm/efi.c
+++ b/plat/kvm/efi.c
@@ -480,7 +480,7 @@ static void uk_efi_setup_bootinfo_cmdl(struct ukplat_bootinfo *bi)
 
 	mrd.pbase = (__paddr_t)cmdl;
 	mrd.vbase = (__vaddr_t)cmdl;
-	mrd.len = PAGE_ALIGN_UP(len);
+	mrd.len = len;
 	mrd.type = UKPLAT_MEMRT_CMDLINE;
 	mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 	rc = ukplat_memregion_list_insert(&bi->mrds, &mrd);
@@ -510,7 +510,7 @@ static void uk_efi_setup_bootinfo_initrd(struct ukplat_bootinfo *bi)
 
 	mrd.pbase = (__paddr_t)initrd;
 	mrd.vbase = (__vaddr_t)initrd;
-	mrd.len = PAGE_ALIGN_UP(len);
+	mrd.len = len;
 	mrd.type = UKPLAT_MEMRT_INITRD;
 	mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 	rc = ukplat_memregion_list_insert(&bi->mrds, &mrd);
@@ -537,7 +537,7 @@ static void uk_efi_setup_bootinfo_dtb(struct ukplat_bootinfo *bi)
 
 	mrd.pbase = (__paddr_t)dtb;
 	mrd.vbase = (__vaddr_t)dtb;
-	mrd.len = PAGE_ALIGN_UP(len);
+	mrd.len = len;
 	mrd.type = UKPLAT_MEMRT_DEVICETREE;
 	mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 	rc = ukplat_memregion_list_insert(&bi->mrds, &mrd);

--- a/plat/kvm/efi.c
+++ b/plat/kvm/efi.c
@@ -335,9 +335,7 @@ static void uk_efi_setup_bootinfo_mrds(struct ukplat_bootinfo *bi)
 			uk_efi_crash("Failed to insert mrd\n");
 	}
 
-	rc = ukplat_memregion_list_coalesce(&bi->mrds);
-	if (unlikely(rc))
-		uk_efi_crash("Failed to coalesce memory regions\n");
+	ukplat_memregion_list_coalesce(&bi->mrds);
 
 #if defined(__X86_64__)
 	rc = ukplat_memregion_alloc_sipi_vect();

--- a/plat/kvm/x86/lxboot.c
+++ b/plat/kvm/x86/lxboot.c
@@ -41,7 +41,7 @@ lxboot_init_cmdline(struct ukplat_bootinfo *bi, struct lxboot_params *bp)
 
 	mrd.pbase = cmdline_addr;
 	mrd.vbase = cmdline_addr;
-	mrd.len   = PAGE_ALIGN_UP(cmdline_size);
+	mrd.len   = cmdline_size;
 	mrd.type  = UKPLAT_MEMRT_CMDLINE;
 	mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 #ifdef CONFIG_UKPLAT_MEMRNAME
@@ -79,7 +79,7 @@ lxboot_init_initrd(struct ukplat_bootinfo *bi, struct lxboot_params *bp)
 	mrd.flags = UKPLAT_MEMRF_MAP | UKPLAT_MEMRF_READ;
 	mrd.vbase = initrd_addr;
 	mrd.pbase = initrd_addr;
-	mrd.len   = PAGE_ALIGN_UP(initrd_size);
+	mrd.len   = initrd_size;
 #ifdef CONFIG_UKPLAT_MEMRNAME
 	memcpy(mrd.name, "initrd", sizeof("initrd"));
 #endif /* CONFIG_UKPLAT_MEMRNAME */
@@ -105,9 +105,6 @@ lxboot_init_mem(struct ukplat_bootinfo *bi, struct lxboot_params *bp)
 		 * not handle address zero well.
 		 */
 		start = MAX(entry->addr, PAGE_SIZE);
-		/* Also make sure to not insert unaligned memory regions */
-		start = PAGE_ALIGN_UP(start);
-
 		end = entry->addr + entry->size;
 
 		if (end <= start)

--- a/plat/kvm/x86/lxboot.c
+++ b/plat/kvm/x86/lxboot.c
@@ -154,9 +154,7 @@ void lxboot_entry(struct lcpu *lcpu, struct lxboot_params *bp)
 	lxboot_init_cmdline(bi, bp);
 	lxboot_init_initrd(bi, bp);
 	lxboot_init_mem(bi, bp);
-	rc = ukplat_memregion_list_coalesce(&bi->mrds);
-	if (unlikely(rc))
-		lxboot_crash(rc, "Could not coalesce memory regions");
+	ukplat_memregion_list_coalesce(&bi->mrds);
 
 	memcpy(bi->bootprotocol, "lxboot", sizeof("lxboot"));
 

--- a/plat/kvm/x86/multiboot.c
+++ b/plat/kvm/x86/multiboot.c
@@ -156,9 +156,7 @@ void multiboot_entry(struct lcpu *lcpu, struct multiboot_info *mi)
 		}
 	}
 
-	rc = ukplat_memregion_list_coalesce(&bi->mrds);
-	if (unlikely(rc))
-		multiboot_crash("Could not coalesce memory regions", rc);
+	ukplat_memregion_list_coalesce(&bi->mrds);
 
 	rc = ukplat_memregion_alloc_sipi_vect();
 	if (unlikely(rc))

--- a/plat/xen/x86/setup.c
+++ b/plat/xen/x86/setup.c
@@ -192,7 +192,9 @@ static int _init_mem(struct ukplat_bootinfo *const bi)
 			return rc;
 	}
 
-	return ukplat_memregion_list_coalesce(&bi->mrds);
+	ukplat_memregion_list_coalesce(&bi->mrds);
+
+	return 0;
 }
 
 static char *cmdline;

--- a/support/scripts/mkbootinfo.py
+++ b/support/scripts/mkbootinfo.py
@@ -123,6 +123,8 @@ def main():
 
             # Align size up to page size
             size = (int(phdr[1], base=16) + (PAGE_SIZE - 1)) & ~(PAGE_SIZE - 1)
+            if size == 0:
+                continue
 
             assert nsecs < cap
             nsecs += 1


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [all]
 - Platform(s): [all]
 - Application(s): [all]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

In order to preserve alignment among memory region descriptors, we
would strive to align every manually inserted memory region. However,
this would also rely on the boot protocol itself to report initial aligned
memory regions, which seems not be the case for some boot protocols
(e.g. cmdline may not be aligned in `Multiboot1`, `initrd` start
address may not be aligned in Linux Boot Protocol).

Therefore, write a single, centralized solution, inside the memory
region coalescing function and make it handle misalignment cases
as well to cope with misbehaving boot protocols. To guarantee
alignment, take each memory region, align it to both ends and
then resolve overlappings. Just like before, free memory regions
are trimmed in favor of other types of memory regions. We know
free memory regions will always be aligned because resolving
conflicts between aligned memory region descriptors will always
yield aligned memory regions.

To preserve original sizes of user allocated memory region descriptors,
in case a deletion is not detected, restore the start address and
length of such region and make sure that the `vbase` field stays updated
with new values of `pbase`.

Finally, now that we offload alignments to the newly improved coalescing
method, remove manual, hardcoded alignments from early boot glue code.
If everything goes as planned and is implemented in a manner where
expectations are met, these alignments should not be needed as they
are transparently ensured by the coalescing method as well as the
paging initialization.

NOTE: Re-adjust the other parts of the code that are a client of the memregion
API's to throw an exception if a memregion is not already aligned. From now on,
client code of such API shall not attempt to align received memory regions,
but rather throw an exception if that has not happened already. This way we
will be able to catch more cases that the coalescing method does not care
of and update it accordingly, to maintain one single centralized solution.