### PR TITLE
plat/common/x86: Make `SIPI Vector` related symbols relocations independent from `ukreloc`

### DIFF
--- a/plat/common/x86/start16_helpers.h
+++ b/plat/common/x86/start16_helpers.h
@@ -32,11 +32,4 @@ extern void *x86_start16_end[];
 	((void *)START16_DATA_SYM(sym, sz) -				\
 	(void *)x86_start16_begin)
 
-#if CONFIG_LIBUKRELOC
-#define START16_UKRELOC_ENTRY(sym, sz, type)				\
-	UKRELOC_ENTRY(START16_##type##_OFF(sym, sz),			\
-		       (void *)sym - (void *)x86_start16_begin,		\
-		       sz, UKRELOC_FLAGS_PHYS_REL)
-#endif /* CONFIG_LIBUKRELOC */
-
 #endif  /* __START16_HELPERS_H__ */

--- a/plat/common/x86/start16_helpers.h
+++ b/plat/common/x86/start16_helpers.h
@@ -14,27 +14,27 @@ extern void *x86_start16_end[];
 #define X86_START16_SIZE						\
 	((__uptr)x86_start16_end - (__uptr)x86_start16_begin)
 
-#if CONFIG_LIBUKRELOC
-#define START16_UKRELOC_MOV_SYM(sym, sz)				\
-	sym##_uk_reloc_imm##sz##_start16
+#define START16_MOV_SYM(sym, sz)					\
+	sym##_imm##sz##_start16
 
-#define START16_UKRELOC_DATA_SYM(sym, sz)				\
-	sym##_uk_reloc_data##sz##_start16
+#define START16_DATA_SYM(sym, sz)					\
+	sym##_data##sz##_start16
 
-#define IMPORT_START16_UKRELOC_SYM(sym, sz, type)			\
+#define IMPORT_START16_SYM(sym, sz, type)				\
 	extern void *sym[];						\
-	extern void *START16_UKRELOC_##type##_SYM(sym, sz)[]
+	extern void *START16_##type##_SYM(sym, sz)[]
 
