### PR TITLE
include/arch: Add raw compare-exchange operation

### DIFF
--- a/include/uk/arch/atomic.h
+++ b/include/uk/arch/atomic.h
@@ -93,6 +93,10 @@ extern "C" {
 #define ukarch_exchange_n(dst, v) \
 	__atomic_exchange_n(dst, v, __ATOMIC_SEQ_CST)
 
+#define ukarch_compare_exchange_n(dst, exp, des)  \
+	__atomic_compare_exchange_n(dst, exp, des, 0, \
+	                            __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)
+
 #define ukarch_compare_exchange_sync(ptr, old, new)                            \
 	({                                                                     \
 		__typeof__(*ptr) stored = old;                                 \


### PR DESCRIPTION
### Description of changes

This change adds a Unikraft macro for the raw compare-exchange operation, which in contrast to the existing macro may modify its arguments. Documentation of behavior [here](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html#index-_005f_005fatomic_005fcompare_005fexchange_005fn).

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

Checkpatch warnings are false-positives (it doesn't like tab-agnostic alignment).

### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A
