### PR TITLE
lib/9pfs: Return ENOTSUP on ioctl requests except for FIONBIO

### DIFF
--- a/lib/9pfs/9pfs_vnops.c
+++ b/lib/9pfs/9pfs_vnops.c
@@ -1016,10 +1016,23 @@ static int uk_9pfs_ioctl(struct vnode *dvp, struct vfscore_file *fp,
 			 unsigned long com, void *data)
 {
 	switch (com) {
-	case TIOCGWINSZ:
-		return ENOTTY;
-	default:
+	/**
+	 * HACK: In binary compatibility mode, Ruby tries to set O_ASYNC,
+	 * which Unikraft does not yet support. If the `ioctl` call returns
+	 * an error, Ruby stops working, even if it does not depend on the
+	 * O_ASYNC being properly set.
+	 *
+	 * Until proper support, just return 0 in case an `FIONBIO` ioctl
+	 * request is done, and ENOTSUP for all other cases.
+	 *
+	 * Setting `ioctl` to a nullop will not work, since it is used by
+	 * interpreted languages (e.g. python3) to check if it should start
+	 * the interpretor or just read a file.
+	 */
+	case FIONBIO:
 		return 0;
+	default:
+		return ENOTSUP;
 	}
 }
 

--- a/lib/vfscore/include/vfscore/vnode.h
+++ b/lib/vfscore/include/vfscore/vnode.h
@@ -43,6 +43,15 @@
 #include <vfscore/uio.h>
 #include <vfscore/dentry.h>
 
+#define IOCTL_CMD_TYPE_SHIFT		(8)
+#define IOCTL_CMD_TYPE_MASK		(0xFF << IOCTL_CMD_TYPE_SHIFT)
+#define IOCTL_CMD_TYPE_TTY		('T')
+
+#define IOCTL_CMD_ISTYPE(cmd, type)			\
+		((cmd & (IOCTL_CMD_TYPE_MASK)) ==	\
+		 (((type) << IOCTL_CMD_TYPE_SHIFT) &	\
+		  IOCTL_CMD_TYPE_MASK))
+
 struct vfsops;
 struct vnops;
 struct vnode;


### PR DESCRIPTION
Currently `9pfs` returns 0 for any `ioctl` request (except for `TIOCGWINSZ`), which leads to multiple cases of files being interpreted as terminals. You can see this problem when running python scripts, since python uses `ioctl` calls to check if it should open up the interactive interpretor or execute a script.

Same thing could happen for other applications that rely on `ioctl` operations being properly executed, so the best way to go would be return `EINVAL` (as is used to happen before commit 28d0edf).

If the `ioctl` call always return `EINVAL`, the Ruby binary compatibility application will fail, since it tries to set O_ASYNC and breaks on error, even if it does not directly depends on that, so for now add a special case for that.

So as an overview:

* current implementation (`staging` branch) -> binary compatibility `python3` scripts (using `glibc` as the libc, since the `musl` case is covered by the `TIOCGWINSZ` special case) fails, since it thinks it runs inside a terminal.
  The same could happen for any application that expects the `ioctl` request to be properly handeled.
  `ruby` works in binary compatibility mode.
* `ioctl` always returns `EINVAL` (as it should, since we do not handle the `ioctl` requests) -> `python3` scripts work fine, `ruby` fails in binary compatibility mode, since it tries to set `O_ASYNC` (even if it works fine without it).
* the implementation in this PR -> both `python3` and `ruby` work fine, nothing else seems to currently break, even if adding the special case for `FIONBIO` is very hackish.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): `python3` bincompat, `ruby` bincompat


