### PR TITLE
build: Add target to print unikernel LoC stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -842,7 +842,7 @@ clean-libs clean:
 
 endif
 
-.PHONY: print-vars print-libs print-objs print-srcs help outputmakefile list-defconfigs
+.PHONY: print-vars print-libs print-objs print-srcs print-loc help outputmakefile list-defconfigs
 
 # Configuration
 # ---------------------------------------------------------------------------
@@ -1048,6 +1048,11 @@ endif
 
 # Misc stuff
 # ---------------------------------------------------------------------------
+print-loc: images
+	@$(info [LoC stats])
+	@$(foreach I,$(UK_DEBUG_IMAGES) $(UK_DEBUG_IMAGES-y),\
+		$(info $(shell basename $(I) .dbg) has $(call measure_loc,$(I)) lines of code))
+
 print-vars:
 	@$(foreach V, \
 		$(sort $(if $(VARS),$(filter $(VARS),$(.VARIABLES)),$(.VARIABLES))), \
@@ -1204,6 +1209,7 @@ endif
 	@echo '  print-objs             - print object file names enabled for build'
 	@echo '  print-srcs             - print source file names enabled for build'
 	@echo '  print-vars             - prints all the variables currently defined in Makefile'
+	@echo '  print-loc              - print Lines-of-Code statistics for built unikernel image(s)'
 	@echo ''
 
 endif #umask

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -76,6 +76,12 @@ $(if $(call clang_version_ge,$(1),$(2)),,\
      $(error Require Clang version >= $(1).$(2) found $(CC_VER_MAJOR).$(CC_VER_MINOR)))
 endef
 
+# Roughly measure lines of code in a built (debug) ELF
+# measure_loc $path
+define measure_loc =
+$(shell $(OBJDUMP) -dl "$(1)" | grep '^/' | grep -v '^/[/*]' | $(SED) -e 's/ [(]discriminator .*[)]//g' | sort -u | wc -l)
+endef
+
 ################################################################################
 #
 # Paths and Filenames


### PR DESCRIPTION
### Description of changes

This change adds the `print-loc` Makefile target which (fairly hackishly) computes and prints statistics about the number of lines of code that make it into a built unikernel image. It is not intended as an end-user metric and thus does not aim for any particular level of accuracy or edge-case handling, rather it is a fun little dev tool that allows rough comparisons of the level of "bloat" between unikernels.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Test with `make print-loc` on your favourite unikernel build.