### PR TITLE
lib/nolibc: Solve warning of Musl imported `strstr`

### DIFF
--- a/lib/nolibc/musl-imported/src/string/strstr.c
+++ b/lib/nolibc/musl-imported/src/string/strstr.c
@@ -128,14 +128,14 @@ static char *twoway_strstr(const unsigned char *h, const unsigned char *n)
 	/* Search loop */
 	for (;;) {
 		/* Update incremental end-of-haystack pointer */
-		if (z - h < l) {
+		if (z - h < (long)l) {
 			/* Fast estimate for MAX(l, 63) */
 			__sz grow = l | 63;
 			const unsigned char *z2 = memchr(z, 0, grow);
 
 			if (z2) {
 				z = z2;
-				if (z - h < l)
+				if (z - h < (long)l)
 					return 0;
 			} else {
 				z += grow;


### PR DESCRIPTION
The Musl imported `strstr` had a warning about comparison between variables of different signedness. Fix it.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
