### PR TITLE
lib/posix-fdtab: Export fdtab init priority

### DIFF
--- a/lib/devfs/include/devfs/device.h
+++ b/lib/devfs/include/devfs/device.h
@@ -126,6 +126,6 @@ int device_destroy(struct device *dev);
  * at priority '3'.
  */
 #define devfs_initcall(fn)						\
-	uk_rootfs_initcall_prio(fn, 0x0, UK_PRIO_AFTER(UK_LIBPOSIX_FDTAB_PRIO))
+	uk_rootfs_initcall_prio(fn, 0x0, UK_PRIO_AFTER(UK_LIBPOSIX_FDTAB_INIT_PRIO))
 
 #endif /* !__DEVFS_DEVICE_H__ */

--- a/lib/posix-fdtab/fdtab.c
+++ b/lib/posix-fdtab/fdtab.c
@@ -381,7 +381,7 @@ static void term_posix_fdtab(const struct uk_term_ctx *tctx __unused)
 }
 
 /* Init fdtab as early as possible, to enable functions that rely on fds */
-uk_lib_initcall_prio(init_posix_fdtab, 0x0, UK_PRIO_EARLIEST);
+uk_lib_initcall_prio(init_posix_fdtab, 0x0, UK_LIBPOSIX_FDTAB_INIT_PRIO);
 /* Place fd cleanup to run latest before any rootfs terminators */
 uk_rootfs_initcall_prio(0x0, term_posix_fdtab, UK_PRIO_LATEST);
 

--- a/lib/posix-fdtab/include/uk/posix-fdtab.h
+++ b/lib/posix-fdtab/include/uk/posix-fdtab.h
@@ -12,6 +12,7 @@
 #include <uk/config.h>
 #include <uk/ofile.h>
 
+#define UK_LIBPOSIX_FDTAB_INIT_PRIO	UK_PRIO_EARLIEST
 #define UK_FD_MAX INT_MAX
 
 /**


### PR DESCRIPTION
Commit 9dc2701 changed the fdtab init priority and removed the macro that exported it. `lib/devfs/` however uses the `fdtab` init priority to register it's own devices, calling
`uk_rootfs_initcall_prio(..., UK_PRIO_AFTER(UK_LIBPOSIX_FDTAB_PRIO))`, resulting in the `devfs` devices not being registered at all.

Reintroduce the macro used to export the fdtab init priority and set it to `UK_PRIO_EARLIEST`.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Additional configuration

You can see [issue #31 on the catalog repo](https://github.com/unikraft/catalog/issues/31).
Adding this line `access_log /dev/stdout;` in the `nginx` config file will lead to an error:
```
open() "/dev/stdout" failed (22: Unknown error)
```

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->
