### PR TITLE
plat/kvm/x86: Remove unused variable from lxboot_entry()

### DIFF
--- a/plat/kvm/x86/lxboot.c
+++ b/plat/kvm/x86/lxboot.c
@@ -142,7 +142,6 @@ lxboot_init_mem(struct ukplat_bootinfo *bi, struct lxboot_params *bp)
 void lxboot_entry(struct lcpu *lcpu, struct lxboot_params *bp)
 {
 	struct ukplat_bootinfo *bi;
-	int rc;
 
 	bi = ukplat_bootinfo_get();
 	if (unlikely(!bi))


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`x86_64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Remove unused variable from lxboot_entry() to prevent compiler warnings.