### PR TITLE
ukboot: Remove explicit PLAT_KVM dependency

### DIFF
--- a/lib/ukboot/Config.uk
+++ b/lib/ukboot/Config.uk
@@ -127,7 +127,6 @@ if LIBUKBOOT
 	default 0x400000000
 	depends on HAVE_PAGING
 	depends on !LIBUKBOOT_NOALLOC
-	depends on PLAT_KVM
 
 	choice LIBUKBOOT_INITSCHED
 	prompt "Initialize scheduler"


### PR DESCRIPTION
Remove an explicit PLAT_KVM dependency in LIBUKBOOT_HEAP_BASE to allow plattforms other then plat/kvm to let ukboot to initialize the heap with paging enabled.

Comment removed in 439868bd0b8d6bb97a40323e9a9df548e080507a:

> TODO: This is temporary until all platforms/archs supporting paging
>       have switched to not initialize the heap in the platform.

LIBUKBOOT_HEAP_BASE also depends on `HAVE_PAGING && !LIBUKBOOT_NOALLOC`, whereas both plat/linuxu and plat/xen depend on `!HAVE_PAGING`.

If LIBUKBOOT_HEAP_BASE is not enabled, `heap_init` already assumes paging is not enabled, so platforms with:

    HAVE_PAGING && !LIBUKBOOT_NOALLOC && !LIBUKBOOT_HEAP_BASE

are not currently supported by ukboot.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A