### PR TITLE
build: Always save architecture with savedefconfig

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -3,18 +3,25 @@
 # see https://www.kernel.org/doc/Documentation/kbuild/Config.in-language.txt.
 #
 mainmenu "Unikraft/$(UK_FULLVERSION) Configuration"
+
 config UK_FULLVERSION
 	string
 	default "$(UK_FULLVERSION)"
+
 config UK_CODENAME
 	string
 	default "$(UK_CODENAME)"
+
 config UK_ARCH
 	string
 	default "x86_64" if ARCH_X86_64
 	default "arm64"  if ARCH_ARM_64
 	default "arm"	if ARCH_ARM_32
 	default "$(UK_ARCH)"
+
+config HOST_ARCH
+	string
+	default "$(HOST_ARCH)"
 
 config NO_APP
 	def_bool $(shell,test $(UK_BASE) = $(UK_APP) && echo y || echo n)

--- a/Makefile
+++ b/Makefile
@@ -872,13 +872,12 @@ DEFCONFIG = $(call qstrip,$(UK_DEFCONFIG))
 # We don't want to fully expand UK_DEFCONFIG here, so Kconfig will
 # recognize that if it's still at its default $(CONFIG_DIR)/defconfig
 COMMON_CONFIG_ENV = \
-	CC=$(CC)\
 	CONFIG_="CONFIG_" \
 	KCONFIG_CONFIG="$(UK_CONFIG)" \
 	KCONFIG_AUTOCONFIG="$(KCONFIG_AUTOCONFIG)" \
 	KCONFIG_AUTOHEADER="$(KCONFIG_AUTOHEADER)" \
 	KCONFIG_TRISTATE="$(KCONFIG_TRISTATE)" \
-	HOST_GCC_VERSION="$(HOSTCC_VERSION)" \
+	HOST_ARCH="$(HOSTARCH)" \
 	BUILD_DIR="$(BUILD_DIR)" \
 	UK_BASE="$(CONFIG_UK_BASE)" \
 	UK_APP="$(CONFIG_UK_APP)" \

--- a/Makefile
+++ b/Makefile
@@ -960,7 +960,6 @@ defconfig:
 
 savedefconfig:
 	@$(COMMON_CONFIG_ENV) $(KPYTHON) $(CONFIGLIB)/savedefconfig.py --kconfig $(CONFIG_CONFIG_IN) --out $(DEFCONFIG)
-	@$(COMMON_CONFIG_ENV) $(SCRIPTS_DIR)/configupdate $(UK_CONFIG) $(UK_CONFIG_OUT)
 
 oldconfig:
 	@$(COMMON_CONFIG_ENV) $(KPYTHON) $(CONFIGLIB)/oldconfig.py $(CONFIG_CONFIG_IN)
@@ -1035,8 +1034,6 @@ savedefconfig: $(KCONFIG_DIR)/conf
 	@$(COMMON_CONFIG_ENV) $< \
 		--savedefconfig=$(if $(DEFCONFIG),$(DEFCONFIG),$(CONFIG_DIR)/defconfig) \
 		$(CONFIG_CONFIG_IN)
-	@$(SED) '/UK_DEFCONFIG=/d' $(if $(DEFCONFIG),$(DEFCONFIG),$(CONFIG_DIR)/defconfig)
-	@$(COMMON_CONFIG_ENV) $(SCRIPTS_DIR)/configupdate $(UK_CONFIG) $(UK_CONFIG_OUT)
 
 .PHONY: defconfig savedefconfig silentoldconfig
 

--- a/Makefile
+++ b/Makefile
@@ -959,6 +959,10 @@ defconfig:
 
 savedefconfig:
 	@$(COMMON_CONFIG_ENV) $(KPYTHON) $(CONFIGLIB)/savedefconfig.py --kconfig $(CONFIG_CONFIG_IN) --out $(DEFCONFIG)
+ifeq ($(HOSTARCH),$(CONFIG_UK_ARCH))
+	@# Make sure arch is stored in the file even if arch matches between host and config
+	@echo "$(call ukarch_str2cfg,$(CONFIG_UK_ARCH))=y" >> $(DEFCONFIG)
+endif
 
 oldconfig:
 	@$(COMMON_CONFIG_ENV) $(KPYTHON) $(CONFIGLIB)/oldconfig.py $(CONFIG_CONFIG_IN)
@@ -1033,6 +1037,11 @@ savedefconfig: $(KCONFIG_DIR)/conf
 	@$(COMMON_CONFIG_ENV) $< \
 		--savedefconfig=$(if $(DEFCONFIG),$(DEFCONFIG),$(CONFIG_DIR)/defconfig) \
 		$(CONFIG_CONFIG_IN)
+ifeq ($(HOSTARCH),$(CONFIG_UK_ARCH))
+	@# Make sure arch is stored in the file even if arch matches between host and config
+	@echo "$(call ukarch_str2cfg,$(CONFIG_UK_ARCH))=y" >> \
+		$(if $(DEFCONFIG),$(DEFCONFIG),$(CONFIG_DIR)/defconfig)
+endif
 
 .PHONY: defconfig savedefconfig silentoldconfig
 

--- a/arch/Config.uk
+++ b/arch/Config.uk
@@ -1,7 +1,7 @@
 choice
 	prompt "Architecture"
-	default ARCH_ARM_32 if ($(shell,$(CC) -dumpmachine | cut -d '-' -f1) = "arm")
-	default ARCH_ARM_64 if ($(shell,$(CC) -dumpmachine | cut -d '-' -f1) = "arm64")
+	default ARCH_ARM_32 if HOST_ARCH = "arm"
+	default ARCH_ARM_64 if HOST_ARCH = "arm64"
 	default ARCH_X86_64
 	help
 	  Select the target CPU architecture.

--- a/arch/Makefile.rules
+++ b/arch/Makefile.rules
@@ -19,3 +19,19 @@ endef
 define aarch64_no_reserved_tcb_overlap =
 	$(eval LIBCONTEXT_CFLAGS-y+=-DCONFIG_AARCH64_NO_TCB_OVERLAP=1)
 endef
+
+# Converts an architecture string to the corresponding name of a configuration
+# variable
+# WARNING: This function might need to get modified as sson as we introduce
+#          another (external) architecture. This is is only necessary if the
+#          following assumption will note be valid:
+#          This function intents that for any future architecture the
+#          configuration name of matches with its name string, like we we have
+#          with x86: For example, the architecture string is called "x86_64" and
+#          its configuration name just contains this string in capital letters:
+#          `CONFIG_ARCH_X86_64`
+# Usage:
+#  $(call ukarch_str2cfg,"<architecture name>")
+define ukarch_str2cfg =
+$(addprefix CONFIG_ARCH_,$(call uc,$(subst arm,ARM_32,$(subst arm64,ARM_64,$(1)))))
+endef


### PR DESCRIPTION
### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Description of changes

With `savedefconfig`, KConfig creates a file that contains only options that are different from the default selection. Because the build system automatically detects the host architecture and sets the default architecture to this detected architecture, the architecture is never part of the defconfig file if the architecture in the configuration matches the host architecture. This becomes problematic as soon as such a file is loaded on a build environment that has a different host architecture: The configuration can fail because of architectural configuration differences.

This PR ensures that the configured architecture is always stored in the defconfig file. The `savedefconfig` target appends the configured architecture to the file if the architectures between host and configuration match.