### PR TITLE
{include/,lib/*}: Separate initializers from anonymous right-hand values

### DIFF
--- a/include/uk/refcount.h
+++ b/include/uk/refcount.h
@@ -56,7 +56,13 @@ extern "C" {
 	} while (0)
 #endif /* CONFIG_LIBUKDEBUG */
 
-#define UK_REFCOUNT_INITIALIZER(val) ((__atomic){ .counter = (val) })
+/*
+ * We define initializers separate from an initial values.
+ * The former can only be used in (static) variable initializations, while the
+ * latter is meant for assigning to variables or as anonymous data structures.
+ */
+#define UK_REFCOUNT_INITIALIZER(val) { .counter = (val) }
+#define UK_REFCOUNT_INIT_VALUE(val) ((__atomic)UK_REFCOUNT_INITIALIZER(val))
 
 /**
  * Initialize the atomic reference.

--- a/include/uk/weak_refcount.h
+++ b/include/uk/weak_refcount.h
@@ -17,10 +17,17 @@ struct uk_swrefcount {
 	__atomic strong; /* Number of strong references; <= .refcount */
 };
 
-#define UK_SWREFCOUNT_INITIALIZER(r, s) ((struct uk_swrefcount){ \
+/*
+ * We define initializers separate from an initial values.
+ * The former can only be used in (static) variable initializations, while the
+ * latter is meant for assigning to variables or as anonymous data structures.
+ */
+#define UK_SWREFCOUNT_INITIALIZER(r, s) { \
 	.refcount = UK_REFCOUNT_INITIALIZER((r)), \
 	.strong = UK_REFCOUNT_INITIALIZER((s)), \
-})
+}
+#define UK_SWREFCOUNT_INIT_VALUE(r, s) \
+	((struct uk_swrefcount)UK_SWREFCOUNT_INITIALIZER((r), (s)))
 
 /**
  * Initialize refcount with `ref` references, of which `strong` are strong.

--- a/lib/posix-eventfd/eventfd.c
+++ b/lib/posix-eventfd/eventfd.c
@@ -136,7 +136,7 @@ struct uk_file *uk_eventfile_create(unsigned int count, int flags)
 
 	al->alloc = a;
 	al->counter = count;
-	al->fstate = UK_FILE_STATE_INITIALIZER(al->fstate);
+	al->fstate = UK_FILE_STATE_INIT_VALUE(al->fstate);
 	al->frefcnt = UK_FILE_REFCNT_INIT_VALUE;
 	al->f = (struct uk_file){
 		.vol = vol,

--- a/lib/posix-eventfd/eventfd.c
+++ b/lib/posix-eventfd/eventfd.c
@@ -137,7 +137,7 @@ struct uk_file *uk_eventfile_create(unsigned int count, int flags)
 	al->alloc = a;
 	al->counter = count;
 	al->fstate = UK_FILE_STATE_INITIALIZER(al->fstate);
-	al->frefcnt = UK_FILE_REFCNT_INITIALIZER;
+	al->frefcnt = UK_FILE_REFCNT_INIT_VALUE;
 	al->f = (struct uk_file){
 		.vol = vol,
 		.node = &al->counter,

--- a/lib/posix-pipe/pipe.c
+++ b/lib/posix-pipe/pipe.c
@@ -291,7 +291,7 @@ int uk_pipefile_create(struct uk_file *pipes[2], int flags)
 	al->node.rhead = 0;
 	al->node.whead = 0;
 	memset(al->node.buf, 0, sizeof(al->node.buf));
-	al->fstate = UK_FILE_STATE_INITIALIZER(al->fstate);
+	al->fstate = UK_FILE_STATE_INIT_VALUE(al->fstate);
 	al->rref = UK_FILE_REFCNT_INIT_VALUE;
 	al->wref = UK_FILE_REFCNT_INIT_VALUE;
 	al->rf = (struct uk_file){

--- a/lib/posix-pipe/pipe.c
+++ b/lib/posix-pipe/pipe.c
@@ -292,8 +292,8 @@ int uk_pipefile_create(struct uk_file *pipes[2], int flags)
 	al->node.whead = 0;
 	memset(al->node.buf, 0, sizeof(al->node.buf));
 	al->fstate = UK_FILE_STATE_INITIALIZER(al->fstate);
-	al->rref = UK_FILE_REFCNT_INITIALIZER;
-	al->wref = UK_FILE_REFCNT_INITIALIZER;
+	al->rref = UK_FILE_REFCNT_INIT_VALUE;
+	al->wref = UK_FILE_REFCNT_INIT_VALUE;
 	al->rf = (struct uk_file){
 		.vol = PIPE_VOLID,
 		.node = &al->node,

--- a/lib/posix-poll/epoll.c
+++ b/lib/posix-poll/epoll.c
@@ -362,7 +362,7 @@ struct uk_file *uk_epollfile_create(void)
 	al->alloc = a;
 	al->list = NULL;
 	al->fstate = UK_FILE_STATE_INITIALIZER(al->fstate);
-	al->frefcnt = UK_FILE_REFCNT_INITIALIZER;
+	al->frefcnt = UK_FILE_REFCNT_INIT_VALUE;
 	al->f = (struct uk_file){
 		.vol = EPOLL_VOLID,
 		.node = &al->list,

--- a/lib/posix-poll/epoll.c
+++ b/lib/posix-poll/epoll.c
@@ -361,7 +361,7 @@ struct uk_file *uk_epollfile_create(void)
 	/* Set fields */
 	al->alloc = a;
 	al->list = NULL;
