### PR TITLE
lib/ukboot: Fix warning on undefined variable

### DIFF
--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -442,7 +442,6 @@ static inline int do_main(int argc, char *argv[])
 	char **envp;
 #endif /* CONFIG_LIBPOSIX_ENVIRON */
 	int ret;
-	int i;
 
 	/*
 	 * Application
@@ -488,7 +487,7 @@ static inline int do_main(int argc, char *argv[])
 #endif /* CONFIG_LIBPOSIX_ENVIRON */
 
 	uk_pr_info("Calling main(%d, [", argc);
-	for (i = 0; i < argc; ++i) {
+	for (int i = 0; i < argc; ++i) {
 		uk_pr_info("'%s'", argv[i]);
 		if ((i + 1) < argc)
 			uk_pr_info(", ");


### PR DESCRIPTION
Move variable into conditionally defined loop to silence GCC warning.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Move variable into conditionally defined loop to silence GCC warning.
