### PR TITLE
lib/posix-poll: Make epoll_ctl identify files by (fd + file description)

### DIFF
--- a/lib/posix-poll/epoll.c
+++ b/lib/posix-poll/epoll.c
@@ -441,7 +441,12 @@ int uk_sys_epoll_ctl(const struct uk_file *epf, int op, int fd,
 	if (unlikely(legacy < 0))
 		return -EBADF;
 	legacy = legacy == UK_SHIM_LEGACY;
-#endif /* CONFIG_LIBVFSCORE */
+#else /* !CONFIG_LIBVFSCORE */
+	ret = uk_fdtab_shim_get(fd, &sf);
+	if (unlikely(ret < 0))
+		return -EBADF;
+	UK_ASSERT(ret == UK_SHIM_OFILE);
+#endif /* !CONFIG_LIBVFSCORE */
 
 	uk_file_wlock(epf);
 	switch (op) {


### PR DESCRIPTION
### Description of changes

Previously epoll_ctl would identify epoll entries by fd alone, in accordance with published documentation (see `epoll_ctl(2)`).
However, the Linux kernel actually identifies entries by a tuple of (fd, file description) instead, a behavior on which some applications mistakenly depend.
In order to support these applications we have to mimic this behavior.

This changeset implements the above described identification of files, along with relevant cleanup of epoll_ctl-related code.
In addition, the first commit in the PR fixes an omission whereby `epoll_ctl` would fail to lookup the `fd` when Unikraft is configured without the legacy vfscore.


### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Should work with or without `CONFIG_LIBVFSCORE`.
