### PR TITLE
lib/vfscore: Replace dup2 syscalls with dup3

### DIFF
--- a/lib/vfscore/stdio.c
+++ b/lib/vfscore/stdio.c
@@ -54,7 +54,7 @@
  */
 
 #if !CONFIG_LIBSYSCALL_SHIM
-long uk_syscall_r_dup2(long oldfd, long newfd);
+long uk_syscall_r_dup3(long oldfd, long newfd, long flags);
 #endif /* !CONFIG_LIBSYSCALL_SHIM */
 
 static int __write_fn(void *dst __unused, void *src, size_t *cnt)
@@ -240,13 +240,13 @@ int init_stdio(void)
 	}
 	vfscore_install_fd(0, &stdio_file);
 
-	fd = uk_syscall_r_dup2(0, 1);
+	fd = uk_syscall_r_dup3(0, 1, 0);
 	if (fd != 1) {
 		uk_pr_crit("failed to dup to stdout (fd=1)\n");
 		return (fd < 0) ? fd : -EBADF;
 	}
 
-	fd = uk_syscall_r_dup2(0, 2);
+	fd = uk_syscall_r_dup3(0, 2, 0);
 	if (fd != 2) {
 		uk_pr_crit("failed to dup to stderr (fd=2)\n");
 		return (fd < 0) ? fd : -EBADF;


### PR DESCRIPTION
### Description of changes

vfscore contained internal calls to the dup2 syscall, which is not universally provided on all architectures, notably absent on AArch64. This change replaces calls to dup2 with dup3 which is more universal.

Fixes https://github.com/unikraft/app-helloworld-cpp/issues/18 once https://github.com/unikraft/lib-libcxx/pull/34 is merged.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): arm64
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Configuration with vfscore enabled.
