### PR TITLE
build, scripts: Ensure using GNU coreutils on Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -639,8 +639,12 @@ AWK		:= gawk --lint
 endif
 ifeq ($(HOSTOSENV),Darwin)
 GREP		:= ggrep
+READLINK	:= greadlink
+DIRNAME		:= gdirname
 else
 GREP		:= grep
+READLINK	:= readlink
+DIRNAME		:= dirname
 endif
 YACC		:= bison
 LEX     	:= flex

--- a/Makefile
+++ b/Makefile
@@ -637,6 +637,11 @@ AWK		:= awk
 else
 AWK		:= gawk --lint
 endif
+ifeq ($(HOSTOSENV),Darwin)
+GREP		:= ggrep
+else
+GREP		:= grep
+endif
 YACC		:= bison
 LEX     	:= flex
 PATCH		:= patch

--- a/lib/ukreloc/Makefile.rules
+++ b/lib/ukreloc/Makefile.rules
@@ -2,5 +2,5 @@ define build_uk_reloc =
 	$(call build_cmd,UKRELOC,,$(1).uk_reloc.bin,\
 		$(SCRIPTS_DIR)/mkukreloc.py $(1) && \
 		$(OBJCOPY) --update-section .uk_reloc=$(1).uk_reloc.bin $(1) 2>&1 | \
-		{ grep -v "section.*lma.*adjusted to.*" || true; })
+		{ $(GREP) -v "section.*lma.*adjusted to.*" || true; })
 endef

--- a/plat/kvm/Linker.uk
+++ b/plat/kvm/Linker.uk
@@ -70,7 +70,7 @@ $(KVM_IMAGE): $(KVM_IMAGE).dbg
 			$(SECT_STRIP_FLAGS) $(SECT_STRIP_FLAGS-y) \
 			$(KVM_STRIPFLAGS) \
 			$< -o $@ 2>&1 | \
-			{ grep -Ev \
+			{ $(GREP) -Ev \
 				"Empty loadable segment detected|section.*lma.*adjusted to.*" || \
 				true; })
 	$(call build_bootinfo,$@)

--- a/plat/linuxu/Linker.uk
+++ b/plat/linuxu/Linker.uk
@@ -29,7 +29,7 @@ $(LINUXU_IMAGE): $(LINUXU_IMAGE).dbg
 		$(STRIP) -s \
 			$(SECT_STRIP_FLAGS) $(SECT_STRIP_FLAGS-y) \
 			$< -o $@ 2>&1 | \
-			{ grep -v "Empty loadable segment detected" || true; })
+			{ $(GREP) -v "Empty loadable segment detected" || true; })
 	$(call build_bootinfo,$@)
 
 $(LINUXU_IMAGE).sym: $(LINUXU_DEBUG_IMAGE)

--- a/plat/xen/Linker.uk
+++ b/plat/xen/Linker.uk
@@ -48,7 +48,7 @@ $(XEN_IMAGE): $(XEN_DEBUG_IMAGE)
 		$(STRIP) -s \
 			$(SECT_STRIP_FLAGS) $(SECT_STRIP_FLAGS-y) \
 			$< -o $@ 2>&1 | \
-		        { grep -Ev \
+		        { $(GREP) -Ev \
 				"Empty loadable segment detected|section.*lma.*adjusted to.*" || \
 				true; })
 	$(call build_bootinfo,$@)

--- a/support/build/config-submenu.sh
+++ b/support/build/config-submenu.sh
@@ -6,6 +6,12 @@
 IFS_ORIG=$IFS
 IFS_NL=$'\n'
 
+if [ $( uname ) = "Darwin" ]; then
+	CMD_READLINK=greadlink
+else
+	CMD_READLINK=readlink
+fi
+
 usage()
 {
 	echo "Usage: $0 [OPTION]... [LIBRARY PATH]..."
@@ -116,7 +122,7 @@ for ARG_PATH in "${ARG_PATHS[@]}" "$@"; do
 		continue;
 	fi
 
-	printf "source \"%s\"\n" "$( readlink -f "${CONFIG_UK}" )" >&7
+	printf "source \"%s\"\n" "$( "${CMD_READLINK}" -f "${CONFIG_UK}" )" >&7
 done
 
 #
@@ -132,6 +138,6 @@ esac
 
 # close FD:7 and print filename
 if [ ! -z "$ARG_OUT" ]; then
-	printf '%s\n' "$( readlink -f $ARG_OUT )"
+	printf '%s\n' "$( "${CMD_READLINK}" -f $ARG_OUT )"
 	exec 7>&-
 fi

--- a/support/scripts/checkpatch.uk
+++ b/support/scripts/checkpatch.uk
@@ -1,6 +1,14 @@
 #!/bin/bash
-_SELF=$( readlink -f "$0" )
-_SELF_BASE=$( dirname "${_SELF}" )
+if [ $( uname ) = "Darwin" ]; then
+	CMD_READLINK=greadlink
+	CMD_DIRNAME=gdirname
+else
+	CMD_READLINK=readlink
+	CMD_DIRNAME=dirname
+fi
+
+_SELF=$( "${CMD_READLINK}" -f "$0" )
+_SELF_BASE=$( "${CMD_DIRNAME}" "${_SELF}" )
 
 if [ -z "${_SELF}" ]; then
 	echo "Failed to detect fully qualified path of '$0'" 1>&2

--- a/support/scripts/configupdate
+++ b/support/scripts/configupdate
@@ -2,9 +2,15 @@
 UK_CONFIG="${1:-${UK_BASE}/.config}"
 UK_CONFIG_OLD="${2:-${UK_BASE}/.config.old}"
 
+if [ $( uname ) = "Darwin" ]; then
+	CMD_GREP=ggrep
+else
+	CMD_GREP=grep
+fi
+
 _subconfig()
 {
-	grep -e "^#\?[[:space:]]*$1.*$" "$2" | sort
+	"${CMD_GREP}" -e "^#\?[[:space:]]*$1.*$" "$2" | sort
 }
 
 _comparesym()

--- a/support/scripts/mkukimg
+++ b/support/scripts/mkukimg
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+if [ $( uname ) != "Linux" ]; then
+	echo "This command can only be run on Linux" 1>&2
+	exit 1
+fi
 
 # help menu
 usage()


### PR DESCRIPTION
### Description of changes

This PR makes sure that on Darwin the GNU version of the following commands are used:
```
readlink, dirname, grep
```
It is assumed that they are typically installed via HomeBrew with a `g` prefix (`brew install coreutils`):
```
greadlink, gdirname, ggrep
```
The scripts and the build system will refer to these commands if they detect that they are executed on Darwin.