### PR TITLE
plat/common: Fix missing chosen node handling

### DIFF
--- a/plat/common/bootinfo_fdt.c
+++ b/plat/common/bootinfo_fdt.c
@@ -90,7 +90,7 @@ static void fdt_bootinfo_cmdl_mrd(struct ukplat_bootinfo *bi, void *fdtp)
 	char *cmdl;
 
 	nchosen = fdt_path_offset(fdtp, "/chosen");
-	if (unlikely(!nchosen))
+	if (unlikely(nchosen < 0))
 		return;
 
 	fdt_cmdl = fdt_getprop(fdtp, nchosen, "bootargs", &fdt_cmdl_len);
@@ -134,7 +134,7 @@ static void fdt_bootinfo_initrd_mrd(struct ukplat_bootinfo *bi, void *fdtp)
 	int rc;
 
 	nchosen = fdt_path_offset(fdtp, "/chosen");
-	if (unlikely(!nchosen))
+	if (unlikely(nchosen < 0))
 		return;
 
 	fdt_initrd_start = fdt_getprop(fdtp, nchosen, "linux,initrd-start",


### PR DESCRIPTION
`fdt_path_offset` returns an negative value on error, not zero. Instead of checking for an zero return value, check for a negative value.

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Use a device tree without a `chosen` node, add additional output to show `fdt_path_offset` returns `-FDT_ERR_NOTFOUND` in that case (see [comment](https://github.com/unikraft/unikraft/blob/97523b55ac9e1327f7294da1feec8d4869da534d/lib/fdt/include/libfdt.h#L534C5-L534C21)).
