### PR TITLE
lib: Remove dirent64-related build warnings

### DIFF
--- a/lib/9pfs/9pfs_vfsops.c
+++ b/lib/9pfs/9pfs_vfsops.c
@@ -30,7 +30,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define _BSD_SOURCE
+#define _GNU_SOURCE
 
 #include <uk/config.h>
 #include <uk/errptr.h>

--- a/lib/posix-event/epoll.c
+++ b/lib/posix-event/epoll.c
@@ -30,7 +30,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define _BSD_SOURCE
+#define _GNU_SOURCE
 
 #include <vfscore/eventpoll.h>
 #include <vfscore/fs.h>

--- a/lib/posix-event/eventfd.c
+++ b/lib/posix-event/eventfd.c
@@ -30,7 +30,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define _BSD_SOURCE
+#define _GNU_SOURCE
 
 #include <vfscore/eventpoll.h>
 #include <vfscore/fs.h>

--- a/lib/posix-socket/driver.c
+++ b/lib/posix-socket/driver.c
@@ -33,6 +33,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _GNU_SOURCE
+
 #include <uk/alloc.h>
 #include <uk/assert.h>
 #include <uk/print.h>

--- a/lib/posix-socket/socket.c
+++ b/lib/posix-socket/socket.c
@@ -34,6 +34,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _GNU_SOURCE
+
 #include <sys/types.h>
 #include <uk/socket.h>
 #include <uk/errptr.h>

--- a/lib/posix-socket/socket_vnops.c
+++ b/lib/posix-socket/socket_vnops.c
@@ -34,7 +34,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define _BSD_SOURCE
+#define _GNU_SOURCE
 
 #include <uk/socket_driver.h>
 #include <uk/socket_vnops.h>

--- a/lib/vfscore/dentry.c
+++ b/lib/vfscore/dentry.c
@@ -30,7 +30,7 @@
  * SUCH DAMAGE.
  */
 
-#define _BSD_SOURCE
+#define _GNU_SOURCE
 
 #include <string.h>
 #include <stdlib.h>

--- a/lib/vfscore/eventpoll.c
+++ b/lib/vfscore/eventpoll.c
@@ -30,6 +30,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _GNU_SOURCE
+
 #include <vfscore/eventpoll.h>
 #include <vfscore/file.h>
 #include <vfscore/dentry.h>

--- a/lib/vfscore/lookup.c
+++ b/lib/vfscore/lookup.c
@@ -30,7 +30,7 @@
  * SUCH DAMAGE.
  */
 
-#define _BSD_SOURCE
+#define _GNU_SOURCE
 
 #include <unistd.h>
 #include <string.h>

--- a/lib/vfscore/pipe.c
+++ b/lib/vfscore/pipe.c
@@ -31,7 +31,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define _BSD_SOURCE
+#define _GNU_SOURCE
 
 #include <uk/config.h>
 #include <stdlib.h>

--- a/lib/vfscore/stdio.c
+++ b/lib/vfscore/stdio.c
@@ -31,7 +31,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define _BSD_SOURCE
+#define _GNU_SOURCE
 
 #include <vfscore/file.h>
 #include <vfscore/fs.h>

--- a/lib/vfscore/vnode.c
+++ b/lib/vfscore/vnode.c
@@ -33,7 +33,7 @@
 /*
  * vfs_vnode.c - vnode service
  */
-#define _BSD_SOURCE
+#define _GNU_SOURCE
 
 #include <limits.h>
 #include <unistd.h>


### PR DESCRIPTION
Using Musl and the dirent64 structure causes build warnings. This is because certain source code files do not define _GNU_SOURCE. Fix build warnings by defining _GNU_SOURCE in the required source code files

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): any application using Musl


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
