### PR TITLE
lib/nolibc: Use strcat() from mini-os

### DIFF
--- a/lib/nolibc/string.c
+++ b/lib/nolibc/string.c
@@ -829,8 +829,14 @@ char *strerror(int errnum)
 
 char *strcat(char *restrict dest, const char *restrict src)
 {
-	strcpy(dest + strlen(dest), src);
-	return dest;
+	char *tmp = dest;
+
+	while (*dest)
+		dest++;
+
+	while ((*dest++ = *src++) != '\0');
+
+	return tmp;
 }
 
 char *strncat(char *dest, const char *src, size_t n)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The update of `strcpy()` introduced in 45677167 combined with the implementation of `strcat()` that calls `strlen()` cause a warning on GCC-13 due to the bounds passed by `strlen()` to `strnlen()`:
```
    note: at offset 9223372036854775807 into destination object ‘dest’ of size [0, 9223372036854775807]
``` 
Replace the implementation of `strcat()` with the one from mini-os.