### PR TITLE
lib/posix-socket: Socket events

### DIFF
--- a/lib/posix-socket/Config.uk
+++ b/lib/posix-socket/Config.uk
@@ -19,4 +19,14 @@ if LIBPOSIX_SOCKET
 config LIBPOSIX_SOCKET_PRINT_ERRORS
 	bool "Print error messages"
 
+config LIBPOSIX_SOCKET_EVENTS
+	bool "Socket events"
+	help
+		With socket events connection states and endpoints can be tracked
+		independently of the target address family. This happens in the
+		following situtations:
+		- LISTEN: The host listens for incoming connections
+		- ACCEPT: An incoming connection request is accepted
+		- CONNECT: A connection to a remote endpoint is established
+		- CLOSE: A connection or listener is closed
 endif

--- a/lib/posix-socket/events.h
+++ b/lib/posix-socket/events.h
@@ -1,0 +1,191 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+#ifndef __UK_POSIX_SOCKET_EVENT_HELPERS_H__
+#define __UK_POSIX_SOCKET_EVENT_HELPERS_H__
+
+#include <uk/config.h>
+
+#if CONFIG_LIBPOSIX_SOCKET_EVENTS
+#include <uk/socket_event.h>
+#include <uk/alloc.h>
+#include <uk/assert.h>
+#include <uk/essentials.h>
+
+struct uk_socket_event_data {
+	uintptr_t id;
+	int family;
+	int type;
+	int protocol;
+	/* NOTE: We use `struct sockaddr_storage` instead of `struct sockaddr *`
+	 *       to have statically allocated memory of enough space to store
+	 *       any socket address without calling malloc.
+	 *       1) This enables us to provide the event handler functions
+	 *       without requiring any error handling at calling code (e.g.,
+	 *       ENOMEM). 2) We can keep the integration with low overhead.
+	 */
+	struct sockaddr_storage laddr;
+	socklen_t laddr_len;
+	struct sockaddr_storage raddr;
+	socklen_t raddr_len;
+	unsigned int raise_cnt;
+};
+
+static inline void uk_socket_evd_init(struct uk_socket_event_data *evd,
+				      int family, int type, int protocol)
+{
+	UK_ASSERT(evd);
+
+	evd->id         = (uintptr_t)evd; /* use ptr as unique id */
+	evd->raise_cnt  = 0;
+	evd->family     = family;
+	evd->type       = type;
+	evd->protocol   = protocol;
+	evd->laddr_len  = 0;
+	evd->raddr_len  = 0;
+}
+
+/**
+ * Initializes socket event data by copying family, type, and protocol from
+ * another socket event data space. Please note that no address is copied.
+ * Depending on the case, this should be done with
+ * `uk_socket_evd_laddr_set_from()` or `uk_socket_evd_raddr_set_from()`.
+ *
+ * @param evd
+ *  Reference to even data area to initialize
+ * @param from_evd
+ *  Reference to even data area to copy from
+ */
+static inline void uk_socket_evd_init_from(struct uk_socket_event_data *evd,
+					   const struct uk_socket_event_data
+					   *from_evd)
+{
+	UK_ASSERT(evd);
+	UK_ASSERT(from_evd);
+
+	evd->id         = (uintptr_t)evd; /* use ptr as unique id */
+	evd->raise_cnt  = 0;
+	evd->family     = from_evd->family;
+	evd->type       = from_evd->type;
+	evd->protocol   = from_evd->protocol;
+	evd->laddr_len  = 0;
+	evd->raddr_len  = 0;
+}
+
+static inline void uk_socket_evd_laddr_set(struct uk_socket_event_data *evd,
+					   const struct sockaddr *laddr,
+					   socklen_t laddr_len)
+{
+	UK_ASSERT(evd);
+
+	if (!laddr || (laddr_len == 0)) {
+		/* Special case: we unset the address */
+		evd->laddr_len = 0;
+		return;
+	}
+
+	memcpy(&evd->laddr, laddr, laddr_len);
+	evd->laddr_len = laddr_len;
+}
+
+static inline void uk_socket_evd_laddr_set_from(struct uk_socket_event_data
+						*evd,
+						const
+						struct uk_socket_event_data
+						*from_evd)
+{
+	uk_socket_evd_laddr_set(evd, (const struct sockaddr *)&from_evd->laddr,
+				from_evd->laddr_len);
+}
+
+static inline void uk_socket_evd_raddr_set(struct uk_socket_event_data *evd,
+					   const struct sockaddr *raddr,
+					   socklen_t raddr_len)
+{
+	UK_ASSERT(evd);
+
+	if (!raddr || (raddr_len == 0)) {
+		/* Special case: we unset the address */
+		evd->raddr_len = 0;
+		return;
+	}
+
+	memcpy(&evd->raddr, raddr, raddr_len);
+	evd->raddr_len = raddr_len;
+}
+
+static inline void uk_socket_evd_raddr_set_from(struct uk_socket_event_data
+						*evd,
+						const
+						struct uk_socket_event_data
+						*from_evd)
+{
+	uk_socket_evd_raddr_set(evd, (const struct sockaddr *)&from_evd->raddr,
+				from_evd->raddr_len);
+}
+
+static inline void uk_socket_event_raise(struct uk_socket_event_data *evd,
+					 enum uk_socket_event_type event)
+{
+	struct uk_socket_event emsg = {
+		.id        = evd->id,
+		.event     = event,
+		.family    = evd->family,
+		.type      = evd->type,
+		.protocol  = evd->protocol,
+		.laddr_len = evd->laddr_len,
+		.laddr     = (evd->laddr_len == 0) ?
+				NULL : (const struct sockaddr *)&evd->laddr,
+		.raddr_len = evd->raddr_len,
+		.raddr     = (evd->raddr_len == 0) ?
+				NULL : (const struct sockaddr *)&evd->raddr,
+	};
+
+	evd->raise_cnt++;
+	uk_raise_event(UK_POSIX_SOCKET_EVENT, &emsg);
+}
+
+static inline unsigned int uk_socket_event_raise_count(struct
+						       uk_socket_event_data
+						       *evd)
+{
+	UK_ASSERT(evd);
+
+	return evd->raise_cnt;
+}
+
+UK_EVENT(UK_POSIX_SOCKET_EVENT);
+
+#else /* !CONFIG_LIBPOSIX_SOCKET_EVENTS */
+
+/*
+ * Stubs
+ */
+
+struct uk_socket_event_data;
+
+#define uk_socket_evd_init(evd, family, type, protocol) \
+	do {} while (0)
+#define uk_socket_evd_init_from(evd, from_evd) \
+	do {} while (0)
+#define uk_socket_evd_laddr_set(evd, laddr, laddr_len) \
+	do {} while (0)
+#define uk_socket_evd_laddr_set_from(evd, from_evd) \
+	do {} while (0)
+#define uk_socket_evd_raddr_set(evd, raddr, raddr_len) \
+	do {} while (0)
+#define uk_socket_evd_raddr_set_from(evd, from_evd) \
+	do {} while (0)
+#define uk_socket_event_raise(evd, event) \
+	do {} while (0)
+#define uk_socket_event_raise_count(evd) \
+	({ 0; })
+
+#endif /* !CONFIG_LIBPOSIX_SOCKET_EVENTS */
+
+#define uk_socket_event_has_raised(evd)		\
+	(uk_socket_event_raise_count(evd) != 0)
+
+#endif /* __UK_POSIX_SOCKET_EVENT_HELPERS_H__ */

