### PR TITLE
lib/posix-fdio: Remove pointer dereference from fcntl

### DIFF
--- a/lib/posix-fdio/fdctl.c
+++ b/lib/posix-fdio/fdctl.c
@@ -58,7 +58,7 @@ int uk_sys_fcntl(struct uk_ofile *of, int cmd, unsigned long arg)
 
 		do {
 			newmode = mode & ~_SETFL_MASK;
-			newmode |= *((unsigned int *)arg) & _SETFL_MASK;
+			newmode |= arg & _SETFL_MASK;
 		} while (!ukarch_compare_exchange_n(&of->mode, &mode, newmode));
 		return 0;
 	}


### PR DESCRIPTION
The argument is the *value* to which the mode should be set.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
