### PR TITLE
uk/plat/memory: Introduce `pg_off` and `pg_count` memregion fields

### DIFF
--- a/include/uk/arch/paging.h
+++ b/include/uk/arch/paging.h
@@ -364,6 +364,17 @@ int PAGE_Lx_IS(__pte_t pte, unsigned int lvl);
 #define _PT_PAGES(lvls, pages)		__PT_PAGES(lvls, pages)
 #define PT_PAGES(pages)			_PT_PAGES(PT_LEVELS, pages)
 
+/** PAGE_COUNT(len) macro
+ *
+ * Computes the total number of pages required to map an area of a given
+ * length.
+ *
+ * @param len length of the area to map
+ *
+ * @return number of pages required to map an area of a given length
+ */
+#define PAGE_COUNT(len)			DIV_ROUND_UP((len), PAGE_SIZE)
+
 /**
  * Tests if a certain range of virtual addresses is valid on the current
  * architecture. For example, most 64-bit architectures do not fully implement

--- a/include/uk/plat/memory.h
+++ b/include/uk/plat/memory.h
@@ -81,12 +81,16 @@ extern "C" {
  * Descriptor of a memory region
  */
 struct ukplat_memregion_desc {
-	/** Physical base address */
+	/** Physical page-aligned base address of the region */
 	__paddr_t pbase;
-	/** Virtual base address */
+	/** Virtual page-aligned base address of the region */
 	__vaddr_t vbase;
-	/** Length in bytes */
+	/** Offset where the resource starts in the region's first page */
+	__off pg_off;
+	/** Length in bytes of the resource inside this region */
 	__sz len;
+	/** Number of pages the end-to-end aligned region occupies */
+	__sz pg_count;
 	/** Memory region type (see UKPLAT_MEMRT_*) */
 	__u16 type;
 	/** Memory region flags (see UKPLAT_MEMRF_*) */

--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -86,7 +86,6 @@
 #ifdef CONFIG_LIBUKSP
 #include <uk/sp.h>
 #endif
-#include <uk/arch/paging.h>
 #include <uk/arch/tls.h>
 #include <uk/plat/tls.h>
 #if CONFIG_LIBUKBOOT_MAINTHREAD
@@ -205,10 +204,7 @@ static struct uk_alloc *heap_init()
 	 * add every subsequent region to it.
 	 */
 	ukplat_memregion_foreach(&md, UKPLAT_MEMRT_FREE, 0, 0) {
-		UK_ASSERT(md->vbase == md->pbase);
-		UK_ASSERT(!(md->pbase & ~PAGE_MASK));
-		UK_ASSERT(md->len);
-		UK_ASSERT(!(md->len & ~PAGE_MASK));
+		UK_ASSERT_VALID_FREE_MRD(md);
 
 		uk_pr_debug("Trying %p-%p 0x%02x %s\n",
 			    (void *)md->vbase, (void *)(md->vbase + md->len),

--- a/lib/ukreloc/reloc.c
+++ b/lib/ukreloc/reloc.c
@@ -124,6 +124,8 @@ void do_uk_reloc_kmrds(__paddr_t r_paddr, __vaddr_t r_vaddr)
 	 * since they contain the link-time addresses, relative to rt_baddr.
 	 */
 	ukplat_memregion_foreach(&mrdp, UKPLAT_MEMRT_KERNEL, 0, 0) {
+		UK_ASSERT_VALID_KERNEL_MRD(mrdp);
+
 		mrdp->pbase -= (__paddr_t)lt_baddr;
 		mrdp->pbase += r_paddr;
 		mrdp->vbase -= (__vaddr_t)lt_baddr;

--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -509,6 +509,8 @@ static int vfscore_extract_volume(const struct vfscore_volume *vv)
 			return -1;
 		}
 
+		UK_ASSERT_VALID_MRD(initrd);
+
 		vbase = (void *)initrd->vbase + initrd->pg_off;
 		vlen = initrd->len;
 	}

--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -509,7 +509,7 @@ static int vfscore_extract_volume(const struct vfscore_volume *vv)
 			return -1;
 		}
 
-		vbase = (void *)initrd->vbase;
+		vbase = (void *)initrd->vbase + initrd->pg_off;
 		vlen = initrd->len;
 	}
 #if CONFIG_LIBVFSCORE_AUTOMOUNT_EINITRD

--- a/plat/common/bootinfo.c
+++ b/plat/common/bootinfo.c
@@ -98,8 +98,10 @@ void ukplat_bootinfo_print(void)
 			break;
 		}
 
