### PR TITLE
Make Unikraft compatible with newlib again

### DIFF
--- a/include/uk/essentials.h
+++ b/include/uk/essentials.h
@@ -39,6 +39,7 @@
 #include <uk/config.h>
 
 #if CONFIG_LIBNEWLIBC
+#ifndef __ASSEMBLY__
 /*
  * Needed for __used, __unused, __packed, __section,
  *   __nonnull, __offsetof, __containerof
@@ -48,6 +49,7 @@
 #include <sys/param.h>
 /* Needed for MIN, MAX */
 #include <inttypes.h>
+#endif /* !__ASSEMBLY__ */
 #endif
 
 #ifdef __cplusplus

--- a/lib/posix-fdio/fdio.c
+++ b/lib/posix-fdio/fdio.c
@@ -6,6 +6,7 @@
 
 /* Internal syscalls for file I/O */
 
+#include <stdio.h>
 #include <poll.h>
 
 #include <uk/posix-fdio.h>

--- a/lib/posix-fdtab/fdtab.c
+++ b/lib/posix-fdtab/fdtab.c
@@ -5,6 +5,7 @@
  */
 
 #include <errno.h>
+#include <limits.h>
 #include <fcntl.h>
 
 #include <uk/alloc.h>


### PR DESCRIPTION
This PR makes the Unikraft compatible with newlib again. The hope is that in general libc compatibility is improved. Please note that still not all Unikraft libraries are compatible with newlib at the moment (e.g., posix-mmap) but the minimum configuration works. This PR depends on PR [#37](https://github.com/unikraft/lib-newlib/pull/37) of newlib.