### PR TITLE
support/scripts: Fix `checkpatch.uk`

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,3 +1,4 @@
+--show-types
 --no-tree
 --ignore ASSIGN_IN_IF
 --ignore NEW_TYPEDEFS

--- a/support/scripts/checkpatch.uk
+++ b/support/scripts/checkpatch.uk
@@ -27,7 +27,7 @@ fi
 
 _CHECKPATCHCONF=
 if [ -f "${_SELF_BASE}/../../.checkpatch.conf" ]; then
-	_CHECKPATCHCONF=$(cat "${_SELF_BASE}/../../.checkpatch.conf")
+	_CHECKPATCHCONF=($(cat "${_SELF_BASE}/../../.checkpatch.conf"))
 fi
 
-exec "${_CHECKPATCHPL}" "${_CHECKPATCHCONF}" "$@"
+exec "${_CHECKPATCHPL}" "${_CHECKPATCHCONF[@]}" "$@"


### PR DESCRIPTION
This PR fixes the use of additional arguments loaded from `.checkpatch.conf`. PR #1246 changed the behavior by passing all additional arguments as single arguments to `checkpatch.pl` (the commit introduced double quotes). In this PR we restores the original behavior, but use an array of arguments instead.