### PR TITLE
build: Forward YACC/LEX to kconfig make invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -858,6 +858,7 @@ $(KCONFIG_TOOLS):
 	$(call verbose_cmd,MAKE,$(notdir $(CONFIG)),$(MAKE) \
 	    --no-print-directory \
 	    CC="$(HOSTCC_NOCCACHE)" HOSTCC="$(HOSTCC_NOCCACHE)" \
+	    YACC="$(YACC)" LEX="$(LEX)" \
 	    obj=$(@D) -C $(CONFIG) -f Makefile.br $(@))
 endif
 


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

KConfig relies on GNU bison and does not work with the classical yacc. While most Linux distributions prefer bison and add a symlink for yacc, there are distributions that do not this (Fedora). They seem to actually use the original Berkeley yacc to provide `yacc`.

Instead of using the default `yacc` for `YACC` in make explicitly forward our preference for `bison` to the kconfig Makefile.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
