### PR TITLE
lib/vfscore: Fix crash in fstatat on NULL args

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1856,6 +1856,8 @@ UK_SYSCALL_R_DEFINE(int, lstat, const char*, pathname, struct stat*, st)
 static int __fxstatat_helper(int ver __unused, int dirfd, const char *pathname,
 		struct stat *st, int flags)
 {
+	if (!pathname || !st)
+		return -EFAULT;
 	if (pathname[0] == '/' || dirfd == AT_FDCWD) {
 		return uk_syscall_r_stat((long) pathname, (long) st);
 	}


### PR DESCRIPTION
### Description of changes

This change makes fstatat gracefully handle NULL arguments by returning -EFAULT, preventing a hard crash.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A
