### PR TITLE
build: Introduce `UK_IMAGE_NAME_OVERWRITE` make var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,6 +396,20 @@ else
 CONFIG_UK_NAME ?= $(notdir $(APP_DIR))
 endif
 
+# Option to overwrite file name of generated images by supported platforms. The
+# target platform has to support this feature.  When unset or unsupported by the
+# platform, the default semantic of the target platform (typically
+# `$(UK_NAME)_$(PLAT)_$(ARCH)`) will be used.
+#
+# NOTE: Please note that multi-platform builds do not work anymore when this
+#       option is used.  The reason is that the build system will generate the
+#       same file by each selected platform.  Make won't be able to proceed
+#       building.
+# NOTE: This feature is currently used by kraftkit.
+ifneq ($(call qstrip,$(UK_IMAGE_NAME_OVERWRITE)),)
+UK_IMAGE_NAME_OVERWRITE := $(call qstrip,$(UK_IMAGE_NAME_OVERWRITE))
+endif
+
 # remove quotes from CONFIG_UK_NAME
 CONFIG_UK_NAME := $(call qstrip,$(CONFIG_UK_NAME))
 export CONFIG_UK_NAME

--- a/plat/kvm/Linker.uk
+++ b/plat/kvm/Linker.uk
@@ -35,7 +35,11 @@ else
 KVM_VMM := kvm
 endif
 
+ifneq ($(UK_IMAGE_NAME_OVERWRITE),)
+KVM_IMAGE := $(BUILD_DIR)/$(UK_IMAGE_NAME_OVERWRITE)
+else
 KVM_IMAGE := $(BUILD_DIR)/$(CONFIG_UK_NAME)_$(KVM_VMM)-$(CONFIG_UK_ARCH)
+endif
 KVM_DEBUG_IMAGE := $(KVM_IMAGE).dbg
 
 KVM_LD_SCRIPT_FLAGS := $(addprefix -Wl$(comma)-dT$(comma),\

--- a/plat/linuxu/Linker.uk
+++ b/plat/linuxu/Linker.uk
@@ -3,7 +3,11 @@ LINUXU_LDFLAGS-y += -Wl,-e,_liblinuxuplat_start
 ##
 ## Link image
 ##
+ifneq ($(UK_IMAGE_NAME_OVERWRITE),)
+LINUXU_IMAGE := $(BUILD_DIR)/$(UK_IMAGE_NAME_OVERWRITE)
+else
 LINUXU_IMAGE := $(BUILD_DIR)/$(CONFIG_UK_NAME)_linuxu-$(CONFIG_UK_ARCH)
+endif
 LINUXU_DEBUG_IMAGE := $(LINUXU_IMAGE).dbg
 LINUXU_LD_SCRIPT_FLAGS := $(addprefix -Wl$(comma)-T$(comma),\
 			    $(LINUXU_LD_SCRIPT-y) $(EXTRA_LD_SCRIPT-y))

--- a/plat/xen/Linker.uk
+++ b/plat/xen/Linker.uk
@@ -5,11 +5,15 @@ endif
 ##
 ## Link image
 ##
-ifeq (arm,$(CONFIG_UK_ARCH))
+ifneq ($(UK_IMAGE_NAME_OVERWRITE),)
+XEN_RAW_IMAGE   := $(BUILD_DIR)/$(UK_IMAGE_NAME_OVERWRITE)
+else
 XEN_RAW_IMAGE   := $(BUILD_DIR)/$(CONFIG_UK_NAME)_xen-$(CONFIG_UK_ARCH)
+endif
+ifeq (arm,$(CONFIG_UK_ARCH))
 XEN_IMAGE       := $(XEN_RAW_IMAGE).elf
 else
-XEN_IMAGE       := $(BUILD_DIR)/$(CONFIG_UK_NAME)_xen-$(CONFIG_UK_ARCH)
+XEN_IMAGE       := $(XEN_RAW_IMAGE)
 endif
 XEN_DEBUG_IMAGE := $(XEN_IMAGE).dbg
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): all
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit introduces a new make variable, `UK_IMAGE_NAME_OVERWRITE`, which is used to customize the output binary name of the kernel image.  This is a special, and experimental, variable which can be helpful in certain use cases, for example where targets with the same architecture and platform are present.  This variable should be used in conjunction with a different build directory, `O=`, as the resulting binary will always have the name from this option.
