### PR TITLE
Makefile: Fix build verbosity for V=0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,14 +83,15 @@ export CDPATH :=
 
 # To put more focus on warnings, be less verbose as default
 # Use 'make V=1' to see the full commands
+# Set KBUILD_VERBOSE and Q to quiet mode
+KBUILD_VERBOSE := 0
+Q := @
+
 ifeq ("$(origin V)", "command line")
   BUILD_VERBOSE = $(V)
 endif
 ifndef BUILD_VERBOSE
   BUILD_VERBOSE = 0
-  # Set KBUILD_VERBOSE and Q to quiet mode
-  KBUILD_VERBOSE := 0
-  Q := @
 endif
 
 ifneq ($(BUILD_VERBOSE),0)


### PR DESCRIPTION
When setting `V=0`, we expect the verbosity level to be reduced, and
only the build output to be printed, not the build commands.
Do that by adding the `-s` option to `MAKEFLAGS` in case `V` is set to 0.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>
GitHub-Fixes: #676

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
