### PR TITLE
lib/posix-sysinfo: Fix off-by-1 error in `sethostname`

### DIFF
--- a/lib/nolibc/include/unistd.h
+++ b/lib/nolibc/include/unistd.h
@@ -46,6 +46,8 @@ extern "C" {
 #define __NEED_off_t
 #define __NEED_useconds_t
 
+#include <nolibc-internal/shareddefs.h>
+
 /*
  * Sysconf name values
  */
@@ -60,9 +62,9 @@ extern "C" {
 #define _SC_NPROCESSORS_ONLN 84
 
 long sysconf(int);
+int gethostname(char *name, size_t len);
+int sethostname(const char *name, size_t len);
 #endif
-
-#include <nolibc-internal/shareddefs.h>
 
 #if CONFIG_HAVE_TIME
 unsigned int sleep(unsigned int seconds);

--- a/lib/posix-sysinfo/sysinfo.c
+++ b/lib/posix-sysinfo/sysinfo.c
@@ -184,13 +184,12 @@ UK_SYSCALL_R_DEFINE(int, sethostname, const char*, name, size_t, len)
 		return -EFAULT;
 	}
 
-	if (len > sizeof(utsname.nodename)) {
+	if (len + 1 > sizeof(utsname.nodename)) {
 		return -EINVAL;
 	}
 
-	strncpy(utsname.nodename, name, len);
-	if (len < sizeof(utsname.nodename))
-		utsname.nodename[len] = 0;
+	memcpy(utsname.nodename, name, len);
+	utsname.nodename[len] = '\0';
 	return 0;
 }
 


### PR DESCRIPTION
### Description of changes

This change corrects an an off-by-1 error in sethostname when checking the length of the new hostname, leading to a missing terminating NUL byte in the `nodename` field of `struct utsname`, contrary to the expected Linux ABI. The suboptimal `strncpy` call is also replaced with a more appropriate `memcpy` call, since (1) we know the length of the input string, which (2) does not need to be NUL-terminated.

Additionally, declarations of `gethostname` and `sethostname` are added to `nolibc`'s `unistd.h`, making these functions available to core unikraft as well as microlibraries.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

`CONFIG_LIBPOSIX_SYSINFO=y`

Test snippet:
```c
int main(void)
{
	char name[4096];
	int r;

	r = gethostname(name, 4096);
	assert(!r);
	puts(name);

	r = sethostname("123456789012345678901234567890123456789012345678901234567890abcde", 65);
	if (!r) {
		r = gethostname(name, 4096);
		assert(!r);
		puts(name);
	} else {
		puts("Errored out");
	}

	r = sethostname("123456789012345678901234567890123456789012345678901234567890abcde", 64);
	assert(!r);

	r = gethostname(name, 4096);
	assert(!r);
	puts(name);

	return 0;
}
```
On `staging` it incorrectly sets a hostname without a NUL byte, resulting in the Unikraft version leaking into the hostname:
```
SeaBIOS (version 1.16.3-1.fc39)
Booting from ROM..Powered by
o.   .o       _ _               __ _
Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
oOo oOO| | | | |   (| | | (_) |  _) :_
 OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
               Telesto 0.16.1~4b12ebc89
unikraft
123456789012345678901234567890123456789012345678901234567890abcde5-Telesto
123456789012345678901234567890123456789012345678901234567890abcd

```
After the fix, it should correctly error out of the first `sethostname` call:
```
SeaBIOS (version 1.16.3-1.fc39)
Booting from ROM..Powered by
o.   .o       _ _               __ _
Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
oOo oOO| | | | |   (| | | (_) |  _) :_
 OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
               Telesto 0.16.1~c704be7ea
unikraft
Errored out
123456789012345678901234567890123456789012345678901234567890abcd
```
