### PR TITLE
build: Recompile everything on `.config` changes (workaround)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -779,9 +779,8 @@ fetch: $(UK_FETCH) $(UK_FETCH-y)
 
 # Copy current configuration in order to detect changes
 $(UK_CONFIG_OUT): $(UK_CONFIG)
-	$(call verbose_cmd,CP,config,$(CP) \
-		$(UK_CONFIG) \
-		$(UK_CONFIG_OUT))
+	$(call verbose_cmd,CP,config, \
+		cmp -s $^ $@; if [ $$? -ne 0 ]; then cp $^ $@; fi)
 
 prepare: $(KCONFIG_AUTOHEADER) $(UK_CONFIG_OUT) $(UK_PREPARE) $(UK_PREPARE-y)
 prepare: $(UK_FIXDEP) | fetch
@@ -984,8 +983,10 @@ oldconfig:
 	@$(COMMON_CONFIG_ENV) $(SCRIPTS_DIR)/configupdate $(UK_CONFIG) $(UK_CONFIG_OUT)
 
 # Regenerate $(KCONFIG_AUTOHEADER) whenever $(UK_CONFIG) changed
-$(KCONFIG_AUTOHEADER): $(UK_CONFIG)
-	@$(COMMON_CONFIG_ENV) $(KPYTHON) $(CONFIGLIB)/genconfig.py --header-path $(KCONFIG_AUTOHEADER) $(CONFIG_CONFIG_IN)
+$(KCONFIG_AUTOHEADER): $(UK_CONFIG_OUT)
+	$(call verbose_cmd,GEN,config.h, \
+		$(COMMON_CONFIG_ENV) $(KPYTHON) $(CONFIGLIB)/genconfig.py \
+			--header-path $(KCONFIG_AUTOHEADER) $(CONFIG_CONFIG_IN))
 else
 # Use traditional KConfig system on Linux
 xconfig: $(KCONFIG_DIR)/qconf
@@ -1063,8 +1064,10 @@ endif
 .PHONY: defconfig savedefconfig silentoldconfig
 
 # Regenerate $(KCONFIG_AUTOHEADER) whenever $(UK_CONFIG) changed
-$(KCONFIG_AUTOHEADER): $(UK_CONFIG) $(KCONFIG_DIR)/conf
-	@$(COMMON_CONFIG_ENV) $(KCONFIG_DIR)/conf --syncconfig $(CONFIG_CONFIG_IN)
+$(KCONFIG_AUTOHEADER): $(UK_CONFIG_OUT) $(KCONFIG_DIR)/conf
+	$(call verbose_cmd,GEN,config.h, \
+		$(COMMON_CONFIG_ENV) $(KCONFIG_DIR)/conf \
+			--syncconfig $(CONFIG_CONFIG_IN))
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -267,10 +267,8 @@ export DATE := $(shell date +%Y%m%d)
 null_targets		:= print-version print-vars help
 nokconfig_targets       := properclean distclean $(null_targets)
 noconfig_targets	:= ukconfig menuconfig nconfig gconfig xconfig config \
-			   oldconfig randconfig \
-			   defconfig %_defconfig allyesconfig allnoconfig \
-			   silentoldconfig \
-			   release olddefconfig \
+			   oldconfig defconfig olddefconfig savedefconfig \
+			   randconfig allyesconfig allnoconfig \
 			   scriptconfig iscriptconfig kmenuconfig guiconfig \
 			   dumpvarsconfig \
 			   $(nokconfig_targets)
@@ -854,7 +852,7 @@ clean-libs clean:
 
 endif
 
-.PHONY: print-vars print-libs print-objs print-srcs print-loc help outputmakefile list-defconfigs
+.PHONY: print-vars print-libs print-objs print-srcs print-loc help
 
 # Configuration
 # ---------------------------------------------------------------------------
@@ -954,10 +952,6 @@ nconfig: kmenuconfig
 gconfig: guiconfig
 xconfig: guiconfig
 
-config:
-	@$(COMMON_CONFIG_ENV) $(KPYTHON) $(CONFIGLIB)/genconfig.py --header-path $(KCONFIG_AUTOHEADER) $(CONFIG_CONFIG_IN)
-	@$(COMMON_CONFIG_ENV) $(SCRIPTS_DIR)/configupdate $(UK_CONFIG) $(UK_CONFIG_OUT)
-
 allyesconfig:
 	@$(COMMON_CONFIG_ENV) $(KPYTHON) $(CONFIGLIB)/allyesconfig.py $(CONFIG_CONFIG_IN)
 	@$(COMMON_CONFIG_ENV) $(SCRIPTS_DIR)/configupdate $(UK_CONFIG) $(UK_CONFIG_OUT)
