### PR TITLE
driver/ukbus: Fix an invalid check in PCI probe

### DIFF
--- a/drivers/ukbus/pci/arch/x86_64/pci_bus.c
+++ b/drivers/ukbus/pci/arch/x86_64/pci_bus.c
@@ -230,7 +230,7 @@ int arch_pci_probe(struct uk_alloc *pha)
 			PCI_CONF_READ(uint32_t, &vendor_id,
 					config_addr, VENDOR_ID);
 
-			if (vendor_id != PCI_INVALID_ID)
+			if (vendor_id == PCI_INVALID_ID)
 				break;
 
 			probe_bus(function);


### PR DESCRIPTION
This causes the PCI driver to not initialize on certain systems. The check should uses `==` instead.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s):`kvm`
 - Application(s): `app-httpreply`


### Additional configuration
Tested on QEMU with `-cpu EPYC-v4 -machine q35`.

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes
Fixed a wrong check condition in PCI probe code for x86.