### PR TITLE
lib/posix-{pipe,unixsocket}: Fix event delivery on closing

### DIFF
--- a/lib/posix-fdio/fdstat.c
+++ b/lib/posix-fdio/fdstat.c
@@ -60,21 +60,12 @@ void statx_cpyout(struct stat *s, const struct uk_statx *sx)
 int uk_sys_fstatx(struct uk_ofile *of, unsigned int mask,
 		  struct uk_statx *statxbuf)
 {
-	int ret;
-	int iolock;
-
 	if (unlikely(!statxbuf))
 		return -EFAULT;
 	if (unlikely(mask & UK_STATX__RESERVED))
 		return -EINVAL;
 
-	iolock = _SHOULD_LOCK(of->mode);
-	if (iolock)
-		uk_file_rlock(of->file);
-	ret = uk_file_getstat(of->file, mask, statxbuf);
-	if (iolock)
-		uk_file_runlock(of->file);
-	return ret;
+	return uk_file_getstat(of->file, mask, statxbuf);
 }
 
 int uk_sys_fstat(struct uk_ofile *of, struct stat *statbuf)

--- a/lib/posix-pipe/pipe.c
+++ b/lib/posix-pipe/pipe.c
@@ -252,8 +252,8 @@ static void pipe_release(const struct uk_file *f, int what)
 		/* Atomically set the HUP flag */
 		ukarch_or(&d->flags, PIPE_HUP);
 		/* If was already set, we can free node */
-		/* Update state w/ EPOLLHUP for read & EPOLLERR for write */
-		uk_file_event_set(f, EPOLLHUP|EPOLLERR);
+		/* Update w/ EPOLL(HUP|IN) for read & EPOLLERR for write */
+		uk_file_event_set(f, EPOLLHUP|EPOLLIN|EPOLLERR);
 	}
 	if (what & UK_FILE_RELEASE_OBJ) {
 		/* Atomically set the FIN flag */

--- a/lib/posix-unixsocket/unixsock.c
+++ b/lib/posix-unixsocket/unixsock.c
@@ -308,16 +308,18 @@ int unix_socket_socketpair(struct posix_socket_driver *d,
 	if (unlikely(ret))
 		goto err_release;
 
-	uk_file_acquire(pipes[0][1]);
-	uk_file_acquire(pipes[1][1]);
 	dat[0]->rpipe = pipes[0][0];
-	dat[0]->bpipe = pipes[0][1];
 	dat[1]->wpipe = pipes[0][1];
 	dat[1]->rpipe = pipes[1][0];
-	dat[1]->bpipe = pipes[1][1];
 	dat[0]->wpipe = pipes[1][1];
 	dat[0]->flags |= UNIXSOCK_CONN;
 	dat[1]->flags |= UNIXSOCK_CONN;
+	if (type == SOCK_DGRAM) {
+		uk_file_acquire(pipes[0][1]);
+		uk_file_acquire(pipes[1][1]);
+		dat[0]->bpipe = pipes[0][1];
+		dat[1]->bpipe = pipes[1][1];
+	}
 
 	sockvec[0] = dat[0];
 	sockvec[1] = dat[1];


### PR DESCRIPTION
### Description of changes

This changeset fixes a number of event delivery inconsistencies between Unikraft and Linux when using pipes & unix sockets:
- read ends of pipes & unix sockets whose connected end has shut down now correctly set EPOLLIN
- stream unix socket pairs correctly set events in their counterpart on shutdown (+ fixed a pipe object leak as side-effect)
- unix sockets do not raise hangup events on themselves on close, only on explicit shutdown

Fixes https://github.com/unikraft/unikraft/issues/1207.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Additional configuration

Both unixsockets & epoll enabled.
