### PR TITLE
lib/uklock: Fix static initializer for recursive mutexes

### DIFF
--- a/lib/uklock/include/uk/mutex.h
+++ b/lib/uklock/include/uk/mutex.h
@@ -102,7 +102,7 @@ extern __spinlock              _uk_mutex_metrics_lock;
 	{ 0, 0, NULL, __WAIT_QUEUE_INITIALIZER((name).wait) }
 
 #define	UK_MUTEX_INITIALIZER_RECURSIVE(name)			\
-	{ _UK_MUTEX_UNOWNED, 0, UK_MUTEX_CONFIG_RECURSE,	\
+	{ 0, 0, UK_MUTEX_CONFIG_RECURSE,			\
 	__WAIT_QUEUE_INITIALIZER((name).wait) }
 
 void uk_mutex_init_config(struct uk_mutex *m, unsigned int flags);


### PR DESCRIPTION
Fix a compile error when using recursive mutexes: `_UK_MUTEX_UNOWNED` is undefined.