### PR TITLE
plat/xen/x86_64: Add missing segment alignment for `xen`

### DIFF
--- a/plat/xen/x86/link64.lds.S
+++ b/plat/xen/x86/link64.lds.S
@@ -55,6 +55,8 @@ SECTIONS
 
 	_etext = .;			/* End of text section */
 
+	. = ALIGN(__PAGE_SIZE);
+
 	_rodata = .;
 	.rodata : {
 		*(.rodata)


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `xen`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Make the second segment in a `xen/x86-64` ELF aligned to the page size.
This fixes a memory overlap issue that triggers an assert during
memory coalescing.