### PR TITLE
support/scripts: Auto-split words and disable info message

### DIFF
--- a/support/scripts/checkpatch.uk
+++ b/support/scripts/checkpatch.uk
@@ -30,4 +30,7 @@ if [ -f "${_SELF_BASE}/../../.checkpatch.conf" ]; then
 	_CHECKPATCHCONF=$(cat "${_SELF_BASE}/../../.checkpatch.conf")
 fi
 
-exec "${_CHECKPATCHPL}" "${_CHECKPATCHCONF}" "$@"
+# We need to auto-split words to make sure arguments are passed correctly to
+# checkpatch. We disable this 'info' style message.
+# shellcheck disable=SC2086
+exec "${_CHECKPATCHPL}" ${_CHECKPATCHCONF} "$@"


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Trying to use `readarray` or anything else to split everything in one go is not possible as the input file has both '\n' and ' ' delimiters.

Ignore the message as it is an info check (it would not have failed even without the ignore)