### PR TITLE
arch/arm64: Fix dependency for `arm64_syscall_adapter`

### DIFF
--- a/plat/common/arm/traps_arm64.c
+++ b/plat/common/arm/traps_arm64.c
@@ -222,7 +222,7 @@ void trap_el1_irq(struct __regs *regs)
 	gic->ops.handle_irq(regs);
 }
 
-#ifdef CONFIG_LIBSYSCALL_SHIM
+#ifdef CONFIG_LIBSYSCALL_SHIM_HANDLER
 
 extern void ukplat_syscall_handler(struct __regs *r);
 
@@ -236,4 +236,4 @@ static int arm64_syscall_adapter(void *data)
 
 UK_EVENT_HANDLER(UKARCH_TRAP_SYSCALL, arm64_syscall_adapter);
 
-#endif /* CONFIG_LIBSYSCALL_SHIM */
+#endif /* CONFIG_LIBSYSCALL_SHIM_HANDLER */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Description of changes

The `arm64_syscall_adapter` was introduced by #1009.

In order to forward binary syscalls, it requires a dependency on `CONFIG_LIBSYSCALL_SHIM_HANDLER`, and the current `CONFIG_LIBSYSCALL_SHIM` is not enough.
