### PR TITLE
include/arch: Make time constants signed

### DIFF
--- a/include/uk/arch/time.h
+++ b/include/uk/arch/time.h
@@ -55,15 +55,15 @@ typedef __s64 __snsec;
 #define __SNSEC_MAX (__S64_MAX)
 #define __SNSEC_MIN (__S64_MIN)
 
-#define UKARCH_NSEC_PER_SEC ((__nsec)1000000000ULL)
+#define UKARCH_NSEC_PER_SEC ((__snsec)1000000000LL)
 
 #define ukarch_time_nsec_to_sec(ns)      ((ns) / UKARCH_NSEC_PER_SEC)
-#define ukarch_time_nsec_to_msec(ns)     ((ns) / 1000000UL)
-#define ukarch_time_nsec_to_usec(ns)     ((ns) / 1000UL)
-#define ukarch_time_subsec(ns)           ((ns) % ((__nsec)1000000000ULL))
+#define ukarch_time_nsec_to_msec(ns)     ((ns) / 1000000L)
+#define ukarch_time_nsec_to_usec(ns)     ((ns) / 1000L)
+#define ukarch_time_subsec(ns)           ((ns) % UKARCH_NSEC_PER_SEC)
 
 #define ukarch_time_sec_to_nsec(sec)     ((sec)  * UKARCH_NSEC_PER_SEC)
-#define ukarch_time_msec_to_nsec(msec)   ((msec) * 1000000UL)
-#define ukarch_time_usec_to_nsec(usec)   ((usec) * 1000UL)
+#define ukarch_time_msec_to_nsec(msec)   ((msec) * 1000000L)
+#define ukarch_time_usec_to_nsec(usec)   ((usec) * 1000L)
 
 #endif /* __UKARCH_TIME_H__ */


### PR DESCRIPTION
### Description of changes

This change removes the unsigned marker on integer literals that define time-related constants, as there is no logical reason for time to always be positive. This also alleviates mixed-signedness warnings when doing arithmetic on time values, as well as when assigning to __snsec.
In addition, use the `UKARCH_NSEC_PER_SEC` macro more consistently.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A