-	al->fstate = UK_FILE_STATE_INITIALIZER(al->fstate);
+	al->fstate = UK_FILE_STATE_INIT_VALUE(al->fstate);
 	al->frefcnt = UK_FILE_REFCNT_INIT_VALUE;
 	al->f = (struct uk_file){
 		.vol = EPOLL_VOLID,

--- a/lib/posix-poll/epoll.c
+++ b/lib/posix-poll/epoll.c
@@ -217,9 +217,11 @@ static int epoll_add(const struct uk_file *epf, struct epoll_entry **tail,
 		.fd = fd,
 		.f = f,
 		.event = *event,
-		.tick = UK_POLL_CHAIN_CALLBACK(events2mask(event->events),
-					       epoll_event_callback,
-					       &epf->state->pollq),
+		.tick = UK_POLL_CHAIN_CALLBACK_INITIALIZER(
+			events2mask(event->events),
+			epoll_event_callback,
+			&epf->state->pollq
+		),
 		.revents = 0
 	};
 	*tail = ent;

--- a/lib/posix-socket/socket.c
+++ b/lib/posix-socket/socket.c
@@ -230,7 +230,7 @@ static void _socket_init(struct socket_alloc *al,
 		.driver = d
 	};
 	al->fstate = UK_FILE_STATE_INITIALIZER(al->fstate);
-	al->fref = UK_FILE_REFCNT_INITIALIZER;
+	al->fref = UK_FILE_REFCNT_INIT_VALUE;
 	al->f = (struct uk_file){
 		.vol = POSIX_SOCKET_VOLID,
 		.node = &al->node,

--- a/lib/posix-socket/socket.c
+++ b/lib/posix-socket/socket.c
@@ -229,7 +229,7 @@ static void _socket_init(struct socket_alloc *al,
 		.sock_data = sock_data,
 		.driver = d
 	};
-	al->fstate = UK_FILE_STATE_INITIALIZER(al->fstate);
+	al->fstate = UK_FILE_STATE_INIT_VALUE(al->fstate);
 	al->fref = UK_FILE_REFCNT_INIT_VALUE;
 	al->f = (struct uk_file){
 		.vol = POSIX_SOCKET_VOLID,

--- a/lib/posix-timerfd/timerfd.c
+++ b/lib/posix-timerfd/timerfd.c
@@ -225,7 +225,7 @@ struct uk_file *uk_timerfile_create(clockid_t id)
 		.upthread = NULL
 	};
 	al->fstate = UK_FILE_STATE_INITIALIZER(al->fstate);
-	al->frefcnt = UK_FILE_REFCNT_INITIALIZER;
+	al->frefcnt = UK_FILE_REFCNT_INIT_VALUE;
 	al->f = (struct uk_file){
 		.vol = TIMERFD_VOLID,
 		.node = &al->node,

--- a/lib/posix-timerfd/timerfd.c
+++ b/lib/posix-timerfd/timerfd.c
@@ -224,7 +224,7 @@ struct uk_file *uk_timerfile_create(clockid_t id)
 		.clkid = id,
 		.upthread = NULL
 	};
-	al->fstate = UK_FILE_STATE_INITIALIZER(al->fstate);
+	al->fstate = UK_FILE_STATE_INIT_VALUE(al->fstate);
 	al->frefcnt = UK_FILE_REFCNT_INIT_VALUE;
 	al->f = (struct uk_file){
 		.vol = TIMERFD_VOLID,

--- a/lib/ukfile/include/uk/file.h
+++ b/lib/ukfile/include/uk/file.h
@@ -104,10 +104,18 @@ struct uk_file_state {
 	/* TODO */
 };
 
-#define UK_FILE_STATE_INITIALIZER(name) ((struct uk_file_state){ \
+/*
+ * We define initializers separate from an initial values.
+ * The former can only be used in (static) variable initializations, while the
+ * latter is meant for assigning to variables or as anonymous data structures.
+ */
+#define UK_FILE_STATE_INITIALIZER(name) { \
 	.iolock = UK_RWLOCK_INITIALIZER((name).iolock, 0), \
 	.pollq = UK_POLLQ_INITIALIZER((name).pollq) \
-})
+}
+#define UK_FILE_STATE_INIT_VALUE(name) \
+	((struct uk_file_state)UK_FILE_STATE_INITIALIZER(name))
+
 
 /*
  * Reference count type used by uk_file.
@@ -132,6 +140,7 @@ struct uk_file {
 };
 
 /* Files always get created with one strong reference held */
