### PR TITLE
lib/ukfile: Ignore MSG_NOSIGNAL flags for UNIX sockets

### DIFF
--- a/lib/posix-unixsocket/unixsock.c
+++ b/lib/posix-unixsocket/unixsock.c
@@ -731,7 +731,7 @@ ssize_t unix_socket_sendmsg(posix_sock *file,
 	const struct uk_file *wpipe;
 	ssize_t ret;
 
-	if (unlikely(flags)) {
+	if (unlikely(flags & ~MSG_NOSIGNAL)) {
 		uk_pr_warn("Unsupported send flags: %x\n", flags);
 		return -ENOSYS;
 	}


### PR DESCRIPTION
The flag does not change the behavior of the UNIX sockets in the current implementation state. Therefore, we can safely ignore that specific flag.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
