### PR TITLE
lib/posix-time: Allow NULL arg in clock_getres

### DIFF
--- a/lib/posix-time/time.c
+++ b/lib/posix-time/time.c
@@ -149,17 +149,14 @@ UK_SYSCALL_R_DEFINE(int, clock_getres, clockid_t, clk_id,
 {
 	int error;
 
-	if (!tp) {
-		error = EFAULT;
-		goto out_error;
-	}
-
 	switch (clk_id) {
 	case CLOCK_MONOTONIC:
 	case CLOCK_MONOTONIC_COARSE:
 	case CLOCK_REALTIME:
-		tp->tv_sec = 0;
-		tp->tv_nsec = UKPLAT_TIME_TICK_NSEC;
+		if (tp) {
+			tp->tv_sec = 0;
+			tp->tv_nsec = UKPLAT_TIME_TICK_NSEC;
+		}
 		break;
 	default:
 		error = EINVAL;


### PR DESCRIPTION
### Description of changes

This change fixes the behavior of `clock_getres` to not return an error when receiving a NULL as its output argument, in accordance with docs.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Additional configuration

`clock_getres(id, NULL)` should return 0 when `id` is valid.