### PR TITLE
lib/vfscore: Stub `F_GETLK` to always return `F_UNLCK`

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1967,7 +1967,20 @@ int vfscore_fcntl(struct vfscore_file *fp, unsigned int cmd, unsigned long arg)
 		uk_pr_warn_once("fcntl(F_SETLK) stubbed\n");
 		break;
 	case F_GETLK:
-		uk_pr_warn_once("fcntl(F_GETLK) stubbed\n");
+		uk_pr_warn_once("fcntl(F_GETLK) stubbed. Always unlocked\n");
+
+		struct flock *flk = (struct flock *)arg;
+
+		if (unlikely(!flk)) {
+			error = EFAULT;
+			goto out_errno;
+		}
+
+		/* For now, stubbing as always unlocked seems to be fine. We
+		 * are, after all, a unikernel.
+		 */
+		flk->l_type = F_UNLCK;
+
 		break;
 	case F_SETLKW:
 		uk_pr_warn_once("fcntl(F_SETLKW) stubbed\n");


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Since we always run in an exclusive virtual filesystem mode (no multiple processes trying to acquire the lock on the same file), it is fine for now to stub `F_GETLK` to always return an unlocked file through the `F_UNLCK` flag.

This way, applications that do assume non-exclusive virtual filesystem mechanisms can still proceed as if the file is free to be acquired.
