### PR TITLE
build: Use ISO 8601 format for `$(HOSTUTC)`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,8 +261,6 @@ else
 export UK_FULLVERSION := $(UK_VERSION).$(UK_SUBVERSION)$(shell cd $(CONFIG_UK_BASE); $(SCRIPTS_DIR)/gitsha1)
 endif
 
-export DATE := $(shell date +%Y%m%d)
-
 # Makefile targets
 null_targets		:= print-version print-vars help
 nokconfig_targets       := properclean distclean $(null_targets)

--- a/Makefile
+++ b/Makefile
@@ -440,7 +440,8 @@ HOSTOBJCOPY	:= $(shell which $(HOSTOBJCOPY) || type -p $(HOSTOBJCOPY) || echo ob
 HOSTRANLIB	:= $(shell which $(HOSTRANLIB) || type -p $(HOSTRANLIB) || echo ranlib)
 HOSTCC_VERSION	:= $(shell $(HOSTCC_NOCCACHE) --version | \
 		   $(SED) -n -r 's/^.* ([0-9]*)\.([0-9]*)\.([0-9]*)[ ]*.*/\1 \2/p')
-HOSTUTC		:= $(shell date -u)
+# UTC time in ISO 8601 format:
+HOSTUTC		:= $(shell date -Iseconds -u)
 HOSTNAME	:= $(shell hostname -s)
 HOSTUSER	:= $(shell whoami)
 


### PR DESCRIPTION
### Description of changes

This PR makes the time format consistent for all host localizations and systems with the ISO 8601 format for UTC.
