### PR TITLE
plat/kvm/x86: Use `ur_pte` for the first page table

### DIFF
--- a/plat/kvm/x86/pagetable64.S
+++ b/plat/kvm/x86/pagetable64.S
@@ -143,7 +143,7 @@ x86_bpt_pt0_0_0: /* 4K pages */
 
 .align 0x1000
 x86_bpt_pd0_0: /* 2M pages */
-	pte x86_bpt_pt0_0_0, PTE_RW
+	ur_pte x86_bpt_pt0_0_0, PTE_RW
 	pte_fill 0x0000000000200000, 0x1ff, PD_LVL, PTE_RW
 
 x86_bpt_pd0_1: /* 2M pages */


### PR DESCRIPTION
After commit f57ca0bbc402 ("plat/kvm/x86: Make zero page inaccessible"), UEFI builds would fail to run due to the first page table becoming unrelocatable.

Therefore, fix this by using the `ur_pte` variant of the `pte` macro.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
