### PR TITLE
lib/posix-unixsocket: Silence unused variable warnings

### DIFF
--- a/lib/posix-unixsocket/unixsock.c
+++ b/lib/posix-unixsocket/unixsock.c
@@ -158,8 +158,9 @@ out:
 
 
 static
-void unix_sock_rdown(uk_pollevent ev,
-		     enum uk_poll_chain_op op, struct uk_poll_chain *tick)
+void unix_sock_rdown(uk_pollevent ev __maybe_unused,
+		     enum uk_poll_chain_op op __maybe_unused,
+		     struct uk_poll_chain *tick)
 {
 	struct unix_sock_data *d;
 	struct uk_pollq *sockq;
@@ -177,8 +178,9 @@ void unix_sock_rdown(uk_pollevent ev,
 }
 
 static
-void unix_sock_wdown(uk_pollevent ev,
-		     enum uk_poll_chain_op op, struct uk_poll_chain *tick)
+void unix_sock_wdown(uk_pollevent ev __maybe_unused,
+		     enum uk_poll_chain_op op __maybe_unused,
+		     struct uk_poll_chain *tick)
 {
 	struct unix_sock_data *d;
 	struct uk_pollq *sockq;


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The `ev` and `op` parameters of `unix_sock_rdown()` and `unix_sock_wdown()` are only used by `UK_ASSERT()` which is defined conditionally. Declare as `_maybe_unused` to silence GCC warnings.