+/* See above comment for file state on initializers vs initial values */
 #define UK_FILE_REFCNT_INITIALIZER UK_SWREFCOUNT_INITIALIZER(1, 1)
 #define UK_FILE_REFCNT_INIT_VALUE UK_SWREFCOUNT_INIT_VALUE(1, 1)
 

--- a/lib/ukfile/include/uk/file.h
+++ b/lib/ukfile/include/uk/file.h
@@ -133,6 +133,7 @@ struct uk_file {
 
 /* Files always get created with one strong reference held */
 #define UK_FILE_REFCNT_INITIALIZER UK_SWREFCOUNT_INITIALIZER(1, 1)
+#define UK_FILE_REFCNT_INIT_VALUE UK_SWREFCOUNT_INIT_VALUE(1, 1)
 
 /* Operations inlines */
 static inline

--- a/lib/ukfile/include/uk/file/pollqueue.h
+++ b/lib/ukfile/include/uk/file/pollqueue.h
@@ -134,29 +134,34 @@ struct uk_pollq {
 	struct uk_rwlock waitlock; /* Wait list lock */
 };
 
+/*
+ * We define initializers separate from an initial values.
+ * The former can only be used in (static) variable initializations, while the
+ * latter is meant for assigning to variables or as anonymous data structures.
+ */
 #if CONFIG_LIBUKFILE_CHAINUPDATE
-#define UK_POLLQ_INITIALIZER(q) \
-	((struct uk_pollq){ \
-		.wait = NULL, \
-		.waitend = &(q).wait, \
-		.prop = NULL, \
-		.propend = &(q).prop, \
-		.events = 0, \
-		.waitmask = 0, \
-		.propmask = 0, \
-		.proplock = UK_RWLOCK_INITIALIZER((q).proplock, 0), \
-		.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0), \
-	})
+#define UK_POLLQ_INITIALIZER(q) { \
+	.wait = NULL, \
+	.waitend = &(q).wait, \
+	.prop = NULL, \
+	.propend = &(q).prop, \
+	.events = 0, \
+	.waitmask = 0, \
+	.propmask = 0, \
+	.proplock = UK_RWLOCK_INITIALIZER((q).proplock, 0), \
+	.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0), \
+}
 #else /* !CONFIG_LIBUKFILE_CHAINUPDATE */
