### PR TITLE
lib/vfscore: Fix spelling mistake in `Config.uk`

### DIFF
--- a/lib/vfscore/Config.uk
+++ b/lib/vfscore/Config.uk
@@ -29,7 +29,7 @@ config LIBVFSCORE_NONLARGEFILE
 		the 64-bit version of the system calls are registered.
 
 config LIBVFSCORE_AUTOMOUNT_ROOTFS
-bool "Automatically mount a root filesysytem (/)"
+bool "Automatically mount a root filesystem (/)"
 default n
 help
 	Automatically mounts '/' during boot. The parameters are


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]

### Description of changes

Fixed typo in line 32
`bool "Automatically mount a root filesysytem (/)"` ---> `bool "Automatically mount a root filesystem (/)"`

