### PR TITLE
lib/vfscore: Fix pipe error codes

### DIFF
--- a/lib/vfscore/pipe.c
+++ b/lib/vfscore/pipe.c
@@ -309,7 +309,7 @@ static int pipe_write(struct vnode *vnode,
 
 	if (!pipe_file->r_refcount) {
 		/* TODO before returning the error, send a SIGPIPE signal */
-		return -EPIPE;
+		return EPIPE;
 	}
 
 	uk_mutex_lock(&pipe_buf->wrlock);
@@ -447,8 +447,7 @@ static int pipe_seek(struct vnode *vnode __unused,
 			struct vfscore_file *vfscore_file __unused,
 			off_t off1 __unused, off_t off2 __unused)
 {
-	errno = ESPIPE;
-	return -1;
+	return ESPIPE;
 }
 
 static int pipe_ioctl(struct vnode *vnode,
@@ -468,7 +467,7 @@ static int pipe_ioctl(struct vnode *vnode,
 		/* sys_ioctl() already sets f_flags, no need to do anything */
 		return 0;
 	default:
-		return -EINVAL;
+		return EINVAL;
 	}
 }
 
@@ -698,6 +697,9 @@ ERR_EXIT:
 UK_SYSCALL_R_DEFINE(int, pipe2, int*, pipefd, int, flags)
 {
 	int rc;
+
+	if (flags & O_DIRECT)
+		return -EINVAL;
 
 	rc = uk_syscall_r_pipe((long) pipefd);
 	if (rc)


### PR DESCRIPTION
### Description of changes

This change fixes incorrect return of error codes in the pipe module of vfscore. Specifically:
- Return positive error codes from internal functions; syscall handlers expect positive errors and will negate them as required
- Do not set errno, rather return the error code
- Correctly return EINVAL when attempting to open a pipe with O_DIRECT, as we do not support packet mode pipes, and calling code needs to be made aware of this (see `pipe2(2)`)

Checkpatch has no sodding clue about (the very messy) error conventions in our codebase; likely a false positive inherited from Linux, will probably fix at the source soonish.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A
