### PR TITLE
plat/kvm/x86: Make zero page inaccessible

### DIFF
--- a/plat/kvm/x86/pagetable64.S
+++ b/plat/kvm/x86/pagetable64.S
@@ -131,13 +131,20 @@ bpt_unmap_mrd:
  * systems supporting 1GB pages.
  *
  * 0x0000000000000000 - 0x00000000ffffffff Mapping of first 4GB
+ * However, the first page is inaccessible.
  *
  * If paging is enabled:
  * 0xffffff8000000000 - 0xffffffffffffffff Mapping of first 512GB (for PTs)
  */
 .align 0x1000
+x86_bpt_pt0_0_0: /* 4K pages */
+	pte_zero 0x0000000000000000, 0x001
+	pte_fill 0x0000000000001000, 0x1ff, PT_LVL, PTE_RW
+
+.align 0x1000
 x86_bpt_pd0_0: /* 2M pages */
-	pte_fill 0x0000000000000000, 0x200, PD_LVL, PTE_RW
+	pte x86_bpt_pt0_0_0, PTE_RW
+	pte_fill 0x0000000000200000, 0x1ff, PD_LVL, PTE_RW
 
 x86_bpt_pd0_1: /* 2M pages */
 	pte_fill 0x0000000040000000, 0x200, PD_LVL, PTE_RW


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Commit ad684b5175f70e78dc37ed63d8a124c2b6e53d1c made the first page accessible. This caused NULL-pointer accesses to not cause a page-fault. This can hide bugs and therefore this commit splits the first 2MiB page into 4KiB pages and marks the first one as inaccessible.

@skuenzer @andreittr 