### PR TITLE
lib/vfscore: Use `unsigned long` for `fcntl`'s third argument's type

### DIFF
--- a/lib/vfscore/include/vfscore/syscalls.h
+++ b/lib/vfscore/include/vfscore/syscalls.h
@@ -30,7 +30,7 @@ int vfscore_lseek(struct vfscore_file *fp, off_t off, int type, off_t *origin);
 
 int vfscore_fstat(struct vfscore_file *fp, struct stat *st);
 
-int vfscore_fcntl(struct vfscore_file *fp, unsigned int cmd, int arg);
+int vfscore_fcntl(struct vfscore_file *fp, unsigned int cmd, unsigned long arg);
 int vfscore_ioctl(struct vfscore_file *fp, unsigned long request, void *buf);
 
 #endif /* __VFSCORE_SYSCALLS_H__ */

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1892,7 +1892,7 @@ UK_TRACEPOINT(trace_vfs_fcntl, "%p %d %#x", void *, int, int);
 UK_TRACEPOINT(trace_vfs_fcntl_ret, "\"%s\"", int);
 UK_TRACEPOINT(trace_vfs_fcntl_err, "%d", int);
 
-int vfscore_fcntl(struct vfscore_file *fp, unsigned int cmd, int arg)
+int vfscore_fcntl(struct vfscore_file *fp, unsigned int cmd, unsigned long arg)
 {
 	int ret = 0, error = 0;
 	int tmp, oldf;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Although `fcntl` is most frequently used in conjunction with `int`s as its third argument, the use case involving file locking with operations such as `F_SETLK` or `F_GETLK` may require that the third argument is a pointer.

Therefore, allow for correct addresses above 2G to be passed through `fcntl` by changing the type of the third argument to `unsigned long`.