### PR TITLE
{include/, lib/uksched, lib/uklock}: Add static initializers

### DIFF
--- a/include/uk/refcount.h
+++ b/include/uk/refcount.h
@@ -56,6 +56,8 @@ extern "C" {
 	} while (0)
 #endif /* CONFIG_LIBUKDEBUG */
 
+#define UK_REFCOUNT_INITIALIZER(val) ((__atomic){ .counter = (val) })
+
 /**
  * Initialize the atomic reference.
  *

--- a/lib/uklock/include/uk/rwlock.h
+++ b/lib/uklock/include/uk/rwlock.h
@@ -54,6 +54,17 @@ void uk_rwlock_init_config(struct uk_rwlock *rwl, unsigned int config_flags);
 
 #define uk_rwlock_init(rwl) uk_rwlock_init_config(rwl, 0)
 
+#define UK_RWLOCK_INITIALIZER(name, flags) \
+	((struct uk_rwlock){ \
+		.nactive = 0, \
+		.npending_reads = 0, \
+		.npending_writes = 0, \
+		.config_flags = flags, \
+		.sl = UK_SPINLOCK_INITIALIZER(), \
+		.shared = UK_WAIT_QUEUE_INITIALIZER((name).shared), \
+		.exclusive = UK_WAIT_QUEUE_INITIALIZER((name).exclusive), \
+	})
+
 /**
  * Acquire the reader-writer lock for reading. Multiple readers can
  * acquire the lock at the same time

--- a/lib/uksched/include/uk/wait_types.h
+++ b/lib/uksched/include/uk/wait_types.h
@@ -50,6 +50,8 @@ struct uk_waitq {
 	UK_STAILQ_HEAD_INITIALIZER(name.wait_list) \
 }
 
+#define UK_WAIT_QUEUE_INITIALIZER(name) __WAIT_QUEUE_INITIALIZER(name)
+
 #define DEFINE_WAIT_QUEUE(name) \
 	struct uk_waitq name = __WAIT_QUEUE_INITIALIZER(name)
 


### PR DESCRIPTION
### Description of changes

This change set adds static initializer macros for various internal Unikraft data structures:
- Refcount fields
- Thread wait queues
- Read-Write locks

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

The one checkpatch warning is a false error and the code is correct: casts must bind to their target without a space.

### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A
