### PR TITLE
lib/posix-fdtab: Fix fdtab cleanup w/o asserts

### DIFF
--- a/lib/posix-fdtab/fdtab.c
+++ b/lib/posix-fdtab/fdtab.c
@@ -360,7 +360,10 @@ static void fdtab_cleanup(int all)
 			struct fdval v = fdtab_decode(p);
 
 			if (all || (v.flags & UK_FDTAB_CLOEXEC)) {
-				UK_ASSERT(p == uk_fmap_take(fmap, i));
+				void **pp __maybe_unused;
+
+				pp = uk_fmap_take(fmap, i);
+				UK_ASSERT(p == pp);
 				file_rel(tab, v.p, v.flags);
 			}
 		}


### PR DESCRIPTION
### Description of changes

Commit 12f7eda56cb1 ("lib/posix-fdtab: Silence unused variable warning") moved `uk_fdtab_take` into an assert statement, preventing its side-effects when asserts are disabled.
This change corrects this, ensuring that `uk_fdtab_take` is run regardless of whether asserts are enabled or not.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Observable behavior should be the same whether `CONFIG_LIBUKDEBUG_ENABLE_ASSERT` is enabled or not.
Warnings should not be emitted in either case.