-#define UK_POLLQ_INITIALIZER(q) \
-	((struct uk_pollq){ \
-		.wait = NULL, \
-		.waitend = &(q).wait, \
-		.events = 0, \
-		.waitmask = 0, \
-		.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0), \
-	})
+#define UK_POLLQ_INITIALIZER(q) { \
+	.wait = NULL, \
+	.waitend = &(q).wait, \
+	.events = 0, \
+	.waitmask = 0, \
+	.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0), \
+}
 #endif /* !CONFIG_LIBUKFILE_CHAINUPDATE */
+
+#define UK_POLLQ_INIT_VALUE(q) ((struct uk_pollq)UK_POLLQ_INITIALIZER(q))
 
 /**
  * Initialize the fields of `q` to a valid empty state.

--- a/lib/ukfile/include/uk/file/pollqueue.h
+++ b/lib/ukfile/include/uk/file/pollqueue.h
@@ -90,23 +90,29 @@ struct uk_poll_chain {
 	};
 };
 
+/* See comment for main queue below on initializers vs initial values */
+
 /* Initializer for a chain ticket that propagates events to another queue */
-#define UK_POLL_CHAIN_UPDATE(msk, to, ev) ((struct uk_poll_chain){ \
+#define UK_POLL_CHAIN_UPDATE_INITIALZER(msk, to, ev) { \
 	.next = NULL, \
 	.mask = (msk), \
 	.type = UK_POLL_CHAINTYPE_UPDATE, \
 	.queue = (to), \
 	.set = (ev) \
-})
+}
+#define UK_POLL_CHAIN_UPDATE(msk, to, ev) ((struct uk_poll_chain) \
+	UK_POLL_CHAIN_UPDATE_INITIALZER((msk), (to), (ev)))
 
 /* Initializer for a chain ticket that calls a custom callback */
-#define UK_POLL_CHAIN_CALLBACK(msk, cb, dat) ((struct uk_poll_chain){ \
+#define UK_POLL_CHAIN_CALLBACK_INITIALIZER(msk, cb, dat) { \
 	.next = NULL, \
 	.mask = (msk), \
 	.type = UK_POLL_CHAINTYPE_CALLBACK, \
 	.callback = (cb), \
 	.arg = (dat) \
-})
+}
+#define UK_POLL_CHAIN_CALLBACK(msk, cb, dat) ((struct uk_poll_chain) \
+	UK_POLL_CHAIN_CALLBACK_INITIALIZER((msk), (cb), (dat)))
 
 #endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
 


### PR DESCRIPTION
### Description of changes

This changeset separates the struct initializer macros related to `lib/ukfile` into separate macros for initializers and value assignment. Specifically:
- _initializers_ are macros that can be used as initializer in (static) variable declarations.
- _values_ are macros that expand to a valid anonymous struct value, usable in variable assignments or function call arguments.

This change is needed because initializer expressions and right-hand values are different (and somewhat orthogonal) concepts in C, thus strictly conforming compilers are not required to cast between the two and might reject the use of one in place of the other. One notable example is GCC <= 12.

Downstream code which used the old initializer macros has been fixed to correctly use either initializers or values.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A