### PR TITLE
Makefile: Save UK_NAME on savedefconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -973,6 +973,7 @@ ifeq ($(HOSTARCH),$(CONFIG_UK_ARCH))
 	@# Make sure arch is stored in the file even if arch matches between host and config
 	@echo "$(call ukarch_str2cfg,$(CONFIG_UK_ARCH))=y" >> $(DEFCONFIG)
 endif
+	@echo "CONFIG_UK_NAME=\"$(CONFIG_UK_NAME)\"" >> $(DEFCONFIG)
 
 oldconfig:
 	@$(COMMON_CONFIG_ENV) $(KPYTHON) $(CONFIGLIB)/oldconfig.py $(CONFIG_CONFIG_IN)
@@ -1052,6 +1053,8 @@ ifeq ($(HOSTARCH),$(CONFIG_UK_ARCH))
 	@echo "$(call ukarch_str2cfg,$(CONFIG_UK_ARCH))=y" >> \
 		$(if $(DEFCONFIG),$(DEFCONFIG),$(CONFIG_DIR)/defconfig)
 endif
+	@echo "CONFIG_UK_NAME=\"$(CONFIG_UK_NAME)\"" >> \
+		$(if $(DEFCONFIG),$(DEFCONFIG),$(CONFIG_DIR)/defconfig)
 
 .PHONY: defconfig savedefconfig silentoldconfig
 


### PR DESCRIPTION
Using `make savedefconfig` did not save the `UK_NAME` config option. Fix that by appending the value by hand at the end of the `DEFCONFIG` file.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