--- a/lib/posix-socket/include/uk/socket_event.h
+++ b/lib/posix-socket/include/uk/socket_event.h
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+#ifndef __UK_POSIX_SOCKET_EVENT_H__
+#define __UK_POSIX_SOCKET_EVENT_H__
+
+#include <uk/config.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <uk/event.h>
+
+/*
+ * POSIX Socket Events are emitted events that can be used to track
+ * connection states and endpoints of sockets
+ */
+
+enum uk_socket_event_type {
+	UK_SOCKET_EVENT_INVALID = 0,  /**< INVALID: Should never be emitted */
+	UK_SOCKET_EVENT_LISTEN,       /**< New listener for incom. connect. */
+	UK_SOCKET_EVENT_ACCEPT,       /**< Incoming connection accepted */
+	UK_SOCKET_EVENT_CONNECT,      /**< Connection to remote established */
+	UK_SOCKET_EVENT_CLOSE         /**< Connection or listener closed */
+
+};
+
+struct uk_socket_event;
+
+#if CONFIG_LIBPOSIX_SOCKET_EVENTS
+/*
+ * Socket event data structure
+ */
+struct uk_socket_event {
+	uintptr_t id;                 /**< Unique socket identifier
+				       *   NOTE: Can be re-used for a new socket
+				       *         after CLOSE
+				       */
+	enum uk_socket_event_type event;
+	int family;
+	int type;
+	int protocol;
+	const struct sockaddr *laddr; /**< Local address
+				       *   Can be NULL if a socket is not `bind`
+				       */
+	socklen_t laddr_len;
+	const struct sockaddr *raddr; /**< Remote address
+				       *   Can be NULL for listening sockets,
+				       *   should have a value on ACCEPT and
+				       *   CONNECT
+				       */
+	socklen_t raddr_len;
+};
+
+#endif /* CONFIG_LIBPOSIX_SOCKET_EVENTS */
+#endif /* __UK_POSIX_SOCKET_EVENT_H__ */


