### PR TITLE
support/scripts: `checkpatch` `WARN` on commit summary > 70 chars

### DIFF
--- a/support/scripts/checkpatch.pl
+++ b/support/scripts/checkpatch.pl
@@ -2548,6 +2548,25 @@ sub process {
 			     "Patch subject line does not follow Unikraft scheme: '[Selector]/[Component]: [Short message]'\n" . $herecurr);
 		}
 
+# Check that the first line in the commit message has less than
+# 70 characters to comply with Github UI. This helps
+# avoid commit message subjects placed at the beginning
+# to overflow into the second line when viewing through
+# the Github UI.
+		if ($in_header_lines &&
+		    $line =~ /^Subject:.*$/i) {
+			my $commit_subject_line0 = $1 if
+				$lines[$linenr - 1] =~ /^Subject: \[.*\] (.*)$/;
+			my $commit_subject_line1 = $lines[$linenr];
+			my $commit_subject = $commit_subject_line0 .
+					     $commit_subject_line1;
+			if (length($commit_subject) > 70) {
+				WARN("COMMIT_SUBJECT_LONG_LINE",
+				     "Possible unwrapped commit subject (prefer a maximum 70 chars)\n" . $commit_subject);
+				$commit_log_long_line = 1;
+			}
+		}
+
 # Check for old stable address
 		if ($line =~ /^\s*cc:\s*.*<?\bstable\@kernel\.org\b>?.*$/i) {
 			ERROR("STABLE_ADDRESS",


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Although `checkpatch.pl` checks for commit message lines to not be longer than `75` characters, in the case of `Github`'s UI, a commit summary longer than `70` character results in its line overflowing into the next.
E.g.
```
[Selector]/[Component]: Lorem ipsum dolor sit amet, consectetuer adipiscin
```
becomes
```
[Selector]/[Component]: Lorem ipsum dolor sit amet, consectetuer adip...
...iscin
```

Since this is not aesthetically pleasing, enforce a character limit for commit message summaries to not be longer than `70` characters.