### PR TITLE
lib/posix-fdtab: Reprioritize fdtab init & cleanup

### DIFF
--- a/lib/posix-fdio/fdstat.c
+++ b/lib/posix-fdio/fdstat.c
@@ -60,21 +60,12 @@ void statx_cpyout(struct stat *s, const struct uk_statx *sx)
 int uk_sys_fstatx(struct uk_ofile *of, unsigned int mask,
 		  struct uk_statx *statxbuf)
 {
-	int ret;
-	int iolock;
-
 	if (unlikely(!statxbuf))
 		return -EFAULT;
 	if (unlikely(mask & UK_STATX__RESERVED))
 		return -EINVAL;
 
-	iolock = _SHOULD_LOCK(of->mode);
-	if (iolock)
-		uk_file_rlock(of->file);
-	ret = uk_file_getstat(of->file, mask, statxbuf);
-	if (iolock)
-		uk_file_runlock(of->file);
-	return ret;
+	return uk_file_getstat(of->file, mask, statxbuf);
 }
 
 int uk_sys_fstat(struct uk_ofile *of, struct stat *statbuf)

--- a/lib/posix-fdtab/fdtab.c
+++ b/lib/posix-fdtab/fdtab.c
@@ -374,14 +374,16 @@ void uk_fdtab_cloexec(void)
 	fdtab_cleanup(0);
 }
 
+/* Cleanup all leftover open fds */
 static void term_posix_fdtab(const struct uk_term_ctx *tctx __unused)
 {
 	fdtab_cleanup(1);
 }
 
 /* Init fdtab as early as possible, to enable functions that rely on fds */
-uk_rootfs_initcall_prio(init_posix_fdtab, term_posix_fdtab,
-			UK_LIBPOSIX_FDTAB_PRIO);
+uk_lib_initcall_prio(init_posix_fdtab, 0x0, UK_PRIO_EARLIEST);
+/* Place fd cleanup to run latest before any rootfs terminators */
+uk_rootfs_initcall_prio(0x0, term_posix_fdtab, UK_PRIO_LATEST);
 
 /* Internal Syscalls */
 

--- a/lib/posix-fdtab/include/uk/posix-fdtab.h
+++ b/lib/posix-fdtab/include/uk/posix-fdtab.h
@@ -12,7 +12,6 @@
 #include <uk/config.h>
 #include <uk/ofile.h>
 
-#define UK_LIBPOSIX_FDTAB_PRIO				1
 #define UK_FD_MAX INT_MAX
 
 /**

--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -50,7 +50,6 @@
 #include <uk/plat/memory.h>
 #include <sys/stat.h>
 #include <vfscore/mount.h>
-#include <uk/posix-fdtab.h>
 
 #ifdef CONFIG_LIBVFSCORE_AUTOMOUNT_ROOTFS
 #include <errno.h>
@@ -459,5 +458,4 @@ static void vfscore_autoumount(const struct uk_term_ctx *tctx __unused)
 	}
 }
 
-uk_rootfs_initcall_prio(vfscore_automount, vfscore_autoumount,
-			UK_PRIO_BEFORE(UK_LIBPOSIX_FDTAB_PRIO));
+uk_rootfs_initcall_prio(vfscore_automount, vfscore_autoumount, 4);

--- a/lib/vfscore/stdio.c
+++ b/lib/vfscore/stdio.c
@@ -258,4 +258,4 @@ static int init_stdio(struct uk_init_ctx *ictx __unused)
 	return 0;
 }
 
-uk_rootfs_initcall_prio(init_stdio, 0x0, UK_PRIO_AFTER(UK_LIBPOSIX_FDTAB_PRIO));
+uk_rootfs_initcall_prio(init_stdio, 0x0, UK_PRIO_LATEST);


### PR DESCRIPTION
### Description of changes

Commit 8e7a01d50 (lib/posix-fdtab: Register library termination method) introduced a fd cleanup function to be run on system shutdown and registered it symmetrically to init_posix_fdtab. This was a logic error, as these two operations do not serve as opposites to each other, leading to undesired behavior in dependent code.

This change fixes this error, registering the init & cleanup functions separately, thereby also removing the need to export fdtab's init priority directly. This simplifies vfscore code, removing changes from 4fc709481 (lib/vfscore: Implement volume unmounting termination method).

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Test with automount initrd (where automount actually needs fd support).


