### PR TITLE
driver/virtio/blk: Ensure request header stays in-page boundaries **AND** some minor sglist cleanup

### DIFF
--- a/drivers/virtio/net/virtio_net.c
+++ b/drivers/virtio/net/virtio_net.c
@@ -415,7 +415,7 @@ static int virtio_netdev_xmit(struct uk_netdev *dev,
 	 *       the first netbuf of a queue. If this is not the case,
 	 *       (e.g., due to encapsulation of protocol headers with
 	 *        prepending netbufs) we need to replace the call
-	 *       to `uk_sglist_append_netbuf()`. However, a netbuf
+	 *       to `uk_netbuf_sglist_append()`. However, a netbuf
 	 *       chain can only once have set the PARTIAL_CSUM flag.
 	 */
 	memset(vhdr, 0, virtio_net_hdr_size(vndev));
@@ -455,7 +455,7 @@ static int virtio_netdev_xmit(struct uk_netdev *dev,
 		goto err_remove_vhdr;
 	}
 	if (pkt->next) {
-		rc = uk_sglist_append_netbuf(&queue->sg, pkt->next);
+		rc = uk_netbuf_sglist_append(&queue->sg, pkt->next);
 		if (unlikely(rc != 0)) {
 			uk_pr_err("Failed to append to the sg list: %d\n", rc);
 			goto err_remove_vhdr;

--- a/lib/uknetdev/exportsyms.uk
+++ b/lib/uknetdev/exportsyms.uk
@@ -7,6 +7,7 @@ uk_netbuf_free
 uk_netbuf_disconnect
 uk_netbuf_connect
 uk_netbuf_append
+uk_netbuf_sglist_append
 uk_netdev_drv_register
 uk_netdev_count
 uk_netdev_get

--- a/lib/uknetdev/include/uk/netbuf.h
+++ b/lib/uknetdev/include/uk/netbuf.h
@@ -41,6 +41,9 @@
 #include <uk/refcount.h>
 #include <uk/alloc.h>
 #include <uk/essentials.h>
+#if CONFIG_LIBUKSGLIST
+#include <uk/sglist.h>
+#endif /* CONFIG_LIBUKSGLIST */
 
 #ifdef __cplusplus
 extern "C" {
@@ -413,6 +416,21 @@ void uk_netbuf_connect(struct uk_netbuf *headtail,
  */
 void uk_netbuf_append(struct uk_netbuf *head,
 		      struct uk_netbuf *tail);
+
+#if CONFIG_LIBUKSGLIST
+/**
+ * This function appends a netbuf to a scatter gather list.
+ *
+ * @param sg
+ *	A reference to the scatter gather list.
+ * @param netbuf
+ *	A reference to the netbuf
+ * @return
+ *	0, on successful creation of the scatter gather list
+ *	-EINVAL, Invalid sg list.
+ */
+int uk_netbuf_sglist_append(struct uk_sglist *sg, struct uk_netbuf *netbuf);
+#endif /* CONFIG_LIBUKSGLIST */
 
 /**
  * Disconnects a netbuf from its chain. The chain will remain

--- a/lib/uksglist/exportsyms.uk
+++ b/lib/uksglist/exportsyms.uk
@@ -9,4 +9,3 @@ uk_sglist_length
 uk_sglist_split
 uk_sglist_join
 uk_sglist_slice
-uk_sglist_append_netbuf

--- a/lib/uksglist/include/uk/sglist.h
+++ b/lib/uksglist/include/uk/sglist.h
@@ -52,9 +52,6 @@ extern "C" {
 #ifdef CONFIG_LIBUKALLOC
 #include <uk/alloc.h>
 #endif /* CONFIG_LIBUKALLOC */
-#ifdef CONFIG_LIBUKNETDEV
-#include <uk/netbuf.h>
-#endif /* CONFIG_LIBUKNETDEV */
 
 struct uk_sglist_seg {
 	__paddr_t  ss_paddr; /* Physical address */
@@ -299,20 +296,6 @@ int uk_sglist_split(struct uk_sglist *original, struct uk_sglist **head,
 int uk_sglist_slice(struct uk_sglist *original, struct uk_sglist **slice,
 			struct uk_alloc *a, size_t offset, size_t length) __nonnull;
 #endif /* CONFIG_LIBUKALLOC */
-
-#ifdef CONFIG_LIBUKNETDEV
-/**
- * The function create a scatter gather list from the netbuf
- * @param sg
- *	A reference to the scatter gather list.
- * @param netbuf
- *	A reference to the netbuf
- * @return
- *	0, on successful creation of the scatter gather list
- *	-EINVAL, Invalid sg list.
- */
-int uk_sglist_append_netbuf(struct uk_sglist *sg, struct uk_netbuf *netbuf) __nonnull;
-#endif /* CONFIG_LIBUKNET */
 
 #ifdef __cplusplus
 }

--- a/lib/uksglist/sglist.c
+++ b/lib/uksglist/sglist.c
@@ -520,28 +520,3 @@ int uk_sglist_slice(struct uk_sglist *original, struct uk_sglist **slice,
 	return 0;
 }
 #endif /* CONFIG_LIBUKALLOC */
-
-#ifdef CONFIG_LIBUKNETDEV
-int uk_sglist_append_netbuf(struct uk_sglist *sg, struct uk_netbuf *netbuf)
-{
-	struct sgsave save;
-	struct uk_netbuf *nb;
-	int error;
-
-	if (sg->sg_maxseg == 0)
-		return -EINVAL;
-
-	error = 0;
-	SGLIST_SAVE(sg, save);
-	UK_NETBUF_CHAIN_FOREACH(nb, netbuf) {
-		if (likely(nb->len > 0)) {
-			error = uk_sglist_append(sg, nb->data, nb->len);
-			if (unlikely(error)) {
-				SGLIST_RESTORE(sg, save);
-				return error;
-			}
-		}
-	}
-	return 0;
-}
-#endif /* CONFIG_LIBUKNETDEV */

--- a/lib/uksglist/sglist.c
+++ b/lib/uksglist/sglist.c
@@ -51,34 +51,8 @@
 #include <uk/vmem.h>
 #endif /* CONFIG_LIBUKVMEM*/
 
-/*
- * Convenience macros to save the state of an sglist so it can be restored
- * if an append attempt fails.  Since sglist's only grow we only need to
- * save the current count of segments and the length of the ending segment.
- * Earlier segments will not be changed by an append, and the only change
- * that can occur to the ending segment is that it can be extended.
- */
-struct sgsave {
-	__u16 sg_nseg;
-	size_t ss_len;
-};
-
 #define page_off(x)    ((unsigned long)(x) & (__PAGE_SIZE - 1))
 #define trunc_page(x)    ((unsigned long)(x) & (__PAGE_MASK))
-
-#define	SGLIST_SAVE(sg, sgsave) do {					\
-	(sgsave).sg_nseg = (sg)->sg_nseg;				\
-	if ((sgsave).sg_nseg > 0)					\
-		(sgsave).ss_len = (sg)->sg_segs[(sgsave).sg_nseg - 1].ss_len; \
-	else								\
-		(sgsave).ss_len = 0;					\
-} while (0)
-
-#define	SGLIST_RESTORE(sg, sgsave) do {					\
-	(sg)->sg_nseg = (sgsave).sg_nseg;				\
-	if ((sgsave).sg_nseg > 0)					\
-		(sg)->sg_segs[(sgsave).sg_nseg - 1].ss_len = (sgsave).ss_len; \
-} while (0)
 
 static inline int _sglist_append_range(struct uk_sglist *sg,
 			struct uk_sglist_seg **ssp, __paddr_t paddr,
@@ -202,7 +176,7 @@ int uk_sglist_count(void *buf, size_t len)
 
 int uk_sglist_append(struct uk_sglist *sg, void *buf, size_t len)
 {
-	struct sgsave save;
+	struct uk_sgsave save;
 	int error;
 
 	UK_ASSERT(sg);
@@ -210,10 +184,10 @@ int uk_sglist_append(struct uk_sglist *sg, void *buf, size_t len)
 	if (sg->sg_maxseg == 0)
 		return -EINVAL;
 
-	SGLIST_SAVE(sg, save);
+	UK_SGLIST_SAVE(sg, save);
 	error = _sglist_append_buf(sg, buf, len,  NULL);
 	if (error)
-		SGLIST_RESTORE(sg, save);
+		UK_SGLIST_RESTORE(sg, save);
 
 	return error;
 }
@@ -222,7 +196,7 @@ int uk_sglist_append_sglist(struct uk_sglist *sg,
 			const struct uk_sglist *source,
 			size_t offset, size_t length)
 {
-	struct sgsave save;
+	struct uk_sgsave save;
 	struct uk_sglist_seg *ss;
 	size_t seglen;
 	int error, i;
@@ -231,7 +205,7 @@ int uk_sglist_append_sglist(struct uk_sglist *sg,
 
 	if (sg->sg_maxseg == 0 || length == 0)
 		return -EINVAL;
-	SGLIST_SAVE(sg, save);
+	UK_SGLIST_SAVE(sg, save);
 	error = -EINVAL;
 	ss = &sg->sg_segs[sg->sg_nseg - 1];
 	for (i = 0; i < source->sg_nseg; i++) {
@@ -256,7 +230,7 @@ int uk_sglist_append_sglist(struct uk_sglist *sg,
 		error = -EINVAL;
 	}
 	if (error)
-		SGLIST_RESTORE(sg, save);
+		UK_SGLIST_RESTORE(sg, save);
 	return error;
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Move some sglist stuff
- netbuf appending to sglist method to `lib/uknetdev/netbuf.c`
- some sglist definitions/macro's for saving/restoring to library header

The important addition of the PR:

The header (first descriptor) of the virtio-blk request must always
come in one piece! By aligning to its size (16), we ensure that
it will be contained entirely in one page only, i.e. the
scatter-gather list will not process it as two segments, which
would result in two descriptors.

E.g. If the address ends something like 0x...ff8 then the header
will span 0x...ff8 -> 0x...008 crossing the next page and resulting
in the scatter-gather list splitting it into two segments and
thus into two descriptors, which QEMU seems to not like.

To help with this, declare the request header at the beginning
of the virtio-blk request structure and make its allocation
16-byte aligned, guaranteeing its length will never cross the page
boundary.

