### PR TITLE
lib/posix-{fdio,socket}: Add stat support to socket files

### DIFF
--- a/lib/posix-fdio/fdstat.c
+++ b/lib/posix-fdio/fdstat.c
@@ -6,6 +6,8 @@
 
 /* Internal syscalls for manipulating file metadata */
 
+#include <string.h>
+
 #include <uk/posix-fdio.h>
 
 #include "fdio-impl.h"
@@ -28,6 +30,7 @@ void statx_cpyout(struct stat *s, const struct uk_statx *sx)
 {
 	unsigned int mask = sx->stx_mask;
 
+	memset(s, 0, sizeof(*s));
 	s->st_dev = nums2dev(sx->stx_dev_major, sx->stx_dev_minor);
 	s->st_rdev = nums2dev(sx->stx_rdev_major, sx->stx_rdev_minor);
 	s->st_blksize = sx->stx_blksize;

--- a/lib/posix-fdio/fdstat.c
+++ b/lib/posix-fdio/fdstat.c
@@ -60,21 +60,12 @@ void statx_cpyout(struct stat *s, const struct uk_statx *sx)
 int uk_sys_fstatx(struct uk_ofile *of, unsigned int mask,
 		  struct uk_statx *statxbuf)
 {
-	int ret;
-	int iolock;
-
 	if (unlikely(!statxbuf))
 		return -EFAULT;
 	if (unlikely(mask & UK_STATX__RESERVED))
 		return -EINVAL;
 
-	iolock = _SHOULD_LOCK(of->mode);
-	if (iolock)
-		uk_file_rlock(of->file);
-	ret = uk_file_getstat(of->file, mask, statxbuf);
-	if (iolock)
-		uk_file_runlock(of->file);
-	return ret;
+	return uk_file_getstat(of->file, mask, statxbuf);
 }
 
 int uk_sys_fstat(struct uk_ofile *of, struct stat *statbuf)


### PR DESCRIPTION
### Description of changes

This changeset adds support for `stat`ing socket files, along with more general improvements to `stat` compatibility & performance. Specifically:
- Have `fstat` zero out the output buffer before writing in values -- an undocumented behavior present in Linux that (bincompat) applications may depend on; we should replicate this for best compatibility
- Remove synchronization from `stat`-like functions -- `stat(2)` documentation specifically permits stat calls to not be synchronized with other syscalls that change file attributes (e.g. `(f)chmod` or I/O); thus we can safely remove locking for better performance
- Actual support for `stat` on socket files -- these are the same for all sockets, as there is no relevant data to be supplied by the driver.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Basic snippet to test against Linux (no struct stat pretty-printing, check `stat(3type)` for the struct layout and eyeball it):
```c
#include <stdio.h>
#include <assert.h>
#include <stdint.h>
#include <string.h>

#include <sys/stat.h>
#include <sys/socket.h>


int main(void)
{
	int s = socket(AF_UNIX, SOCK_STREAM, 0);
	assert(s >= 0);

	struct stat sb;
	memset(&sb, -1, sizeof(sb));
	int r = fstat(s, &sb);
	assert(!r);

	printf("%zu\n\n", sizeof(sb));
	for (int i = 0; i < sizeof(sb)/4; i++)
		printf("%x\n", ((uint32_t *)&sb)[i]);

	return 0;
}
```
(needs `CONFIG_LIBPOSX_UNIXSOCKET`, but should work similarly with any sockets)