### PR TITLE
lib/nolibc: Expose FD_SETSIZE as Kconfig option

### DIFF
--- a/lib/nolibc/Config.uk
+++ b/lib/nolibc/Config.uk
@@ -20,4 +20,11 @@ if LIBNOLIBC
 		help
 			Provide implementation of syslog/openlog/closelog functions which use the
 			ukdebug facility.
+
+	config LIBNOLIBC_FD_SETSIZE
+		int "Maximum number of file descriptors in an fd_set"
+		range 64 32768
+		default 64
+		help
+			Determines the largest fd that can be passed to select().
 endif

--- a/lib/nolibc/include/sys/select.h
+++ b/lib/nolibc/include/sys/select.h
@@ -53,7 +53,7 @@ typedef unsigned long __fd_mask;
  * be enough for most uses.
  */
 #ifndef FD_SETSIZE
-#define FD_SETSIZE 64
+#define FD_SETSIZE CONFIG_LIBNOLIBC_FD_SETSIZE
 #endif
 
 #define _NFDBITS (sizeof(__fd_mask) * 8) /* bits per mask */


### PR DESCRIPTION
### Description of changes

This change adds a Kconfig option to select the desired value for FD_SETSIZE, defaulting to 64.

This PR replaces https://github.com/unikraft/unikraft/pull/1280.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A
