### PR TITLE
lib/posix-pipe: Fix stack overflow on struct init

### DIFF
--- a/lib/posix-pipe/pipe.c
+++ b/lib/posix-pipe/pipe.c
@@ -287,11 +287,10 @@ int uk_pipefile_create(struct uk_file *pipes[2], int flags)
 		return -ENOMEM;
 
 	al->alloc = a;
-	al->node = (struct pipe_node){
-		.flags = 0,
-		.rhead = 0,
-		.whead = 0,
-	};
+	al->node.flags = 0;
+	al->node.rhead = 0;
+	al->node.whead = 0;
+	memset(al->node.buf, 0, sizeof(al->node.buf));
 	al->fstate = UK_FILE_STATE_INITIALIZER(al->fstate);
 	al->rref = UK_FILE_REFCNT_INITIALIZER;
 	al->wref = UK_FILE_REFCNT_INITIALIZER;


### PR DESCRIPTION
### Description of changes

The initialization of `struct pipe_node` in `uk_pipefile_create` could previously cause a stack overflow due to the struct initializer being stored on the stack, containing the entire pipe buffer. This change prevents this failure case by ensuring that the pipe node is initialized with assignments and memset.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A