### PR TITLE
lib/vfscore: Re-enable the mounting of `initrd`'s through `fstab`

### DIFF
--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -78,6 +78,53 @@ struct vfscore_volume {
 #endif /* CONFIG_LIBVFSCORE_FSTAB */
 };
 
+#if CONFIG_LIBUKCPIO && CONFIG_LIBRAMFS
+static int do_mount_initrd(const void *initrd, size_t len, const char *path)
+{
+	int rc;
+
+	UK_ASSERT(path);
+
+	rc = mount("", path, "ramfs", 0x0, NULL);
+	if (unlikely(rc)) {
+		uk_pr_crit("Failed to mount ramfs to \"%s\": %d\n",
+			   path, errno);
+		return -1;
+	}
+
+	uk_pr_info("Extracting initrd @ %p (%"__PRIsz" bytes) to %s...\n",
+		   (void *)initrd, len, path);
+	rc = ukcpio_extract(path, (void *)initrd, len);
+	if (unlikely(rc)) {
+		uk_pr_crit("Failed to extract cpio archive to %s: %d\n",
+			   path, rc);
+		return -1;
+	}
+
+	return 0;
+}
+
+static int vfscore_mount_initrd_volume(struct vfscore_volume *vv)
+{
+	struct ukplat_memregion_desc *initrd;
+	int rc;
+
+	UK_ASSERT(vv);
+	UK_ASSERT(vv->path);
+
+	/* TODO: Support multiple Initial RAM Disks */
+	rc = ukplat_memregion_find_initrd0(&initrd);
+	if (unlikely(rc < 0)) {
+		uk_pr_crit("Could not find an initrd!\n");
+
+		return -1;
+	}
+
+	return do_mount_initrd((void *)initrd->vbase, initrd->len,
+			       vv->path);
+}
+#endif /* CONFIG_LIBUKCPIO && CONFIG_LIBRAMFS */
+
 #if CONFIG_LIBVFSCORE_FSTAB
 /* Handle `mkmp` Unikraft Mount Option */
 static int vfscore_volume_process_ukopts_do_mkmp(char *path)
@@ -178,11 +225,20 @@ static int vfscore_volume_process_ukopts(struct vfscore_volume *vv)
 
 static inline int vfscore_mount_volume(struct vfscore_volume *vv)
 {
+	UK_ASSERT(vv);
+
 #if CONFIG_LIBVFSCORE_FSTAB
 	vfscore_volume_process_ukopts(vv);
 #endif /* CONFIG_LIBVFSCORE_FSTAB */
 
-	return mount(vv->sdev, vv->path, vv->drv, vv->flags, vv->opts);
+#if CONFIG_LIBUKCPIO && CONFIG_LIBRAMFS
+	if (!strcmp(vv->drv, "initrd")) {
+		return vfscore_mount_initrd_volume(vv);
+	} else
+#endif /* CONFIG_LIBUKCPIO && CONFIG_LIBRAMFS */
+	{
+		return mount(vv->sdev, vv->path, vv->drv, vv->flags, vv->opts);
+	}
 }
 
 #ifdef CONFIG_LIBVFSCORE_FSTAB
@@ -280,34 +336,6 @@ static void vfscore_fstab_fetch_volume_args(char *v, struct vfscore_volume *vv)
 }
 #endif /* CONFIG_LIBVFSCORE_FSTAB */
 
