### PR TITLE
lib/posix-fdtab: Silence unused parameter warning

### DIFF
--- a/lib/posix-fdtab/fdtab.c
+++ b/lib/posix-fdtab/fdtab.c
@@ -125,7 +125,7 @@ static inline void ofile_rel(struct uk_fdtab *tab, struct uk_ofile *of)
 
 #if CONFIG_LIBPOSIX_FDTAB_LEGACY_SHIM
 
-static inline void file_acq(void *p, int flags)
+static inline void file_acq(void *p, int flags __maybe_unused)
 {
 #if CONFIG_LIBVFSCORE
 	if (flags & UK_FDTAB_VFSCORE)
@@ -134,7 +134,9 @@ static inline void file_acq(void *p, int flags)
 #endif /* CONFIG_LIBVFSCORE */
 		ofile_acq((struct uk_ofile *)p);
 }
-static inline void file_rel(struct uk_fdtab *tab, void *p, int flags)
+
+static inline
+void file_rel(struct uk_fdtab *tab, void *p, int flags __maybe_unused)
 {
 #if CONFIG_LIBVFSCORE
 	if (flags & UK_FDTAB_VFSCORE)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The `flags` parameter in `file_ack` and `file_rel` is used conditionally to `CONFIG_LIBVFSCORE`. Add the `__maybe_unused` attribute to silience GCC warnings.