### PR TITLE
lib/posix-*: Add support for packet pipes & datagram unix sockets

### DIFF
--- a/lib/posix-fdio/fdio.c
+++ b/lib/posix-fdio/fdio.c
@@ -13,8 +13,8 @@
 #include "fdio-impl.h"
 
 /* Stable mode bits to pass onto the read/write implementations */
-#define _READ_MODEMASK 0
-#define _WRITE_MODEMASK (O_SYNC|O_DSYNC)
+#define _READ_MODEMASK (O_DIRECT)
+#define _WRITE_MODEMASK (O_DIRECT|O_SYNC|O_DSYNC)
 
 
 #define _buf2iov(buf, count) \

--- a/lib/posix-fdio/include/uk/posix-fd.h
+++ b/lib/posix-fdio/include/uk/posix-fd.h
@@ -15,7 +15,8 @@
 #include <uk/ofile.h>
 
 /* Mode bits from fcntl.h that open files are interested in */
-#define UKFD_MODE_MASK (O_WRONLY|O_RDWR|O_NONBLOCK|O_APPEND|O_SYNC|O_DSYNC)
+#define UKFD_MODE_MASK \
+	(O_WRONLY|O_RDWR|O_NONBLOCK|O_APPEND|O_DIRECT|O_SYNC|O_DSYNC)
 
 /* Unikraft-specific mode bits, chosen to not overlap with any O_* flags */
 /* Open file is not seekable (e.g. for pipes, sockets & FIFOs) */

--- a/lib/posix-pipe/Config.uk
+++ b/lib/posix-pipe/Config.uk
@@ -9,4 +9,13 @@ if LIBPOSIX_PIPE
 	help
 		Pipe buffer size will be 2^(order) bytes.
 
+	config LIBPOSIX_PIPE_PACKET
+	bool "Support packet-mode (O_DIRECT) pipes"
+	default y
+
+	config LIBPOSIX_PIPE_MAX_PACKETS
+	int "Max number of pending packets per pipe"
+	default 64
+	depends on LIBPOSIX_PIPE_PACKET
+
 endif

--- a/lib/posix-pipe/include/uk/posix-pipe.h
+++ b/lib/posix-pipe/include/uk/posix-pipe.h
@@ -14,7 +14,7 @@
 
 /* File creation */
 
-int uk_pipefile_create(struct uk_file *pipes[2], int flags);
+int uk_pipefile_create(struct uk_file *pipes[2]);
 
 /* Internal syscalls */
 

--- a/lib/posix-pipe/pipe.c
+++ b/lib/posix-pipe/pipe.c
@@ -18,29 +18,41 @@
 
 #define PIPE_SIZE (1L << CONFIG_LIBPOSIX_PIPE_SIZE_ORDER)
 
+#if CONFIG_LIBPOSIX_PIPE_PACKET
+#define PIPE_MSGCOUNT CONFIG_LIBPOSIX_PIPE_MAX_PACKETS
+#else /* !CONFIG_LIBPOSIX_PIPE_PACKET */
+#define PIPE_MSGCOUNT 1
+#endif
+
 #define _PIPE_SZMASK (PIPE_SIZE - 1)
 #define PIPE_IDX(x) ((x) & _PIPE_SZMASK)
 
-#define PIPE_SPACE(start, lim, want) MIN((want), \
-	((start) <= (lim)) ? ((lim) - (start)) : (PIPE_SIZE - (start) + (lim)))
+#define PIPE_SPACE(start, lim) \
+	(((start) <= (lim)) ? ((lim) - (start)) : (PIPE_SIZE - (start) + (lim)))
+#define PIPE_USED(start, lim) \
+	(((start) == (lim)) ? PIPE_SIZE : PIPE_SPACE(start, lim))
 
 static const char PIPE_VOLID[] = "pipe_vol";
 
 typedef __u32 pipeidx;
 
+struct pipe_msg {
+	struct pipe_msg *next;
+	pipeidx start;
+	pipeidx end;
+};
 
 struct pipe_node {
+	struct pipe_msg *volatile head;
+	struct pipe_msg *tail;
+	struct pipe_msg *free;
 	unsigned int flags;
-	volatile pipeidx rhead;
-	pipeidx whead;
+	struct pipe_msg msgs[PIPE_MSGCOUNT];
 	char buf[PIPE_SIZE];
 };
 
 #define PIPE_HUP    1
 #define PIPE_FIN    2
