### PR TITLE
lib/uknetdev: Include `semaphore.h` conditionally to DISPATCHERTHREADS

### DIFF
--- a/lib/uknetdev/include/uk/netdev_driver.h
+++ b/lib/uknetdev/include/uk/netdev_driver.h
@@ -33,8 +33,11 @@
 #define __UK_NETDEV_DRIVER__
 
 #include <uk/netdev_core.h>
-#include <uk/isr/semaphore.h>
 #include <uk/assert.h>
+
+#if CONFIG_LIBUKNETDEV_DISPATCHERTHREADS
+#include <uk/isr/semaphore.h>
+#endif /* CONFIG_LIBUKNETDEV_DISPATCHERTHREADS */
 
 /**
  * Unikraft network driver API.
@@ -86,12 +89,12 @@ static inline void uk_netdev_drv_rx_event(struct uk_netdev *dev,
 
 	rxq_handler = &dev->_data->rxq_handler[queue_id];
 
-#ifdef CONFIG_LIBUKNETDEV_DISPATCHERTHREADS
+#if CONFIG_LIBUKNETDEV_DISPATCHERTHREADS
 	uk_semaphore_up_isr(&rxq_handler->events);
-#else
+#else /* !CONFIG_LIBUKNETDEV_DISPATCHERTHREADS */
 	if (rxq_handler->callback)
 		rxq_handler->callback(dev, queue_id, rxq_handler->cookie);
-#endif
+#endif /* !CONFIG_LIBUKNETDEV_DISPATCHERTHREADS */
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
`uknetdev` selects `uklock` when `CONFIG_LIBUKNETDEV_DISPATCHERTHREADS` is set. Include `semaphore.h` conditionally to that config option to prevent compile errors when dispatcher threads are not enabled.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

`uknetdev` selects `uklock` when `CONFIG_LIBUKNETDEV_DISPATCHERTHREADS` is set. Include `semaphore.h` conditionally to that config option to prevent compile errors when dispatcher threads are not enabled.