### PR TITLE
Misc fixes found during the development of the Aarch64 XEN support.

### DIFF
--- a/lib/isrlib/string.c
+++ b/lib/isrlib/string.c
@@ -171,7 +171,11 @@ char *strncpy_isr(char *dst, const char *src, size_t len)
 
 char *strcpy_isr(char *dst, const char *src)
 {
-	return strncpy_isr(dst, src, SIZE_MAX);
+	char *save = dst;
+
+	for (; (*dst = *src) != '\0'; ++src, ++dst)
+		;
+	return save;
 }
 
 int strncmp_isr(const char *str1, const char *str2, size_t len)

--- a/lib/nolibc/string.c
+++ b/lib/nolibc/string.c
@@ -171,7 +171,11 @@ char *strncpy(char *dst, const char *src, size_t len)
 
 char *strcpy(char *dst, const char *src)
 {
-	return strncpy(dst, src, SIZE_MAX);
+	char *save = dst;
+
+	for (; (*dst = *src) != '\0'; ++src, ++dst)
+		;
+	return save;
 }
 
 int strncmp(const char *str1, const char *str2, size_t len)

--- a/lib/posix-socket/socket.c
+++ b/lib/posix-socket/socket.c
@@ -341,9 +341,11 @@ int uk_sys_accept(const struct uk_file *sock, int blocking,
 	_socket_init(al, n->driver, new_data);
 
 	al_listener = __containerof(sock, struct socket_alloc, f);
+#if CONFIG_LIBPOSIX_SOCKET_EVENTS
 	uk_socket_evd_init_from(&al->evd, &al_listener->evd);
 	uk_socket_evd_laddr_set_from(&al->evd, &al_listener->evd);
-	uk_socket_evd_raddr_set(&al->evd, addr, *addr_len);
+	uk_socket_evd_raddr_set(&al->evd, addr, (addr_len ? *addr_len : 0));
+#endif /* CONFIG_LIBPOSIX_SOCKET_EVENTS */
 
 	if (flags & SOCK_NONBLOCK)
 		mode |= O_NONBLOCK;

--- a/lib/ukring/include/uk/ring.h
+++ b/lib/ukring/include/uk/ring.h
@@ -52,14 +52,14 @@ struct uk_ring {
 	int               br_prod_size;
 	int               br_prod_mask;
 	uint64_t          br_drops;
-	volatile uint32_t br_cons_head __aligned(CACHE_LINE_SIZE);
+	volatile uint32_t br_cons_head __align(CACHE_LINE_SIZE);
 	volatile uint32_t br_cons_tail;
 	int               br_cons_size;
 	int               br_cons_mask;
 #ifdef DEBUG_BUFRING
 	struct uk_mutex  *br_lock;
 #endif
-	void             *br_ring[0] __aligned(CACHE_LINE_SIZE);
+	void             *br_ring[0] __align(CACHE_LINE_SIZE);
 };
 
 /*

--- a/lib/ukring/include/uk/ring.h
+++ b/lib/ukring/include/uk/ring.h
@@ -321,7 +321,7 @@ uk_ring_peek_clear_sc(struct uk_ring *br)
 	if (br->br_cons_head == br->br_prod_tail)
 		return NULL;
 
-#if defined(CONFIG_ARCH_ARM_32) || defined(CONFIG_ARCH_ARM_64)
+#if defined(CONFIG_ARCH_ARM_32)
 	/*
 	 * The barrier is required there on ARM and ARM64 to ensure, that
 	 * br->br_ring[br->br_cons_head] will not be fetched before the above
@@ -334,6 +334,8 @@ uk_ring_peek_clear_sc(struct uk_ring *br)
 	 */
 	#error "unsupported: atomic_thread_fence_acq()"
 	/* TODO atomic_thread_fence_acq(); */
+#elif defined(CONFIG_ARCH_ARM64)
+	dmb();
 #endif
 
 #ifdef DEBUG_BUFRING


### PR DESCRIPTION
### Prerequisite checklist

- [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
- [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

None.

### Description of changes

This set of changes includes the following list 
* [lib/ukring: Update __aligned to __align attribute](https://github.com/unikraft/unikraft/commit/bafc65d5fa6fd64a2be052bef7f1c7eaaaff4a5c) - current unikraft implementation doesn't have __aligned attribure, so update ukring to use __align as defined in compiler.h
* [lib/ukring: Implement ukarch_thread_fence_acq](https://github.com/unikraft/unikraft/commit/c73c193f320f8048e7391b4fad2c3b826f4c84b5) - Add basic implementation of the ukarch_thread_fence_acq for aarch64
* [lib/string: Fix strcpy and strcpy_isr implementation](https://github.com/unikraft/unikraft/commit/257bd8b6e0314f4b472f95d343b96a843c620c81) - the original version of the strcpy was incorrect because it called strncpy with the SIZE_MAX parameter. Consequently, strncpy would apply 0-padding up until the SIZE_MAX - 1 was reached. This was causing buffer overflows.
* [lib/posix-socket: Fix raddr set call in uk_sys_accept](https://github.com/unikraft/unikraft/commit/e6f320fac2f3960bc31c7cdc25167e7fb8b9f443) - uk_sys_accept call doesn't handle the situation when addr_len pointer is NULL 