### PR TITLE
plat/kvm: Fix typo in configuration variable

### DIFF
--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -131,7 +131,7 @@ config KVM_KERNEL_SERIAL_CONSOLE
         help
           Choose serial console for the kernel printing
 
-if (KVM_KVM_KERNEL_SERIAL_CONSOLE || KVM_DEBUG_SERIAL_CONSOLE)
+if (KVM_KERNEL_SERIAL_CONSOLE || KVM_DEBUG_SERIAL_CONSOLE)
 
 choice
 	prompt "Serial console driver"


### PR DESCRIPTION
Remove a redundant `KVM_` in order to reference `KVM_KERNEL_SERIAL_CONSOLE` when deciding if a serial console driver needs to be chosen.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`
 - Platform(s): `kvm`
