### PR TITLE
lib/{uksched, ukboot}: Use `uk_memalign` for auxstack allocation

### DIFF
--- a/include/uk/plat/memory.h
+++ b/include/uk/plat/memory.h
@@ -70,6 +70,13 @@ extern "C" {
 #define UKPLAT_MEMRF_UNMAP		0x0010	/* Must be unmapped at boot */
 #define UKPLAT_MEMRF_MAP		0x0020	/* Must be mapped at boot */
 
+#define UKPLAT_AUXSP_ALIGN					\
+	UKARCH_ECTX_ALIGN
+#define UKPLAT_AUXSP_LEN					\
+	ALIGN_UP((PAGE_SIZE *					\
+		  (1 << CONFIG_UKPLAT_AUXSP_PAGE_ORDER)),	\
+		  UKPLAT_AUXSP_ALIGN)
+
 /**
  * Descriptor of a memory region
  */
@@ -297,9 +304,7 @@ static inline __uptr ukplat_auxsp_alloc(struct uk_alloc __maybe_unused *a,
 	 * length the resulted stack pointer should on its own be ECTX aligned.
 	 */
 	if (!auxsp_len)
-		auxsp_len = ALIGN_UP(PAGE_SIZE *
-				     (1 << CONFIG_UKPLAT_AUXSP_PAGE_ORDER),
-				     UKARCH_ECTX_ALIGN);
+		auxsp_len = UKPLAT_AUXSP_LEN;
 
 #if CONFIG_LIBUKVMEM
 	int rc;

--- a/lib/posix-process/clone.c
+++ b/lib/posix-process/clone.c
@@ -400,7 +400,7 @@ static int _clone(struct clone_args *cl_args, size_t cl_args_len,
 			    (void *) cl_args->tls);
 		child = uk_thread_create_container2(s->a,
 						    (__uptr) cl_args->stack,
-						    0,
+						    s->a_auxstack, 0,
 						    (__uptr) cl_args->tls,
 						    true, /* TLS is an UKTLS */
 						    false, /* We want ECTX */
@@ -424,7 +424,7 @@ static int _clone(struct clone_args *cl_args, size_t cl_args_len,
 		}
 		child = uk_thread_create_container(s->a,
 						   NULL, 0, /* Stack is given */
-						   NULL, 0,
+						   s->a_auxstack, 0,
 						   s->a_uktls,
 						   false, /* We want ECTX */
 						   (t->name) ? strdup(t->name)

--- a/lib/uksched/include/uk/thread.h
+++ b/lib/uksched/include/uk/thread.h
@@ -143,9 +143,10 @@ struct uk_thread *uk_thread_current(void)
  */
 
 #define UK_THREADF_ECTX       (0x001)	/**< Extended context available */
-#define UK_THREADF_UKTLS      (0x002)	/**< Unikraft allocated TLS */
-#define UK_THREADF_RUNNABLE   (0x004)
-#define UK_THREADF_EXITED     (0x008)
+#define UK_THREADF_AUXSP      (0x002)	/**< Thread has auxiliary stack */
+#define UK_THREADF_UKTLS      (0x004)	/**< Unikraft allocated TLS */
+#define UK_THREADF_RUNNABLE   (0x008)
+#define UK_THREADF_EXITED     (0x010)
 /*
  *  A flag used for marking that a thread could potentially
  *  be added to the run queue. A thread marked as such must
@@ -153,7 +154,7 @@ struct uk_thread *uk_thread_current(void)
  *  out from the CPU during a context switch), nor be already
  *  present in the run queue.
  */
-#define UK_THREADF_QUEUEABLE  (0x010)
+#define UK_THREADF_QUEUEABLE  (0x020)
 
 #define uk_thread_is_exited(t)   ((t)->flags & UK_THREADF_EXITED)
 #define uk_thread_is_runnable(t) (!uk_thread_is_exited(t) \
@@ -709,8 +710,10 @@ struct uk_thread_inittab_entry {
 };
 
 #define UK_THREAD_INITF_ECTX  (UK_THREADF_ECTX)
+#define UK_THREAD_INITF_AUXSP (UK_THREADF_AUXSP)
 #define UK_THREAD_INITF_UKTLS (UK_THREADF_UKTLS)
-#define UK_THREAD_INITF_ALL   (UK_THREAD_INITF_ECTX | UK_THREAD_INITF_UKTLS)
+#define UK_THREAD_INITF_ALL   (UK_THREAD_INITF_ECTX | UK_THREAD_INITF_AUXSP | \
+			       UK_THREAD_INITF_UKTLS)
 
 #define __UK_THREAD_INITTAB_ENTRY(init_fn, term_fn, prio, arg_flags)	\
 	static const struct uk_thread_inittab_entry			\

--- a/lib/uksched/include/uk/thread.h
+++ b/lib/uksched/include/uk/thread.h
@@ -471,6 +471,7 @@ struct uk_thread *uk_thread_create_bare(struct uk_alloc *a,
  *   for the stack allocation.
  * @param a_auxstack
  *   Reference to an allocator for allocating an auxiliary stack
+ *   Set to `NULL` to continue without an auxiliary stack (not recommended).
  * @param auxstack_len
  *   Size of the thread auxiliary stack. If set to 0, a default stack size is
  *   used for the allocation.
@@ -514,8 +515,12 @@ struct uk_thread *uk_thread_create_container(struct uk_alloc *a,
  *   Reference t o an allocator (required)
  * @param sp
  *   Stack pointer
- * @param auxsp
- *   Auxiliary stack pointer
+ * @param a_auxstack
+ *   Reference to an allocator for allocating an auxiliary stack
+ *   Set to `NULL` to continue without an auxiliary stack (not recommended).
+ * @param auxstack_len
+ *   Size of the thread auxiliary stack. If set to 0, a default stack size is
+ *   used for the allocation.
  * @param tlsp
  *   Architecture pointer to TLS. If set to NULL, the thread cannot
  *   access thread-local variables
@@ -539,7 +544,8 @@ struct uk_thread *uk_thread_create_container(struct uk_alloc *a,
  */
 struct uk_thread *uk_thread_create_container2(struct uk_alloc *a,
 					      uintptr_t sp,
-					      uintptr_t auxsp,
+					      struct uk_alloc *a_auxstack,
+					      size_t auxstack_len,
 					      uintptr_t tlsp,
 					      bool is_uktls,
 					      bool no_ectx,

--- a/lib/uksched/sched.c
+++ b/lib/uksched/sched.c
@@ -201,6 +201,7 @@ int uk_sched_start(struct uk_sched *s)
 {
 	struct uk_thread *main_thread;
 	uintptr_t tlsp;
+	uintptr_t auxsp;
 	int ret;
 
 	UK_ASSERT(s);
@@ -213,8 +214,9 @@ int uk_sched_start(struct uk_sched *s)
 	 *       an TLS that is derived from the Unikraft TLS template.
 	 */
 	tlsp = ukplat_tlsp_get();
+	auxsp = ukplat_lcpu_get_auxsp();
 	main_thread = uk_thread_create_bare(s->a,
-					    0x0, 0x0, 0x0,
+					    0x0, 0x0, auxsp,
 					    tlsp, !(!tlsp), false,
 					    "init", NULL, NULL);
 	if (!main_thread) {
@@ -231,9 +233,6 @@ int uk_sched_start(struct uk_sched *s)
 
 	/* Set main_thread as current scheduled thread */
 	ukplat_per_lcpu_current(__uk_sched_thread_current) = main_thread;
-
-	/* Set current LCPU's Kernel Stack pointer */
-	ukplat_lcpu_set_auxsp(main_thread->auxsp);
 
 	/* Add main to the scheduler's thread list */
 	UK_TAILQ_INSERT_TAIL(&s->thread_list, main_thread, thread_list);

--- a/lib/uksched/sched.c
+++ b/lib/uksched/sched.c
@@ -406,7 +406,7 @@ void uk_sched_dumpk_threads(int klvl, struct uk_sched *s)
 		uk_printk(klvl,
 			  " + thread %p (%s), ctx: %p, "
 			  "execution time: %"__PRInsec".%06"__PRInsec"s, "
-			  "flags: %c%c%c%c\n",
+			  "flags: %c%c%c%c%c\n",
 			  t, t->name ? t->name : "<unnamed>",
 			  &t->ctx,
 			  ukarch_time_nsec_to_sec(t->exec_time),
@@ -414,6 +414,7 @@ void uk_sched_dumpk_threads(int klvl, struct uk_sched *s)
 			  (t->flags & UK_THREADF_RUNNABLE) ? 'R' : '-',
 			  (t->flags & UK_THREADF_EXITED)   ? 'D' : '-',
 			  (t->flags & UK_THREADF_ECTX)     ? 'E' : '-',
+			  (t->flags & UK_THREADF_AUXSP)    ? 'A' : '-',
 			  (t->flags & UK_THREADF_UKTLS)    ? 'T' : '-');
 	}
 }

--- a/lib/uksched/thread.c
+++ b/lib/uksched/thread.c
@@ -188,14 +188,18 @@ static int _uk_thread_call_termtab(struct uk_thread *child)
 		if (unlikely(!itr->term))
 			continue;
 		if (unlikely((itr->flags & child->flags) != itr->flags)) {
-			uk_pr_debug("uk_thread %p (%s) term cb: Skip %p() due to feature mismatch: %c%c required (has %c%c)\n",
+			uk_pr_debug("uk_thread %p (%s) term cb: Skip %p() due to feature mismatch: %c%c%c required (has %c%c%c)\n",
 				    child, child->name
 				     ? child->name : "<unnamed>",
 				    *itr->term,
+				    (itr->flags & UK_THREAD_INITF_AUXSP)
+				     ? 'A' : '-',
 				    (itr->flags & UK_THREAD_INITF_ECTX)
 				     ? 'E' : '-',
 				    (itr->flags & UK_THREAD_INITF_UKTLS)
 				     ? 'T' : '-',
+				    (child->flags & UK_THREADF_AUXSP)
+				     ? 'A' : '-',
 				    (child->flags & UK_THREADF_ECTX)
 				     ? 'E' : '-',
 				    (child->flags & UK_THREADF_UKTLS)
@@ -245,9 +249,10 @@ static void _uk_thread_struct_init(struct uk_thread *t,
 	t->dtor = dtor;
 	t->exec_time = 0;
 
-
-	t->auxsp = auxsp;
-
+	if (auxsp) {
+		t->flags |= UK_THREADF_AUXSP;
+		t->auxsp = auxsp;
+	}
 	if (tlsp && is_uktls) {
 		t->flags |= UK_THREADF_UKTLS;
 		t->uktlsp = tlsp;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

NOTE: THIS IS A TEMPORARY QUICK FIX FOR A BUG THAT MANIFESTS WHENEVER A THREAD GETS FREED!

For now, if `CONFIG_LIBUKVMEM` is enabled, freed threads wrongly try to free the other end of the stack instead of the beginning of the allocated buffer. If `CONFIG_LIBUKVMEM` is enabled this is even worse since a `uk_free` is not enough and the VMA needs to be unmapped for which we need to keep track of the length. Therefore, further adjustments to `lib/uksched` need to be done before we can freely allocate auxiliary stacks this way.

With this commit, `ukplat_auxsp_alloc` remains unused.
