### PR TITLE
arch/ctx.h: Update ctx members declaration order

### DIFF
--- a/include/uk/arch/ctx.h
+++ b/include/uk/arch/ctx.h
@@ -93,7 +93,7 @@ static inline void ukarch_ctx_init_bare(struct ukarch_ctx *ctx,
 	/* NOTE: We are not checking if SP is given or if SP is aligned because
 	 *       execution does not have to start with a function entry.
 	 */
-	(*ctx) = (struct ukarch_ctx){ .sp = sp, .ip = ip };
+	(*ctx) = (struct ukarch_ctx){ .ip = ip, .sp = sp };
 }
 
 /**


### PR DESCRIPTION
Out-of-order designated initialization is [not allowed in C++](https://en.cppreference.com/w/cpp/language/aggregate_initialization), so change the `ctx` declaration order to match the `ukarch_ctx` definition order.

You can see this error show up when building [`app-click`](https://github.com/unikraft/app-click).

```
  CXX     libclick: click.o
In file included from /workdir/unikraft/lib/uksched/include/uk/thread.h:36,
                 from /workdir/unikraft/lib/uksched/include/uk/sched.h:42,
                 from /workdir/libs/click/click.cc:55:
/workdir/unikraft/include/uk/arch/ctx.h: In function ‘void ukarch_ctx_init_bare(ukarch_ctx*, __uptr, __uptr)’:
/workdir/unikraft/include/uk/arch/ctx.h:100:58: warning: missing initializer for member ‘ukarch_ctx::ip’ [-Wmissing-field-initializers]
  100 |         (*ctx) = (struct ukarch_ctx){ .sp = sp, .ip = ip };
      |                                                          ^
/workdir/unikraft/include/uk/arch/ctx.h:100:58: error: designator order for field ‘ukarch_ctx::ip’ does not match declaration order in ‘ukarch_ctx’
```

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