### PR DESCRIPTION
### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

 - `CONFIG_LIBPOSIX_SOCKET=y`
 - `CONFIG_LIBPOSIX_SOCKET_EVENTS=y`

### Description of changes

POSIX-Socket events are events that can be used to track socket connections. As part of the provided information, also the endpoint addresses (local and remote) are reported. Because the implementation is purely integrated to `lib/posix-socket`, it is independent of the target address family or underlying network stack or implementation.
An event is emitted in the following situations:
- LISTEN: The host listens on a given address for incoming connections
- ACCEPT: An incoming connection is accepted
- CONNECT: A connection to a remote endpoint is established
- CLOSE: A connection or listener is closed

The following snippet is a short example that demonstrates the integration and receiving of  event messages: `example.c`:

```c
#include <sys/socket.h>
#include <uk/socket_event.h>
#include <uk/print.h>
#include <uk/hexdump.h>

static const char *evname(enum uk_socket_event_type event)
{
	switch (event) {
	case UK_SOCKET_EVENT_LISTEN:
		return "listen";
	case UK_SOCKET_EVENT_ACCEPT:
		return "accept";
	case UK_SOCKET_EVENT_CONNECT:
		return "connect";
	case UK_SOCKET_EVENT_CLOSE:
		return "close";
	default:
	}

	return "<undef>";
}

static const char *afname(int family)
{
	switch (family) {
	case AF_UNIX:
		return "unix";
	case AF_INET:
		return "inet";
	case AF_INET6:
		return "inet6";
	default:
	}

	return "<unknown>";
}

static const char *stname(int sockettype)
{
	sockettype &= ~ SOCK_NONBLOCK;
	sockettype &= ~ SOCK_CLOEXEC;

	switch (sockettype) {
	case SOCK_STREAM:
		return "stream";
	case SOCK_DGRAM:
		return "dgram";
	case SOCK_RAW:
		return "raw";
	case SOCK_SEQPACKET:
		return "seqpacket";
	case SOCK_RDM:
		return "rdm";
	default:
	}

	return "<unknown>";
}

static void socket_event(const struct uk_socket_event *e)
{
	uk_pr_crit("- SOCKET EVENT ------------\n");
	uk_pr_crit("socket id: 0x%"__PRIx64"\n", (__u64)e->id);
	uk_pr_crit("event:     %s\n", evname(e->event));
	uk_pr_crit("family:    %s (%u)\n", afname(e->family), e->family);
	uk_pr_crit("type:      %s (%u)\n", stname(e->type), e->type);
	uk_pr_crit("protocol:  %u\n", e->protocol);
	uk_pr_crit("laddr_len: %u\n", e->laddr_len);
	uk_hexdumpk(KLVL_CRIT, e->laddr, e->laddr_len, UK_HXDF_GRPQWORD, 2);
	uk_pr_crit("raddr_len: %u\n", e->raddr_len);
	uk_hexdumpk(KLVL_CRIT, e->raddr, e->raddr_len, UK_HXDF_GRPQWORD, 2);
	uk_pr_crit("===========================\n");
}

UK_SOCKET_EVENT_RECEIVER(AF_INET, socket_event);
```