### PR TITLE
lib/posix-user: Allow custom user & group

### DIFF
--- a/lib/posix-user/Config.uk
+++ b/lib/posix-user/Config.uk
@@ -1,3 +1,23 @@
-config LIBPOSIX_USER
+menuconfig LIBPOSIX_USER
 	bool "posix-user: User-related functions"
 	default n
+
+if LIBPOSIX_USER
+
+config LIBPOSIX_USER_UID
+	int "User ID (uid)"
+	default 0
+
+config LIBPOSIX_USER_GID
+	int "Group ID (gid)"
+	default 0
+
+config LIBPOSIX_USER_USERNAME
+	string "User Name"
+	default "root"
+
+config LIBPOSIX_USER_GROUPNAME
+	string "Group Name"
+	default "root"
+
+endif

--- a/lib/posix-user/user.h
+++ b/lib/posix-user/user.h
@@ -35,11 +35,12 @@
 #define __LIBPOSIX_USER_H__
 
 #include <uk/assert.h>
+#include <uk/config.h>
 
-#define UK_DEFAULT_UID		0
-#define UK_DEFAULT_GID		0
-#define UK_DEFAULT_USER		"root"
-#define UK_DEFAULT_GROUP	"root"
+#define UK_DEFAULT_UID		CONFIG_LIBPOSIX_USER_UID
+#define UK_DEFAULT_GID		CONFIG_LIBPOSIX_USER_GID
+#define UK_DEFAULT_USER		CONFIG_LIBPOSIX_USER_USERNAME
+#define UK_DEFAULT_GROUP	CONFIG_LIBPOSIX_USER_GROUPNAME
 #define UK_DEFAULT_PASS		""
 
 void pu_init_passwds(void);


### PR DESCRIPTION
### Description of changes

This change adds Kconfig options to select the default UID, GID, username, and groupname that Unikraft reports to applications. It's a mostly cosmetic effect that helps with overly defensive code that checks for a specific UID/GID. No actual access permissions are affected.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Additional configuration

N/A