### PR TITLE
plat/virtio: Fix vring_avail_event macro

### DIFF
--- a/drivers/virtio/ring/include/virtio/virtio_ring.h
+++ b/drivers/virtio/ring/include/virtio/virtio_ring.h
@@ -157,7 +157,9 @@ struct vring {
  * versa. They are at the end for backwards compatibility.
  */
 #define vring_used_event(vr) ((vr)->avail->ring[(vr)->num])
-#define vring_avail_event(vr) (*(__virtio_le16 *)&(vr)->used->ring[(vr)->num])
+typedef __virtio_le16 __may_alias __virtio_le16_ma;
+#define vring_avail_event(vr) \
+	(*(__virtio_le16_ma *)&(vr)->used->ring[(vr)->num])
 
 static inline void vring_init(struct vring *vr, unsigned int num, uint8_t *p,
 			      unsigned long align)

--- a/drivers/virtio/ring/include/virtio/virtio_ring.h
+++ b/drivers/virtio/ring/include/virtio/virtio_ring.h
@@ -157,7 +157,7 @@ struct vring {
  * versa. They are at the end for backwards compatibility.
  */
 #define vring_used_event(vr) ((vr)->avail->ring[(vr)->num])
-#define vring_avail_event(vr) (*(__virtio16 *)&(vr)->used->ring[(vr)->num])
+#define vring_avail_event(vr) (*(__virtio_le16 *)&(vr)->used->ring[(vr)->num])
 
 static inline void vring_init(struct vring *vr, unsigned int num, uint8_t *p,
 			      unsigned long align)

--- a/include/uk/essentials.h
+++ b/include/uk/essentials.h
@@ -99,6 +99,9 @@ extern "C" {
 #ifndef __check_result
 #define __check_result         __attribute__((warn_unused_result))
 #endif
+#ifndef __may_alias
+#define __may_alias            __attribute__((may_alias))
+#endif
 
 #ifndef __alias
 #define __alias(old, new) \


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

This fixes the `vring_avail_event` to not cause miscompilations by violating the strict aliasing rules.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