@@ -1005,10 +999,6 @@ nconfig: $(KCONFIG_DIR)/nconf
 	@$(COMMON_CONFIG_ENV) $< $(CONFIG_CONFIG_IN)
 	@$(COMMON_CONFIG_ENV) $(SCRIPTS_DIR)/configupdate $(UK_CONFIG) $(UK_CONFIG_OUT)
 
-config: $(KCONFIG_DIR)/conf
-	@$(COMMON_CONFIG_ENV) $< $(CONFIG_CONFIG_IN)
-	@$(COMMON_CONFIG_ENV) $(SCRIPTS_DIR)/configupdate $(UK_CONFIG) $(UK_CONFIG_OUT)
-
 # For the config targets that automatically select options, we pass
 # SKIP_LEGACY=y to disable the legacy options. However, in that case
 # no values are set for the legacy options so a subsequent oldconfig
@@ -1044,11 +1034,6 @@ defconfig: $(KCONFIG_DIR)/conf
 	@$(COMMON_CONFIG_ENV) $< --defconfig$(if $(DEFCONFIG),=$(DEFCONFIG)) $(CONFIG_CONFIG_IN)
 	@$(COMMON_CONFIG_ENV) $(SCRIPTS_DIR)/configupdate $(UK_CONFIG) $(UK_CONFIG_OUT)
 
-# Override the UK_DEFCONFIG from COMMON_CONFIG_ENV with the new defconfig
-%_defconfig: $(KCONFIG_DIR)/conf $(A)/configs/%_defconfig
-	@$(COMMON_CONFIG_ENV) UK_DEFCONFIG=$(A)/configs/$@ \
-		$< --defconfig=$(A)/configs/$@ $(CONFIG_CONFIG_IN)
-
 savedefconfig: $(KCONFIG_DIR)/conf
 	@$(COMMON_CONFIG_ENV) $< \
 		--savedefconfig=$(if $(DEFCONFIG),$(DEFCONFIG),$(CONFIG_DIR)/defconfig) \
@@ -1061,7 +1046,7 @@ endif
 	@echo "CONFIG_UK_NAME=\"$(CONFIG_UK_NAME)\"" >> \
 		$(if $(DEFCONFIG),$(DEFCONFIG),$(CONFIG_DIR)/defconfig)
 
-.PHONY: defconfig savedefconfig silentoldconfig
+.PHONY: defconfig savedefconfig
 
 # Regenerate $(KCONFIG_AUTOHEADER) whenever $(UK_CONFIG) changed
 $(KCONFIG_AUTOHEADER): $(UK_CONFIG_OUT) $(KCONFIG_DIR)/conf
@@ -1199,7 +1184,7 @@ help:
 ifeq ($(HOSTOSENV),Linux)
 	@echo '  syncconfig             - Same as oldconfig, but quietly, additionally update deps'
 	@echo '  scriptsyncconfig       - Same as oldconfig, but quietly, additionally update deps'
