### PR TITLE
plat/kvm/arm: Ensure restoration of `x0` on binary system calls

### DIFF
--- a/plat/kvm/arm/exceptions.S
+++ b/plat/kvm/arm/exceptions.S
@@ -129,11 +129,10 @@
 	str	x0, [sp, #__SP_OFFSET]  /* Store old SP in auxiliary stack */
 	b	1f
 0:
-	/* Restore x0 */
-	mrs     x0, tpidrro_el0
-
 	sub	sp, sp, #__TRAP_STACK_SIZE
 1:
+	/* Restore x0 */
+	mrs     x0, tpidrro_el0
 
 	/* Save general purpose registers */
 	stp	x0, x1, [sp, #16 * 0]


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Commit 76d5701c19b0 ("lib/syscall_shim: Save `struct uk_syscall_ctx` on binary syscalls") placed the `1:` label to be used by binary system calls to avoid subtracting the register frame size that would normally be done during the handling of other trap types and instead use the per-thread auxiliary stack from which `UK_SYSCALL_CTX_SIZE` was already previously subtracted. However, this label placement skips restoration of `x0` which was originally stored in the `TPIDRRO_EL0` system register.

Fix this by always restoring the `x0` register on both paths: binary system call traps and other traps.

Relevant [discussion](https://github.com/unikraft/unikraft/pull/1175#discussion_r1442569750) from #1175 