### PR TITLE
Align auxiliary stack with regular stacks and add guard pages on per-thread regular stacks

### DIFF
--- a/arch/Config.uk
+++ b/arch/Config.uk
@@ -44,6 +44,15 @@ config CPU_EXCEPT_STACK_SIZE_PAGE_ORDER
 		2 ^ order * page size (e.g. 4KB).
 		Only change this if you know what you're doing.
 
+config AUXSTACK_SIZE_PAGE_ORDER
+	int
+	prompt "Auxiliary stack size page order"
+	default 4
+	help
+		Indirectly configures the auxiliary stack size by changing the
+		stack size page	order. Stack size is equal with 2^order * page
+		size (e.g. 4KB). Only change this if you know what you're doing.
+
 config HAVE_MEMTAG
 	bool
 	help

--- a/include/uk/plat/memory.h
+++ b/include/uk/plat/memory.h
@@ -312,7 +312,7 @@ static inline __uptr ukplat_auxsp_alloc(struct uk_alloc __maybe_unused *a,
 	rc = uk_vma_map_stack(vas,
 			      &auxsp,
 			      auxsp_len,
-			      UK_VMA_MAP_POPULATE,
+			      UK_VMA_MAP_POPULATE | UK_VMA_MAP_UNINITIALIZED,
 			      NULL,
 			      0);
 	if (unlikely(rc)) {

--- a/include/uk/plat/memory.h
+++ b/include/uk/plat/memory.h
@@ -258,6 +258,7 @@ void *ukplat_memregion_alloc(__sz size, int type, __u16 flags);
  */
 int ukplat_mem_init(void);
 
+#if CONFIG_LIBUKALLOC
 /* Allocates and returns an auxiliary stack that can be used in emergency cases
  * such as when switching system call stacks. The size is that given by
  * (1 << CONFIG_AUXSP_PAGE_ORDER) * PAGE_SIZE.
@@ -337,6 +338,7 @@ static inline __uptr ukplat_auxsp_alloc(struct uk_alloc __maybe_unused *a,
 	 */
 	return (__uptr)ukarch_gen_sp((__uptr)auxsp, auxsp_len);
 }
+#endif /* CONFIG_LIBUKALLOC */
 
 #ifdef __cplusplus
 }

--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -361,12 +361,17 @@ void ukplat_entry(int argc, char *argv[])
 	uk_sched_start(s);
 #else /* CONFIG_LIBUKBOOT_NOSCHED */
 	struct lcpu *bsp_lcpu = lcpu_get_current();
+	void *auxstack;
+
 	UK_ASSERT(bsp_lcpu);
-	bsp_lcpu->auxsp = ukplat_auxsp_alloc(a,
+
+	auxstack = ukplat_auxstack_alloc(a,
 #if defined(CONFIG_LIBUKBOOT_HEAP_BASE) && defined(CONFIG_LIBUKVMEM)
-					     &kernel_vas,
+					 &kernel_vas,
 #endif /* !CONFIG_LIBUKBOOT_HEAP_BASE && CONFIG_LIBUKVMEM */
-					     0);  /* Default auxsp size */
+					 0);  /* Default auxstack size */
+	bsp_lcpu->auxsp = ukarch_gen_sp(auxstack,
+					ukplat_auxstack_len_default());
 #endif /* CONFIG_LIBUKBOOT_NOSCHED */
 
 	ictx.cmdline.argc = argc;

--- a/lib/uksched/thread.c
+++ b/lib/uksched/thread.c
@@ -398,8 +398,12 @@ static int _uk_thread_struct_init_alloc(struct uk_thread *t,
 	int rc;
 
 	if (a_stack && stack_len) {
-		stack = uk_memalign(a_stack, UKARCH_SP_ALIGN, stack_len);
-		if (!stack) {
+		stack = ukplat_stack_alloc(a_stack,
+#if CONFIG_LIBUKVMEM
+					   uk_vas_get_active(),
+#endif /* CONFIG_LIBUKVMEM */
+					   stack_len);
+		if (unlikely(!stack)) {
 			rc = -ENOMEM;
 			goto err_out;
 		}

--- a/plat/Config.uk
+++ b/plat/Config.uk
@@ -115,7 +115,3 @@ config FPSIMD
 	depends on ARCH_ARM_64
 	help
 		Enable support FPU usage in application
-
-config UKPLAT_AUXSP_PAGE_ORDER
-	int "Maximum size allocated for the auxiliary stack"
-	default 4

--- a/plat/common/x86/syscall.S
+++ b/plat/common/x86/syscall.S
@@ -103,7 +103,7 @@ ENTRY(_ukplat_syscall)
 	 *	|             |
 	 *	--------------- <-- (auxsp -
 	 *			     (PAGE_SIZE *
-	 *			      (1 << CONFIG_UKPLAT_AUXSP_PAGE_ORDER)))
+	 *			      (1 << CONFIG_AUXSTACK_SIZE_PAGE_ORDER)))
 	 *	  END OF AUXSP
 	 */
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`, `arm64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Some post #1174 minor fixups:
- do not memset(0) the auxiliary stack
- `LIBUKALLOC` guard auxiliary stack allocation method
- align auxiliary stack semantics with those of the regular stacks

Implement regular stack allocation method similar to that of auxiliary stacks: page-guarded stacks if `LIBUKVMEM` enabled and just `uk_memalign`d stacks otherwise.