### PR TITLE
plat/kvm/x86: Pre-initialize VGA framebuffer `terminal_buffer`

### DIFF
--- a/plat/kvm/x86/vga_console.c
+++ b/plat/kvm/x86/vga_console.c
@@ -66,11 +66,12 @@ static inline uint16_t vga_entry(unsigned char uc, uint8_t color)
 #define TAB_ALIGNMENT 8
 #define VGA_WIDTH     80
 #define VGA_HEIGHT    25
+#define VGA_FB_BASE   0xb8000
 
 static size_t terminal_row;
 static size_t terminal_column;
 static uint8_t terminal_color;
-static uint16_t *terminal_buffer;
+static uint16_t *const terminal_buffer = (uint16_t *)VGA_FB_BASE;
 static uint16_t areg;   /* VGA address register */
 static uint16_t dreg;   /* VGA data register */
 
@@ -117,7 +118,6 @@ void _libkvmplat_init_vga_console(void)
 	outb(dreg, 0x0f);
 	local_irq_restore(irq_flags);
 
-	terminal_buffer = (uint16_t *) 0xb8000;
 	clear_terminal();
 }
 


### PR DESCRIPTION
After commit f57ca0bbc402 ("plat/kvm/x86: Make zero page inaccessible"), early accesses to uninitialized VGA framebuffer would issue an unhandled page fault and thus crashing the application. Solve this by preinitializing the `terminal_buffer` variable.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
