### PR TITLE
lib/ukmmap: Fix wrong return of NULL

### DIFF
--- a/lib/ukmmap/mmap.c
+++ b/lib/ukmmap/mmap.c
@@ -78,13 +78,13 @@ UK_SYSCALL_DEFINE(void*, mmap, void*, addr, size_t, len, int, prot,
 	 * Otherwise return 0 (unimplemented mmap)
 	 */
 	if (fildes != -1 || off)
-		return 0;
+		return MAP_FAILED;
 	if (!(prot & (PROT_READ|PROT_WRITE)) && (prot != 0))
-		return 0;
+		return MAP_FAILED;
 	if (!(flags & (MAP_ANON|MAP_PRIVATE)) &&
 			!(flags & (MAP_FIXED|MAP_ANON|MAP_PRIVATE)) &&
 			!(flags & (MAP_NORESERVE|MAP_ANON|MAP_PRIVATE)))
-		return 0;
+		return MAP_FAILED;
 
 	while (tmp) {
 		if (addr) {
@@ -98,14 +98,14 @@ UK_SYSCALL_DEFINE(void*, mmap, void*, addr, size_t, len, int, prot,
 	void *mem = uk_memalign(uk_alloc_get_default(), __PAGE_SIZE, len);
 	if (!mem) {
 		errno = ENOMEM;
-		return (void *) -1;
+		return MAP_FAILED;
 	}
 
 	new = uk_malloc(uk_alloc_get_default(), sizeof(struct mmap_addr));
 	if (!new) {
 		uk_free(uk_alloc_get_default(), mem);
 		errno = ENOMEM;
-		return (void *) -1;
+		return MAP_FAILED;
 	}
 
 	/* The caller expects the memory to be zeroed */


### PR DESCRIPTION
### Description of changes

Previously ukmmap's `mmap()` would return `NULL` for unimplemented cases. However, no calling code expects this, and will wrongly try to use the returned buffer.
This change corrects this oversight and returns `MAP_FAILED` in all cases of error. Additionally, bare references to `(void *) -1` are also replaced by the more readable `MAP_FAILED`.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A