### PR TITLE
lib/uknetdev: New `netdev.ip` kernel parameter

### DIFF
--- a/lib/uknetdev/Config.uk
+++ b/lib/uknetdev/Config.uk
@@ -31,6 +31,24 @@ config LIBUKNETDEV_DISPATCHERTHREADS
 		allocated for each configured receive queue.
 		libuksched is required for this option.
 
+config LIBUKNETDEV_EINFO_LIBPARAM
+	bool "Netdev einfo with kernel parameters"
+	select LIBUKLIBPARAM
+	help
+		Extended information field are used to pass IPv4 addresses
+		and network settings to network stacks. This option enables to
+		overwrite the values that are provided by underlying drivers
+		with the `netdev.ip` kernel parameter.
+
+config LIBUKNETDEV_EINFO_LIBPARAM_MAXCOUNT
+	int "Maximum number of configurable netdevs"
+	depends on LIBUKNETDEV_EINFO_LIBPARAM
+	range 1 512
+	default 4
+	help
+		This number defines an upper limit of netdev devices that can
+		be configured via the kernel command line.
+
 config LIBUKNETDEV_STATS
 	bool "Collect network statistics"
 	default n

--- a/lib/uknetdev/include/uk/netdev.h
+++ b/lib/uknetdev/include/uk/netdev.h
@@ -173,9 +173,9 @@ void uk_netdev_info_get(struct uk_netdev *dev,
  *   Extra configuration type selection (see enum definition).
  * @return
  *   - (NULL): if configuration unavailable or data type unsupported
- *   - (void *): Reference to configuration, format specified by *einfo*
+ *   - (const char *): Reference to configuration as C string
  */
-const void *uk_netdev_einfo_get(struct uk_netdev *dev,
+const char *uk_netdev_einfo_get(struct uk_netdev *dev,
 				enum uk_netdev_einfo_type einfo);
 
 /**

--- a/lib/uknetdev/include/uk/netdev_core.h
+++ b/lib/uknetdev/include/uk/netdev_core.h
@@ -455,6 +455,9 @@ struct uk_netdev_data {
 	const char           *drv_name;
 };
 
+#if CONFIG_LIBUKNETDEV_EINFO_LIBPARAM
+struct uk_netdev_einfo_overwrites;
+#endif /* CONFIG_LIBUKNETDEV_EINFO_LIBPARAM */
 
 struct uk_netdev_tx_stats {
 	/** The total number of bytes of data transmitted by the interface */
@@ -517,6 +520,10 @@ struct uk_netdev {
 
 	UK_TAILQ_ENTRY(struct uk_netdev) _list;
 
+#if CONFIG_LIBUKNETDEV_EINFO_LIBPARAM
+	/** Netdevice einfo overwrites by kernel parameters */
+	struct uk_netdev_einfo_overwrites *_einfo;
+#endif /* CONFIG_LIBUKNETDEV_EINFO_LIBPARAM */
 
 #if (CONFIG_UK_NETDEV_SCRATCH_SIZE > 0)
 	char scratch_pad[CONFIG_UK_NETDEV_SCRATCH_SIZE];

--- a/lib/uknetdev/include/uk/netdev_core.h
+++ b/lib/uknetdev/include/uk/netdev_core.h
@@ -219,28 +219,22 @@ enum uk_netdev_state {
  * This list is extensible in the future without needing the drivers to adopt
  * any or all of the data types.
  *
- * The extra information can available in one of the following formats:
- * - *_NINT16: Network-order raw int (4 bytes)
- * - *_STR: Null-terminated string
+ * Each of the extra information field is available as Null-terminated string
  */
 enum uk_netdev_einfo_type {
-	/* IPv4 address and mask */
-	UK_NETDEV_IPV4_ADDR_NINT16,
-	UK_NETDEV_IPV4_ADDR_STR,
-	UK_NETDEV_IPV4_MASK_NINT16,
-	UK_NETDEV_IPV4_MASK_STR,
+	/* IPv4 */
+	UK_NETDEV_IPV4_ADDR,
+	UK_NETDEV_IPV4_MASK,
+	UK_NETDEV_IPV4_CIDR,	/* IPv4 address in CIDR notation
+				 * (if set, addr/mask fields are NULL)
+				 */
+	UK_NETDEV_IPV4_GW,	/* IPv4 gateway */
+	UK_NETDEV_IPV4_DNS0,	/* Primary DNS (IPv4 address) */
+	UK_NETDEV_IPV4_DNS1,	/* Secondary DNS (IPv4 address) */
+	UK_NETDEV_IPV4_HOSTNAME,/* Hostname for IPv4 address */
+	UK_NETDEV_IPV4_DOMAIN,	/* Domain/Search suffix for IPv4 address */
 
-	/* IPv4 gateway */
-	UK_NETDEV_IPV4_GW_NINT16,
-	UK_NETDEV_IPV4_GW_STR,
-
-	/* IPv4 Primary DNS */
-	UK_NETDEV_IPV4_DNS0_NINT16,
-	UK_NETDEV_IPV4_DNS0_STR,
-
-	/* IPv4 Secondary DNS */
-	UK_NETDEV_IPV4_DNS1_NINT16,
-	UK_NETDEV_IPV4_DNS1_STR,
+	/* TODO: IPv6 */
 };
 
 /**
@@ -311,7 +305,7 @@ typedef void (*uk_netdev_info_get_t)(struct uk_netdev *dev,
 				     struct uk_netdev_info *dev_info);
 
 /** Driver callback type to read any extra configuration. */
-typedef const void *(*uk_netdev_einfo_get_t)(struct uk_netdev *dev,
+typedef const char *(*uk_netdev_einfo_get_t)(struct uk_netdev *dev,
 					     enum uk_netdev_einfo_type econf);
 
 /** Driver callback type to configure a network device. */

--- a/lib/uknetdev/include/uk/netdev_core.h
+++ b/lib/uknetdev/include/uk/netdev_core.h
@@ -461,12 +461,6 @@ struct uk_netdev_data {
 	const char           *drv_name;
 };
 
-struct uk_netdev_einfo {
-	const char *ipv4_addr;
-	const char *ipv4_net_mask;
-	const char *ipv4_gw_addr;
-	const char *ipv4_dns0_addr;
-};
 
 struct uk_netdev_tx_stats {
 	/** The total number of bytes of data transmitted by the interface */
@@ -529,8 +523,6 @@ struct uk_netdev {
 
 	UK_TAILQ_ENTRY(struct uk_netdev) _list;
 
-	/** Netdevice address configuration */
-	struct uk_netdev_einfo *_einfo;
 
 #if (CONFIG_UK_NETDEV_SCRATCH_SIZE > 0)
 	char scratch_pad[CONFIG_UK_NETDEV_SCRATCH_SIZE];

--- a/lib/uknetdev/netdev.c
+++ b/lib/uknetdev/netdev.c
@@ -187,15 +187,28 @@ void uk_netdev_info_get(struct uk_netdev *dev,
 				      dev_info->max_tx_queues);
 }
 
-const void *uk_netdev_einfo_get(struct uk_netdev *dev,
+const char *uk_netdev_einfo_get(struct uk_netdev *dev,
 				enum uk_netdev_einfo_type einfo)
 {
 	UK_ASSERT(dev);
 	UK_ASSERT(dev->ops);
 	UK_ASSERT(dev->_data->state >= UK_NETDEV_UNCONFIGURED);
 
-	if (dev->ops->einfo_get)
+	if (dev->ops->einfo_get) {
+		switch (einfo) {
+		case UK_NETDEV_IPV4_ADDR:
+			if (dev->ops->einfo_get(dev, UK_NETDEV_IPV4_CIDR))
+				return NULL; /* IPv4 CIDR exists */
+			break;
+		case UK_NETDEV_IPV4_MASK:
+			if (dev->ops->einfo_get(dev, UK_NETDEV_IPV4_CIDR))
+				return NULL; /* IPv4 CIDR exists */
+			break;
+		default:
+			break;
+		}
 		return dev->ops->einfo_get(dev, einfo);
+	}
 	return NULL;
 }
 

--- a/plat/xen/drivers/net/netfront.c
+++ b/plat/xen/drivers/net/netfront.c
@@ -780,11 +780,11 @@ static const void *netfront_einfo_get(struct uk_netdev *n,
 
 	nfdev = to_netfront_dev(n);
 	switch (einfo_type) {
-	case UK_NETDEV_IPV4_ADDR_STR:
+	case UK_NETDEV_IPV4_ADDR:
 		return nfdev->econf.ipv4addr;
-	case UK_NETDEV_IPV4_MASK_STR:
+	case UK_NETDEV_IPV4_MASK:
 		return nfdev->econf.ipv4mask;
-	case UK_NETDEV_IPV4_GW_STR:
+	case UK_NETDEV_IPV4_GW:
 		return nfdev->econf.ipv4gw;
 	default:
 		break;


### PR DESCRIPTION
### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]

### Additional configuration

 - `CONFIG_LIBUKNETDEV=y`
 - `CONFIG_LIBUKNETDEV_EINFO_LIBPARAM=y`

### Description of changes

This commit reintroduces the ability to override netdev einfo fields via kernel command line parameters. The `netdev.ip` parameter can be used to override IPv4 address information for multiple devices. For each device the following colon-separated format is introduced:

  `cidr[:gw[:dns0[:dns1[:hostname[:domain]]]]]`

Any of the fields can be left blank and fewer fields can be passed by omitting fields from the right. This also ensures that more fields can be appended in the future while maintaining backwards compatibility.

Example 1:
 - IPv4 address: `192.168.0.123`
 - IPv4 mask: `255.255.255.0`
 - IPv4 default gateway: `192.168.0.1`
 - Primary DNS server (IPv4): `192.168.0.1`
...converts to:
 `netdev.ip=192.168.0.123/24:192.168.0.1:192.168.0.1`

Example 2:
 Additionally to example 1, we add the following fields:
 - We do not hand-over a secondary DNS server
 - Hostname: `example`
 - Domain suffix: `unikraft.org`
...this converts to:
 `netdev.ip=192.168.0.123/24:192.168.0.1:192.168.0.1::example:unikraft.org`

> [!CAUTION]
> This is a breaking change and this PR should be checked in conjunction with [unikraft/kraftkit#1150][0] and merged simultaneously with [#1150][0] to avoid incompatibility issues. Simultaneously, all [catalog](https://github.com/unikraft/catalog) entries should be retriggered against Unikraft's `staging` branch following the merge. Since Unikraft is pre-v1.0, no backwards compatibility is included in this refactor.

[0]: https://github.com/unikraft/kraftkit/pull/1150
