### PR TITLE
support/scripts: mkcpio: Support Darwin (MacOS) environments

### DIFF
--- a/support/scripts/mkcpio
+++ b/support/scripts/mkcpio
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-CPIOTOOL="$( which bsdcpio )"
+OSENV=$( uname )
+CPIOTOOL=
+if [ "$OSENV" = "Linux" ]; then
+	CPIOTOOL="$( which bsdcpio )"
+else
+	CPIOTOOL="$( which cpio )"
+fi
 
 usage()
 {


### PR DESCRIPTION
### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]
 - Host: [Darwin (MacOS)]


### Description of changes

This PR makes the `mkcpio` script work under Darwin (MacOS). Additionally, the script requires the coreutils to be installed:
```
brew install coreutils
```