### PR TITLE
lib/posix-process: Add option to context switch away from clone caller

### DIFF
--- a/lib/posix-process/Config.uk
+++ b/lib/posix-process/Config.uk
@@ -25,6 +25,15 @@ endif
 	default n
 	select LIBPOSIX_PROCESS_PIDS
 
+	config LIBPOSIX_PROCESS_CLONE_PREFER_CHILD
+	bool "Prefer scheduling of child"
+	depends on LIBPOSIX_PROCESS_CLONE
+	help
+		If enabled, clone will context switch away from the clone
+		caller. This is necessary for some applications that assume that
+		the new thread does progress while the clone caller is not
+		context switching.
+
 	config LIBPOSIX_PROCESS_DEBUG
 	bool "Enable debug messages"
 	default n

--- a/lib/posix-process/clone.c
+++ b/lib/posix-process/clone.c
@@ -474,6 +474,10 @@ static int _clone(struct clone_args *cl_args, size_t cl_args_len,
 	/* Assign the child to the scheduler */
 	uk_sched_thread_add(s, child);
 
+#ifdef CONFIG_LIBPOSIX_PROCESS_CLONE_PREFER_CHILD
+	uk_sched_yield();
+#endif /* CONFIG_LIBPOSIX_PROCESS_CLONE_PREFER_CHILD */
+
 	return ret;
 
 err_free_child:


### PR DESCRIPTION
Some applications are expecting to run on a cooperative scheduler and will naively assume that the new thread will do some progress even if the clone caller does not context-switch by blocking/yielding.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:
-->
 - `CONFIG_LIBPOSIX_PROCESS_CLONE_PREFER_CHILD=y`

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