-		uk_pr_info(" %012lx-%012lx %012lx %c%c%c %016lx %s %s\n",
-			   mrd->pbase, mrd->pbase + mrd->len, mrd->len,
+		uk_pr_info(" %012lx-%012lx %012lx-%012lx %c%c%c %016lx %s %s\n",
+			   mrd->pbase, mrd->pbase + mrd->pg_count * PAGE_SIZE,
+			   mrd->pbase + mrd->pg_off,
+			   mrd->pbase + mrd->pg_off + mrd->len,
 			   (mrd->flags & UKPLAT_MEMRF_READ) ? 'r' : '-',
 			   (mrd->flags & UKPLAT_MEMRF_WRITE) ? 'w' : '-',
 			   (mrd->flags & UKPLAT_MEMRF_EXECUTE) ? 'x' : '-',

--- a/plat/common/include/uk/plat/common/bootinfo.h
+++ b/plat/common/include/uk/plat/common/bootinfo.h
@@ -52,17 +52,17 @@ struct ukplat_bootinfo {
 
 UK_CTASSERT(sizeof(struct ukplat_bootinfo) == 80);
 
-#ifdef CONFIG_UKPLAT_MEMRNAME
+#if CONFIG_UKPLAT_MEMRNAME
 #if __SIZEOF_LONG__ == 8
-UK_CTASSERT(sizeof(struct ukplat_memregion_desc) == 64);
-#else /* __SIZEOF_LONG__ == 8 */
-UK_CTASSERT(sizeof(struct ukplat_memregion_desc) == 52);
+UK_CTASSERT(sizeof(struct ukplat_memregion_desc) == 80);
+#else /* __SIZEOF_LONG__ != 8 */
+UK_CTASSERT(sizeof(struct ukplat_memregion_desc) == 60);
 #endif /* __SIZEOF_LONG__ != 8 */
-#else /* CONFIG_UKPLAT_MEMRNAME */
+#else /* !CONFIG_UKPLAT_MEMRNAME */
 #if __SIZEOF_LONG__ == 8
-UK_CTASSERT(sizeof(struct ukplat_memregion_desc) == 32);
-#else /* __SIZEOF_LONG__ == 8 */
-UK_CTASSERT(sizeof(struct ukplat_memregion_desc) == 16);
+UK_CTASSERT(sizeof(struct ukplat_memregion_desc) == 48);
+#else /* __SIZEOF_LONG__ != 8 */
+UK_CTASSERT(sizeof(struct ukplat_memregion_desc) == 24);
 #endif /* __SIZEOF_LONG__ != 8 */
 #endif /* !CONFIG_UKPLAT_MEMRNAME */
 

--- a/plat/common/include/uk/plat/common/memory.h
+++ b/plat/common/include/uk/plat/common/memory.h
@@ -133,9 +133,11 @@ ukplat_memregion_list_insert_legacy_hi_mem(struct ukplat_memregion_list *list)
 	 */
 	rc = ukplat_memregion_list_insert(list,
 			&(struct ukplat_memregion_desc){
-				.vbase = X86_HI_MEM_START,
 				.pbase = X86_HI_MEM_START,
+				.vbase = X86_HI_MEM_START,
+				.pg_off = 0,
 				.len   = X86_HI_MEM_LEN,
+				.pg_count = PAGE_COUNT(X86_HI_MEM_LEN),
 				.type  = UKPLAT_MEMRT_RESERVED,
 				.flags = UKPLAT_MEMRF_READ  |
 					 UKPLAT_MEMRF_WRITE |
@@ -149,9 +151,11 @@ ukplat_memregion_list_insert_legacy_hi_mem(struct ukplat_memregion_list *list)
 	 */
 	rc = ukplat_memregion_list_insert(list,
 			&(struct ukplat_memregion_desc){
-				.vbase = X86_BIOS_ROM_START,
 				.pbase = X86_BIOS_ROM_START,
+				.vbase = X86_BIOS_ROM_START,
+				.pg_off = 0,
 				.len   = X86_BIOS_ROM_LEN,
+				.pg_count = PAGE_COUNT(X86_BIOS_ROM_LEN),
 				.type  = UKPLAT_MEMRT_RESERVED,
 				.flags = UKPLAT_MEMRF_READ  |
 					 UKPLAT_MEMRF_MAP,
@@ -358,17 +362,19 @@ ukplat_memregion_print_desc(struct ukplat_memregion_desc *mrd)
 		break;
 	}
 
-	uk_pr_debug(" %012lx-%012lx %012lx %c%c%c %016lx %s %s\n",
-		   mrd->pbase, mrd->pbase + mrd->len, mrd->len,
-		   (mrd->flags & UKPLAT_MEMRF_READ) ? 'r' : '-',
-		   (mrd->flags & UKPLAT_MEMRF_WRITE) ? 'w' : '-',
-		   (mrd->flags & UKPLAT_MEMRF_EXECUTE) ? 'x' : '-',
-		   mrd->vbase,
-		   type,
+	uk_pr_debug(" %012lx-%012lx %012lx-%012lx %c%c%c %016lx %s %s\n",
+		    mrd->pbase, mrd->pbase + mrd->pg_count * PAGE_SIZE,
+		    mrd->pbase + mrd->pg_off,
+		    mrd->pbase + mrd->pg_off + mrd->len,
+		    (mrd->flags & UKPLAT_MEMRF_READ) ? 'r' : '-',
+		    (mrd->flags & UKPLAT_MEMRF_WRITE) ? 'w' : '-',
+		    (mrd->flags & UKPLAT_MEMRF_EXECUTE) ? 'x' : '-',
+		    mrd->vbase,
+		    type,
 #if CONFIG_UKPLAT_MEMRNAME
-		   mrd->name
+		    mrd->name
 #else /* !CONFIG_UKPLAT_MEMRNAME */
-		   ""
+		    ""
 #endif /* !CONFIG_UKPLAT_MEMRNAME */
 		   );
 }

--- a/plat/common/memory.c
+++ b/plat/common/memory.c
@@ -79,9 +79,11 @@ void *ukplat_memregion_alloc(__sz size, int type, __u16 flags)
 	desired_sz = size;
 	size = ALIGN_UP(size, __PAGE_SIZE);
 	ukplat_memregion_foreach(&mrd, UKPLAT_MEMRT_FREE, 0, 0) {
+		UK_ASSERT_VALID_FREE_MRD(mrd);
 		UK_ASSERT(mrd->pbase <= __U64_MAX - size);
+
 		pstart = ALIGN_UP(mrd->pbase, __PAGE_SIZE);
-		pend   = pstart + size;
+		pend = pstart + size;
 
 		if (unmap_len &&
 		    (!RANGE_CONTAIN(unmap_start, unmap_len, pstart, size) ||
@@ -93,7 +95,7 @@ void *ukplat_memregion_alloc(__sz size, int type, __u16 flags)
 			return NULL;
 
 		ostart = mrd->pbase;
-		olen   = mrd->len;
+		olen = mrd->len;
 
 		/* Check whether we are allocating from an in-image memory hole
 		 * or not. If no, then it is not already mapped.
@@ -318,7 +320,8 @@ void ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 		ukplat_memregion_print_desc(ml);
 		ukplat_memregion_print_desc(mr);
 
-		UK_ASSERT(ml->pbase <= mr->pbase);
+		UK_ASSERT_VALID_MRD(ml);
+		UK_ASSERT_VALID_MRD(mr);
 
 		ml_prio = get_mrd_prio(ml);
 		uk_pr_debug("Priority of left memory region: %d\n", ml_prio);
@@ -571,6 +574,8 @@ int ukplat_mem_init(void)
 			       __PAGE_SIZE);
 	for (i = (int)bi->mrds.count - 1; i >= 0; i--) {
 		ukplat_memregion_get(i, &mrdp);
+		UK_ASSERT_VALID_MRD(mrdp);
+
 		if (mrdp->vbase >= unmap_end) {
 			/* Region is outside the mapped area */
 			uk_pr_info("Memory %012lx-%012lx outside mapped area\n",

--- a/plat/common/memory.c
+++ b/plat/common/memory.c
@@ -108,7 +108,9 @@ void *ukplat_memregion_alloc(__sz size, int type, __u16 flags)
 		if (olen - (pstart - ostart) == size) {
 			mrd->pbase = pstart;
 			mrd->vbase = pstart;
+			mrd->pg_off = 0;
 			mrd->len = desired_sz;
+			mrd->pg_count = PAGE_COUNT(desired_sz);
 			mrd->type = type;
 			mrd->flags = flags;
 
@@ -116,16 +118,19 @@ void *ukplat_memregion_alloc(__sz size, int type, __u16 flags)
 		}
 
 		/* Adjust free region */
-		mrd->len  -= pend - mrd->pbase;
+		mrd->len -= pend - mrd->pbase;
+		mrd->pg_count = PAGE_COUNT(mrd->len);
 		mrd->pbase = pend;
 
 		mrd->vbase = (__vaddr_t)mrd->pbase;
 
 		/* Insert allocated region */
-		alloc_mrd.vbase = pstart;
 		alloc_mrd.pbase = pstart;
-		alloc_mrd.len   = desired_sz;
-		alloc_mrd.type  = type;
+		alloc_mrd.vbase = pstart;
+		alloc_mrd.pg_off = 0;
+		alloc_mrd.len = desired_sz;
+		alloc_mrd.pg_count = PAGE_COUNT(desired_sz);
+		alloc_mrd.type = type;
 		alloc_mrd.flags = flags | UKPLAT_MEMRF_MAP;
 
 		bi = ukplat_bootinfo_get();
@@ -194,35 +199,54 @@ static inline void overlapping_mrd_fixup(struct ukplat_memregion_list *list,
 		/* If the right region is contained within the left region,
 		 * drop it entirely
 		 */
-		if (RANGE_CONTAIN(ml->pbase, ml->len, mr->pbase, mr->len)) {
+		/* This can only happen if mr is a free mrd or if it has
+		 * the same type as ml
+		 */
+		UK_ASSERT(mr->type == UKPLAT_MEMRT_FREE ||
+			  mr->type == ml->type);
+
+		if (RANGE_CONTAIN(ml->pbase, ml->pg_count * PAGE_SIZE,
+				  mr->pbase, mr->pg_count * PAGE_SIZE)) {
 			mr->len = 0;
+			mr->pg_count = 0;
 
 		/* If the right region has a part of itself in the left region,
 		 * drop that part of the right region only
 		 */
 		} else {
 			mr->len -= ml->pbase + ml->len - mr->pbase;
-			mr->pbase = ml->pbase + ml->len;
+			mr->pg_count = PAGE_COUNT(mr->len);
+			mr->pbase = ml->pbase + ml->pg_count * PAGE_SIZE;
 			mr->vbase = mr->pbase;
 		}
 
 	/* If left memory region is of lower priority */
 	} else {
+		/* This can only happen if ml is a free mrd or if it has the
+		 * same type as mr
+		 */
+		UK_ASSERT(ml->type == UKPLAT_MEMRT_FREE ||
+			  ml->type == mr->type);
+
 		/* If the left memory region is contained within the right
 		 * region, drop it entirely
 		 */
-		if (RANGE_CONTAIN(mr->pbase, mr->len, ml->pbase, ml->len)) {
+		if (RANGE_CONTAIN(mr->pbase, mr->pg_count * PAGE_SIZE,
+				  ml->pbase, ml->pg_count * PAGE_SIZE)) {
 			ml->len = 0;
+			ml->pg_count = 0;
 
 		/* If the left region has a part of itself in the right region,
 		 * drop that part of the left region only and split by creating
 		 * a new one if the left region is larger than the right region.
 		 */
 		} else {
-			__sz len = ml->pbase + ml->len - mr->pbase - mr->len;
+			__sz len = ml->pbase + ml->pg_count * PAGE_SIZE -
+				   mr->pbase - mr->pg_count * PAGE_SIZE;
+			__uptr base = PAGE_ALIGN_UP(mr->pbase + mr->len);
 
-			if (RANGE_CONTAIN(ml->pbase, ml->len,
-					  mr->pbase, mr->len && len))
+			if (RANGE_CONTAIN(ml->pbase, ml->pg_count * PAGE_SIZE,
+					  mr->pbase, mr->pg_count * PAGE_SIZE))
 				/* len here is basically ml_end - mr_end. Thus,
 				 * len == 0 can happen only if mr is at the end
 				 * of the ml and we therefore ignore the rest.
@@ -232,55 +256,21 @@ static inline void overlapping_mrd_fixup(struct ukplat_memregion_list *list,
 				 */
 				ukplat_memregion_list_insert_at_idx(list,
 					&(struct ukplat_memregion_desc){
-						.vbase = mr->pbase + mr->len,
-						.pbase = mr->pbase + mr->len,
-						.len   = len,
-						.type  = ml->type,
+						.pbase = base,
+						.vbase = base,
+						.pg_off = 0,
+						.len = len,
+						.pg_count = PAGE_COUNT(len),
+						.type = UKPLAT_MEMRT_FREE,
 						.flags = ml->flags
 					}, ridx + 1);
 
 			/* Drop the fraction of ml that overlaps with mr */
-			ml->len = mr->pbase - ml->pbase;
+			ml->len = (mr->pbase + mr->pg_off) -
+				  (ml->pbase + ml->pg_off);
+			ml->pg_count = PAGE_COUNT(ml->pg_off + ml->len);
 		}
 	}
-}
-
-/* During coalescing of two memory region descriptors, we first call this
- * function which would overwrite the physical and length of a given memory
- * region descriptor with its equivalent page-aligned physical base and length
- * if the end address of the memory region would have also been page-aligned.
- * The coalesce function then, at the end, calls ukplat_memregion_restore_mrd
- * to undo this.
- */
-static void ukplat_memregion_align_mrd(struct ukplat_memregion_desc *mrd,
-				       __paddr_t *opbase, __sz *olen)
-{
-	__sz pend;
-
-	/* Store the **original** physical base and length */
-	*opbase = mrd->pbase;
-	*olen = mrd->len;
-
-	/* Compute the page-aligned end address of the region */
-	pend = ALIGN_UP(mrd->pbase + mrd->len, __PAGE_SIZE);
-
-	/* Overwrite original pbase with its page-aligned value */
-	mrd->pbase = ALIGN_DOWN(mrd->pbase, __PAGE_SIZE);
-
-	/* Overwrite original len with the supposed size of end-to-end
-	 * page-aligned memory region.
-	 */
-	mrd->len = pend - mrd->pbase;
-}
-
-/* Called at the end of ukplat_memregion_list_coalesce to undo what
- * ukplat_memregion_align_mrd has done.
- */
-static void ukplat_memregion_restore_mrd(struct ukplat_memregion_desc *mrd,
-					 __paddr_t opbase, __sz olen)
-{
-	mrd->len = olen;
-	mrd->pbase = opbase;
 }
 
 /* Quick function to do potentially necessary swapping of two adjacent memory
@@ -307,10 +297,7 @@ static void ukplat_memregion_swap_if_unordered(struct ukplat_memregion_list *l,
 void ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 {
 	struct ukplat_memregion_desc *m, *ml, *mr;
-	__paddr_t ml_opbase, mr_opbase;
-	__sz ml_olen, mr_olen;
 	int ml_prio, mr_prio;
-	__u8 del; /* lets us know if a deletion happened */
 	__u32 i;
 
 	UK_ASSERT(list);
@@ -320,8 +307,6 @@ void ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 	i = 0;
 	m = list->mrds;
 	while (i + 1 < list->count) {
-		del = 0;
-
 		/* Make sure first that they are ordered. If not, swap them */
 		ukplat_memregion_swap_if_unordered(list, i, i + 1);
 
@@ -343,10 +328,8 @@ void ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 		uk_pr_debug("Priority of right memory region: %d\n", mr_prio);
 		UK_ASSERT(mr_prio >= 0);
 
-		ukplat_memregion_align_mrd(ml, &ml_opbase, &ml_olen);
-		ukplat_memregion_align_mrd(mr, &mr_opbase, &mr_olen);
-
-		if (RANGE_OVERLAP(ml->pbase, ml->len, mr->pbase, mr->len)) {
+		if (RANGE_OVERLAP(ml->pbase, ml->pg_count * PAGE_SIZE,
+				  mr->pbase, mr->pg_count * PAGE_SIZE)) {
 			/* If they are not of the same priority */
 			if (ml_prio != mr_prio) {
 				uk_pr_debug("mrd's of different priority "
@@ -363,7 +346,6 @@ void ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 						      mr_prio, i, i + 1);
 
 				/* Remove dropped regions */
-				del = 1;
 				if (ml->len == 0) {
 					uk_pr_debug("Deleting left mrd!\n");
 					ukplat_memregion_list_delete(list, i);
@@ -374,44 +356,62 @@ void ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 								     i + 1);
 				} else {
 					i++;
-					del = 0;  /* No deletions */
 				}
 
 			/* If they have the same priority, merge them. If they
 			 * are contained within each other, drop the contained
-			 * one.
+			 * one. Do not allow merging of kernel resources, as
+			 * their resource page offset into the region is
+			 * important!
 			 */
 			} else {
+				/* Kernel regions must never overlap! */
+				UK_ASSERT(ml_prio != MRD_PRIO_KRNL_RSRC);
+				UK_ASSERT(mr_prio != MRD_PRIO_KRNL_RSRC);
+
 				/* We do not allow overlaps of same priority
 				 * and of different flags.
 				 */
 				UK_ASSERT(ml->flags == mr->flags);
 
+				/* We do not allow overlaps of memory regions
+				 * whose resource page offset into their region
+				 * is not equal to 0. Regions don't that meet
+				 * this condition are hand-inserted by us and
+				 * should not overlap.
+				 */
+				UK_ASSERT(!ml->pg_off);
+				UK_ASSERT(!mr->pg_off);
+				UK_ASSERT(PAGE_ALIGNED(ml->pbase));
+				UK_ASSERT(PAGE_ALIGNED(mr->pbase));
+
 				/* If the left region is contained within the
 				 * right region, drop it
 				 */
-				if (RANGE_CONTAIN(mr->pbase, mr->len,
-						  ml->pbase, ml->len)) {
+				if (RANGE_CONTAIN(mr->pbase,
+						  mr->pg_count * PAGE_SIZE,
+						  ml->pbase,
+						  ml->pg_count * PAGE_SIZE)) {
 					uk_pr_debug("Deleting left mrd!\n");
 					ukplat_memregion_list_delete(list, i);
-					del = 1;
-
-					goto restore_mrds;
+					continue;
 
 				/* If the right region is contained within the
 				 * left region, drop it
 				 */
-				} else if (RANGE_CONTAIN(ml->pbase, ml->len,
-							 mr->pbase, mr->len)) {
+				} else if (RANGE_CONTAIN(ml->pbase,
+							 ml->pg_count *
+							 PAGE_SIZE,
+							 mr->pbase,
+							 mr->pg_count *
+							 PAGE_SIZE)) {
 					uk_pr_debug("Deleting right mrd!\n");
 					ukplat_memregion_list_delete(list,
 								     i + 1);
-					del = 1;
-
-					goto restore_mrds;
+					continue;
 				}
 
-				uk_pr_debug("Merging two overlapping mrd's.\n");
+				uk_pr_debug("Merging two overlapping mrds.\n");
 
 				/* If they are not contained within each other,
 				 * merge them.
@@ -422,60 +422,41 @@ void ukplat_memregion_list_coalesce(struct ukplat_memregion_list *list)
 				 * overlapping region
 				 */
 				ml->len -= ml->pbase + ml->len - mr->pbase;
+				ml->pg_count = PAGE_COUNT(ml->pg_off + ml->len);
 
 				/* Delete the memory region we just merged into
 				 * the previous region.
 				 */
 				ukplat_memregion_list_delete(list, i + 1);
-				del = 1;
 			}
 
 		/* If they do not overlap but they are contiguous and have the
-		 * same flags and priority.
+		 * same flags and priority. Do not merge Kernel type memregions,
+		 * as we have to preserve pg_off's and len's.
 		 */
 		} else if (ml->pbase + ml->len == mr->pbase &&
-			   ml_prio == mr_prio && ml->flags == mr->flags) {
+			   ml_prio == mr_prio && ml->flags == mr->flags &&
+			   ml_prio != MRD_PRIO_KRNL_RSRC) {
+			/* We do not allow overlaps of memory regions
+			 * whose resource page offset into their region
+			 * is not equal to 0. Regions don't that meet
+			 * this condition are hand-inserted by us and
+			 * should not overlap.
+			 */
+			UK_ASSERT(!ml->pg_off);
+			UK_ASSERT(!mr->pg_off);
+			UK_ASSERT(PAGE_ALIGNED(ml->pbase));
+			UK_ASSERT(PAGE_ALIGNED(mr->pbase));
+
 			uk_pr_debug("Merging two contiguous mrd's.\n");
 			ml->len += mr->len;
+			ml->pg_count = PAGE_COUNT(ml->len);
 			ukplat_memregion_list_delete(list, i + 1);
-			del = 1;
 		} else {
 			uk_pr_debug("No adjustment for these mrd's.\n");
 			i++;
 		}
-
-restore_mrds:
-		if (!del) {
-			/* We assume only MRD_PRIO_FREE can be dropped. We want
-			 * to maintain !MRD_PRIO_FREE start addresses and
-			 * length so that the kernel may use them (e.g. initrd
-			 * start address).
-			 */
-			if (ml_prio != MRD_PRIO_FREE)
-				ukplat_memregion_restore_mrd(ml, ml_opbase,
-							     ml_olen);
-
-			/* This here can only happen if two adjacent
-			 * !MRD_PRIO_FREE regions are resolved without a
-			 * deletion. Preserve mr's original data as well.
-			 */
-			if (mr_prio != MRD_PRIO_FREE)
-				ukplat_memregion_restore_mrd(mr, mr_opbase,
-							     mr_olen);
-		}
-
-		/* Update ml's vbase, since it might not be equal to pbase
-		 * anymore. Whether we deleted ml or mr it does not matter,
-		 * as ml is now equal to the remaining one, because
-		 * ukplat_memregion_list_delete() removes by `memmove()`ing.
-		 */
-		ml->vbase = ml->pbase;
 	}
-
-	/* Make sure the last memory region always ends up being updated when
-	 * we exit this function
-	 */
-	m[i].vbase = m[i].pbase;
 }
 
 int ukplat_memregion_count(void)
@@ -521,10 +502,14 @@ static int ukplat_memregion_list_insert_unmaps(struct ukplat_bootinfo *bi)
 	/* After Kernel image */
 	rc = ukplat_memregion_list_insert(&bi->mrds,
 			&(struct ukplat_memregion_desc){
-				.vbase = ALIGN_UP(__END, __PAGE_SIZE),
 				.pbase = 0,
+				.vbase = ALIGN_UP(__END, __PAGE_SIZE),
+				.pg_off = 0,
 				.len   = unmap_end -
 					 ALIGN_UP(__END, __PAGE_SIZE),
+				.pg_count = PAGE_COUNT(unmap_end -
+						       ALIGN_UP(__END,
+								__PAGE_SIZE)),
 				.type  = 0,
 				.flags = UKPLAT_MEMRF_UNMAP,
 			});
@@ -534,10 +519,14 @@ static int ukplat_memregion_list_insert_unmaps(struct ukplat_bootinfo *bi)
 	/* Before Kernel image */
 	return ukplat_memregion_list_insert(&bi->mrds,
 			&(struct ukplat_memregion_desc){
-				.vbase = unmap_start,
 				.pbase = 0,
+				.vbase = unmap_start,
+				.pg_off = 0,
 				.len   = ALIGN_DOWN(__BASE_ADDR, __PAGE_SIZE) -
 					 unmap_start,
+				.pg_count = PAGE_COUNT(ALIGN_DOWN(__BASE_ADDR,
+								  __PAGE_SIZE) -
+						       unmap_start),
 				.type  = 0,
 				.flags = UKPLAT_MEMRF_UNMAP,
 			});
@@ -593,11 +582,13 @@ int ukplat_mem_init(void)
 			/* Region overlaps with unmapped area */
 			uk_pr_info("Memory %012lx-%012lx outside mapped area\n",
 				   unmap_end,
-				   mrdp->vbase + mrdp->len);
+				   mrdp->vbase + mrdp->pg_count * PAGE_SIZE);
 
-			if (mrdp->type == UKPLAT_MEMRT_FREE)
+			if (mrdp->type == UKPLAT_MEMRT_FREE) {
 				mrdp->len -= (mrdp->vbase + mrdp->len) -
 					     unmap_end;
+				mrdp->pg_count = PAGE_COUNT(mrdp->len);
+			}
 
 			/* Since regions are non-overlapping and ordered, we
 			 * can stop here, as the next region would be fully

--- a/plat/common/paging.c
+++ b/plat/common/paging.c
@@ -1450,9 +1450,7 @@ int ukplat_paging_init(void)
 	 */
 	rc = -ENOMEM; /* In case there is no region */
 	ukplat_memregion_foreach(&mrd, UKPLAT_MEMRT_FREE, 0, 0) {
-		UK_ASSERT(mrd->vbase == mrd->pbase);
-		UK_ASSERT(!(mrd->pbase & ~PAGE_MASK));
-		UK_ASSERT(mrd->len);
+		UK_ASSERT_VALID_FREE_MRD(mrd);
 
 		/* Not mapped */
 		mrd->vbase = __U64_MAX;
@@ -1509,8 +1507,9 @@ int ukplat_paging_init(void)
 	/* Perform mappings */
 	ukplat_memregion_foreach(&mrd, 0, UKPLAT_MEMRF_MAP,
 				 UKPLAT_MEMRF_MAP) {
-		UK_ASSERT(!(mrd->vbase & ~PAGE_MASK));
-		UK_ASSERT(mrd->vbase != __U64_MAX);
+		UK_ASSERT_VALID_MRD(mrd);
+		/* Do not allow mapping of free memory regions */
+		UK_ASSERT(mrd->type != UKPLAT_MEMRT_FREE);
 
 #if defined(CONFIG_ARCH_ARM_64)
 		if (!RANGE_CONTAIN(bpt_unmap_mrd.pbase, bpt_unmap_mrd.len,

--- a/plat/common/w_xor_x.c
+++ b/plat/common/w_xor_x.c
@@ -69,6 +69,8 @@ void __weak enforce_w_xor_x(void)
 		if (d->type == UKPLAT_MEMRT_FREE)
 			continue;
 
+		UK_ASSERT_VALID_MRD(d);
+
 #ifdef CONFIG_ARCH_ARM_64
 		/* Skip RW regions. These will be protected by WXN */
 		if (d->flags & UKPLAT_MEMRF_WRITE)

--- a/plat/kvm/arm/firecracker_bpt64.S
+++ b/plat/kvm/arm/firecracker_bpt64.S
@@ -22,8 +22,10 @@
 bpt_unmap_mrd:
 	.quad	0x0000000080000000		/* 1 GiB */
 	.quad	0x0000000080000000		/* 1 GiB */
+	.quad	0x0000000000000000		/* Page-aligned */
 	/* FIXME: Unmap to 1TiB */
 	.quad	(255 - 1) * 0x0000000080000000
+	.quad	(255 - 1) * 0x0000000000080000  /* Page count */
 	.short	0x0000000000000000
 	.short	0x0000000000000010		/* UKPLAT_MEMRF_UNMAP */
 	.space	36

--- a/plat/kvm/arm/qemu_bpt64.S
+++ b/plat/kvm/arm/qemu_bpt64.S
@@ -24,6 +24,7 @@
 bpt_unmap_mrd:
 	.quad	0x0000000040000000		/* 1 GiB */
 	.quad	0x0000000040000000		/* 1 GiB */
+	.quad	0x0000000000000000		/* Page-aligned */
 	/* QEMU-VIRT's legacy RAM max is 255 GiB, but it can also depend on the
 	 * settings, see QEMU upstream commit:
 	 * 50a17297e2f0c ("hw/arm/virt: Bump the 255GB initial RAM limit").
@@ -31,6 +32,7 @@ bpt_unmap_mrd:
 	 * high memory.
 	 */
 	.quad	(255 - 1) * 0x0000000040000000
+	.quad	(255 - 1) * 0x0000000000040000  /* Page count */
 	.short	0x0000000000000000
 	.short	0x0000000000000010		/* UKPLAT_MEMRF_UNMAP */
 	.space	36

--- a/plat/kvm/efi.c
+++ b/plat/kvm/efi.c
@@ -213,6 +213,10 @@ static int uk_efi_md_to_bi_mrd(struct uk_efi_mem_desc *const md,
 	mrd->vbase = start;
 	mrd->len = end - start;
 
+	/* All UEFI memory regions are page-aligned */
+	mrd->pg_off = 0;
+	mrd->pg_count = md->number_of_pages;
+
 	return 0;
 }
 
@@ -338,6 +342,8 @@ static void uk_efi_rt_md_to_bi_mrds(struct ukplat_memregion_desc **rt_mrds,
 		rt_mrd = *rt_mrds + i;
 		rt_mrd->pbase = mat_md->physical_start;
 		rt_mrd->len = mat_md->number_of_pages * UK_EFI_PAGE_SIZE;
+		rt_mrd->pg_off = 0;
+		rt_mrd->pg_count = mat_md->number_of_pages;
 		rt_mrd->vbase = rt_mrd->pbase;
 		rt_mrd->type = UKPLAT_MEMRT_RESERVED;
 		rt_mrd->flags = UKPLAT_MEMRF_MAP;
@@ -547,7 +553,9 @@ static void uk_efi_setup_bootinfo_cmdl(struct ukplat_bootinfo *bi)
 
 	mrd.pbase = (__paddr_t)cmdl;
 	mrd.vbase = (__vaddr_t)cmdl;
+	mrd.pg_off = 0;
 	mrd.len = len;
+	mrd.pg_count = PAGE_COUNT(len);
 	mrd.type = UKPLAT_MEMRT_CMDLINE;
 	mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 	rc = ukplat_memregion_list_insert(&bi->mrds, &mrd);
@@ -577,7 +585,9 @@ static void uk_efi_setup_bootinfo_initrd(struct ukplat_bootinfo *bi)
 
 	mrd.pbase = (__paddr_t)initrd;
 	mrd.vbase = (__vaddr_t)initrd;
+	mrd.pg_off = 0;
 	mrd.len = len;
+	mrd.pg_count = PAGE_COUNT(len);
 	mrd.type = UKPLAT_MEMRT_INITRD;
 	mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 	rc = ukplat_memregion_list_insert(&bi->mrds, &mrd);
@@ -604,7 +614,9 @@ static void uk_efi_setup_bootinfo_dtb(struct ukplat_bootinfo *bi)
 
 	mrd.pbase = (__paddr_t)dtb;
 	mrd.vbase = (__vaddr_t)dtb;
+	mrd.pg_off = 0;
 	mrd.len = len;
+	mrd.pg_count = PAGE_COUNT(len);
 	mrd.type = UKPLAT_MEMRT_DEVICETREE;
 	mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 	rc = ukplat_memregion_list_insert(&bi->mrds, &mrd);

--- a/plat/kvm/x86/lxboot.c
+++ b/plat/kvm/x86/lxboot.c
@@ -39,10 +39,12 @@ lxboot_init_cmdline(struct ukplat_bootinfo *bi, struct lxboot_params *bp)
 	if (cmdline_size == 0)
 		return;
 
-	mrd.pbase = cmdline_addr;
-	mrd.vbase = cmdline_addr;
-	mrd.len   = cmdline_size;
-	mrd.type  = UKPLAT_MEMRT_CMDLINE;
+	mrd.pbase = PAGE_ALIGN_DOWN(cmdline_addr);
+	mrd.vbase = mrd.pbase;
+	mrd.pg_off = cmdline_addr - mrd.pbase;
+	mrd.len = cmdline_size;
+	mrd.pg_count = PAGE_COUNT(mrd.pg_off + mrd.len);
+	mrd.type = UKPLAT_MEMRT_CMDLINE;
 	mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 #ifdef CONFIG_UKPLAT_MEMRNAME
 	memcpy(mrd.name, "cmdline", sizeof("cmdline"));
@@ -75,11 +77,13 @@ lxboot_init_initrd(struct ukplat_bootinfo *bi, struct lxboot_params *bp)
 	if (initrd_addr == 0 || initrd_size == 0)
 		return;
 
-	mrd.type  = UKPLAT_MEMRT_INITRD;
+	mrd.pbase = PAGE_ALIGN_DOWN(initrd_addr);
+	mrd.vbase = mrd.pbase;
+	mrd.pg_off = initrd_addr - mrd.pbase;
+	mrd.len = initrd_size;
+	mrd.type = UKPLAT_MEMRT_INITRD;
+	mrd.pg_count = PAGE_COUNT(mrd.pg_off + initrd_size);
 	mrd.flags = UKPLAT_MEMRF_MAP | UKPLAT_MEMRF_READ;
-	mrd.vbase = initrd_addr;
-	mrd.pbase = initrd_addr;
-	mrd.len   = initrd_size;
 #ifdef CONFIG_UKPLAT_MEMRNAME
 	memcpy(mrd.name, "initrd", sizeof("initrd"));
 #endif /* CONFIG_UKPLAT_MEMRNAME */
@@ -110,14 +114,20 @@ lxboot_init_mem(struct ukplat_bootinfo *bi, struct lxboot_params *bp)
 		if (end <= start)
 			continue;
 
-		mrd.pbase = start;
-		mrd.vbase = start; /* 1:1 mapping */
+		mrd.pbase = PAGE_ALIGN_DOWN(start);
+		mrd.vbase = mrd.pbase; /* 1:1 mapping */
+		mrd.pg_off = start - mrd.pbase;
 		mrd.len = end - start;
+		mrd.pg_count = PAGE_COUNT(mrd.pg_off + mrd.len);
 
 		if (entry->type == LXBOOT_E820_TYPE_RAM) {
 			mrd.type = UKPLAT_MEMRT_FREE;
 			mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_WRITE;
 
+			/* Free memory regions have
+			 * mrd.len == mrd.pg_count * PAGE_SIZE
+			 */
+			mrd.len = PAGE_ALIGN_UP(mrd.len);
 		} else {
 			mrd.type = UKPLAT_MEMRT_RESERVED;
 			mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;

--- a/plat/kvm/x86/multiboot.c
+++ b/plat/kvm/x86/multiboot.c
@@ -71,10 +71,13 @@ void multiboot_entry(struct lcpu *lcpu, struct multiboot_info *mi)
 	if (mi->flags & MULTIBOOT_INFO_CMDLINE) {
 		if (mi->cmdline) {
 			cmdline_len = strlen((const char *)(__uptr)mi->cmdline);
-			mrd.pbase = mi->cmdline;
-			mrd.vbase = mi->cmdline; /* 1:1 mapping */
-			mrd.len   = cmdline_len;
-			mrd.type  = UKPLAT_MEMRT_CMDLINE;
+			/* 1:1 mapping */
+			mrd.pbase = PAGE_ALIGN_DOWN(mi->cmdline);
+			mrd.vbase = mrd.pbase;
+			mrd.pg_off = mi->cmdline - mrd.pbase;
+			mrd.len = cmdline_len;
+			mrd.pg_count = PAGE_COUNT(mrd.pg_off + cmdline_len);
+			mrd.type = UKPLAT_MEMRT_CMDLINE;
 			mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 
 			mrd_insert(bi, &mrd);
@@ -99,9 +102,11 @@ void multiboot_entry(struct lcpu *lcpu, struct multiboot_info *mi)
 	if (mi->flags & MULTIBOOT_INFO_MODS) {
 		mods = (multiboot_module_t *)(__uptr)mi->mods_addr;
 		for (i = 0; i < mi->mods_count; i++) {
-			mrd.pbase = mods[i].mod_start;
-			mrd.vbase = mods[i].mod_start; /* 1:1 mapping */
-			mrd.len   = mods[i].mod_end - mods[i].mod_start;
+			mrd.pbase = PAGE_ALIGN_DOWN(mods[i].mod_start);
+			mrd.vbase = mrd.pbase; /* 1:1 mapping */
+			mrd.pg_off = mods[i].mod_start - mrd.pbase;
+			mrd.len = mods[i].mod_end - mods[i].mod_start;
+			mrd.pg_count = PAGE_COUNT(mrd.pg_off + mrd.len);
 			mrd.type  = UKPLAT_MEMRT_INITRD;
 			mrd.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP;
 
@@ -134,14 +139,21 @@ void multiboot_entry(struct lcpu *lcpu, struct multiboot_info *mi)
 			if (unlikely(end <= start || end - start < PAGE_SIZE))
 				continue;
 
-			mrd.pbase = start;
-			mrd.vbase = start; /* 1:1 mapping */
-			mrd.len   = end - start;
+			mrd.pbase = PAGE_ALIGN_DOWN(start);
+			mrd.vbase = mrd.pbase; /* 1:1 mapping */
+			mrd.pg_off = start - mrd.pbase;
+			mrd.len = end - start;
+			mrd.pg_count = PAGE_COUNT(mrd.pg_off + mrd.len);
 
 			if (m->type == MULTIBOOT_MEMORY_AVAILABLE) {
 				mrd.type  = UKPLAT_MEMRT_FREE;
 				mrd.flags = UKPLAT_MEMRF_READ |
 					    UKPLAT_MEMRF_WRITE;
+
+				/* Free memory regions have
+				 * mrd.len == mrd.pg_count * PAGE_SIZE
+				 */
+				mrd.len = PAGE_ALIGN_UP(mrd.len + mrd.pg_off);
 			} else {
 				mrd.type  = UKPLAT_MEMRT_RESERVED;
 				mrd.flags = UKPLAT_MEMRF_READ |

--- a/plat/kvm/x86/pagetable64.S
+++ b/plat/kvm/x86/pagetable64.S
@@ -117,7 +117,9 @@
 bpt_unmap_mrd:
 	.quad	0x0000000000000000		/* 0 GiB */
 	.quad	0x0000000000000000		/* 0 GiB */
+	.quad	0x0000000000000000		/* Page-aligned */
 	.quad	0x0000000100000000		/* 4 GiB */
+	.quad	0x0000000000100000		/* Page count */
 	.short	0x0000000000000000
 	.short	0x0000000000000010		/* UKPLAT_MEMRF_UNMAP */
 	.fill	36, 1, 0

--- a/support/scripts/mkbootinfo.py
+++ b/support/scripts/mkbootinfo.py
@@ -29,6 +29,7 @@ UKPLAT_BOOTINFO_MAGIC = 0xB007B0B0  # Boot Bobo
 UKPLAT_BOOTINFO_VERSION = 0x01
 
 PAGE_SIZE = 4096
+PAGE_SHIFT = 12
 
 
 def main():
@@ -129,18 +130,23 @@ def main():
 
             # We have 1:1 mapping
             vbase = pbase
+            # Offset in the first page is equal to the start of the first page
+            pg_off = 0
 
             # Align size up to page size
             size = (int(phdr[1], base=16) + (PAGE_SIZE - 1)) & ~(PAGE_SIZE - 1)
             if size == 0:
                 continue
+            pg_count = size >> PAGE_SHIFT
 
             assert nsecs < cap
             nsecs += 1
 
             secobj.write(pbase.to_bytes(8, endianness))  # pbase
             secobj.write(vbase.to_bytes(8, endianness))  # vbase
+            secobj.write(pg_off.to_bytes(8, endianness))  # pg_off
             secobj.write(size.to_bytes(8, endianness))  # len
+            secobj.write(pg_count.to_bytes(8, endianness))  # pg_count
             secobj.write(UKPLAT_MEMRT_KERNEL.to_bytes(2, endianness))  # type
             secobj.write(flags.to_bytes(2, endianness))  # flags
             secobj.write(name)  # name or padding


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

To make memory region management easier w.r.t. alignment handling,
define two additional fields for `struct ukplat_memregion_desc`:
- `pg_off` to represent the in-page offset from where the actual
resource this memory region is dedicated to starts
- `pg_count` to represent the length of the entire, end-to-end
page-aligned, memory region in number of pages

Thus, the definition of some other fields shall then change:
- `pbase` will be the physical page-aligned base address of the
region. This means that in order to get the actual address of a
resource, one may have to make the following basic addition:
        `pbase` + `pg_off`
- `vbase` same as `pbase` but for virtual base address
- `len` will now represent the length of the resource inside the
region, not the length of the region.

E.g.
For a resource with address `0x1050` and length `0x430` the
corresponding memory region descriptor will have the following
values:
- `pbase` and `vbase` equal to `0x1000` (`PAGE_ALIGN_DOWN(0x1050)`)
- `pg_off` equal to `0x50` (`0x1050 & ~PAGE_MASK`)
- `pg_count` equal to `5` (`PAGE_COUNT(0x1050 + 0x430)`)
- `len` equal to `0x430`

The other fields (`type`, `flags`, `name`) will keep their meaning.
