### PR TITLE
lib/posix-time: Add support for CLOCK_BOOTTIME

### DIFF
--- a/lib/posix-time/time.c
+++ b/lib/posix-time/time.c
@@ -153,6 +153,7 @@ UK_SYSCALL_R_DEFINE(int, clock_getres, clockid_t, clk_id,
 	case CLOCK_MONOTONIC:
 	case CLOCK_MONOTONIC_COARSE:
 	case CLOCK_REALTIME:
+	case CLOCK_BOOTTIME:
 		if (tp) {
 			tp->tv_sec = 0;
 			tp->tv_nsec = UKPLAT_TIME_TICK_NSEC;
@@ -182,6 +183,7 @@ UK_SYSCALL_R_DEFINE(int, clock_gettime, clockid_t, clk_id, struct timespec*, tp)
 	switch (clk_id) {
 	case CLOCK_MONOTONIC:
 	case CLOCK_MONOTONIC_COARSE:
+	case CLOCK_BOOTTIME:
 		now = ukplat_monotonic_clock();
 		break;
 	case CLOCK_REALTIME:


### PR DESCRIPTION
### Description of changes

This change adds rudimentary support for CLOCK_BOOTTIME, implemented as a synonym for CLOCK_MONOTONIC.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Test snippet:
```c
int main(void)
{
	struct timespec t;
	for (;;) {
		clock_gettime(CLOCK_BOOTTIME, &t);
		printf("%ld.%9ld\n", t.tv_sec, t.tv_nsec);
		sleep(1);
	}
	return 0;
}
```
Should start printing reasonable times since boot.