### PR TITLE
Add `lib/posix-fdtab` and `lib/vfscore` destructors

### DIFF
--- a/include/uk/prio.h
+++ b/include/uk/prio.h
@@ -38,7 +38,7 @@ extern "C" {
 #endif
 
 /**
- * Computes the priority level that has one lower priority than
+ * Computes the priority level that has one lower/higher priority than
  * the given priority level. This macro can be used to state
  * initialization dependencies. It is intended to be used for
  * declaring macro constants.
@@ -48,7 +48,7 @@ extern "C" {
  * @param x
  *  Given Unikraft priority level
  * @return
- *  Priority level that has one priority less than x
+ *  Priority level that has one priority less/more than x
  */
 #define __UK_PRIO_AFTER_0 1
 #define __UK_PRIO_AFTER_1 2
@@ -62,6 +62,19 @@ extern "C" {
 #define __UK_PRIO_AFTER_9 __UK_PRIO_OUT_OF_BOUNDS
 #define __UK_PRIO_AFTER(x) __UK_PRIO_AFTER_##x
 #define UK_PRIO_AFTER(x)   __UK_PRIO_AFTER(x)
+
+#define __UK_PRIO_BEFORE_0 __UK_PRIO_OUT_OF_BOUNDS
+#define __UK_PRIO_BEFORE_1 0
+#define __UK_PRIO_BEFORE_2 1
+#define __UK_PRIO_BEFORE_3 2
+#define __UK_PRIO_BEFORE_4 3
+#define __UK_PRIO_BEFORE_5 4
+#define __UK_PRIO_BEFORE_6 5
+#define __UK_PRIO_BEFORE_7 6
+#define __UK_PRIO_BEFORE_8 7
+#define __UK_PRIO_BEFORE_9 8
+#define __UK_PRIO_BEFORE(x) __UK_PRIO_BEFORE_##x
+#define UK_PRIO_BEFORE(x)   __UK_PRIO_BEFORE(x)
 
 #define UK_PRIO_EARLIEST 0
 #define UK_PRIO_LATEST   9

--- a/lib/devfs/include/devfs/device.h
+++ b/lib/devfs/include/devfs/device.h
@@ -35,6 +35,7 @@
 
 #include <sys/types.h>
 #include <uk/init.h>
+#include <uk/posix-fdtab.h>
 
 #define MAXDEVNAME	12
 #define DO_RWMASK	0x3
@@ -124,6 +125,7 @@ int device_destroy(struct device *dev);
  * To be on the safe side, we do the registration to devfs before both,
  * at priority '3'.
  */
-#define devfs_initcall(fn) uk_rootfs_initcall_prio(fn, 0x0, 3)
+#define devfs_initcall(fn)						\
+	uk_rootfs_initcall_prio(fn, 0x0, UK_PRIO_AFTER(UK_LIBPOSIX_FDTAB_PRIO))
 
 #endif /* !__DEVFS_DEVICE_H__ */

--- a/lib/posix-fdtab/fdtab.c
+++ b/lib/posix-fdtab/fdtab.c
@@ -380,7 +380,8 @@ static void term_posix_fdtab(const struct uk_term_ctx *tctx __unused)
 }
 
 /* Init fdtab as early as possible, to enable functions that rely on fds */
-uk_rootfs_initcall_prio(init_posix_fdtab, term_posix_fdtab, UK_PRIO_EARLIEST);
+uk_rootfs_initcall_prio(init_posix_fdtab, term_posix_fdtab,
+			UK_LIBPOSIX_FDTAB_PRIO);
 
 /* Internal Syscalls */
 

--- a/lib/posix-fdtab/include/uk/posix-fdtab.h
+++ b/lib/posix-fdtab/include/uk/posix-fdtab.h
@@ -12,6 +12,7 @@
 #include <uk/config.h>
 #include <uk/ofile.h>
 
+#define UK_LIBPOSIX_FDTAB_PRIO				1
 #define UK_FD_MAX INT_MAX
 
 /**

--- a/lib/vfscore/fops.c
+++ b/lib/vfscore/fops.c
@@ -45,6 +45,16 @@ int vfs_close(struct vfscore_file *fp)
 	int error;
 
 	vn_lock(vp);
+	/* This is called when there are no more strong references to this file
+	 * so also fsync it when that happens.
+	 *
+	 * NOTE: We do this because on umount not all of our filesystem drivers
+	 * may flush cached contents.
+	 */
+	error = VOP_FSYNC(vp, fp);
+	if (unlikely(error))
+		return error;
+
 	error = VOP_CLOSE(vp, fp);
 	vn_unlock(vp);
 

--- a/lib/vfscore/stdio.c
+++ b/lib/vfscore/stdio.c
@@ -48,6 +48,7 @@
 #include <uk/init.h>
 
 #include <uk/posix-fdtab-legacy.h>
+#include <uk/posix-fdtab.h>
 
 /*
  * When the syscall_shim library is not part of the build, there is warning
@@ -257,4 +258,4 @@ static int init_stdio(struct uk_init_ctx *ictx __unused)
 	return 0;
 }
 
-uk_early_initcall(init_stdio, 0x0);
+uk_rootfs_initcall_prio(init_stdio, 0x0, UK_PRIO_AFTER(UK_LIBPOSIX_FDTAB_PRIO));


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Add `lib/posix-fdtab` destructor:
When all strong references to an open file structure are gone, `fdrop`
calls `vfs_close` which invokes the `close` method of the underlying
filesystem driver. The latter may not necessarily flush cached open
file contents back to the storage device.

Thus, fix this by also invoking the `sync` method of the aforementioned
filesystem driver right before invoking the `close` method.

Add `lib/vfscore/automount` destructor:
Since the constructor of `vfscore` simply mounts the `rootfs` and any
additional volumes in `vfs.fstab`, the destructor shall iterate in
reverse upon these mount points and perform an unmount operation on
them.

Furthermore, and most importantly, a special adjustment must be taken
into consideration w.r.t. the registration of this destructor: priority
of termination functions. Since the vfscore destructor unmounts active
volumes, it makes sense to be preceded by the termination of
`lib/posix-fdtab` which syncs and closes remaining open file structures.
However, right now the aforemention library has the highest priority and
would thus end up being executed after the unmounting termination method
introduced in this commit.

Therefore, fix this by declaring an explicit `lib/posix-fdtab` priority
of `1`, enough to make room for one more preceding priority to be taken
by the unmounting method so that its termination function succeeds that
of `lib/posix-fdtab`. Additionally, sync the other libraries that depend
on `lib/posix-fdtab` to the newly introduced priority value.
