### PR TITLE
lib/ramfs: Return proper errors on `ioctl` calls

### DIFF
--- a/lib/ramfs/ramfs_vnops.c
+++ b/lib/ramfs/ramfs_vnops.c
@@ -39,6 +39,7 @@
 #include <sys/stat.h>
 #include <dirent.h>
 #include <sys/param.h>
+#include <sys/ioctl.h>
 
 #include <errno.h>
 #include <string.h>
@@ -659,10 +660,37 @@ ramfs_inactive(struct vnode *vp)
 	return 0;
 }
 
+static int ramfs_ioctl(struct vnode *dvp __unused,
+			 struct vfscore_file *fp __unused,
+			 unsigned long com,
+			 void *data __unused)
+{
+	/**
+	 * HACK: In binary compatibility mode, Ruby tries to set O_ASYNC,
+	 * which Unikraft does not yet support. If the `ioctl` call returns
+	 * an error, Ruby stops working, even if it does not depend on the
+	 * O_ASYNC being properly set.
+	 *
+	 * Until proper support, just return 0 in case an `FIONBIO` ioctl
+	 * request is done, and ENOTSUP for all other cases.
+	 *
+	 * Setting `ioctl` to a nullop will not work, since it is used by
+	 * interpreted languages (e.g. python3) to check if it should start
+	 * the interpretor or just read a file.
+	 *
+	 * For every `ioctl` request related to a terminal, return ENOTTY.
+	 */
+	if (com == FIONBIO)
+		return 0;
+	if (IOCTL_CMD_ISTYPE(com, IOCTL_CMD_TYPE_TTY))
+		return ENOTTY;
+
+	return ENOTSUP;
+}
+
 #define ramfs_open      ((vnop_open_t)vfscore_vop_nullop)
 #define ramfs_close     ((vnop_close_t)vfscore_vop_nullop)
 #define ramfs_seek      ((vnop_seek_t)vfscore_vop_nullop)
-#define ramfs_ioctl     ((vnop_ioctl_t)vfscore_vop_einval)
 #define ramfs_fsync     ((vnop_fsync_t)vfscore_vop_nullop)
 #define ramfs_link      ((vnop_link_t)vfscore_vop_eperm)
 #define ramfs_fallocate ((vnop_fallocate_t)vfscore_vop_nullop)


### PR DESCRIPTION
Currently ramfs returns EINVAL for any ioctl request, which leads to the Ruby binary compatibility application to fail, since it tries to set `O_ASYNC` and breaks on error, even if it does not directly depends on it being set.

Add a special case to treat `O_ASYNC`, return `ENOTSUP` by default, and return `ENOTTY` on every `ioctl()` call related to a terminal. The implementation is similar to what we currently have in `lib/9pfs/`, introduced by unikraft/#1098

GitHub-Fixes: #1186

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Application(s): `http-ruby` on binary compatibility mode 