-#if CONFIG_LIBUKCPIO && CONFIG_LIBRAMFS
-static int do_mount_initrd(const void *initrd, size_t len, const char *path)
-{
-	int rc;
-
-	UK_ASSERT(initrd);
-	UK_ASSERT(path);
-
-	rc = mount("", path, "ramfs", 0x0, NULL);
-	if (unlikely(rc)) {
-		uk_pr_crit("Failed to mount ramfs to \"%s\": %d\n",
-			   path, errno);
-		return -1;
-	}
-
-	uk_pr_info("Extracting initrd @ %p (%"__PRIsz" bytes) to %s...\n",
-		   (void *)initrd, len, path);
-	rc = ukcpio_extract(path, (void *)initrd, len);
-	if (unlikely(rc)) {
-		uk_pr_crit("Failed to extract cpio archive to %s: %d\n",
-			   path, rc);
-		return -1;
-	}
-
-	return 0;
-}
-#endif /* CONFIG_LIBUKCPIO && CONFIG_LIBRAMFS */
-
 #if CONFIG_LIBVFSCORE_AUTOMOUNT_ROOTFS
 #if CONFIG_LIBVFSCORE_ROOTFS_EINITRD
 extern const char vfscore_einitrd_start[];
@@ -326,27 +354,6 @@ static int vfscore_automount_rootfs(void)
 }
 
 #else /* !CONFIG_LIBVFSCORE_ROOTFS_EINITRD */
-#if CONFIG_LIBUKCPIO && CONFIG_LIBRAMFS
-static int vfscore_mount_initrd_volume(struct vfscore_volume *vv)
-{
-	struct ukplat_memregion_desc *initrd;
-	int rc;
-
-	UK_ASSERT(vv);
-
-	/* TODO: Support multiple Initial RAM Disks */
-	rc = ukplat_memregion_find_initrd0(&initrd);
-	if (unlikely(rc < 0)) {
-		uk_pr_crit("Could not find an initrd!\n");
-
-		return -1;
-	}
-
-	return do_mount_initrd((void *)initrd->vbase, initrd->len,
-			       vv->path);
-}
-#endif /* CONFIG_LIBUKCPIO && CONFIG_LIBRAMFS */
-
 static int vfscore_automount_rootfs(void)
 {
 	/* Convert to `struct vfscore_volume` */
@@ -381,11 +388,6 @@ static int vfscore_automount_rootfs(void)
 	if (!vv.drv || vv.drv[0] == '\0')
 		return 0;
 
-#if CONFIG_LIBUKCPIO && CONFIG_LIBRAMFS
-	if (!strncmp(vv.drv, "initrd", sizeof("initrd") - 1))
-		return vfscore_mount_initrd_volume(&vv);
-#endif /* CONFIG_LIBUKCPIO && CONFIG_LIBRAMFS */
-
 	rc = vfscore_mount_volume(&vv);
 	if (unlikely(rc))
 		uk_pr_crit("Failed to mount %s (%s) at /: %d\n", vv.sdev,
@@ -410,14 +412,7 @@ static int vfscore_automount_fstab_volumes(void)
 	for (i = 0; i < CONFIG_LIBVFSCORE_FSTAB_SIZE && vfscore_fstab[i]; i++) {
 		vfscore_fstab_fetch_volume_args(vfscore_fstab[i], &vv);
 
-#if CONFIG_LIBUKCPIO && CONFIG_LIBRAMFS
-		if (!strncmp(vv.drv, "initrd", sizeof("initrd") - 1)) {
-			rc = vfscore_mount_initrd_volume(&vv);
-		} else
-#endif /* CONFIG_LIBUKCPIO && CONFIG_LIBRAMFS */
-		{
-			rc = vfscore_mount_volume(&vv);
-		}
+		rc = vfscore_mount_volume(&vv);
 		if (unlikely(rc)) {
 			uk_pr_err("Failed to mount %s: error %d\n", vv.sdev,
 				  rc);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

After commit 9946c9329346 ("lib/vfscore: Embedded initrd"), the mounting of `initrd`'s became dependent on having the option `CONFIG_LIBVFSCORE_AUTOMOUNT_ROOTFS` enabled. Thus, if someone wanted to mount an `initrd` through `fstab` only and with that configuration option disabled, their build would fail.

Solve this dependency misconfiguration by making
`vfscore_mount_initrd_volume` only depend on  the
`CONFIG_LIBUKCPIO && CONFIG_LIBRAMFS` options instead.

Depends on #1145 