### PR TITLE
arch/*: Align virtual/physical address validation on x86 and arm64

### DIFF
--- a/arch/arm/arm64/include/uk/asm/paging.h
+++ b/arch/arm/arm64/include/uk/asm/paging.h
@@ -202,7 +202,11 @@ static inline __paddr_t PT_Lx_PTE_SET_PADDR(__pte_t pte, unsigned int lvl,
 	return pte | paddr;
 }
 
+static inline int ukarch_paddr_isvalid(__paddr_t addr)
 {
+	return ARM64_PADDR_VALID(addr);
+}
+
 static inline int ukarch_paddr_range_isvalid(__paddr_t start, __sz len)
 {
 	__paddr_t end = start + len - 1;
@@ -212,6 +216,11 @@ static inline int ukarch_paddr_range_isvalid(__paddr_t start, __sz len)
 #endif /* CONFIG_LIBUKDEBUG */
 
 	return (ARM64_PADDR_VALID(end)) && (ARM64_PADDR_VALID(start));
+}
+
+static inline int ukarch_vaddr_isvalid(__vaddr_t addr)
+{
+	return ARM64_VADDR_VALID(addr);
 }
 
 static inline int ukarch_vaddr_range_isvalid(__vaddr_t start, __sz len)

--- a/arch/arm/arm64/include/uk/asm/paging.h
+++ b/arch/arm/arm64/include/uk/asm/paging.h
@@ -202,8 +202,11 @@ static inline __paddr_t PT_Lx_PTE_SET_PADDR(__pte_t pte, unsigned int lvl,
 	return pte | paddr;
 }
 
