### PR TITLE
lib/9pfs: Add check for `NULL` `data` in `uk_9pfs_parse_options`

### DIFF
--- a/lib/9pfs/9pfs_vfsops.c
+++ b/lib/9pfs/9pfs_vfsops.c
@@ -118,16 +118,17 @@ static int uk_9pfs_parse_options(struct uk_9pfs_mount_data *md,
 		goto err;
 	}
 
+	md->proto = UK_9P_PROTO_2000L;
+	md->uname = strdup("");
+	md->aname = strdup("");
+
 	/*
 	 * musl/nolibc strtok_r resets saveptr at the end, so we need to feed
 	 * the option string only once; otherwise strtok_r would loop over the
 	 * options string forever
 	 */
-	options = options_tok = strdup(data);
-
-	md->proto = UK_9P_PROTO_2000L;
-	md->uname = strdup("");
-	md->aname = strdup("");
+	if (data)
+		options = options_tok = strdup(data);
 
 	while ((option = strtok_r(options_tok, ",", &options_save))) {
 		options_tok = NULL;

--- a/lib/9pfs/9pfs_vfsops.c
+++ b/lib/9pfs/9pfs_vfsops.c
@@ -106,7 +106,7 @@ static int uk_9pfs_parse_option(struct uk_9pfs_mount_data *md,
 }
 
 static int uk_9pfs_parse_options(struct uk_9pfs_mount_data *md,
-		const void *data __unused)
+				 const void *data __unused)
 {
 	int rc = 0;
 	char *options = NULL, *options_tok = NULL, *options_save = NULL;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The `mount` system call may actually allow ignoring the `data` argument depending on the usecase. Therefore allow `data` to be `NULL` by adding a check in `uk_9pfs_parse_options`.
