### PR TITLE
lib/nolibc: Change default FD_SETSIZE to 1024

### DIFF
--- a/lib/nolibc/include/sys/select.h
+++ b/lib/nolibc/include/sys/select.h
@@ -53,7 +53,7 @@ typedef unsigned long __fd_mask;
  * be enough for most uses.
  */
 #ifndef FD_SETSIZE
-#define FD_SETSIZE 64
+#define FD_SETSIZE 1024
 #endif
 
 #define _NFDBITS (sizeof(__fd_mask) * 8) /* bits per mask */


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

The current nolibc defines FD_SETSIZE in select.h. This definition propagates to lwip and limits the number of concurrent connections. This commit changes the default value to 1024. This is also used in musl.