### PR TITLE
lib/posix-fdio: ENOTTY for unsupported tty ioctls

### DIFF
--- a/lib/posix-fdio/fdctl.c
+++ b/lib/posix-fdio/fdctl.c
@@ -14,6 +14,8 @@
 
 #include "fdio-impl.h"
 
+/* Needed for IOCTL_CMD_ISTYPE */
+#include <vfscore/vnode.h>
 
 int uk_sys_ioctl(struct uk_ofile *of, int cmd, void *arg)
 {
@@ -38,6 +40,10 @@ int uk_sys_ioctl(struct uk_ofile *of, int cmd, void *arg)
 	r = uk_file_ctl(f, UKFILE_CTL_IOCTL, cmd, (uintptr_t)arg, 0, 0);
 	if (iolock)
 		uk_file_wunlock(f);
+
+	/* Universally return -ENOTTY for unimplemented TTY ioctls */
+	if (unlikely(r == -ENOSYS && IOCTL_CMD_ISTYPE(cmd, IOCTL_CMD_TYPE_TTY)))
+		return -ENOTTY;
 	return r;
 }
 


### PR DESCRIPTION
### Description of changes

This change makes ioctl universally return -ENOTTY for tty-specific ioctls that are not supported by the file driver, which it in turn signals by returning -ENOSYS.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A