### PR TITLE
Enable SMP on Firecracker through Intel Multiprocessor specification

### DIFF
--- a/include/uk/plat/memory.h
+++ b/include/uk/plat/memory.h
@@ -52,6 +52,7 @@ extern "C" {
 #define UKPLAT_MEMRT_CMDLINE		0x0010	/* Command line */
 #define UKPLAT_MEMRT_DEVICETREE		0x0020	/* Device tree */
 #define UKPLAT_MEMRT_STACK		0x0040	/* Thread stack */
+#define UKPLAT_MEMRT_LBIOS		0x0080	/* Legacy BIOS SYS ROM, EBDA */
 
 /* Memory region flags */
 #define UKPLAT_MEMRF_ALL		0xffff

--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -86,6 +86,7 @@
 #ifdef CONFIG_LIBUKSP
 #include <uk/sp.h>
 #endif
+#include <uk/arch/paging.h>
 #include <uk/arch/tls.h>
 #include <uk/plat/tls.h>
 #include "banner.h"
@@ -186,6 +187,11 @@ static struct uk_alloc *heap_init()
 	 * add every subsequent region to it.
 	 */
 	ukplat_memregion_foreach(&md, UKPLAT_MEMRT_FREE, 0, 0) {
+		UK_ASSERT(md->vbase == md->pbase);
+		UK_ASSERT(!(md->pbase & ~PAGE_MASK));
+		UK_ASSERT(md->len);
+		UK_ASSERT(!(md->len & ~PAGE_MASK));
+
 		uk_pr_debug("Trying %p-%p 0x%02x %s\n",
 			    (void *)md->vbase, (void *)(md->vbase + md->len),
 			    md->flags,

--- a/plat/Config.uk
+++ b/plat/Config.uk
@@ -40,7 +40,7 @@ config HAVE_SMP
 	bool
 	default y if UKPLAT_LCPU_MAXCOUNT > 1
 	default n
-	select UKPLAT_ACPI if ARCH_X86_64
+	imply UKPLAT_ACPI if ARCH_X86_64
 
 menu "Multiprocessor Configuration"
 	depends on HAVE_SMP

--- a/plat/common/bootinfo.c
+++ b/plat/common/bootinfo.c
@@ -90,6 +90,9 @@ void ukplat_bootinfo_print(void)
 		case UKPLAT_MEMRT_DEVICETREE:
 			type = "dtb ";
 			break;
+		case UKPLAT_MEMRT_LBIOS:
+			type = "lbios ";
+			break;
 		case UKPLAT_MEMRT_STACK:
 			type = "stck";
 			break;

--- a/plat/common/include/uk/plat/common/memory.h
+++ b/plat/common/include/uk/plat/common/memory.h
@@ -90,6 +90,9 @@ ukplat_memregion_list_insert(struct ukplat_memregion_list *list,
 	struct ukplat_memregion_desc *p;
 	__u32 i;
 
+	if (unlikely(!mrd->len))
+		return -EINVAL;
+
 	if (unlikely(list->count == list->capacity))
 		return -ENOMEM;
 
@@ -206,6 +209,9 @@ ukplat_memregion_list_insert_at_idx(struct ukplat_memregion_list *list,
 {
 	struct ukplat_memregion_desc *p;
 
+	if (unlikely(!mrd->len))
+		return -EINVAL;
+
 	if (unlikely(list->count == list->capacity))
 		return -ENOMEM;
 
@@ -246,6 +252,9 @@ ukplat_memregion_list_insert_split_phys(struct ukplat_memregion_list *list,
 	__vaddr_t voffset;
 	int i;
 	int rc;
+
+	if (unlikely(!mrd->len))
+		return -EINVAL;
 
 	voffset = mrd->vbase - mrd->pbase;
 	pstart = mrd->pbase;

--- a/plat/common/include/uk/plat/common/memory.h
+++ b/plat/common/include/uk/plat/common/memory.h
@@ -117,28 +117,121 @@ ukplat_memregion_list_insert(struct ukplat_memregion_list *list,
 }
 
 #if defined(__X86_64__)
-#define	X86_HI_MEM_START		0xA0000UL
-#define X86_HI_MEM_LEN			0x40000UL
+/* For EISA or MCA systems, the EBDA real-mode segmented pointer can be found
+ * in the two-byte location 40:0Eh, right after the BIOS IVT.
+ */
+#define X86_EBDA_PTR			((0x40UL << 4) + 0x0EUL)
+#define X86_EBDA_LEN			0x400UL
+static inline unsigned long get_ebda_addr(void)
+{
+	__u16 *ebda_ptr = (__u16 *)X86_EBDA_PTR;
 
-#define X86_BIOS_ROM_START		0xE0000UL
-#define X86_BIOS_ROM_LEN		0x20000UL
+	return (*ebda_ptr << 4);
+}
 
+#define X86_HI_MEM_START		0xA0000UL
+#define X86_DISPLAY_BUF_START		0xA0000UL
+#define X86_DISPLAY_BUF_LEN		0x20000UL
+
+#define X86_BIOS_XROM_START		0xC0000UL
+#define X86_BIOS_XROM_LEN		0x20000UL
+
+#define X86_BIOS_SYSROM_START		0xE0000UL
+#define X86_BIOS_SYSROM_LEN		0x20000UL
+
+/* WARNING! DO NOT CALL THIS FUNCTION AFTER PAGING INITIALIZATION! THIS RELIES
+ * ON THE VERY FIRST PAGE (0 - 4KB) BEING MAPPED! ONLY CALL IF YOU KNOW WHAT YOU
+ * YOU ARE DOING!
+ *
+ * Expected memory map for the first 1MiB w.r.t. PC-AT systems compatiblity
+ * 0x00000 – 0x9FFFF 640KB Main memory, DOS compatible. May contain the
+ *		     following memory subregions that we will not need after
+ *		     boot. If the EBDA is defined here, then 1KB starting
+ *		     at that address shall be treated as a reserved region
+ *	0x00000 - 0x003FF Legacy BIOS IVT, segmented pointers to software
+ *			  interrupt routines defined in the ROM BIOS
+ *	0x0040E - 0x0040F Optional EBDA segmented pointer
+ *	0x9FC00 - 0xA0000 Default 1KB of EBDA if not defined in previous region
+ * 0xA0000 – 0xBFFFF 128KB Display buffer for video adapters and possible SMM
+ *		     Shadow Memory
+ * 0xC0000 – 0xDFFFF 128KB ROM BIOS for add-on cards (PCI XROMBARs)
+ * 0xE0000 – 0xFFFFF 128KB System ROM BIOS
+ */
 static inline int
 ukplat_memregion_list_insert_legacy_hi_mem(struct ukplat_memregion_list *list)
 {
+	unsigned long ebda_addr;
 	int rc;
+
+	/* According to ACPI spec for IA-PC systems, RSDP can be in:
+	 * 1. the first 1KiB of EBDA
+	 * 2. BIOS read-only memory space between 0xE0000 and 0xFFFFF
+	 *
+	 * According to MP spec for PC-AT systems, MP Floating Pointer Structure
+	 * can be found in:
+	 * 1. the first 1KiB of EBDA
+	 * 2. if EBDA segment is not defined, the last 1KiB of PC-AT base ram:
+	 * e.g., 639K-640K for systems with 640 KB of base memory or 511K-512K
+	 * for systems with 512 KB of base memory (WE DO NOT TARGET THE LATTER)
+	 * 3. BIOS read-only memory space between 0xE0000 and 0xFFFFF
+	 */
+
+	/* Check for EBDA explicit segmented pointer */
+	ebda_addr = get_ebda_addr();
+
+	/* If we do not have an EBDA pointer or it is invalid (beyond DOS
+	 * compatible RAM), then resort to default: the last 1KB of DOS
+	 * compatible RAM.
+	 */
+	if (!ebda_addr || ebda_addr > X86_HI_MEM_START - X86_EBDA_LEN)
+		ebda_addr = X86_HI_MEM_START - X86_EBDA_LEN;
+
+	/* Now insert EBDA memregion */
+	rc = ukplat_memregion_list_insert(list,
+			&(struct ukplat_memregion_desc){
+				.vbase = ebda_addr,
+				.pbase = ebda_addr,
+				.len   = X86_EBDA_LEN,
+				.type  = UKPLAT_MEMRT_LBIOS,
+				.flags = UKPLAT_MEMRF_READ  |
+					 UKPLAT_MEMRF_MAP,
+			});
+	if (unlikely(rc < 0))
+		return rc;
 
 	/* Note that we are mapping it as writable as well to cope with the
 	 * potential existence of the VGA framebuffer/SMM shadow memory.
 	 */
 	rc = ukplat_memregion_list_insert(list,
 			&(struct ukplat_memregion_desc){
-				.vbase = X86_HI_MEM_START,
-				.pbase = X86_HI_MEM_START,
-				.len   = X86_HI_MEM_LEN,
+				.vbase = X86_DISPLAY_BUF_START,
+				.pbase = X86_DISPLAY_BUF_START,
+				.len   = X86_DISPLAY_BUF_LEN,
 				.type  = UKPLAT_MEMRT_RESERVED,
 				.flags = UKPLAT_MEMRF_READ  |
 					 UKPLAT_MEMRF_WRITE |
+					 UKPLAT_MEMRF_MAP,
+			});
+	if (unlikely(rc < 0))
+		return rc;
+
+	/* Note that we are assigning UKPLAT_MEMRT_RESERVED to BIOS PCI ROM,
+	 * instead of UKPLAT_MEMRT_LBIOS, as this is not needed at boot time,
+	 * and it's rather more related to the XROM of add-on cards than BIOS
+	 * itself. We usually have here the routines used by real-mode
+	 * bootloaders invoked through the BIOS IVT. Although this may not be
+	 * necessary anymore, we cannot assign UKPLAT_MEMRT_FREE either since
+	 * some BIOSes do set this as a RO segment in the corresponding chipset
+	 * registers, leaving this potentially unusable. Thus, just treat it
+	 * as a memory hole.
+	 */
+	rc = ukplat_memregion_list_insert(list,
+			&(struct ukplat_memregion_desc){
+				.vbase = X86_BIOS_XROM_START,
+				.pbase = X86_BIOS_XROM_START,
+				.len   = X86_BIOS_XROM_LEN,
+				.type  = UKPLAT_MEMRT_RESERVED,
+				.flags = UKPLAT_MEMRF_READ  |
 					 UKPLAT_MEMRF_MAP,
 			});
 	if (unlikely(rc < 0))
@@ -149,10 +242,10 @@ ukplat_memregion_list_insert_legacy_hi_mem(struct ukplat_memregion_list *list)
 	 */
 	rc = ukplat_memregion_list_insert(list,
 			&(struct ukplat_memregion_desc){
-				.vbase = X86_BIOS_ROM_START,
-				.pbase = X86_BIOS_ROM_START,
-				.len   = X86_BIOS_ROM_LEN,
-				.type  = UKPLAT_MEMRT_RESERVED,
+				.vbase = X86_BIOS_SYSROM_START,
+				.pbase = X86_BIOS_SYSROM_START,
+				.len   = X86_BIOS_SYSROM_LEN,
+				.type  = UKPLAT_MEMRT_LBIOS,
 				.flags = UKPLAT_MEMRF_READ  |
 					 UKPLAT_MEMRF_MAP,
 			});

--- a/plat/common/include/uk/plat/common/mps.h
+++ b/plat/common/include/uk/plat/common/mps.h
@@ -208,4 +208,6 @@ struct uk_mps_mpfp *uk_mps_get_mpfp(void);
 
 struct uk_mps_mpc *uk_mps_get_mpc(void);
 
+void uk_mps_next_mpc_entry(void **entryp);
+
 #endif /* __PLAT_CMN_MPS_H__ */

--- a/plat/common/include/uk/plat/common/mps.h
+++ b/plat/common/include/uk/plat/common/mps.h
@@ -1,0 +1,205 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+
+#ifndef __PLAT_CMN_MPS_H__
+#define __PLAT_CMN_MPS_H__
+
+#include <stddef.h>
+#include <uk/arch/types.h>
+#include <uk/essentials.h>
+
+#define UK_MPS_SIG_LEN				4
+#define UK_MPS_PARAGRAPH_LEN			16
+#define UK_MPS_OEM_ID_LEN			8
+#define UK_MPS_PRODUCT_ID_LEN			12
+
+#define UK_MPS_MPFP_SIG				"_MP_"
+#define UK_MPS_MPFP_FEAT_B1_MPC_PRESENT_MASK	0xFF
+#define UK_MPS_MPFP_FEAT_B2_IMCRP_PRESENT	(1 << 7)
+struct uk_mps_mpfp {
+	__u8 sig[UK_MPS_SIG_LEN];
+	__u32 mpc_paddr;
+	__u8 tbl_len;
+	__u8 revision;
+	__u8 checksum;
+	__u8 feat_b1;		/* MP feature info byte 1 */
+	__u8 feat_b2;		/* MP feature info byte 2 */
+	__u8 feat_b35[3];	/* MP feature info byts 3-5, RESERVED */
+} __packed;
+
+UK_CTASSERT(sizeof(struct uk_mps_mpfp) == UK_MPS_PARAGRAPH_LEN);
+
+#define UK_MPS_MPC_SIG				"PCMP"
+#define UK_MPS_MPC_TYPE_CPU			0x0
+#define UK_MPS_MPC_TYPE_BUS			0x1
+#define UK_MPS_MPC_TYPE_IOAPIC			0x2
+#define UK_MPS_MPC_TYPE_INTSRC			0x3
+#define UK_MPS_MPC_TYPE_LINTSRC			0x4
+#define UK_MPS_XMPC_TYPE_SYSMEM			0x80
+#define UK_MPS_XMPC_TYPE_BUSLINK		0x81
+#define UK_MPS_XMPC_TYPE_BUSOVR			0x82
+struct uk_mps_mpc {
+	__u8 sig[UK_MPS_SIG_LEN];
+	__u16 tbl_len;
+	__u8 revision;
+	__u8 checksum;
+	__u8 oem_id[UK_MPS_OEM_ID_LEN];
+	__u8 product_id[UK_MPS_PRODUCT_ID_LEN];
+	__u32 oem_tbl_paddr;
+	__u16 oem_tbl_len;
+	__u16 oem_tbl_count;
+	__u32 lapic_paddr;
+	__u16 oem_xtbl_len;
+	__u8 oem_xtbl_checksum;
+	__u8 reserved;
+} __packed;
+
+UK_CTASSERT(sizeof(struct uk_mps_mpc) == 44);
+
+#define UK_MPS_CPU_FLAGS_EN			(1 << 0)
+#define UK_MPS_CPU_FLAGS_BP			(1 << 1)
+#define UK_MPS_CPU_SIG_LEN			4
+#define UK_MPS_CPU_SIG_STEPPING_MASK		0x000F
+#define UK_MPS_CPU_SIG_MODEL_MASK		0x00F0
+#define UK_MPS_CPU_SIG_FAMILY_MASK		0x0F00
+#define UK_MPS_CPU_FEAT_FPU			(1 << 0)
+#define UK_MPS_CPU_FEAT_MCE			(1 << 7)
+#define UK_MPS_CPU_FEAT_CX8			(1 << 8)
+#define UK_MPS_CPU_FEAT_APIC			(1 << 9)
+struct uk_mps_cpu {
+	__u8 type;
+	__u8 lapic_id;
+	__u8 lapic_version;
+	__u8 cpu_flags;
+	__u32 cpu_sig;
+	__u32 cpu_feat;
+	__u32 reserved[2];
+} __packed;
+
+UK_CTASSERT(sizeof(struct uk_mps_cpu) == 20);
+
+#define UK_MPS_BUS_STR_LEN			6
+#define UK_MPS_BUS_STR_CBUS			"CBUS"
+#define UK_MPS_BUS_STR_CBUSII			"CBUSII"
+#define UK_MPS_BUS_STR_EISA			"EISA"
+#define UK_MPS_BUS_STR_FUTURE			"FUTURE"
+#define UK_MPS_BUS_STR_INTERN			"INTERN"
+#define UK_MPS_BUS_STR_ISA			"ISA"
+#define UK_MPS_BUS_STR_MBI			"MBI"
+#define UK_MPS_BUS_STR_MBII			"MBII"
+#define UK_MPS_BUS_STR_MCA			"MCA"
+#define UK_MPS_BUS_STR_MPI			"MPI"
+#define UK_MPS_BUS_STR_MPSA			"MPSA"
+#define UK_MPS_BUS_STR_NUBUS			"NUBUS"
+#define UK_MPS_BUS_STR_PCI			"PCI"
+#define UK_MPS_BUS_STR_PCMCIA			"PCMCIA"
+#define UK_MPS_BUS_STR_TC			"TC"
+#define UK_MPS_BUS_STR_VL			"VL"
+#define UK_MPS_BUS_STR_VME			"VME"
+#define UK_MPS_BUS_STR_XPRESS			"XPRESS"
+struct uk_mps_bus {
+	__u8 type;
+	__u8 bus_id;
+	__u8 bus_str[UK_MPS_BUS_STR_LEN];
+} __packed;
+
+UK_CTASSERT(sizeof(struct uk_mps_bus) == 8);
+
+#define UK_MPS_IOAPIC_FLAGS_EN			(1 << 0)
+struct uk_mps_ioapic {
+	__u8 type;
+	__u8 ioapic_id;
+	__u8 ioapic_version;
+	__u8 ioapic_flags;
+	__u32 ioapic_paddr;
+} __packed;
+
+UK_CTASSERT(sizeof(struct uk_mps_ioapic) == 8);
+
+#define UK_MPS_INTSRC_IRQ_TYPE_INT		0x0
+#define UK_MPS_INTSRC_IRQ_TYPE_NMI		0x1
+#define UK_MPS_INTSRC_IRQ_TYPE_SMI		0x2
+#define UK_MPS_INTSRC_IRQ_TYPE_EXTINT		0x3
+#define UK_MPS_INTSRC_IRQ_FLAG_PO_DEFAULT	0x0
+#define UK_MPS_INTSRC_IRQ_FLAG_PO_HI		0x1
+#define UK_MPS_INTSRC_IRQ_FLAG_PO_LO		0x3
+#define UK_MPS_INTSRC_IRQ_FLAG_EL_DEFAULT	0x0
+#define UK_MPS_INTSRC_IRQ_FLAG_EL_EDGE		0x1
+#define UK_MPS_INTSRC_IRQ_FLAG_EL_LEVEL		0x3
+struct uk_mps_intsrc {
+	__u8 type;
+	__u8 irq_type;
+	__u16 irq_flag;
+	__u8 src_bus_id;
+	__u8 src_bus_irq;
+	__u8 dest_ioapic_id;
+	__u8 dest_ioapic_irq;
+} __packed;
+
+UK_CTASSERT(sizeof(struct uk_mps_intsrc) == 8);
+
+#define UK_MPS_LINTSRC_IRQ_TYPE_INT		0x0
+#define UK_MPS_LINTSRC_IRQ_TYPE_NMI		0x1
+#define UK_MPS_LINTSRC_IRQ_TYPE_SMI		0x2
+#define UK_MPS_LINTSRC_IRQ_TYPE_EXTINT		0x3
+#define UK_MPS_LINTSRC_IRQ_FLAG_PO_DEFAULT	0x0
+#define UK_MPS_LINTSRC_IRQ_FLAG_PO_HI		0x1
+#define UK_MPS_LINTSRC_IRQ_FLAG_PO_LO		0x3
+#define UK_MPS_LINTSRC_IRQ_FLAG_EL_DEFAULT	0x0
+#define UK_MPS_LINTSRC_IRQ_FLAG_EL_EDGE		0x1
+#define UK_MPS_LINTSRC_IRQ_FLAG_EL_LEVEL	0x3
+struct uk_mps_lintsrc {
+	__u8 type;
+	__u8 irq_type;
+	__u16 irq_flag;
+	__u8 src_bus_id;
+	__u8 src_bus_irq;
+	__u8 dest_lapic_id;
+	__u8 dest_lapic_irq;
+} __packed;
+
+UK_CTASSERT(sizeof(struct uk_mps_lintsrc) == 8);
+
+#define UK_MPS_SYSMEM_MEM_TYPE_IO			0x0
+#define UK_MPS_SYSMEM_MEM_TYPE_MEM			0x1
+#define UK_MPS_SYSMEM_MEM_TYPE_PREFETCH			0x2
+struct uk_mps_sysmem {
+	__u8 type;
+	__u8 len;
+	__u8 bus_id;
+	__u8 mem_type;
+	__u64 mem_base;
+	__u64 mem_len;
+} __packed;
+
+UK_CTASSERT(sizeof(struct uk_mps_sysmem) == 20);
+
+#define UK_MPS_BUSLINK_BUS_INFO_SD			(1 << 0)
+struct uk_mps_buslink {
+	__u8 type;
+	__u8 len;
+	__u8 bus_id;
+	__u8 bus_info;
+	__u8 parent_bus;
+	__u8 reserved[3];
+} __packed;
+
+UK_CTASSERT(sizeof(struct uk_mps_buslink) == 8);
+
+#define UK_MPS_BUSOVR_ADDR_MOD_PR			(1 << 0)
+#define UK_MPS_BUSOVR_RANGES_ISA_IO			0x0
+#define UK_MPS_BUSOVR_RANGES_VGA_IO			0x1
+struct uk_mps_busovr {
+	__u8 type;
+	__u8 len;
+	__u8 bus_id;
+	__u8 addr_mod;
+	__u32 ranges;
+} __packed;
+
+UK_CTASSERT(sizeof(struct uk_mps_busovr) == 8);
+
+#endif /* __PLAT_CMN_MPS_H__ */

--- a/plat/common/include/uk/plat/common/mps.h
+++ b/plat/common/include/uk/plat/common/mps.h
@@ -202,4 +202,10 @@ struct uk_mps_busovr {
 
 UK_CTASSERT(sizeof(struct uk_mps_busovr) == 8);
 
+int uk_mps_init(void);
+
+struct uk_mps_mpfp *uk_mps_get_mpfp(void);
+
+struct uk_mps_mpc *uk_mps_get_mpc(void);
+
 #endif /* __PLAT_CMN_MPS_H__ */

--- a/plat/common/memory.c
+++ b/plat/common/memory.c
@@ -168,6 +168,7 @@ static inline int get_mrd_prio(struct ukplat_memregion_desc *const m)
 	case UKPLAT_MEMRT_DEVICETREE:
 	case UKPLAT_MEMRT_KERNEL:
 		return MRD_PRIO_KRNL_RSRC;
+	case UKPLAT_MEMRT_LBIOS:
 	case UKPLAT_MEMRT_RESERVED:
 		return MRD_PRIO_RSVD;
 	default:

--- a/plat/common/memory.c
+++ b/plat/common/memory.c
@@ -65,16 +65,18 @@ void *ukplat_memregion_alloc(__sz size, int type, __u16 flags)
 {
 	struct ukplat_memregion_desc *mrd, alloc_mrd = {0};
 	__vaddr_t unmap_start, unmap_end;
+	__sz unmap_len, desired_sz;
 	struct ukplat_bootinfo *bi;
 	__paddr_t pstart, pend;
 	__paddr_t ostart, olen;
-	__sz unmap_len;
 	int rc;
 
 	unmap_start = ALIGN_DOWN(bpt_unmap_mrd.vbase, __PAGE_SIZE);
 	unmap_end = unmap_start + ALIGN_DOWN(bpt_unmap_mrd.len, __PAGE_SIZE);
 	unmap_len = unmap_end - unmap_start;
 
+	/* Preserve desired size */
+	desired_sz = size;
 	size = ALIGN_UP(size, __PAGE_SIZE);
 	ukplat_memregion_foreach(&mrd, UKPLAT_MEMRT_FREE, 0, 0) {
 		UK_ASSERT(mrd->pbase <= __U64_MAX - size);
@@ -106,7 +108,7 @@ void *ukplat_memregion_alloc(__sz size, int type, __u16 flags)
 		if (olen - (pstart - ostart) == size) {
 			mrd->pbase = pstart;
 			mrd->vbase = pstart;
-			mrd->len = pend - pstart;
+			mrd->len = desired_sz;
 			mrd->type = type;
 			mrd->flags = flags;
 
@@ -122,7 +124,7 @@ void *ukplat_memregion_alloc(__sz size, int type, __u16 flags)
 		/* Insert allocated region */
 		alloc_mrd.vbase = pstart;
 		alloc_mrd.pbase = pstart;
-		alloc_mrd.len   = size;
+		alloc_mrd.len   = desired_sz;
 		alloc_mrd.type  = type;
 		alloc_mrd.flags = flags | UKPLAT_MEMRF_MAP;
 
@@ -152,19 +154,22 @@ void *ukplat_memregion_alloc(__sz size, int type, __u16 flags)
  * - the others are all allocated for Unikraft so they will have the same
  * priority
  */
+#define MRD_PRIO_FREE			0
+#define MRD_PRIO_KRNL_RSRC		1
+#define MRD_PRIO_RSVD			2
 static inline int get_mrd_prio(struct ukplat_memregion_desc *const m)
 {
 	switch (m->type) {
 	case UKPLAT_MEMRT_FREE:
-		return 0;
+		return MRD_PRIO_FREE;
 	case UKPLAT_MEMRT_INITRD:
 	case UKPLAT_MEMRT_CMDLINE:
 	case UKPLAT_MEMRT_STACK:
 	case UKPLAT_MEMRT_DEVICETREE:
 	case UKPLAT_MEMRT_KERNEL:
-		return 1;
+		return MRD_PRIO_KRNL_RSRC;
 	case UKPLAT_MEMRT_RESERVED:
-		return 2;
+		return MRD_PRIO_RSVD;
 	default:
 		return -1;
 	}
@@ -212,66 +217,167 @@ static inline void overlapping_mrd_fixup(struct ukplat_memregion_list *list,
 		 * a new one if the left region is larger than the right region.
 		 */
 		} else {
+			/* len here is basically ml_end - mr_end. Thus,
+			 * len == 0 can happen only if:
+			 * - mr is at the end of the ml
+			 * - mr == ml, as mr can't be at the beginning
+			 * since ukplat_memregion_swap_if_unordered()
+			 * would have assigned mr as the actual ml.
+			 */
+			__sz len = ml->pbase + ml->len - mr->pbase - mr->len;
+
 			if (RANGE_CONTAIN(ml->pbase, ml->len,
-					  mr->pbase, mr->len))
-				/* Ignore insertion failure as there is nothing
-				 * we can do about it and it is not worth caring
-				 * about.
+					  mr->pbase, mr->len) && len) {
+
+				/* If we ended up here then mr is actually
+				 * somewhere in the middle of ml and we are
+				 * inserting the mrd between mr_end and ml_end
 				 */
 				ukplat_memregion_list_insert_at_idx(list,
 					&(struct ukplat_memregion_desc){
 						.vbase = mr->pbase + mr->len,
 						.pbase = mr->pbase + mr->len,
-						.len   = ml->pbase + ml->len -
-							 mr->pbase - mr->len,
+						.len   = len,
 						.type  = ml->type,
 						.flags = ml->flags
 					}, ridx + 1);
+			}
 
+			/* You may think that this could be 0 if mr is at the
+			 * beginning of ml, however this is not the case
+			 * because ukplat_memregion_swap_if_unordered()
+			 * guarantees that if ml_base == mr_base then mr
+			 * will be the one of higher length. And if that
+			 * would be the case, this would have been caught by
+			 * the
+			 * RANGE_CONTAIN(mr->pbase, mr->len, ml->pbase, ml->len)
+			 * if statement a few lines above.
+			 * Thus, this here can either:
+			 * - be 0 if ml is the same as mr
+			 * - be different from 0 if the two regions simply have
+			 * an overlapping fraction, in which case we drop the
+			 * overlapping region on ml's side, as it's of lower
+			 * priority.
+			 */
 			ml->len = mr->pbase - ml->pbase;
 		}
+	}
+}
+
+/* During coalescing of two memory region descriptors, we first call this
+ * function which would overwrite the physical and length of a given memory
+ * region descriptor with its equivalent page-aligned physical base and length
+ * if the end address of the memory region would have also been page-aligned.
+ * The coalesce function then, at the end, calls ukplat_memregion_restore_mrd
+ * to undo this.
+ */
+static void ukplat_memregion_align_mrd(struct ukplat_memregion_desc *mrd,
+				       __paddr_t *opbase, __sz *olen)
+{
+	__sz pend;
+
+	/* Store the **original** physical base and length */
+	*opbase = mrd->pbase;
+	*olen = mrd->len;
+
+	/* Compute the page-aligned end address of the region */
+	pend = ALIGN_UP(mrd->pbase + mrd->len, __PAGE_SIZE);
+
+	/* Overwrite original pbase with its page-aligned value */
+	mrd->pbase = ALIGN_DOWN(mrd->pbase, __PAGE_SIZE);
+
+	/* Overwrite original len with the supposed size of end-to-end
+	 * page-aligned memory region.
+	 */
+	mrd->len = pend - mrd->pbase;
+}
+
+/* Called at the end of ukplat_memregion_list_coalesce to undo what
+ * ukplat_memregion_align_mrd has done.
+ */
+static void ukplat_memregion_restore_mrd(struct ukplat_memregion_desc *mrd,
+					 __paddr_t opbase, __sz olen)
+{
+	mrd->len = olen;
+	mrd->pbase = opbase;
+}
+
+/* Quick function to do potentially necessary swapping of two adjacent memory
+ * region descriptors. Here just to modularize code because
+ * ukplat_memregion_list_coalesce was quite large already.
+ */
+static void ukplat_memregion_swap_if_unordered(struct ukplat_memregion_list *l,
+					       __u32 l_idx, __u32 r_idx)
+{
+	struct ukplat_memregion_desc tmp, *m;
+
+	m = l->mrds;
+	if (m[l_idx].pbase > m[r_idx].pbase ||
+	    (m[l_idx].pbase == m[r_idx].pbase &&
+	     m[l_idx].pbase + m[l_idx].len > m[r_idx].pbase + m[r_idx].len)) {
+		tmp = m[l_idx];
+		m[l_idx] = m[r_idx];
+		m[r_idx] = tmp;
 	}
 }
 
 int ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 {
 	struct ukplat_memregion_desc *m, *ml, *mr;
+	__paddr_t ml_opbase, mr_opbase;
+	__sz ml_olen, mr_olen;
 	int ml_prio, mr_prio;
+	__u8 del; /* lets us know if a deletion happened */
 	__u32 i;
 
 	i = 0;
 	m = list->mrds;
 	while (i + 1 < list->count) {
-		/* Make sure first that they are ordered. If not, swap them */
-		if (m[i].pbase > m[i + 1].pbase ||
-		    (m[i].pbase == m[i + 1].pbase &&
-		     m[i].pbase + m[i].len > m[i + 1].pbase + m[i + 1].len)) {
-			struct ukplat_memregion_desc tmp;
+		del = 0;
 
-			tmp = m[i];
-			m[i] = m[i + 1];
-			m[i + 1] = tmp;
-		}
+		/* Make sure first that they are ordered. If not, swap them */
+		ukplat_memregion_swap_if_unordered(list, i, i + 1);
+
 		ml = &m[i];
 		mr = &m[i + 1];
-		ml_prio = get_mrd_prio(ml);
-		mr_prio = get_mrd_prio(mr);
 
-		/* If they overlap */
-		if (RANGE_OVERLAP(ml->pbase,  ml->len, mr->pbase, mr->len)) {
+		ml_prio = get_mrd_prio(ml);
+		if (unlikely(ml_prio < 0))
+			return -EINVAL;
+
+		mr_prio = get_mrd_prio(mr);
+		if (unlikely(mr_prio < 0))
+			return -EINVAL;
+
+		ukplat_memregion_align_mrd(ml, &ml_opbase, &ml_olen);
+		ukplat_memregion_align_mrd(mr, &mr_opbase, &mr_olen);
+
+		if (RANGE_OVERLAP(ml->pbase, ml->len, mr->pbase, mr->len)) {
 			/* If they are not of the same priority */
 			if (ml_prio != mr_prio) {
+				/* At least one of the overlapping regions must
+				 * be a free one. Otherwise, something wrong
+				 * happened.
+				 */
+				if (unlikely(!(mr_prio == MRD_PRIO_FREE ||
+					       ml_prio == MRD_PRIO_FREE)))
+					return -EINVAL;
+
 				overlapping_mrd_fixup(list, ml, mr, ml_prio,
 						      mr_prio, i, i + 1);
 
 				/* Remove dropped regions */
-				if (ml->len == 0)
+				del = 1;
+				if (ml->len == 0) {
 					ukplat_memregion_list_delete(list, i);
-				else if (mr->len == 0)
+
+				} else if (mr->len == 0) {
 					ukplat_memregion_list_delete(list,
 								     i + 1);
-				else
+				} else {
 					i++;
+					del = 0;  /* No deletions */
+				}
 
 			} else if (ml->flags != mr->flags) {
 				return -EINVAL;
@@ -287,8 +393,9 @@ int ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 				if (RANGE_CONTAIN(mr->pbase, mr->len,
 						  ml->pbase, ml->len)) {
 					ukplat_memregion_list_delete(list, i);
+					del = 1;
 
-					continue;
+					goto restore_mrds;
 
 				/* If the right region is contained within the
 				 * left region, drop it
@@ -297,8 +404,9 @@ int ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 							 mr->pbase, mr->len)) {
 					ukplat_memregion_list_delete(list,
 								     i + 1);
+					del = 1;
 
-					continue;
+					goto restore_mrds;
 				}
 
 				/* If they are not contained within each other,
@@ -315,6 +423,7 @@ int ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 				 * the previous region.
 				 */
 				ukplat_memregion_list_delete(list, i + 1);
+				del = 1;
 			}
 
 		/* If they do not overlap but they are contiguous and have the
@@ -324,10 +433,43 @@ int ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 			   ml_prio == mr_prio && ml->flags == mr->flags) {
 			ml->len += mr->len;
 			ukplat_memregion_list_delete(list, i + 1);
+			del = 1;
 		} else {
 			i++;
 		}
+
+restore_mrds:
+		if (!del) {
+			/* We assume only MRD_PRIO_FREE can be dropped. We want
+			 * to maintain !MRD_PRIO_FREE start addresses and
+			 * length so that the kernel may use them (e.g. initrd
+			 * start address).
+			 */
+			if (ml_prio != MRD_PRIO_FREE)
+				ukplat_memregion_restore_mrd(ml, ml_opbase,
+							     ml_olen);
+
+			/* This here can only happen if two adjacent
+			 * !MRD_PRIO_FREE regions are resolved without a
+			 * deletion. Preserve mr's original data as well.
+			 */
+			if (mr_prio != MRD_PRIO_FREE)
+				ukplat_memregion_restore_mrd(mr, mr_opbase,
+							     mr_olen);
+		}
+
+		/* Update ml's vbase, since it might not be equal to pbase
+		 * anymore. Whether we deleted ml or mr it does not matter,
+		 * as ml is now equal to the remaining one, because
+		 * ukplat_memregion_list_delete() removes by `memmove()`ing.
+		 */
+		ml->vbase = ml->pbase;
 	}
+
+	/* Make sure the last memory region always ends up being updated when
+	 * we exit this function
+	 */
+	m[i].vbase = m[i].pbase;
 
 	return 0;
 }

--- a/plat/common/mps.c
+++ b/plat/common/mps.c
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+
+#include <uk/assert.h>
+#include <uk/plat/common/mps.h>
+#include <uk/plat/common/bootinfo.h>
+#include <uk/print.h>
+
+#define BIOS_ROM_STEP		16
+
+struct uk_mps_mpfp *mpfp;
+struct uk_mps_mpc *mpc;
+
+static int uk_mps_get_checksum(void *buf, __sz len)
+{
+	const __u8 *const ptr_end = (__u8 *)buf + len;
+	const __u8 *ptr = (__u8 *)buf;
+	__u8 checksum = 0;
+
+	while (ptr < ptr_end)
+		checksum += *ptr++;
+
+	return checksum;
+}
+
+int uk_mps_init(void)
+{
+	struct ukplat_memregion_desc *mrdp;
+	__paddr_t ptr, start, end;
+
+	ukplat_memregion_foreach(&mrdp, UKPLAT_MEMRT_LBIOS, 0, 0) {
+		start = mrdp->pbase;
+		end = mrdp->pbase + mrdp->len;
+
+		for (ptr = start; ptr < end; ptr += BIOS_ROM_STEP)
+			if (!memcmp((void *)ptr, UK_MPS_MPFP_SIG,
+			    sizeof(UK_MPS_MPFP_SIG) - 1)) {
+				uk_pr_debug("MPS MPFP present at %lx\n", ptr);
+				mpfp = (struct uk_mps_mpfp *)ptr;
+				break;
+			}
+	}
+
+	UK_ASSERT(mpfp->tbl_len == 1 &&  /* One paragraph long */
+		  !uk_mps_get_checksum(mpfp, UK_MPS_PARAGRAPH_LEN));
+
+	/* Feature info byte 1 of mpfp tells which of the default MP system
+	 * configurations we are dealing with. In this case, MPC must be 0.
+	 */
+	if (mpfp->feat_b1)
+		return 0;
+
+	mpc = (struct uk_mps_mpc *)(__uptr)mpfp->mpc_paddr;
+	/* Revision must either be 4 (MPS 1.4) or 1 (MPS 1.1) */
+	UK_ASSERT(mpc->revision == 0x4 || mpc->revision == 0x1);
+	UK_ASSERT(!uk_mps_get_checksum(mpc, mpc->tbl_len));
+
+	return 0;
+}
+
+struct uk_mps_mpfp *uk_mps_get_mpfp(void)
+{
+	return mpfp;
+}
+
+struct uk_mps_mpc *uk_mps_get_mpc(void)
+{
+	return mpc;
+}

--- a/plat/common/mps.c
+++ b/plat/common/mps.c
@@ -70,3 +70,42 @@ struct uk_mps_mpc *uk_mps_get_mpc(void)
 {
 	return mpc;
 }
+
+void uk_mps_next_mpc_entry(void **entryp)
+{
+	__u8 **entry = (__u8 **)entryp;
+
+	UK_ASSERT(entryp);
+
+	if (!mpc)
+		*entry = NULL;
+
+	switch (**entry) {
+	case UK_MPS_MPC_TYPE_CPU:
+		*entry += sizeof(struct uk_mps_cpu);
+		break;
+	case UK_MPS_MPC_TYPE_BUS:
+		*entry += sizeof(struct uk_mps_bus);
+		break;
+	case UK_MPS_MPC_TYPE_IOAPIC:
+		*entry += sizeof(struct uk_mps_ioapic);
+		break;
+	case UK_MPS_MPC_TYPE_INTSRC:
+		*entry += sizeof(struct uk_mps_intsrc);
+		break;
+	case UK_MPS_MPC_TYPE_LINTSRC:
+		*entry += sizeof(struct uk_mps_lintsrc);
+		break;
+	case UK_MPS_XMPC_TYPE_SYSMEM:
+		*entry += sizeof(struct uk_mps_sysmem);
+		break;
+	case UK_MPS_XMPC_TYPE_BUSLINK:
+		*entry += sizeof(struct uk_mps_buslink);
+		break;
+	case UK_MPS_XMPC_TYPE_BUSOVR:
+		*entry += sizeof(struct uk_mps_busovr);
+		break;
+	default:
+		*entry = NULL;
+	}
+}

--- a/plat/common/x86/lcpu.c
+++ b/plat/common/x86/lcpu.c
@@ -104,47 +104,61 @@ void __noreturn lcpu_arch_jump_to(void *sp, ukplat_lcpu_entry_t entry)
 	__builtin_unreachable();
 }
 
-#ifdef CONFIG_HAVE_SMP
-/* Secondary cores start in 16-bit real-mode and we have to provide the
- * corresponding boot code somewhere in the first 1 MiB. We copy the trampoline
- * code to the target address during MP initialization.
- */
-#if CONFIG_LIBUKRELOC
-IMPORT_START16_UKRELOC_SYM(gdt32_ptr, 2, MOV);
-IMPORT_START16_UKRELOC_SYM(gdt32, 4, DATA);
-IMPORT_START16_UKRELOC_SYM(lcpu_start16, 2, MOV);
-IMPORT_START16_UKRELOC_SYM(jump_to32, 2, MOV);
-IMPORT_START16_UKRELOC_SYM(lcpu_start32, 4, MOV);
+#if CONFIG_HAVE_SMP
+IMPORT_START16_SYM(gdt32_ptr, 2, MOV);
+IMPORT_START16_SYM(gdt32, 4, DATA);
+IMPORT_START16_SYM(lcpu_start16, 2, MOV);
+IMPORT_START16_SYM(jump_to32, 2, MOV);
+IMPORT_START16_SYM(lcpu_start32, 4, MOV);
 
-static void uk_reloc_mp_init(void)
+#define START16_RELOC_ENTRY(sym, sz, type)				\
+	{								\
+		.r_mem_off = START16_##type##_OFF(sym, sz),		\
+		.r_addr = (void *)(sym) - (void *)x86_start16_begin,	\
+		.r_sz = (sz),						\
+	}
+
+static void apply_start16_reloc(__u64 baddr, __u64 r_mem_off,
+				__u64 r_addr, __u32 r_sz)
 {
-	size_t i;
-	struct uk_reloc x86_start16_relocs[] = {
-		START16_UKRELOC_ENTRY(lcpu_start16, 2, MOV),
-		START16_UKRELOC_ENTRY(gdt32, 4, DATA),
-		START16_UKRELOC_ENTRY(gdt32_ptr, 2, MOV),
-		START16_UKRELOC_ENTRY(jump_to32, 2, MOV),
+	switch (r_sz) {
+	case 2:
+		*(__u16 *)((__u8 *)baddr + r_mem_off) = (__u16)(baddr + r_addr);
+		break;
+	case 4:
+		*(__u32 *)((__u8 *)baddr + r_mem_off) = (__u32)(baddr + r_addr);
+		break;
+	}
+}
+
+static void start16_reloc_mp_init(void)
+{
+	struct {
+		__u64 r_mem_off;
+		__u64 r_addr;
+		__u32 r_sz;
+	} x86_start16_relocs[] = {
+		START16_RELOC_ENTRY(lcpu_start16, 2, MOV),
+		START16_RELOC_ENTRY(gdt32_ptr, 2, MOV),
+		START16_RELOC_ENTRY(gdt32, 4, DATA),
+		START16_RELOC_ENTRY(jump_to32, 2, MOV),
+		START16_RELOC_ENTRY(lcpu_start32, 4, MOV),
 	};
+	__sz i;
 
 	for (i = 0; i < ARRAY_SIZE(x86_start16_relocs); i++)
-		apply_uk_reloc(&x86_start16_relocs[i],
-			      (__u64)x86_start16_addr +
-			      x86_start16_relocs[i].r_addr,
-			      (void *)x86_start16_addr);
+		apply_start16_reloc((__u64)x86_start16_addr,
+				    x86_start16_relocs[i].r_mem_off,
+				    x86_start16_relocs[i].r_addr,
+				    x86_start16_relocs[i].r_sz);
 
 	/* Unlike the other entries, lcpu_start32 must stay the same
 	 * as it is not part of the start16 section
 	 */
-	apply_uk_reloc(&(struct uk_reloc)UKRELOC_ENTRY(
-				START16_UKRELOC_MOV_OFF(lcpu_start32, 4),
-				(__u64)lcpu_start32, 4,
-				UKRELOC_FLAGS_PHYS_REL),
-		       (__u64)lcpu_start32,
-		       (void *)x86_start16_addr);
+	apply_start16_reloc((__u64)x86_start16_addr,
+			    START16_MOV_OFF(lcpu_start32, 4),
+			    (__u64)lcpu_start32 - (__u64)x86_start16_addr, 4);
 }
-#else  /* CONFIG_LIBUKRELOC */
-static void uk_reloc_mp_init(void) { }
-#endif /* !CONFIG_LIBUKRELOC */
 
 int lcpu_arch_mp_init(void *arg __unused)
 {
@@ -214,7 +228,7 @@ int lcpu_arch_mp_init(void *arg __unused)
 	UK_ASSERT(x86_start16_addr < 0x100000);
 	memcpy((void *)x86_start16_addr, &x86_start16_begin, X86_START16_SIZE);
 
-	uk_reloc_mp_init();
+	start16_reloc_mp_init();
 
 	uk_pr_debug("Copied AP 16-bit boot code to 0x%"__PRIvaddr"\n",
 		    x86_start16_addr);

--- a/plat/common/x86/start16_helpers.h
+++ b/plat/common/x86/start16_helpers.h
@@ -14,29 +14,22 @@ extern void *x86_start16_end[];
 #define X86_START16_SIZE						\
 	((__uptr)x86_start16_end - (__uptr)x86_start16_begin)
 
-#if CONFIG_LIBUKRELOC
-#define START16_UKRELOC_MOV_SYM(sym, sz)				\
-	sym##_uk_reloc_imm##sz##_start16
+#define START16_MOV_SYM(sym, sz)					\
+	sym##_imm##sz##_start16
 
-#define START16_UKRELOC_DATA_SYM(sym, sz)				\
-	sym##_uk_reloc_data##sz##_start16
+#define START16_DATA_SYM(sym, sz)					\
+	sym##_data##sz##_start16
 
-#define IMPORT_START16_UKRELOC_SYM(sym, sz, type)			\
+#define IMPORT_START16_SYM(sym, sz, type)				\
 	extern void *sym[];						\
-	extern void *START16_UKRELOC_##type##_SYM(sym, sz)[]
+	extern void *START16_##type##_SYM(sym, sz)[]
 
-#define START16_UKRELOC_MOV_OFF(sym, sz)				\
-	((void *)START16_UKRELOC_MOV_SYM(sym, sz) -			\
+#define START16_MOV_OFF(sym, sz)					\
+	((void *)START16_MOV_SYM(sym, sz) -				\
 	(void *)x86_start16_begin)
 
-#define START16_UKRELOC_DATA_OFF(sym, sz)				\
-	((void *)START16_UKRELOC_DATA_SYM(sym, sz) -			\
+#define START16_DATA_OFF(sym, sz)					\
+	((void *)START16_DATA_SYM(sym, sz) -				\
 	(void *)x86_start16_begin)
-
-#define START16_UKRELOC_ENTRY(sym, sz, type)				\
-	UKRELOC_ENTRY(START16_UKRELOC_##type##_OFF(sym, sz),		\
-		       (void *)sym - (void *)x86_start16_begin,		\
-		       sz, UKRELOC_FLAGS_PHYS_REL)
-#endif /* CONFIG_LIBUKRELOC */
 
 #endif  /* __START16_HELPERS_H__ */

--- a/plat/kvm/Makefile.uk
+++ b/plat/kvm/Makefile.uk
@@ -125,6 +125,9 @@ LIBKVMPLAT_SRCS-y                          += $(UK_PLAT_COMMON_BASE)/lcpu.c|comm
 LIBKVMPLAT_SRCS-y                          += $(UK_PLAT_COMMON_BASE)/memory.c|common
 LIBKVMPLAT_SRCS-y                          += $(UK_PLAT_KVM_DEF_LDS)
 LIBKVMPLAT_SRCS-$(CONFIG_UKPLAT_ACPI)      += $(UK_PLAT_COMMON_BASE)/acpi.c|common
+ifneq ($(CONFIG_UKPLAT_ACPI),y)
+LIBKVMPLAT_SRCS-$(CONFIG_ARCH_X86_64)      += $(UK_PLAT_COMMON_BASE)/mps.c|common
+endif
 ifeq ($(CONFIG_KVM_BOOT_PROTO_EFI_STUB),y)
 LIBKVMPLAT_SRCS-y                          += $(LIBKVMPLAT_BASE)/efi.c|common
 endif

--- a/plat/kvm/efi.c
+++ b/plat/kvm/efi.c
@@ -480,7 +480,7 @@ static void uk_efi_setup_bootinfo_cmdl(struct ukplat_bootinfo *bi)
 
 	mrd.pbase = (__paddr_t)cmdl;
 	mrd.vbase = (__vaddr_t)cmdl;
-	mrd.len = PAGE_ALIGN_UP(len);
+	mrd.len = len;
 	mrd.type = UKPLAT_MEMRT_CMDLINE;
 	mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 	rc = ukplat_memregion_list_insert(&bi->mrds, &mrd);
@@ -510,7 +510,7 @@ static void uk_efi_setup_bootinfo_initrd(struct ukplat_bootinfo *bi)
 
 	mrd.pbase = (__paddr_t)initrd;
 	mrd.vbase = (__vaddr_t)initrd;
-	mrd.len = PAGE_ALIGN_UP(len);
+	mrd.len = len;
 	mrd.type = UKPLAT_MEMRT_INITRD;
 	mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 	rc = ukplat_memregion_list_insert(&bi->mrds, &mrd);
@@ -537,7 +537,7 @@ static void uk_efi_setup_bootinfo_dtb(struct ukplat_bootinfo *bi)
 
 	mrd.pbase = (__paddr_t)dtb;
 	mrd.vbase = (__vaddr_t)dtb;
-	mrd.len = PAGE_ALIGN_UP(len);
+	mrd.len = len;
 	mrd.type = UKPLAT_MEMRT_DEVICETREE;
 	mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 	rc = ukplat_memregion_list_insert(&bi->mrds, &mrd);

--- a/plat/kvm/x86/lcpu_start.S
+++ b/plat/kvm/x86/lcpu_start.S
@@ -53,25 +53,26 @@
 x86_start16_addr:
 	.quad	START16_PLACEHOLDER
 
-/* Implement dedicate ur_* macro's whose only use-case is this file to cope with
- * the existence of 16-bit code. This is so it does not interfere with the other
- * uses of the ur_* macro's. For example, we not want symbols for these to
- * occupy unnecessary space in .uk_reloc.
+/* Implement dedicated start16 macro's whose only use-case is this file to cope
+ * with the existence of 16-bit code. This is so it does not interfere with the
+ * other uses of the ur_* macro's.
+ * For example, we do not want symbols for these to occupy unnecessary space in
+ * .uk_reloc.
  *
  * NOTE:IF ADDING/REMOVING RELOCATIONS FROM HERE, THEN ADD/REMOVE
- *	CORRESPONDENT SYMBOL TO `lcpu.c` (see IMPORT_START16_UKRELOC_SYM
+ *	CORRESPONDENT SYMBOL TO `lcpu.c` (see IMPORT_START16_SYM
  *	start16_helpers.h macros being used on start16 symbols)
  */
-.macro ur_mov_start16	sym:req, reg:req, bytes:req
+.macro mov_start16	sym:req, reg:req, bytes:req
 	mov	$START16_PLACEHOLDER, \reg
-.globl	\sym\()_uk_reloc_imm\bytes\()_start16
-.set	\sym\()_uk_reloc_imm\bytes\()_start16, (. - \bytes)
+.globl	\sym\()_imm\bytes\()_start16
+.set	\sym\()_imm\bytes\()_start16, (. - \bytes)
 	nop
 .endm
 
-.macro ur_data_start16	type:req, sym:req, bytes:req
-.globl	\sym\()_uk_reloc_data\bytes\()_start16
-.set	\sym\()_uk_reloc_data\bytes\()_start16, .
+.macro data_start16	type:req, sym:req, bytes:req
+.globl	\sym\()_data\bytes\()_start16
+.set	\sym\()_data\bytes\()_start16, .
 	.\type	START16_PLACEHOLDER
 .endm
 
@@ -94,7 +95,7 @@ ENTRY(lcpu_start16_ap)
 	xorl	%edi, %edi
 	xorl	%esi, %esi
 
-	ur_mov_start16	lcpu_start16, %ax, 2
+	mov_start16	lcpu_start16, %ax, 2
 	/* On start-up a core's %cs is set depending on the value of the vector
 	 * inside the SIPI message, so make sure we are jumping to the
 	 * proper address w.r.t. segmentation.
@@ -123,7 +124,7 @@ gdt32_null:
 .globl gdt32_ptr
 gdt32_ptr:
 	.word	(gdt32_end - gdt32 - 1)	/* size - 1	*/
-	ur_data_start16	long, gdt32, 4	/* GDT address	*/
+	data_start16	long, gdt32, 4	/* GDT address	*/
 gdt32_cs:
 	.quad	GDT_DESC_CODE32_VAL	/* 32-bit CS	*/
 gdt32_ds:
@@ -143,7 +144,7 @@ ENTRY(lcpu_start16)
 	movl	%eax, %cr0
 
 	/* Load 32-bit GDT and jump into 32-bit code segment */
-	ur_mov_start16	gdt32_ptr, %ax, 2
+	mov_start16	gdt32_ptr, %ax, 2
 	lgdt	(%eax)
 
 	/* ljmp encoding has 5 opcodes, thus 40 bits, which in our case
@@ -161,7 +162,7 @@ ENTRY(lcpu_start16)
 	 * address corresponds to the very next instruction in memory
 	 * after our ljmp.
 	 */
-	ur_mov_start16	jump_to32, %ax, 2
+	mov_start16	jump_to32, %ax, 2
 	movw	%ax, -4(%eax)
 	ljmp	$(gdt32_cs - gdt32), $START16_PLACEHOLDER
 
@@ -178,7 +179,7 @@ jump_to32:
 	movl	%eax, %fs
 	movl	%eax, %gs
 
-	ur_mov_start16	lcpu_start32, %eax, 4
+	mov_start16	lcpu_start32, %eax, 4
 
 	jmp	*%eax
 END(lcpu_start16)

--- a/plat/kvm/x86/lxboot.c
+++ b/plat/kvm/x86/lxboot.c
@@ -41,7 +41,7 @@ lxboot_init_cmdline(struct ukplat_bootinfo *bi, struct lxboot_params *bp)
 
 	mrd.pbase = cmdline_addr;
 	mrd.vbase = cmdline_addr;
-	mrd.len   = PAGE_ALIGN_UP(cmdline_size);
+	mrd.len   = cmdline_size;
 	mrd.type  = UKPLAT_MEMRT_CMDLINE;
 	mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 #ifdef CONFIG_UKPLAT_MEMRNAME
@@ -79,7 +79,7 @@ lxboot_init_initrd(struct ukplat_bootinfo *bi, struct lxboot_params *bp)
 	mrd.flags = UKPLAT_MEMRF_MAP | UKPLAT_MEMRF_READ;
 	mrd.vbase = initrd_addr;
 	mrd.pbase = initrd_addr;
-	mrd.len   = PAGE_ALIGN_UP(initrd_size);
+	mrd.len   = initrd_size;
 #ifdef CONFIG_UKPLAT_MEMRNAME
 	memcpy(mrd.name, "initrd", sizeof("initrd"));
 #endif /* CONFIG_UKPLAT_MEMRNAME */
@@ -105,9 +105,6 @@ lxboot_init_mem(struct ukplat_bootinfo *bi, struct lxboot_params *bp)
 		 * not handle address zero well.
 		 */
 		start = MAX(entry->addr, PAGE_SIZE);
-		/* Also make sure to not insert unaligned memory regions */
-		start = PAGE_ALIGN_UP(start);
-
 		end = entry->addr + entry->size;
 
 		if (end <= start)

--- a/plat/kvm/x86/lxboot.c
+++ b/plat/kvm/x86/lxboot.c
@@ -158,6 +158,10 @@ void lxboot_entry(struct lcpu *lcpu, struct lxboot_params *bp)
 	if (unlikely(rc))
 		lxboot_crash(rc, "Could not coalesce memory regions");
 
+	rc = ukplat_memregion_alloc_sipi_vect();
+	if (unlikely(rc))
+		lxboot_crash(rc, "Could not insert SIPI vector region");
+
 	memcpy(bi->bootprotocol, "lxboot", sizeof("lxboot"));
 
 	_ukplat_entry(lcpu, bi);

--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -7,7 +7,11 @@
 #include <string.h>
 #include <x86/cpu.h>
 #include <x86/traps.h>
+#if CONFIG_UKPLAT_ACPI
 #include <uk/plat/common/acpi.h>
+#else /* !CONFIG_UKPLAT_ACPI */
+#include <uk/plat/common/mps.h>
+#endif /* !CONFIG_UKPLAT_ACPI */
 #include <uk/arch/limits.h>
 #include <uk/arch/types.h>
 #include <uk/arch/paging.h>
@@ -111,8 +115,12 @@ void _ukplat_entry(struct lcpu *lcpu, struct ukplat_bootinfo *bi)
 	/* Print boot information */
 	ukplat_bootinfo_print();
 
-#if defined(CONFIG_HAVE_SMP) && defined(CONFIG_UKPLAT_ACPI)
+#if CONFIG_HAVE_SMP
+#if CONFIG_UKPLAT_ACPI
 	rc = acpi_init();
+#else /* !CONFIG_UKPLAT_ACPI */
+	rc = uk_mps_init();
+#endif /* !CONFIG_UKPLAT_ACPI */
 	if (likely(rc == 0)) {
 		rc = lcpu_mp_init(CONFIG_UKPLAT_LCPU_RUN_IRQ,
 				  CONFIG_UKPLAT_LCPU_WAKEUP_IRQ,
@@ -120,7 +128,7 @@ void _ukplat_entry(struct lcpu *lcpu, struct ukplat_bootinfo *bi)
 		if (unlikely(rc))
 			uk_pr_err("SMP init failed: %d\n", rc);
 	} else {
-		uk_pr_err("ACPI init failed: %d\n", rc);
+		uk_pr_err("ACPI/MPS init failed: %d\n", rc);
 	}
 #endif /* CONFIG_HAVE_SMP && CONFIG_UKPLAT_ACPI */
 

--- a/support/scripts/mkbootinfo.py
+++ b/support/scripts/mkbootinfo.py
@@ -123,6 +123,8 @@ def main():
 
             # Align size up to page size
             size = (int(phdr[1], base=16) + (PAGE_SIZE - 1)) & ~(PAGE_SIZE - 1)
+            if size == 0:
+                continue
 
             assert nsecs < cap
             nsecs += 1


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

At this moment, Firecracker does not speak ACPI and to report secondary cores, among
other things, it makes use of the Intel Multiprocessor specification. Thus, in order to enable
SMP builds to run on Firecracker x86, integrate this specification accordingly.

This PR depends on #1113 to be able to build SMP correctly without PIE, #1121 for EBDA and #1060
as a dependency for #1121.