### PR TITLE
lib/ukvmem: Use correct argument type in format string

### DIFF
--- a/lib/ukvmem/arch/arm/pagefault64.c
+++ b/lib/ukvmem/arch/arm/pagefault64.c
@@ -40,7 +40,7 @@ static int vmem_arch_pagefault(void *data)
 	rc = vmem_pagefault(vaddr, faulttype, ctx->regs);
 	if (unlikely(rc < 0)) {
 		uk_pr_debug("Cannot handle %s page fault at 0x%"__PRIvaddr
-			    " (ec: 0x%x): %d\n",
+			    " (ec: 0x%lx): %d\n",
 			    faultstr[faulttype & UK_VMA_FAULT_ACCESSTYPE],
 			    vaddr, ctx->esr, rc);
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Use the `%lx` type in format string for ctx->esr. Fixes a GCC warning.