### PR TITLE
build: Import .config for noconfig targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,11 +380,13 @@ EACHOLIB_LOCALS :=
 EACHOLIB_LOCALS-y :=
 
 # Pull in the user's configuration file
-ifeq ($(filter $(noconfig_targets),$(MAKECMDGOALS)),)
 ifneq ("$(wildcard $(UK_CONFIG))","")
+# Import the .config even if we do not expect it to be complete:
+# COMMON_CONFIG_ENV imports some values, savedefconfig uses UK_ARCH, ...
 $(call verbose_info,Including $(UK_CONFIG)...)
 -include $(UK_CONFIG)
-UK_HAVE_DOT_CONFIG := y
+ifeq ($(filter $(noconfig_targets),$(MAKECMDGOALS)),)
+UK_HAVE_COMPLETE_DOT_CONFIG := y
 endif
 endif
 
@@ -570,7 +572,7 @@ endif
 # Compiler and linker tools
 ################################################################################
 ifeq ($(sub_make_exec), 1)
-ifeq ($(UK_HAVE_DOT_CONFIG),y)
+ifeq ($(UK_HAVE_COMPLETE_DOT_CONFIG),y)
 # Hide troublesome environment variables from sub processes
 unexport CONFIG_CROSS_COMPILE
 unexport CONFIG_LLVM_TARGET_ARCH
@@ -826,7 +828,7 @@ clean: clean-libs
 		$(GDB_HELPER_LINKS) $(BUILD_DIR)/uk-gdb.py \
 		$(UK_CLEAN) $(UK_CLEAN-y))
 
-else # !($(UK_HAVE_DOT_CONFIG),y)
+else # !($(UK_HAVE_COMPLETE_DOT_CONFIG),y)
 
 
 $(filter %config,$(MAKECMDGOALS)): $(BUILD_DIR)/Makefile
@@ -1078,7 +1080,7 @@ print-vars:
 print-version:
 	@echo $(UK_FULLVERSION)
 
-ifeq ($(UK_HAVE_DOT_CONFIG),y)
+ifeq ($(UK_HAVE_COMPLETE_DOT_CONFIG),y)
 print-libs:
 	@echo 	$(foreach P,$(UK_PLATS) $(UK_PLATS-y),\
 		$(if $(call qstrip,$($(call uc,$(P))_LIBS) $($(call uc,$(P))_LIBS-y)),\


### PR DESCRIPTION
Most of the noconfig_targets still need to import parts of the .config if it is available:

- `COMMON_CONFIG_ENV` imports values from the .config
- `savedefconfig` uses `UK_ARCH`

This fixes multiple problems with the noconfig targets for me, especially:

- savedefconfig saves wrong architecture when for x86_64 host arch and am64 guest arch
- olddefconfig does not use a known `UK_NAME` because it is not imported into `COMMON_CONFIG_ENV` 

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A