### PR TITLE
arch/*: Add an non-aligned version for stack-pushing

### DIFF
--- a/arch/arm/arm64/include/uk/asm/ctx.h
+++ b/arch/arm/arm64/include/uk/asm/ctx.h
@@ -56,6 +56,14 @@
 		__sp__;					\
 	})
 
+#define ukarch_rstack_push_packed(sp, value)		\
+	({						\
+		unsigned long __sp__ = (sp);		\
+		__sp__ -= sizeof(value);		\
+		*((typeof(value) *) __sp__) = (value);	\
+		__sp__;					\
+	})
+
 #define ukarch_gen_sp(base, len)					\
 	({								\
 		unsigned long __sp__ = (unsigned long) (base)		\

--- a/arch/x86/x86_64/include/uk/asm/ctx.h
+++ b/arch/x86/x86_64/include/uk/asm/ctx.h
@@ -39,6 +39,9 @@
 		__sp__;					\
 	})
 
+#define ukarch_rstack_push_packed(sp, value)		\
+	ukarch_rstack_push(sp, value)
+
 #define UKARCH_SP_ALIGN		(1 << 4)
 #define UKARCH_SP_ALIGN_MASK	(UKARCH_SP_ALIGN - 1)
 

--- a/include/uk/arch/ctx.h
+++ b/include/uk/arch/ctx.h
@@ -174,6 +174,14 @@ void ukarch_ctx_init_entry2(struct ukarch_ctx *ctx,
 	})
 
 /**
+ * Similar to `ukarch_rctx_stackpush()` but without alignment.
+ */
+#define ukarch_rctx_stackpush_packed(ctx, value)			\
+	({								\
+		(ctx)->sp = ukarch_rstack_push_packed((ctx)->sp, (value)); \
+	})
+
+/**
  * Switch the current logical CPU to context `load`. The current context
  * is stored to `store`. The standard register set is saved to `store`'s
  * stack and will be restored when the context will be loaded again.


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): *

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

For AArch64, `ukarch_rctx_stackpush` may add padding to make sure the `sp` register is aligned to 16 bytes.
But there're also some use cases where alignment is not allowed.
In such cases, the newly introduced `ukarch_rctx_stackpush_packed` and `ukarch_rstack_push_packed` will be useful.