-#define START16_UKRELOC_MOV_OFF(sym, sz)				\
-	((void *)START16_UKRELOC_MOV_SYM(sym, sz) -			\
+#define START16_MOV_OFF(sym, sz)					\
+	((void *)START16_MOV_SYM(sym, sz) -				\
 	(void *)x86_start16_begin)
 
-#define START16_UKRELOC_DATA_OFF(sym, sz)				\
-	((void *)START16_UKRELOC_DATA_SYM(sym, sz) -			\
+#define START16_DATA_OFF(sym, sz)					\
+	((void *)START16_DATA_SYM(sym, sz) -				\
 	(void *)x86_start16_begin)
 
+#if CONFIG_LIBUKRELOC
 #define START16_UKRELOC_ENTRY(sym, sz, type)				\
-	UKRELOC_ENTRY(START16_UKRELOC_##type##_OFF(sym, sz),		\
+	UKRELOC_ENTRY(START16_##type##_OFF(sym, sz),			\
 		       (void *)sym - (void *)x86_start16_begin,		\
 		       sz, UKRELOC_FLAGS_PHYS_REL)
 #endif /* CONFIG_LIBUKRELOC */

--- a/plat/kvm/x86/lcpu_start.S
+++ b/plat/kvm/x86/lcpu_start.S
@@ -53,25 +53,26 @@
 x86_start16_addr:
 	.quad	START16_PLACEHOLDER
 
-/* Implement dedicate ur_* macro's whose only use-case is this file to cope with
- * the existence of 16-bit code. This is so it does not interfere with the other
- * uses of the ur_* macro's. For example, we not want symbols for these to
- * occupy unnecessary space in .uk_reloc.
+/* Implement dedicated start16 macro's whose only use-case is this file to cope
+ * with the existence of 16-bit code. This is so it does not interfere with the
+ * other uses of the ur_* macro's.
+ * For example, we do not want symbols for these to occupy unnecessary space in
+ * .uk_reloc.
  *
  * NOTE:IF ADDING/REMOVING RELOCATIONS FROM HERE, THEN ADD/REMOVE
- *	CORRESPONDENT SYMBOL TO `lcpu.c` (see IMPORT_START16_UKRELOC_SYM
+ *	CORRESPONDENT SYMBOL TO `lcpu.c` (see IMPORT_START16_SYM
  *	start16_helpers.h macros being used on start16 symbols)
  */
-.macro ur_mov_start16	sym:req, reg:req, bytes:req
+.macro mov_start16	sym:req, reg:req, bytes:req
 	mov	$START16_PLACEHOLDER, \reg
-.globl	\sym\()_uk_reloc_imm\bytes\()_start16
-.set	\sym\()_uk_reloc_imm\bytes\()_start16, (. - \bytes)
+.globl	\sym\()_imm\bytes\()_start16
+.set	\sym\()_imm\bytes\()_start16, (. - \bytes)
 	nop
 .endm
 
-.macro ur_data_start16	type:req, sym:req, bytes:req
-.globl	\sym\()_uk_reloc_data\bytes\()_start16
-.set	\sym\()_uk_reloc_data\bytes\()_start16, .
+.macro data_start16	type:req, sym:req, bytes:req
+.globl	\sym\()_data\bytes\()_start16
+.set	\sym\()_data\bytes\()_start16, .
 	.\type	START16_PLACEHOLDER
 .endm
 
@@ -94,7 +95,7 @@ ENTRY(lcpu_start16_ap)
 	xorl	%edi, %edi
 	xorl	%esi, %esi
 
-	ur_mov_start16	lcpu_start16, %ax, 2
+	mov_start16	lcpu_start16, %ax, 2
 	/* On start-up a core's %cs is set depending on the value of the vector
 	 * inside the SIPI message, so make sure we are jumping to the
 	 * proper address w.r.t. segmentation.
@@ -123,7 +124,7 @@ gdt32_null:
 .globl gdt32_ptr
 gdt32_ptr:
 	.word	(gdt32_end - gdt32 - 1)	/* size - 1	*/
-	ur_data_start16	long, gdt32, 4	/* GDT address	*/
+	data_start16	long, gdt32, 4	/* GDT address	*/
 gdt32_cs:
 	.quad	GDT_DESC_CODE32_VAL	/* 32-bit CS	*/
 gdt32_ds:
@@ -143,7 +144,7 @@ ENTRY(lcpu_start16)
 	movl	%eax, %cr0
 
 	/* Load 32-bit GDT and jump into 32-bit code segment */
-	ur_mov_start16	gdt32_ptr, %ax, 2
+	mov_start16	gdt32_ptr, %ax, 2
 	lgdt	(%eax)
 
 	/* ljmp encoding has 5 opcodes, thus 40 bits, which in our case
@@ -161,7 +162,7 @@ ENTRY(lcpu_start16)
 	 * address corresponds to the very next instruction in memory
 	 * after our ljmp.
 	 */
-	ur_mov_start16	jump_to32, %ax, 2
+	mov_start16	jump_to32, %ax, 2
 	movw	%ax, -4(%eax)
 	ljmp	$(gdt32_cs - gdt32), $START16_PLACEHOLDER
 
@@ -178,7 +179,7 @@ jump_to32:
 	movl	%eax, %fs
 	movl	%eax, %gs
 
-	ur_mov_start16	lcpu_start32, %eax, 4
+	mov_start16	lcpu_start32, %eax, 4
 
 	jmp	*%eax
 END(lcpu_start16)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Following an offline discussion it was decided to make SIPI vector initialization/relocation entirely independent from whether Unikraft is built with/without `ukreloc`/`PIE`. This is done by ensuring `start16` related symbols are relocated through their own mechanism, separated from, but similar to, from `ukreloc`.