### PR TITLE
drivers/ukintctrl: Update GICv2 compatible list

### DIFF
--- a/drivers/ukintctlr/gic/gic-v2.c
+++ b/drivers/ukintctlr/gic/gic-v2.c
@@ -78,6 +78,7 @@ struct _gic_dev gicv2_drv = {
 
 static const char * const gic_device_list[] __maybe_unused = {
 	"arm,cortex-a15-gic",
+	"arm,gic-400",
 	NULL
 };
 


### PR DESCRIPTION


### Prerequisite checklist

 - [X] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [X] Updated relevant documentation.


### Base target

 - Architecture(s): `aarch64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Description of changes

To support devices that feature a GICv2 with FC, we need to update the list of compatible GICv2 controllers. This is tested on RPi 4 & 5, as well as on an NVIDIA AGX Xavier.

