### PR TITLE
lib/posix-mmap: Round-up madvise length to page size

### DIFF
--- a/lib/posix-mmap/mmap.c
+++ b/lib/posix-mmap/mmap.c
@@ -266,7 +266,7 @@ UK_SYSCALL_R_DEFINE(int, madvise, void *, addr, size_t, len, int, advice)
 		break;
 	}
 
-	rc = uk_vma_advise(vas, vaddr, len, vadvice,
+	rc = uk_vma_advise(vas, vaddr, PAGE_ALIGN_UP(len), vadvice,
 			   UK_VMA_FLAG_STRICT_VMA_CHECK);
 	if (unlikely(rc)) {
 		if (rc == -ENOENT)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]

### Additional configuration

None

### Description of changes

According to [1] madvise() rounds up the length to a multiple of page size. Round up the length to avoid returning an error when the caller passes an unaligned length value.

[1] https://man7.org/linux/man-pages/man2/madvise.2.html