-#if CONFIG_LIBPOSIX_PIPE_PACKET
-#define PIPE_PACKET 4
-#endif
 
 struct pipe_alloc {
 	struct uk_alloc *alloc;
@@ -131,65 +143,102 @@ static ssize_t pipe_read(const struct uk_file *f,
 {
 	ssize_t toread;
 	struct pipe_node *d;
+	struct pipe_msg *m;
+	struct pipe_msg *prev;
 	ssize_t canread;
-	pipeidx rend;
-	pipeidx ri;
+	pipeidx start;
 
-	if (unlikely(f->vol != PIPE_VOLID))
-		return -EINVAL;
+	UK_ASSERT(f->vol == PIPE_VOLID);
 	if (unlikely(off))
 		return -ESPIPE;
 
 	toread = _iovsz(iov, iovcnt);
-	if (unlikely(toread < 0))
+	if (unlikely(toread <= 0))
 		return toread;
 
 	d = (struct pipe_node *)f->node;
-	ri = d->rhead;
-	do {
-		canread = PIPE_SPACE(ri, d->whead, toread);
-		UK_ASSERT(canread >= 0);
-		if (!canread) {
-			/* Ambiguous whether full or empty; check event flags */
-			if (uk_file_event_clear(f, UKFD_POLLIN) & UKFD_POLLIN)
-				canread = MIN(toread, PIPE_SIZE);
-			else
-				if (d->flags & PIPE_HUP)
-					return 0;
-				else
-					return -EAGAIN;
-		}
-		rend = PIPE_IDX(ri + canread);
-		/* If buffer will be empty after our read, clear POLLIN */
-		if (rend == d->whead)
+	m = d->head;
+	for (;;) {
+		if (!m) {
 			uk_file_event_clear(f, UKFD_POLLIN);
-	} while (!uk_compare_exchange_n(&d->rhead, &ri, rend));
-	/* Reserved `canread` bytes starting from ri */
+			if (d->flags & PIPE_HUP)
+				return 0;
+			else
+				return -EAGAIN;
+		}
 
-	/* If we're reading only part of a full buffer, reset POLLIN */
-	if (ri == d->whead && rend != d->whead)
-		uk_file_event_set(f, UKFD_POLLIN);
-	/* Do read */
-	pipebuf_iovread(d->buf, ri, iov, canread);
-	/* If pipe was full, set POLLOUT */
-	if (ri == d->whead)
-		uk_file_event_set(f, UKFD_POLLOUT);
+		if (m->next != m) { /* Packet msg */
+			if (!uk_compare_exchange_n(&d->head, &m, m->next))
+				continue;
+			if (!m->next) {
+				d->tail = NULL;
+				uk_file_event_clear(f, UKFD_POLLIN);
+			}
+
+			start = m->start;
+			canread = MIN(PIPE_USED(start, m->end), toread);
+			UK_ASSERT(canread); /* 0-length packets not allowed */
+			prev = uk_exchange_n(&d->free, m);
+			m->next = prev;
+		} else { /* Stream msg; always last in queue */
+			ssize_t avail;
+
+			start = m->start;
+			if (start == PIPE_SIZE) {
+				m = d->head;
+				continue;
+			}
+			avail = PIPE_USED(start, m->end);
+			canread = MIN(avail, toread);
+			UK_ASSERT(canread);
+
+			if (canread == avail) {
+				if (!uk_compare_exchange_n(&d->head, &m, NULL))
+					continue;
+				while (!uk_compare_exchange_n(&m->start,
+							      &start,
+							      PIPE_SIZE));
+				uk_file_event_clear(f, UKFD_POLLIN);
+
+				canread = MIN(PIPE_USED(start, m->end), toread);
+
+				d->tail = NULL;
+				prev = uk_exchange_n(&d->free, m);
+				m->next = prev;
+			} else {
+				pipeidx lim = PIPE_IDX(start + canread);
+
+				UK_ASSERT(lim != start);
+				if (!uk_compare_exchange_n(&m->start,
+							   &start, lim)) {
+					m = d->head;
+					continue;
+				}
+			}
+		}
+		break;
+	}
+	UK_ASSERT(canread);
+	pipebuf_iovread(d->buf, start, iov, canread);
+	uk_file_event_set(f, UKFD_POLLOUT);
 
 	return canread;
 }
 
 static ssize_t pipe_write(const struct uk_file *f,
 			  const struct iovec *iov, int iovcnt,
-			  off_t off, long flags __unused)
+			  off_t off, long flags)
 {
 	struct pipe_node *d;
+	struct pipe_msg *tail;
 	ssize_t towrite;
-	pipeidx head;
 	ssize_t canwrite;
+	ssize_t capacity;
+	pipeidx whead;
 	pipeidx wend;
+	int empty = 0;
 
-	if (unlikely(f->vol != PIPE_VOLID))
-		return -EINVAL;
+	UK_ASSERT(f->vol == PIPE_VOLID);
 	if (unlikely(off))
 		return -ESPIPE;
 
@@ -198,31 +247,65 @@ static ssize_t pipe_write(const struct uk_file *f,
 		return -EPIPE;
 
 	towrite = _iovsz(iov, iovcnt);
-	if (unlikely(towrite < 0))
+	if (unlikely(towrite <= 0))
 		return towrite;
 
-	head = d->whead;
-	canwrite = PIPE_SPACE(head, d->rhead, _iovsz(iov, iovcnt));
-	UK_ASSERT(canwrite >= 0);
-	if (!canwrite) {
-		/* Ambiguous whether full or empty, check flags */
-		if (uk_file_poll_immediate(f, UKFD_POLLOUT))
-			canwrite = MIN(towrite, PIPE_SIZE);
+	tail = d->tail;
+	if (!tail || tail->next != tail) { /* Empty or last msg is packet */
+		struct pipe_msg *m;
+
+		if (tail) {
+			UK_ASSERT(d->head);
+			UK_ASSERT(!tail->next);
+			whead = tail->end;
+			wend = d->head->start;
+		} else {
+			UK_ASSERT(!d->head);
+			whead = 0;
+			wend = PIPE_SIZE;
+			empty = 1;
+		}
+		capacity = PIPE_SPACE(whead, wend);
+		canwrite = MIN(capacity, towrite);
+		if (!canwrite)
+			goto out_full;
+		wend = PIPE_IDX(whead + canwrite);
+
+		m = d->free;
+		if (!m)
+			goto out_full;
+		d->free = m->next;
+
+		m->start = whead;
+		m->end = wend;
+		m->next = (flags & O_DIRECT) ? NULL : m;
+
+		d->tail = m;
+		if (tail)
+			tail->next = m;
 		else
-			return -EAGAIN;
+			d->head = m;
+	} else { /* Last msg is stream, extend */
+		UK_ASSERT(d->head);
+		whead = tail->end;
+		wend = d->head->start;
+		capacity = PIPE_SPACE(whead, wend);
+		canwrite = MIN(towrite, capacity);
+		if (!canwrite)
+			goto out_full;
+		tail->end = PIPE_IDX(whead + canwrite);
 	}
-
-	wend = PIPE_IDX(head + canwrite);
-	d->whead = wend;
-	pipebuf_iovwrite(d->buf, head, iov, canwrite);
-	/* if buffer full, clear POLLOUT */
-	if (wend == d->rhead)
+	UK_ASSERT(canwrite);
+	pipebuf_iovwrite(d->buf, whead, iov, canwrite);
+	if (canwrite == capacity)
 		uk_file_event_clear(f, UKFD_POLLOUT);
-	/* if buffer was empty, set POLLIN */
-	if (head == d->rhead)
+	if (empty)
 		uk_file_event_set(f, UKFD_POLLIN);
-
 	return canwrite;
+
+out_full:
+	uk_file_event_clear(f, UKFD_POLLOUT);
+	return -EAGAIN;
 }
 
 static const struct uk_file_ops rpipe_ops = {
@@ -271,15 +354,10 @@ static void pipe_release(const struct uk_file *f, int what)
 
 /* File creation */
 
-int uk_pipefile_create(struct uk_file *pipes[2], int flags)
+int uk_pipefile_create(struct uk_file *pipes[2])
 {
 	struct uk_alloc *a;
 	struct pipe_alloc *al;
-
-	if (unlikely(flags & O_DIRECT)) {
-		uk_pr_warn("STUB: O_DIRECT pipes\n");
-		return -EINVAL; /* Not supported yet */
-	}
 
 	a = uk_alloc_get_default();
 	al = uk_malloc(a, sizeof(*al));
@@ -287,10 +365,15 @@ int uk_pipefile_create(struct uk_file *pipes[2], int flags)
 		return -ENOMEM;
 
 	al->alloc = a;
+
+	al->node.head = NULL;
+	al->node.tail = NULL;
 	al->node.flags = 0;
-	al->node.rhead = 0;
-	al->node.whead = 0;
-	memset(al->node.buf, 0, sizeof(al->node.buf));
+	al->node.free = &al->node.msgs[0];
+	for (int i = 0; i < PIPE_MSGCOUNT - 1; i++)
+		al->node.msgs[i].next = &al->node.msgs[i + 1];
+	al->node.msgs[PIPE_MSGCOUNT - 1].next = NULL;
+
 	al->fstate = UK_FILE_STATE_INIT_VALUE(al->fstate);
 	al->rref = UK_FILE_REFCNT_INIT_VALUE;
 	al->wref = UK_FILE_REFCNT_INIT_VALUE;
@@ -319,7 +402,7 @@ int uk_pipefile_create(struct uk_file *pipes[2], int flags)
 
 /* Internal syscalls */
 
-#define _OPEN_FLAGS (O_CLOEXEC|O_NONBLOCK)
+#define _OPEN_FLAGS (O_CLOEXEC|O_NONBLOCK|O_DIRECT)
 
 int uk_sys_pipe(int pipefd[2], int flags)
 {
@@ -328,7 +411,14 @@ int uk_sys_pipe(int pipefd[2], int flags)
 	int oflags;
 	int rpipe;
 
-	r = uk_pipefile_create(pipes, flags);
+#if !CONFIG_LIBPOSIX_PIPE_PACKET
+	if (unlikely(flags & O_DIRECT)) {
+		uk_pr_warn_once("packet pipes requested but not enabled\n");
+		return -EINVAL;
+	}
+#endif /* CONFIG_LIBPOSIX_PIPE_PACKET */
+
+	r = uk_pipefile_create(pipes);
 	if (unlikely(r))
 		return r;
 

--- a/lib/posix-unixsocket/unixsock.c
+++ b/lib/posix-unixsocket/unixsock.c
@@ -780,6 +780,10 @@ ssize_t unix_socket_sendmsg(posix_sock *file,
 	uk_file_wunlock(data->wpipe);
 	/* We ignore ancillary data for now */
 
+	/* 0-length datagrams will be silently lost; warn */
+	if (!ret && data->type != SOCK_STREAM)
+		uk_pr_warn("0-length datagram write; message will be lost\n");
+
 	if (!_SOCK_CONNECTION(data->type) && remote) {
 		uk_file_release(wpipe);
 		if (ret == -EPIPE)

--- a/lib/posix-unixsocket/unixsock.c
+++ b/lib/posix-unixsocket/unixsock.c
@@ -217,7 +217,7 @@ void *unix_socket_create(struct posix_socket_driver *d,
 		if (type == SOCK_DGRAM) {
 			/* Create rpipe */
 			struct uk_file *pipes[2];
-			int r = uk_pipefile_create(pipes, O_DIRECT);
+			int r = uk_pipefile_create(pipes);
 			if (unlikely(r)) {
 				uk_free(d->allocator, data);
 				data = ERR2PTR(r);
@@ -280,7 +280,6 @@ int unix_socket_socketpair(struct posix_socket_driver *d,
 	int ret;
 	struct unix_sock_data *dat[2];
 	struct uk_file *pipes[2][2];
-	int flags;
 
 	if (unlikely(family != AF_UNIX))
 		return -EAFNOSUPPORT;
@@ -302,11 +301,10 @@ int unix_socket_socketpair(struct posix_socket_driver *d,
 		goto err_free0;
 	}
 
-	flags = type != SOCK_STREAM ? O_DIRECT : 0;
-	ret = uk_pipefile_create(pipes[0], flags);
+	ret = uk_pipefile_create(pipes[0]);
 	if (unlikely(ret))
 		goto err_free;
-	ret = uk_pipefile_create(pipes[1], flags);
+	ret = uk_pipefile_create(pipes[1]);
 	if (unlikely(ret))
 		goto err_release;
 
@@ -512,7 +510,6 @@ int unix_sock_connect_stream(posix_sock *file, posix_sock *target)
 	struct unix_sock_data *data = posix_sock_get_data(file);
 	struct unix_sock_data *td;
 	struct uk_file *pipes[2][2];
-	int flags;
 	struct unix_listenmsg *lmsg;
 
 	/* Wlock target sock */
@@ -540,11 +537,10 @@ int unix_sock_connect_stream(posix_sock *file, posix_sock *target)
 		goto err_out;
 	}
 	/* Create pipes */
-	flags = data->type != SOCK_STREAM ? O_DIRECT : 0;
-	err = uk_pipefile_create(pipes[0], flags);
+	err = uk_pipefile_create(pipes[0]);
 	if (unlikely(err))
 		goto err_out;
-	err = uk_pipefile_create(pipes[1], flags);
+	err = uk_pipefile_create(pipes[1]);
 	if (unlikely(err))
 		goto err_release;
 
@@ -779,7 +775,8 @@ ssize_t unix_socket_sendmsg(posix_sock *file,
 			: -ENOTCONN;
 
 	uk_file_wlock(wpipe);
-	ret = uk_file_write(wpipe, msg->msg_iov, msg->msg_iovlen, 0, 0);
+	ret = uk_file_write(wpipe, msg->msg_iov, msg->msg_iovlen, 0,
+			    data->type != SOCK_STREAM ? O_DIRECT : 0);
 	uk_file_wunlock(data->wpipe);
 	/* We ignore ancillary data for now */
 


### PR DESCRIPTION
### Description of changes

This changeset adds support for packet-mode pipes and datagram unix sockets, along with accompanying code to better make use of them. Specifically:
- Have `posix-fdio` honor the `O_DIRECT` flag set on open file decriptions and pass it to the I/O operations
- Replace implementation of `posix-pipe`
- Stream- or packet-mode is selected at runtime by the O_DIRECT flag passed to the `write` operation
- Add support for `AF_UNIX` sockets of type `SOCK_DGRAM` and `SOCK_SEQPACKET` (0-length datagrams are not supported)
- Add warning about not supporting 0-length datagrams

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

```
CONFIG_LIBPOSIX_PIPE=y
CONFIG_LIBPOSIX_PIPE_PACKET=y
CONFIG_LIBPOSIX_UNIXSOCKET=y
```

Pipe test snippet:
```c
int main(void)
{
	int p[2];
	char b[32];

	int r = pipe2(p, O_DIRECT|O_NONBLOCK);
	assert(!r);

	/* These writes are packets */
	printf("%zd\n", write(p[1], "qwert", 5));
	printf("%zd\n", write(p[1], "asdfgh", 6));
	printf("%zd\n", write(p[1], "12345678", 8));
	errno = 0;
	fcntl(p[1], F_SETFL, O_NONBLOCK);
	printf("-%d\n", errno);
	/* Switched to stream now */
	printf("%zd\n", write(p[1], "qwert", 5));
	printf("%zd\n", write(p[1], "asdfgh", 6));
	printf("%zd\n", write(p[1], "12345678", 8));
	errno = 0;
	fcntl(p[1], F_SETFL, O_DIRECT|O_NONBLOCK);
	printf("-%d\n", errno);
	/* Switched back to packet; however, stream still unread, writes append to it */
	printf("%zd\n", write(p[1], "qwert", 5));
	printf("%zd\n", write(p[1], "asdfgh", 6));
	printf("%zd\n", write(p[1], "12345678", 8));

	/* Read out */
	while ((r = read(p[0], b, 3)) > 0) {
		b[r] = '\0';
		puts(b);
	}
	printf("-%d\n", errno);

	/* Stream emptied, only now are writes actually packets */
	printf("%zd\n", write(p[1], "qwert", 5));
	printf("%zd\n", write(p[1], "asdfgh", 6));
	printf("%zd\n", write(p[1], "12345678", 8));
	printf("%zd\n", write(p[1], "qwert", 5));
	printf("%zd\n", write(p[1], "asdfgh", 6));
	printf("%zd\n", write(p[1], "12345678", 8));

	while ((r = read(p[0], b, 3)) > 0) {
		b[r] = '\0';
		puts(b);
	}
	printf("-%d\n", errno);

	return 0;
}
```

DGRAM socket test snippet (should print warning under Unikraft):
```c
int main(void)
{
	int sv[2];
	char b[32];

	int r = socketpair(AF_UNIX, SOCK_DGRAM|SOCK_NONBLOCK, 0, sv);
	assert(!r);

	printf("%zd\n", send(sv[1], "qwert", 5, 0));
	printf("%zd\n", send(sv[1], "asdfgh", 6, 0));
	printf("%zd\n", send(sv[1], "", 0, 0));
	printf("%zd\n", send(sv[1], "12345678", 8, 0));

	while ((r = read(sv[0], b, 3)) >= 0) {
		b[r] = '\0';
		puts(b);
	}
	printf("-%d\n", errno);

	return 0;
}
```