### PR TITLE
lib/fdtab: Fix compiler warnings

### DIFF
--- a/lib/posix-fdtab/fdtab.c
+++ b/lib/posix-fdtab/fdtab.c
@@ -360,9 +360,7 @@ static void fdtab_cleanup(int all)
 			struct fdval v = fdtab_decode(p);
 
 			if (all || (v.flags & UK_FDTAB_CLOEXEC)) {
-				void *pp = uk_fmap_take(fmap, i);
-
-				UK_ASSERT(p == pp);
+				UK_ASSERT(p == uk_fmap_take(fmap, i));
 				file_rel(tab, v.p, v.flags);
 			}
 		}

--- a/lib/posix-fdtab/fmap.h
+++ b/lib/posix-fdtab/fmap.h
@@ -164,7 +164,7 @@ static inline void *uk_fmap_lookup(const struct uk_fmap *m, int idx)
 static inline
 int uk_fmap_put(const struct uk_fmap *m, const void *p, int min)
 {
-	void *got;
+	void *got __maybe_unused;
 	int pos;
 
 	pos = uk_bmap_request(&m->bmap, min);
@@ -250,7 +250,7 @@ void *uk_fmap_critical_take(const struct uk_fmap *m, int idx)
 static inline
 int uk_fmap_critical_put(const struct uk_fmap *m, int idx, const void *p)
 {
-	void *got;
+	void *got __maybe_unused;
 
 	if (!_FMAP_INRANGE(m, idx))
 		return -1;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Define the `got` variable as `__maybe_unused` in `uk_fmap_put()` and `uk_fmap_critical_put`, as it is only used by `UK_ASSERT()` causing compiler warnings on unused variable.
    
Eliminate the `pp` variable in `fdtab_cleanup()`, as it is only used by `UK_ASSERT()` causing a compiler warning when
the latter is not defined.
