### PR TITLE
include/arch: Add atomic fetch & AND operation

### DIFF
--- a/include/uk/arch/atomic.h
+++ b/include/uk/arch/atomic.h
@@ -79,7 +79,13 @@ extern "C" {
  * Perform an atomic OR operation and return the previous value.
  */
 #define ukarch_or(src, val) \
-	__atomic_or_fetch(src, val, __ATOMIC_SEQ_CST)
+	__atomic_fetch_or(src, val, __ATOMIC_SEQ_CST)
+
+/**
+ * Perform an atomic AND operation and return the previous value.
+ */
+#define ukarch_and(src, val) \
+	__atomic_fetch_and(src, val, __ATOMIC_SEQ_CST)
 
 /**
  * Writes *src into *dst, and returns the previous contents of *dst.


### PR DESCRIPTION
### Description of changes

This change adds a Unikraft macro for an architecture's atomic fetch & AND operation, similar to the fetch & OR we already have.
It also fixes the order of the fetch & OR operations to be truthful to the docstring. All internal uses of fetch & OR discard the fetched result, so no behavior will change.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A