### PR TITLE
plat/common/lcpu: Fix re-def warnings of `LCPU_AUXSP_OFFSET`

### DIFF
--- a/plat/common/include/uk/plat/common/lcpu.h
+++ b/plat/common/include/uk/plat/common/lcpu.h
@@ -97,6 +97,10 @@ UK_CTASSERT(sizeof(struct lcpu_sargs) == LCPU_SARGS_SIZE);
 #define LCPU_ENTRY_OFFSET		(LCPU_ID_OFFSET    + 0x08)
 #define LCPU_STACKP_OFFSET		(LCPU_ENTRY_OFFSET + 0x08)
 #define LCPU_ERR_OFFSET			(LCPU_ENTRY_OFFSET + 0x00)
+/* TODO: See comment from syscall_prologue.h architecture specific files */
+#ifdef LCPU_AUXSP_OFFSET
+#undef LCPU_AUXSP_OFFSET
+#endif /* LCPU_AUXSP_OFFSET */
 #define LCPU_AUXSP_OFFSET		(LCPU_ENTRY_OFFSET + 0x10)
 #define LCPU_ARCH_OFFSET		(LCPU_ENTRY_OFFSET + 0x18)
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Add a temporary fix for the re-definition of the `LCPU_AUXSP_OFFSET` macro warnings. This is caused by `syscall_prologue.h` architecture specific files already having their own local temporary definition of the macro due to it not being a good idea to include the very header that defines this macro because it would create unwanted dependencies throughout libraries that include `uk/syscall.h`. Thus, in the case where `uk/syscall.h` is included before `uk/plat/common/lcpu.h`, a warning related to the re-definition of the macro is issued.

This must be fixed ASAP as part of the plat re-architecting track where the LCPU subsystem is moved to its own driver/library and thus getting rid of the weird dependencies. Until then, unfortunately, care must be taken when keeping track of `LCPU_*` macro changes as these might also have to be done in `syscall_prologue.h`.