### PR TITLE
lib: Remove timeval-related build warnings

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -2550,7 +2550,7 @@ UK_TRACEPOINT(trace_vfs_utimes, "\"%s\"", const char*);
 UK_TRACEPOINT(trace_vfs_utimes_ret, "");
 UK_TRACEPOINT(trace_vfs_utimes_err, "%d", int);
 
-int futimes(int fd, const struct timeval *times)
+int futimes(int fd, const struct timeval times[2])
 {
     return futimesat(fd, NULL, times);
 }
@@ -2688,7 +2688,7 @@ UK_SYSCALL_R_DEFINE(int, utimes, const char*, pathname,
 	return do_utimes(pathname, times, 0);
 }
 
-int lutimes(const char *pathname, const struct timeval *times)
+int lutimes(const char *pathname, const struct timeval times[2])
 {
 	return do_utimes(pathname, times, AT_SYMLINK_NOFOLLOW);
 }


### PR DESCRIPTION
The futimes and lutimes functions were defined with a `struct timeval [2]` argument but they were instantiated with a pointer.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): any application using Musl


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
