### PR TITLE
plat/common/acpi: Check for offline `GICC`'s and fix `VGIC` `IRQ Mode` flag

### DIFF
--- a/plat/common/arm/lcpu.c
+++ b/plat/common/arm/lcpu.c
@@ -118,7 +118,8 @@ static int do_arch_mp_init(void *arg __unused)
 		m.h = (struct acpi_subsdt_hdr *)(madt->entries + off);
 
 		if (m.h->type != ACPI_MADT_GICC ||
-		    !(m.gicc->flags & ACPI_MADT_GICC_FLAGS_EN))
+		    (!(m.gicc->flags & ACPI_MADT_GICC_FLAGS_EN) &&
+		     !(m.gicc->flags & ACPI_MADT_GICC_FLAGS_ON_CAP)))
 			continue;
 
 		cpu_id = m.gicc->mpidr & CPU_ID_MASK;

--- a/plat/common/include/uk/plat/common/madt.h
+++ b/plat/common/include/uk/plat/common/madt.h
@@ -170,6 +170,7 @@ struct acpi_madt_x2apic_nmi {
 #define ACPI_MADT_GICC_FLAGS_EN					0x01
 #define ACPI_MADT_GICC_FLAGS_PERF_IRQ_MODE			0x02
 #define ACPI_MADT_GICC_FLAGS_VGIC_IRQ_MODE			0x04
+#define ACPI_MADT_GICC_FLAGS_ON_CAP				0x08
 struct acpi_madt_gicc {
 	struct acpi_subsdt_hdr hdr;
 	__u16 reserved;

--- a/plat/common/include/uk/plat/common/madt.h
+++ b/plat/common/include/uk/plat/common/madt.h
@@ -169,7 +169,7 @@ struct acpi_madt_x2apic_nmi {
 /* GIC CPU Interface (GICC) Structure */
 #define ACPI_MADT_GICC_FLAGS_EN					0x01
 #define ACPI_MADT_GICC_FLAGS_PERF_IRQ_MODE			0x02
-#define ACPI_MADT_GICC_FLAGS_VGIC_IRQ_MODE			0x03
+#define ACPI_MADT_GICC_FLAGS_VGIC_IRQ_MODE			0x04
 struct acpi_madt_gicc {
 	struct acpi_subsdt_hdr hdr;
 	__u16 reserved;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

    
When we probe for available, valid, GICC's we only look for those
that are already online and initialized, totally forgetting about
those that are usable but offline. Therefore, check for powered off
GICC's as well, since, during probe, we re-initialize GICC's anyway.

As a side fix,  the bitfield `ACPI_MADT_GICC_FLAGS_VGIC_IRQ_MODE` of `GICC` had
the wrong value: it usedvalue `0x3` instead of the actual
value `(1 << 2)`. Therefore, fix it.
