### PR TITLE
lib/vfscore: Fix potential vfscore_file mem leak

### DIFF
--- a/lib/vfscore/fd.c
+++ b/lib/vfscore/fd.c
@@ -188,13 +188,13 @@ int fdalloc(struct vfscore_file *fp, int *newfd)
 {
 	int fd, ret = 0;
 
-	fhold(fp);
-
 	fd = vfscore_alloc_fd();
 	if (fd < 0) {
 		ret = fd;
 		goto exit;
 	}
+
+	fhold(fp);
 
 	ret = vfscore_install_fd(fd, fp);
 	if (ret)


### PR DESCRIPTION
### Description of changes

Previously if `fdalloc` failed to allocate a file descriptor, the function would exit without decrementing the reference count on the vfscore_file object, leading to a potential memory leak. This change reorders operations to prevent this scenario.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Additional configuration

N/A