-	@echo '  olddefconfig           - Same as silentoldconfig but sets new symbols to their default value'
+	@echo '  olddefconfig           - Same as defconfig but sets new symbols to their default value'
 	@echo '  randconfig             - New config with random answer to all options'
 endif
 	@echo '  defconfig              - New config with default answer to all options'

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -819,7 +819,12 @@ $(error buildrule_$(call fileext,$(strip $(2))) is not defined: Failed to instal
 $(call buildrule_$(call fileext,$(strip $(2))),$(strip $(1)),$(strip $(2)),$(strip $(3)),$(strip $(4)),$(strip $(5)))
 
 # Default buildrule_* dependencies
-$(4): $(call qstrip,$($(call vprefix_src,$(1),$(2),$(3),CDEPS)) $($(call vprefix_src,$(1),$(2),$(3),CDEPS-y))) | preprocess
+# FIXME: We add $(KCONFIG_AUTOHEADER) in order to forcefully retrigger compiling
+#        whenever there is a config change. This is a workaround until we can
+#        handle changes that affect the compile command lines properly.
+$(4): $(call qstrip,$($(call vprefix_src,$(1),$(2),$(3),CDEPS)) \
+      $($(call vprefix_src,$(1),$(2),$(3),CDEPS-y))) $(KCONFIG_AUTOHEADER) \
+      | preprocess
 endef
 
 #################################################
@@ -886,8 +891,11 @@ $(error preprule_$(call fileext,$(strip $(2))) is not defined: Failed to install
 
 $(call preprule_$(call fileext,$(strip $(2))),$(strip $(1)),$(strip $(2)),$(strip $(3)),$(strip $(4)),$(strip $(5)))
 
-# default preprule dependencies
-$(strip $(3)): $(strip $(2))
+# Default preprule dependencies
+# FIXME: We add $(KCONFIG_AUTOHEADER) in order to forcefully retrigger compiling
+#        whenever there is a config change. This is a workaround until we can
+#        handle changes that affect the compile command lines properly.
+$(strip $(3)): $(strip $(2)) $(KCONFIG_AUTOHEADER)
 endef
 
 

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -981,7 +981,9 @@ $(call libname2preolib,$(1)): $$($(call vprefix_lib,$(1),OBJS)) \
 			      $$($(call vprefix_lib,$(1),LDS)) \
 			      $$($(call vprefix_lib,$(1),LDS-y)) \
 			      $$($(call vprefix_lib,$(1),DTB)) \
-			      $$($(call vprefix_lib,$(1),DTB-y))
+			      $$($(call vprefix_lib,$(1),DTB-y)) \
+			      $$($(call vprefix_lib,$(1),LDEPS)) \
+			      $$($(call vprefix_lib,$(1),LDEPS-y))
 	$(call build_cmd,LD,,$(call libname2preolib,$(1)),\
 		$(LD) $$(LIBLDFLAGS) $$(LIBLDFLAGS-y) \
 		      $$($(call vprefix_lib,$(1),LDFLAGS)) \

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -885,6 +885,9 @@ $(if $(filter preprule_$(call fileext,$(strip $(2))),$(.VARIABLES)),,\
 $(error preprule_$(call fileext,$(strip $(2))) is not defined: Failed to install rule for $(2)))
 
 $(call preprule_$(call fileext,$(strip $(2))),$(strip $(1)),$(strip $(2)),$(strip $(3)),$(strip $(4)),$(strip $(5)))
+
+# default preprule dependencies
+$(strip $(3)): $(strip $(2))
 endef
 
 

--- a/support/scripts/configupdate
+++ b/support/scripts/configupdate
@@ -31,18 +31,12 @@ NL=$'\n'
 # Change of architecture?
 _comparesym "CONFIG_ARCH_" "${UK_CONFIG}" "${UK_CONFIG_OLD}" || UPDATES+="*** - CPU architecture changed${NL}"
 
-# Change of CPU options?
-_comparesym "CONFIG_MARCH_" "${UK_CONFIG}" "${UK_CONFIG_OLD}" || UPDATES+="*** - CPU optimization changed${NL}"
-
-# Change of optimizations?
-_comparesym "CONFIG_OPTIMIZE_" "${UK_CONFIG}" "${UK_CONFIG_OLD}" || UPDATES+="*** - Code optimization changed${NL}"
-
 if [ ! -z "$UPDATES" ]; then
 	echo "*** The following configuration changes were detected:"
 	echo -n "${UPDATES}"
-	echo "*** Execute 'make clean' before executing 'make'."
-	echo "*** This is to ensure that the new setting is applied"
-	echo "*** to every compilation unit."
+	echo "*** We highly recommend to execute 'make properclean' before"
+	echo "*** calling 'make'. This is to ensure that the new setting"
+	echo "*** is also considered by the fetch and prepare targets."
 	echo ""
 fi
 exit 0


### PR DESCRIPTION
### Description of changes

Unfortunately, our build system is still not able to re-trigger the compilation if only the command line of a compilation unit changed due to a configuration change. This can result in broken builds if the user did not call `make clean` in between.

This commit introduces a workaround that attempts to improve the user experience by triggering a recompile when the configuration is changed. This makes this cleaning step unecessary.

It is intended that commit "build: Recompile on `.config` changes (workaround)" gets reverted as soon as the build system can properly detect changes to the compiler command line.

This PR depends on PR #1070.
This is a workaround for issue #47.