### PR TITLE
lib/posix-poll: Fix epoll crash on NULL event arg

### DIFF
--- a/lib/posix-poll/epoll.c
+++ b/lib/posix-poll/epoll.c
@@ -434,7 +434,9 @@ int uk_sys_epoll_ctl(const struct uk_file *epf, int op, int fd,
 
 	switch (op) {
 	case EPOLL_CTL_ADD:
-		if (unlikely(*entp))
+		if (unlikely(!event))
+			ret = -EFAULT;
+		else if (unlikely(*entp))
 			ret = -EEXIST;
 		else
 #if CONFIG_LIBVFSCORE
@@ -448,7 +450,9 @@ int uk_sys_epoll_ctl(const struct uk_file *epf, int op, int fd,
 		break;
 
 	case EPOLL_CTL_MOD:
-		if (unlikely(!*entp))
+		if (unlikely(!event))
+			ret = -EFAULT;
+		else if (unlikely(!*entp))
 			ret = -ENOENT;
 		else
 #if CONFIG_LIBVFSCORE


### PR DESCRIPTION
### Description of changes

Previously epoll_ctl would crash on `EPOLL_CTL_ADD` and `EPOLL_CTL_MOD` if its `event` arg was NULL.
No global checking is done since `event == NULL` is a valid case for `EPOLL_CTL_DEL`.
This change fixes this oversight, safely returning -EFAULT on a NULL arg for the add and mod operations.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

`CONFIG_LIBPOSIX_POLL=y`

Test snippet:
```c
int e = epoll_create1(0);
int r = epoll_ctl(e, EPOLL_CTL_ADD, 0, NULL);
assert(r == -EFAULT); /* No segfault should happen */
```