### PR TITLE
Promote unhandled page fault message level and add stack guard page explicit message

### DIFF
--- a/lib/ukvmem/arch/arm/pagefault64.c
+++ b/lib/ukvmem/arch/arm/pagefault64.c
@@ -39,10 +39,10 @@ static int vmem_arch_pagefault(void *data)
 
 	rc = vmem_pagefault(vaddr, faulttype, ctx->regs);
 	if (unlikely(rc < 0)) {
-		uk_pr_debug("Cannot handle %s page fault at 0x%"__PRIvaddr
-			    " (ec: 0x%lx): %d\n",
-			    faultstr[faulttype & UK_VMA_FAULT_ACCESSTYPE],
-			    vaddr, ctx->esr, rc);
+		uk_pr_crit("Cannot handle %s page fault at 0x%"__PRIvaddr
+			   " (ec: 0x%lx): %d\n",
+			   faultstr[faulttype & UK_VMA_FAULT_ACCESSTYPE],
+			   vaddr, ctx->esr, rc);
 
 		return UK_EVENT_NOT_HANDLED;
 	}

--- a/lib/ukvmem/arch/x86_64/pagefault.c
+++ b/lib/ukvmem/arch/x86_64/pagefault.c
@@ -36,10 +36,10 @@ static int vmem_arch_pagefault(void *data)
 
 	rc = vmem_pagefault(vaddr, faulttype, ctx->regs);
 	if (unlikely(rc < 0)) {
-		uk_pr_debug("Cannot handle %s page fault at 0x%"__PRIvaddr
-			    " (ec: 0x%x): %d\n",
-			    faultstr[faulttype & UK_VMA_FAULT_ACCESSTYPE],
-			    vaddr, ctx->error_code, rc);
+		uk_pr_crit("Cannot handle %s page fault at 0x%"__PRIvaddr
+			   " (ec: 0x%x): %d\n",
+			   faultstr[faulttype & UK_VMA_FAULT_ACCESSTYPE],
+			   vaddr, ctx->error_code, rc);
 
 		return UK_EVENT_NOT_HANDLED;
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`, `arm64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

It would so happen that on exceptions the very useful explicit message of informing you whether the exception was generated by an unhandled page fault or not would not show itself unless `uk_pr_debug` was enabled - promote message level of this print.

Whenever the guard page of a stack VMA would be hit there would be no one informing us of that, potentially resulting in wasted time debugging. Therefore add an explicit `uk_pr_crit` message if that were to happen.