### PR TITLE
lib/posix-fdio: Handle FD_CLOEXEC flag in fcntl correctly

### DIFF
--- a/lib/posix-fdio/fd-shim.c
+++ b/lib/posix-fdio/fd-shim.c
@@ -325,9 +325,10 @@ UK_LLSYSCALL_R_DEFINE(int, fcntl, int, fd,
 	case F_DUPFD:
 		return uk_sys_dup_min(fd, (int)arg, fdflags);
 	case F_GETFD:
-		return uk_fdtab_getflags(fd);
+		return (uk_fdtab_getflags(fd) & O_CLOEXEC) ? FD_CLOEXEC : 0;
 	case F_SETFD:
-		return uk_fdtab_setflags(fd, (int)arg);
+		return uk_fdtab_setflags(fd,
+			((int)arg & FD_CLOEXEC) ? O_CLOEXEC : 0);
 	default:
 	{
 		int r;


### PR DESCRIPTION
### Description of changes

Previously fcntl (wronly) passed the FD_CLOEXEC flag to uk_fdtab_* functions instead of O_CLOEXEC on F_GETFD and F_SETFD operations. Fdtab always uses O_* flags to be in line with arguments passed to open, dup, and similar calls. This change makes fcntl properly translate between O_CLOEXEC and FD_CLOEXEC for F_GETFD and F_SETFD operations.


### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A
