### PR TITLE
lib/posix-poll: Fix poll() ignoring fd 0

### DIFF
--- a/lib/posix-poll/poll.c
+++ b/lib/posix-poll/poll.c
@@ -62,7 +62,7 @@ int uk_sys_ppoll(struct pollfd *fds, nfds_t nfds,
 		struct pollfd *p = &fds[i];
 		int r = 0;
 
-		if (p->fd > 0) {
+		if (p->fd >= 0) {
 			struct epoll_event ev = {
 				.events = p->events,
 				.data.fd = p->fd


### PR DESCRIPTION
### Description of changes

This change fixes a bug where poll() would ignore fd 0 as if it were a negative fd, which are explicitly allowed as NOP entries.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Additional configuration

`CONFIG_LIBPOSIX_POLL=y`

Test snippet (assumes fd:0 is tty stdin):
```c
struct pollfd fds = {
	.fd = 0,
	.events = POLLIN|POLLOUT
};
int r = poll(&fds, 1, 1000);
printf("%d %d %hd\n", r, errno, fds.revents);
```
On Linux `poll` immediately returns with `POLLOUT` set.
On `staging`, with or without this fix, Unikraft waits until the timeout, because vfscore stdio files never emit events.

Applying https://github.com/unikraft/unikraft/pull/1226 that implements tty files more consistently we can test the above snippet. 
(GCC 13 or clang is required, otherwise you also need https://github.com/unikraft/unikraft/pull/1245)

Without fix, Unikraft waits until the timeout, with the fix it immediately returns `POLLIN|POLLOUT`.