### PR TITLE
lib/posix-fdtab: Support independent (per-process) fdtabs

### DIFF
--- a/lib/posix-fdtab/Config.uk
+++ b/lib/posix-fdtab/Config.uk
@@ -9,6 +9,11 @@ if LIBPOSIX_FDTAB
 	int "Maximum number of file descriptors"
 	default 1024
 
+	# Hidden, will autoselect when required
+	config LIBPOSIX_FDTAB_MULTITAB
+	bool
+	select LIBUKSCHED
+
 	# Hidden, selected by core components when needed
 	config LIBPOSIX_FDTAB_LEGACY_SHIM
 	bool

--- a/lib/posix-fdtab/Config.uk
+++ b/lib/posix-fdtab/Config.uk
@@ -12,6 +12,7 @@ if LIBPOSIX_FDTAB
 	# Hidden, will autoselect when required
 	config LIBPOSIX_FDTAB_MULTITAB
 	bool
+	default y if LIBPOSIX_PROCESS_CLONE
 	select LIBUKSCHED
 
 	# Hidden, selected by core components when needed

--- a/lib/posix-fdtab/fdtab.c
+++ b/lib/posix-fdtab/fdtab.c
@@ -392,13 +392,13 @@ void uk_fdtab_cloexec(void)
 	fdtab_cleanup(active_fdtab, 0);
 }
 
+#if CONFIG_LIBPOSIX_PROCESS_EXECVE
 static int fdtab_handle_execve(void *data __unused)
 {
 	uk_fdtab_cloexec();
-	return 0;
+	return UK_EVENT_HANDLED_CONT;
 }
 
-#if CONFIG_LIBPOSIX_PROCESS_EXECVE
 UK_EVENT_HANDLER_PRIO(POSIX_PROCESS_EXECVE_EVENT, fdtab_handle_execve,
 		      UK_PRIO_EARLIEST);
 #endif /* CONFIG_LIBPOSIX_PROCESS_EXECVE */

--- a/lib/posix-fdtab/fmap.h
+++ b/lib/posix-fdtab/fmap.h
@@ -385,6 +385,7 @@ int uk_fmap_xchg(const struct uk_fmap *m, int idx,
 {
 	void *got;
 
+	UK_ASSERT(p); /* Cannot exchange with NULL, use uk_fmap_take instead */
 	if (!_FMAP_INRANGE(m, idx))
 		return -1;
 

--- a/lib/posix-fdtab/fmap.h
+++ b/lib/posix-fdtab/fmap.h
@@ -28,6 +28,8 @@ struct uk_bmap {
 	size_t size;
 };
 
+#define UK_BMAP_NELEM(s) UK_BITS_TO_LONGS(s)
+
 /**
  * Gets the size of the bitmap in bytes.
  *
@@ -36,7 +38,7 @@ struct uk_bmap {
  * @return
  *   Size of the bitmap in bytes
  */
-#define UK_BMAP_SZ(s) (UK_BITS_TO_LONGS(s) * sizeof(unsigned long))
+#define UK_BMAP_SZ(s) (UK_BMAP_NELEM(s) * sizeof(unsigned long))
 
 
 /**
@@ -182,6 +184,23 @@ static inline void uk_fmap_init(const struct uk_fmap *m)
 {
 	memset((void *)m->map, 0, m->bmap.size * sizeof(void *));
 	uk_bmap_init(&m->bmap);
+}
+
+/**
+ * Sets the value at `idx` to `p`.
+ *
+ * WARNING: This function is not thread-safe, take care when calling.
+ */
+static inline void uk_fmap_set(const struct uk_fmap *m, int idx, const void *p)
+{
+	if (!_FMAP_INRANGE(m, idx))
+		return;
+
+	if (p)
+		uk_bmap_reserve(&m->bmap, idx);
+	else
+		uk_bmap_free(&m->bmap, idx);
+	m->map[idx] = (void *)p;
 }
 
 /**


### PR DESCRIPTION
### Description of changes

This PR changes the way `posix-fdtab` handles tables, from a single, static, OS-wide table, to a thread-local reference to one of possibly many independent tables. This allows for, among others, per-process independent fdtabs. Specifically, the commits in this changeset:
- Make the currently active fdtab a thread-local reference
- Support dynamically allocated (and freed) fdtabs
- Handle the `clone()` syscall to duplicate the fdtable when needed

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

`CONFIG_LIBPOSIX_FDTAB=y`

All single-process code should keep working as-is, with a shared fdtab (albeit through independent, refcounted references).
Once multi-process support is added, every thread spawned with `clone()` without the `CLONE_FILES` flag should have independent tables.