### PR TITLE
lib/devfs: select rootfs automount on devfs automount

### DIFF
--- a/lib/devfs/Config.uk
+++ b/lib/devfs/Config.uk
@@ -6,6 +6,7 @@ menuconfig LIBDEVFS
 if LIBDEVFS
 	config LIBDEVFS_AUTOMOUNT
 	bool "Mount /dev during boot"
+	select LIBVFSCORE_AUTOMOUNT_ROOTFS
 	default n
 
 	# hidden


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation. (no documentation to update)


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

devfs automount fails without rootfs automount:
```
[    0.102003] ERR:  [libdevfs] <devfs_vnops.c @  315> Failed to create /dev: 20
[    0.107465] ERR:  [libukboot] <boot.c @  393> Init function at 0x116ea0 returned error -1
```

When `LIBVFSCORE_AUTOMOUNT_ROOTFS` is selected, `ramfs` is chosen by default, which is a reasonable choice if you just need `/dev`.