### PR TITLE
lib/posix-process: Add support for RLIMIT_AS

### DIFF
--- a/lib/posix-process/deprecated.c
+++ b/lib/posix-process/deprecated.c
@@ -326,8 +326,8 @@ UK_LLSYSCALL_R_DEFINE(int, prlimit64, int, pid, unsigned int, resource,
 	 */
 	switch (resource) {
 	case RLIMIT_DATA:
-		break;
 	case RLIMIT_STACK:
+	case RLIMIT_AS:
 		break;
 #if CONFIG_LIBVFSCORE
 	case RLIMIT_NOFILE:
@@ -362,6 +362,10 @@ UK_LLSYSCALL_R_DEFINE(int, prlimit64, int, pid, unsigned int, resource,
 	case RLIMIT_STACK:
 		old_limit->rlim_cur = __STACK_SIZE;
 		old_limit->rlim_max = __STACK_SIZE;
+		break;
+	case RLIMIT_AS:
+		old_limit->rlim_cur = RLIM_INFINITY;
+		old_limit->rlim_max = RLIM_INFINITY;
 		break;
 
 #if CONFIG_LIBVFSCORE


### PR DESCRIPTION
### Description of changes

This change adds support for retrieving the address space resource limit using the *rlimit syscalls. In line with other 64-bit systems, the limit returned is unlimited.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

### Additional configuration

N/A
