### PR TITLE
plat/kvm/arm: Fix implicit declaration of enforce_w_xor_x()

### DIFF
--- a/plat/kvm/arm/setup.c
+++ b/plat/kvm/arm/setup.c
@@ -38,6 +38,10 @@
 #include <arm/smccc.h>
 #include <uk/arch/limits.h>
 
+#if CONFIG_ENFORCE_W_XOR_X && CONFIG_PAGING
+#include <uk/plat/common/w_xor_x.h>
+#endif /* CONFIG_ENFORCE_W_XOR_X && CONFIG_PAGING */
+
 #ifdef CONFIG_ARM64_FEAT_PAUTH
 #include <arm/arm64/pauth.h>
 #endif /* CONFIG_ARM64_FEAT_PAUTH */
@@ -184,7 +188,7 @@ void __no_pauth _ukplat_entry(struct ukplat_bootinfo *bi)
 	if (unlikely(rc))
 		UK_CRASH("Could not initialize paging (%d)\n", rc);
 
-#if defined(CONFIG_ENFORCE_W_XOR_X) && defined(CONFIG_PAGING)
+#if CONFIG_ENFORCE_W_XOR_X && CONFIG_PAGING
 	enforce_w_xor_x();
 #endif /* CONFIG_ENFORCE_W_XOR_X && CONFIG_PAGING */
 


### PR DESCRIPTION
Include `uk/plat/enforce_w_xor_x.h` to fix GCC implicit declaration warning.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Include `uk/plat/enforce_w_xor_x.h` to fix GCC implicit declaration warning.