### PR TITLE
lib/posix-poll: Fix EPOLL_CTL_MOD missing events

### DIFF
--- a/lib/ukfile/include/uk/file/pollqueue.h
+++ b/lib/ukfile/include/uk/file/pollqueue.h
@@ -461,28 +461,6 @@ void uk_pollq_unregister(struct uk_pollq *q, struct uk_poll_chain *tick)
 }
 
 /**
- * Update the registration ticket `tick` with values from `ntick` atomically.
- *
- * `ntick` should first be initialized from `tick`, then have values updated.
- * Supplying a `tick` that is not registered with `q` or `ntick` with a `next`
- * field different from the one in `tick` is undefined behavior.
- *
- * @param q Target queue.
- * @param tick Update chaining ticket to update.
- * @param ntick New values for fields in `tick`.
- */
-static inline
-void uk_pollq_reregister(struct uk_pollq *q, struct uk_poll_chain *tick,
-			 const struct uk_poll_chain *ntick)
-{
-	UK_ASSERT(tick->next == ntick->next);
-	uk_rwlock_rlock(&q->proplock);
-	uk_or(&q->propmask, ntick->mask);
-	*tick = *ntick;
-	uk_rwlock_runlock(&q->proplock);
-}
-
-/**
  * Poll for events and/or register for propagation on `q`.
  *
  * @param q Target queue.


### PR DESCRIPTION
### Description of changes

Previously a epoll_ctl(EPOLL_CTL_MOD) call that added new events to be monitored would miss events already present on the target file.
This was due to a design error misunderstanding the semantics.

This change fixes this issue by making MOD behave as a pair of DEL & ADD operations performed atomically on the epoll file, while minimizing redundant work.

Furthermore, since epoll was the only user of the somewhat hacky `uk_pollq_reregister` function, this PR also prunes the function from the API (thankfully well before 1.0).

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Test snippet (requires `CONFIG_LIBPOSIX_UNIXSOCKET=y`):
```c
int main(void)
{
	struct epoll_event ev;
	int sv[2];

	int r = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
	assert(!r);

	int e = epoll_create(1);
	assert(e >= 0);

	ev.events = EPOLLIN;
	ev.data.fd = sv[0];
	r = epoll_ctl(e, EPOLL_CTL_ADD, sv[0], &ev);
	assert(!r);

	r = epoll_wait(e, &ev, 1, 0);
	printf("%d\n", r);

	ev.events = EPOLLOUT;
	ev.data.fd = sv[0];
	r = epoll_ctl(e, EPOLL_CTL_MOD, sv[0], &ev);
	assert(!r);

	r = epoll_wait(e, &ev, 1, 0);
	printf("%d\n", r);

	return 0;
}
```
Should print
```
0
1
```
on both Linux and Unikraft. Current staging it prints
```
0
0
```