### PR TITLE
plat/kvm: Adapt EFI boot to new APIC driver

### DIFF
--- a/plat/kvm/x86/efi_post.c
+++ b/plat/kvm/x86/efi_post.c
@@ -7,7 +7,6 @@
 #include <uk/arch/paging.h>
 #include <uk/plat/common/bootinfo.h>
 #include <uk/plat/lcpu.h>
-#include <x86/apic_defs.h>
 #include <x86/cpu.h>
 
 /* Slave Controller Edge/Level Triggered Register */
@@ -17,6 +16,11 @@
 
 /* Initial Count Register (for Timer) */
 #define LAPIC_TMICT					0xFEE00380
+
+/* APIC MSR Register */
+/* TODO: This should be removed once our APIC driver is able to handle LAPIC */
+#define LAPIC_MSR_BASE					0x01B
+#define LAPIC_BASE_EN					(1 << 11)
 
 /* Master/Slave PIC Data Registers */
 #define PIC1_DATA					0x21
@@ -51,8 +55,8 @@ static inline void lapic_timer_disable(void)
 	__u32 eax, edx;
 
 	/* Check if APIC is active */
-	rdmsr(APIC_MSR_BASE, &eax, &edx);
-	if (unlikely(!(eax & APIC_BASE_EN)))
+	rdmsr(LAPIC_MSR_BASE, &eax, &edx);
+	if (unlikely(!(eax & LAPIC_BASE_EN)))
 		return;
 
 	/* Zero-ing out this register disables the LAPIC Timer */


### PR DESCRIPTION
Fixed the header include, and also added config guard for APIC-related operations in `efi_post.c`.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The re-arched upstream APIC driver breaks EFI compilation. This PR adds minor changes to EFI boot to make it work.