### PR TITLE
lib/uklock: Fix recursive mutex static inititializer

### DIFF
--- a/lib/uklock/include/uk/mutex.h
+++ b/lib/uklock/include/uk/mutex.h
@@ -102,7 +102,7 @@ extern __spinlock              _uk_mutex_metrics_lock;
 	{ 0, 0, NULL, __WAIT_QUEUE_INITIALIZER((name).wait) }
 
 #define	UK_MUTEX_INITIALIZER_RECURSIVE(name)			\
-	{ 0, 0, UK_MUTEX_CONFIG_RECURSE,			\
+	{ 0, UK_MUTEX_CONFIG_RECURSE, 0,			\
 	__WAIT_QUEUE_INITIALIZER((name).wait) }
 
 void uk_mutex_init_config(struct uk_mutex *m, unsigned int flags);


### PR DESCRIPTION
The `struct uk_mutex` structure expects the members to be, in order, `lock_count`, `flags`, `owner`, `waitq`. Change the static inititializer to set the flags to `UK_MUTEX_CONFIG_RECURSE` instead of the owner.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.



