### PR TITLE
lib: Remove vfscore_mount_initrd_volume-related build warnings

### DIFF
--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -151,6 +151,9 @@ static void vfscore_fstab_fetch_volume_args(char *v, struct vfscore_volume *vv)
 }
 #endif /* CONFIG_LIBVFSCORE_FSTAB */
 
+#if (CONFIG_LIBVFSCORE_AUTOMOUNT_ROOTFS && \
+	CONFIG_LIBVFSCORE_ROOTFS_INITRD) || \
+	CONFIG_LIBVFSCORE_FSTAB
 #ifdef CONFIG_LIBUKCPIO
 static int vfscore_mount_initrd_volume(struct vfscore_volume *vv)
 {
@@ -194,6 +197,7 @@ static int vfscore_mount_initrd_volume(struct vfscore_volume *vv __unused)
 	return -1;
 }
 #endif /* !CONFIG_LIBUKCPIO */
+#endif /* CONFIG_... */
 
 #ifdef CONFIG_LIBVFSCORE_AUTOMOUNT_ROOTFS
 static int vfscore_automount_rootfs(void)


### PR DESCRIPTION
The `vfscore_mount_initrd_volume` function was defined but not used. A #if was added in line 154 to fix this issue.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): any application using Musl


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