-static inline int ukarch_paddr_range_isvalid(__paddr_t start, __paddr_t end)
 {
+static inline int ukarch_paddr_range_isvalid(__paddr_t start, __sz len)
+{
+	__paddr_t end = start + len - 1;
+
 #ifdef CONFIG_LIBUKDEBUG
 	UK_ASSERT(start <= end);
 #endif /* CONFIG_LIBUKDEBUG */
@@ -211,8 +214,10 @@ static inline int ukarch_paddr_range_isvalid(__paddr_t start, __paddr_t end)
 	return (ARM64_PADDR_VALID(end)) && (ARM64_PADDR_VALID(start));
 }
 
-static inline int ukarch_vaddr_range_isvalid(__vaddr_t start, __vaddr_t end)
+static inline int ukarch_vaddr_range_isvalid(__vaddr_t start, __sz len)
 {
+	__vaddr_t end = start + len - 1;
+
 #ifdef CONFIG_LIBUKDEBUG
 	UK_ASSERT(start <= end);
 #endif /* CONFIG_LIBUKDEBUG */

--- a/arch/x86/x86_64/include/uk/asm/paging.h
+++ b/arch/x86/x86_64/include/uk/asm/paging.h
@@ -128,7 +128,11 @@ struct ukarch_pagetable {
 	((__vaddr_t)(((__ssz)(vaddr) << (64 - X86_VADDR_BITS)) >>	\
 		(64 - X86_VADDR_BITS)))
 
+static inline int ukarch_vaddr_isvalid(__vaddr_t addr)
 {
+	return X86_VADDR_CANONICALIZE(addr) == addr;
+}
+
 static inline int ukarch_vaddr_range_isvalid(__vaddr_t start, __sz len)
 {
 	__vaddr_t end = start + len - 1;

--- a/arch/x86/x86_64/include/uk/asm/paging.h
+++ b/arch/x86/x86_64/include/uk/asm/paging.h
@@ -128,8 +128,11 @@ struct ukarch_pagetable {
 	((__vaddr_t)(((__ssz)(vaddr) << (64 - X86_VADDR_BITS)) >>	\
 		(64 - X86_VADDR_BITS)))
 
-static inline int ukarch_vaddr_range_isvalid(__vaddr_t start, __vaddr_t end)
 {
+static inline int ukarch_vaddr_range_isvalid(__vaddr_t start, __sz len)
+{
+	__vaddr_t end = start + len - 1;
+
 #ifdef CONFIG_LIBUKDEBUG
 	UK_ASSERT(start <= end);
 #endif /* CONFIG_LIBUKDEBUG */

--- a/include/uk/arch/paging.h
+++ b/include/uk/arch/paging.h
@@ -375,8 +375,13 @@ int PAGE_Lx_IS(__pte_t pte, unsigned int lvl);
  */
 int ukarch_vaddr_range_isvalid(__vaddr_t start, __sz len);
 
-#define ukarch_vaddr_isvalid(vaddr)				\
-	ukarch_vaddr_range_isvalid(vaddr, vaddr)
+/**
+ * Tests if a virtual address is valid on the current architecture.
+ *
+ * @param addr the virtual address to test
+ * @return a non-zero value if the address is supported
+ */
+int ukarch_vaddr_isvalid(__vaddr_t addr);
 
 /**
  * Tests if a certain range of physical addresses is valid on the current
@@ -390,8 +395,13 @@ int ukarch_vaddr_range_isvalid(__vaddr_t start, __sz len);
  */
 int ukarch_paddr_range_isvalid(__paddr_t start, __sz len);
 
-#define ukarch_paddr_isvalid(paddr)				\
-	ukarch_paddr_range_isvalid(paddr, paddr)
+/**
+ * Tests if a physical address is valid on the current architecture.
+ *
+ * @param addr the physical address to test
+ * @return a non-zero value if the address is supported
+ */
+int ukarch_paddr_isvalid(__paddr_t addr);
 
 /**
  * Reads a page table entry from the given page table.

--- a/include/uk/arch/paging.h
+++ b/include/uk/arch/paging.h
@@ -370,11 +370,10 @@ int PAGE_Lx_IS(__pte_t pte, unsigned int lvl);
  * 64 bits for the virtual address.
  *
  * @param start the start of the virtual address range
- * @param end the end of the virtual address range
- *
+ * @param  len the length of the virtual address range
  * @return a non-zero value if the addresses in the range are supported
  */
-int ukarch_vaddr_range_isvalid(__vaddr_t start, __vaddr_t end);
+int ukarch_vaddr_range_isvalid(__vaddr_t start, __sz len);
 
 #define ukarch_vaddr_isvalid(vaddr)				\
 	ukarch_vaddr_range_isvalid(vaddr, vaddr)
@@ -386,11 +385,10 @@ int ukarch_vaddr_range_isvalid(__vaddr_t start, __vaddr_t end);
  * installed in the system.
  *
  * @param start the start of the physical address range
- * @param end the end of the physical address range
- *
+ * @param len the length of the physical address range
  * @return a non-zero value if the addresses in the range are supported
  */
-int ukarch_paddr_range_isvalid(__paddr_t start, __paddr_t end);
+int ukarch_paddr_range_isvalid(__paddr_t start, __sz len);
 
 #define ukarch_paddr_isvalid(paddr)				\
 	ukarch_paddr_range_isvalid(paddr, paddr)

--- a/lib/ukfallocbuddy/fallocbuddy.c
+++ b/lib/ukfallocbuddy/fallocbuddy.c
@@ -495,7 +495,7 @@ static struct bfa_zone *bfa_zone_init(void *buffer, __paddr_t start, __sz len,
 	UK_ASSERT(BFA_Lx_ALIGNED(start, 0));
 	UK_ASSERT(start <= __PADDR_MAX - len);
 #ifdef CONFIG_PAGING
-	UK_ASSERT(ukarch_paddr_range_isvalid(start, start + len));
+	UK_ASSERT(ukarch_paddr_range_isvalid(start, len));
 #endif /* CONFIG_PAGING */
 	zn->start = start;
 	zn->end = start + len;
@@ -1366,7 +1366,7 @@ static int bfa_do_free(struct buddy_framealloc *bfa, __paddr_t paddr, __sz len)
 	UK_ASSERT(BFA_Lx_ALIGNED(len, 0));
 	UK_ASSERT(paddr <= (__PADDR_MAX - len));
 #ifdef CONFIG_PAGING
-	UK_ASSERT(ukarch_paddr_range_isvalid(paddr, paddr + len));
+	UK_ASSERT(ukarch_paddr_range_isvalid(paddr, len));
 #endif /* CONFIG_PAGING */
 
 	/* The memory area might cross multiple buddies and zones */
@@ -1440,7 +1440,7 @@ static int bfa_do_addmem(struct buddy_framealloc *bfa, void *metadata,
 	UK_ASSERT(BFA_Lx_ALIGNED(len, 0));
 	UK_ASSERT(paddr <= (__PADDR_MAX - len));
 #ifdef CONFIG_PAGING
-	UK_ASSERT(ukarch_paddr_range_isvalid(paddr, paddr + len));
+	UK_ASSERT(ukarch_paddr_range_isvalid(paddr, len));
 #endif /* CONFIG_PAGING */
 
 	zone = bfa_zone_init(metadata, paddr, len, dm_off);

--- a/lib/ukvmem/vma_dma.c
+++ b/lib/ukvmem/vma_dma.c
@@ -38,7 +38,7 @@ int vma_op_dma_new(struct uk_vas *vas, __vaddr_t vaddr __unused,
 	UK_ASSERT(data);
 	UK_ASSERT(PAGE_ALIGNED(args->paddr));
 	UK_ASSERT(args->paddr <= __PADDR_MAX - len);
-	UK_ASSERT(ukarch_paddr_range_isvalid(args->paddr, args->paddr + len));
+	UK_ASSERT(ukarch_paddr_range_isvalid(args->paddr, len));
 
 	vma_dma = uk_malloc(vas->a, sizeof(struct uk_vma_dma));
 	if (unlikely(!vma_dma))

--- a/lib/ukvmem/vmem.c
+++ b/lib/ukvmem/vmem.c
@@ -215,7 +215,7 @@ static int vmem_vma_find_range(struct uk_vas *vas, __vaddr_t *vaddr, __sz *len,
 	UK_ASSERT(vend > vstart);
 	UK_ASSERT(vstart >= vma_start->start && vstart < vma_start->end);
 	UK_ASSERT(vend > vma_end->start && vend <= vma_end->end);
-	UK_ASSERT(ukarch_vaddr_range_isvalid(vstart, vend));
+	UK_ASSERT(ukarch_vaddr_range_isvalid(vstart, vl));
 
 	*vaddr = vstart;
 	*len   = vend - vstart;
@@ -662,7 +662,7 @@ int uk_vma_map(struct uk_vas *vas, __vaddr_t *vaddr, __sz len,
 
 	UK_ASSERT(PAGE_Lx_ALIGNED(va, algn_lvl));
 	UK_ASSERT(va <= __VADDR_MAX - len);
-	UK_ASSERT(ukarch_vaddr_range_isvalid(va, va + len));
+	UK_ASSERT(ukarch_vaddr_range_isvalid(va, len));
 
 	/* Create a new VMA for the requested range. */
 	if (ops->new) {

--- a/plat/common/include/arm/arm64/paging.h
+++ b/plat/common/include/arm/arm64/paging.h
@@ -346,7 +346,7 @@ pgarch_pt_add_mem(struct uk_pagetable *pt, __paddr_t start, __sz len)
 	int rc;
 
 	UK_ASSERT(start <= __PADDR_MAX - len);
-	UK_ASSERT(ukarch_paddr_range_isvalid(start, start + len));
+	UK_ASSERT(ukarch_paddr_range_isvalid(start, len));
 
 	/* Reserve space for the metadata at the beginning of the area. Note
 	 * that the metadata area will be a bit too large because we eat away

--- a/plat/common/include/x86/paging.h
+++ b/plat/common/include/x86/paging.h
@@ -246,7 +246,11 @@ static __paddr_t x86_pg_maxphysaddr;
 
 #define X86_PG_VALID_PADDR(paddr)	((paddr) <= x86_pg_maxphysaddr)
 
+int ukarch_paddr_isvalid(__paddr_t addr)
 {
+	return X86_PG_VALID_PADDR(addr);
+}
+
 int ukarch_paddr_range_isvalid(__paddr_t start, __sz len)
 {
 	__paddr_t end = start + len - 1;

--- a/plat/common/include/x86/paging.h
+++ b/plat/common/include/x86/paging.h
@@ -246,8 +246,11 @@ static __paddr_t x86_pg_maxphysaddr;
 
 #define X86_PG_VALID_PADDR(paddr)	((paddr) <= x86_pg_maxphysaddr)
 
-int ukarch_paddr_range_isvalid(__paddr_t start, __paddr_t end)
 {
+int ukarch_paddr_range_isvalid(__paddr_t start, __sz len)
+{
+	__paddr_t end = start + len - 1;
+
 	UK_ASSERT(start <= end);
 	return (X86_PG_VALID_PADDR(start) && X86_PG_VALID_PADDR(end));
 }
@@ -323,7 +326,7 @@ pgarch_pt_add_mem(struct uk_pagetable *pt, __paddr_t start, __sz len)
 	int rc;
 
 	UK_ASSERT(start <= __PADDR_MAX - len);
-	UK_ASSERT(ukarch_paddr_range_isvalid(start, start + len));
+	UK_ASSERT(ukarch_paddr_range_isvalid(start, len));
 
 	/* Reserve space for the metadata at the beginning of the area. Note
 	 * that the metadata area will be a bit too large because we eat away

--- a/plat/common/include/x86/paging.h
+++ b/plat/common/include/x86/paging.h
@@ -244,7 +244,7 @@ pgarch_kunmap(struct uk_pagetable *pt __unused, __vaddr_t vaddr __unused,
 
 static __paddr_t x86_pg_maxphysaddr;
 
-#define X86_PG_VALID_PADDR(paddr)	((paddr) < x86_pg_maxphysaddr)
+#define X86_PG_VALID_PADDR(paddr)	((paddr) <= x86_pg_maxphysaddr)
 
 int ukarch_paddr_range_isvalid(__paddr_t start, __paddr_t end)
 {
@@ -308,7 +308,7 @@ pgarch_init(void)
 	}
 
 	max_addr_bit = (eax & X86_PG_PADDR_MASK) >> X86_PG_PADDR_SHIFT;
-	x86_pg_maxphysaddr = (1UL << max_addr_bit);
+	x86_pg_maxphysaddr = (1UL << max_addr_bit) - 1;
 
 	return 0;
 }

--- a/plat/common/paging.c
+++ b/plat/common/paging.c
@@ -267,7 +267,7 @@ int ukplat_pt_init(struct uk_pagetable *pt, __paddr_t start, __sz len)
 	}
 
 	UK_ASSERT(start <= __PADDR_MAX - len);
-	UK_ASSERT(ukarch_paddr_range_isvalid(start, start + len));
+	UK_ASSERT(ukarch_paddr_range_isvalid(start, len));
 
 	/* Initialize the frame allocator and any architecture-dependent parts
 	 * of the new page table
@@ -307,7 +307,7 @@ int ukplat_pt_add_mem(struct uk_pagetable *pt, __paddr_t start, __sz len)
 		return 0;
 
 	UK_ASSERT(start <= __PADDR_MAX - len);
-	UK_ASSERT(ukarch_paddr_range_isvalid(start, start + len));
+	UK_ASSERT(ukarch_paddr_range_isvalid(start, len));
 
 	return pgarch_pt_add_mem(pt, start, len);
 }
@@ -533,12 +533,12 @@ static int pg_page_mapx(struct uk_pagetable *pt, __vaddr_t pt_vaddr,
 	UK_ASSERT(PAGE_Lx_ALIGNED(len, to_lvl));
 	UK_ASSERT(PAGE_Lx_ALIGNED(vaddr, to_lvl));
 	UK_ASSERT(vaddr <= __VADDR_MAX - len);
-	UK_ASSERT(ukarch_vaddr_range_isvalid(vaddr, vaddr + len));
+	UK_ASSERT(ukarch_vaddr_range_isvalid(vaddr, len));
 
 	if (paddr != __PADDR_ANY) {
 		UK_ASSERT(PAGE_Lx_ALIGNED(paddr, to_lvl));
 		UK_ASSERT(paddr <= __PADDR_MAX - len);
-		UK_ASSERT(ukarch_paddr_range_isvalid(paddr, paddr + len));
+		UK_ASSERT(ukarch_paddr_range_isvalid(paddr, len));
 
 		alloc_pmem = 0;
 	} else
@@ -956,7 +956,7 @@ static int pg_page_unmap(struct uk_pagetable *pt, __vaddr_t pt_vaddr,
 		UK_ASSERT(PAGE_Lx_ALIGNED(len, to_lvl));
 		UK_ASSERT(PAGE_Lx_ALIGNED(vaddr, to_lvl));
 		UK_ASSERT(vaddr <= __VADDR_MAX - len);
-		UK_ASSERT(ukarch_vaddr_range_isvalid(vaddr, vaddr + len));
+		UK_ASSERT(ukarch_vaddr_range_isvalid(vaddr, len));
 
 		pte_idx = PT_Lx_IDX(vaddr, lvl);
 		page_size = PAGE_Lx_SIZE(lvl);
@@ -1237,7 +1237,7 @@ static int pg_page_set_attr(struct uk_pagetable *pt, __vaddr_t pt_vaddr,
 		UK_ASSERT(PAGE_Lx_ALIGNED(len, to_lvl));
 		UK_ASSERT(PAGE_Lx_ALIGNED(vaddr, to_lvl));
 		UK_ASSERT(vaddr <= __VADDR_MAX - len);
-		UK_ASSERT(ukarch_vaddr_range_isvalid(vaddr, vaddr + len));
+		UK_ASSERT(ukarch_vaddr_range_isvalid(vaddr, len));
 
 		pte_idx = PT_Lx_IDX(vaddr, lvl);
 		page_size = PAGE_Lx_SIZE(lvl);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): x86, arm64
 - Platform(s): kvm
 - Application(s): helloworld


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes
This PR fixes the signature of the address range validation functions `ukarch_paddr_range_isvalid`, and `ukarch_vaddr_range_isvalid`  to take the length of the range, instead of the start and end addresses. 
It also make the logic consistent across x86 and arm64.
