### PR TITLE
lib/vfscore: initrd: `extract` option

### DIFF
--- a/lib/vfscore/Config.uk
+++ b/lib/vfscore/Config.uk
@@ -12,12 +12,6 @@ menuconfig LIBVFSCORE
 	select LIBPOSIX_PIPE
 
 if LIBVFSCORE
-config LIBVFSCORE_PIPE_SIZE_ORDER
-	int "Pipe size order"
-	default 16
-	help
-		The size of the internal buffer for anonymous pipes is 2^order.
-
 config LIBVFSCORE_NONLARGEFILE
 	bool "Non-largefile system calls"
 	default y if LIBSYSCALL_SHIM_HANDLER

--- a/lib/vfscore/Config.uk
+++ b/lib/vfscore/Config.uk
@@ -147,6 +147,17 @@ config LIBVFSCORE_FSTAB_SIZE
 	help
 		The maximum amount of automatically mounted volumes that are
 		passed through the vfs.fstab argument.
+
+config LIBVFSCORE_INITRD_EXTRACT_WORKAROUND
+	bool "Workaround: InitRD-Root-Extract"
+	depends on !LIBVFSCORE_AUTOMOUNT_ROOTFS
+	depends on LIBUKCPIO
+	depends on LIBRAMFS
+	help
+		This option activates a workaround in the event that an "initrd"
+		with "extract" was specified as the root file system via the
+		fstab feature. In such a case, a "ramfs" volume is mounted
+		before extraction.
 endif
 
 endif

--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -422,6 +422,28 @@ static int vfscore_automount_fstab_volumes(void)
 	for (i = 0; i < CONFIG_LIBVFSCORE_FSTAB_SIZE && vfscore_fstab[i]; i++) {
 		vfscore_fstab_fetch_volume_args(vfscore_fstab[i], &vv);
 
+#if CONFIG_LIBVFSCORE_INITRD_EXTRACT_WORKAROUND && \
+    !CONFIG_LIBVFSCORE_AUTOMOUNT_ROOTFS
+		/* WORKAROUND: In case the image was built without predefined
+		 *             rootfs and we are asked to `extract` an initrd
+		 *             to `/` as first filesystem, we mount an empty
+		 *             ramfs as base.
+		 */
+		if (i == 0 &&
+		    vv.drv &&
+		    strcmp("initrd", vv.drv) == 0 &&
+		    vv.opts &&
+		    strcmp(LIBVFSCORE_INITRD_OPT_EXTRACT, vv.opts) == 0 &&
+		    vv.path && vv.path[0] == '/' && vv.path[1] == '\0') {
+			/* Removing the "extract" option will cause mounting
+			 * an empty ramfs volume for `/`.
+			 */
+			vv.opts = NULL;
+		}
+#endif /* CONFIG_LIBVFSCORE_INITRD_EXTRACT_WORKAROUND &&
+	* !CONFIG_LIBVFSCORE_AUTOMOUNT_ROOTFS
+	*/
+
 		rc = vfscore_mount_volume(&vv);
 		if (unlikely(rc)) {
 			uk_pr_err("Failed to mount %s: error %d\n", vv.sdev,


### PR DESCRIPTION
### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

 - `CONFIG_LIBVFSCORE=y`
 - `CONFIG_LIBVFSCORE_FSTAB=y`

### Description of changes

This PR introcues the mount option "extract" to the virtual `initrd` filesystem. This option will only perform an extraction of a CPIO archive over an already mounted filesystem. Its intention is to use it as sort of emulating an overlay filesystem.