### PR TITLE
arch/x86: Use function pointers instead of switch cases for ECTX ops

### DIFF
--- a/arch/arm/arm64/execenv.S
+++ b/arch/arm/arm64/execenv.S
@@ -7,6 +7,7 @@
 #include <uk/arch/ctx.h>
 #include <uk/arch/lcpu.h>
 #include <uk/asm.h>
+#include <uk/reloc.h>
 
 /**
  * Loads a given execution environment on the currently executing CPU.
@@ -35,7 +36,9 @@ ENTRY(ukarch_execenv_load)
 	 * of execenv.
 	 */
 	add	x0, x0, #(__REGS_SIZEOF + UKARCH_SYSCTX_SIZE)
-	bl	ukarch_ectx_load
+	ur_ldr	x20, ukarch_ectx_load
+	ldr	x20, [x20]
+	blr	x20
 	/**
 	 * As stated previously, after function calls, x19 preserved value of
 	 * execenv pointer so restore that into %rdi.

--- a/arch/arm/ectx.c
+++ b/arch/arm/ectx.c
@@ -60,7 +60,7 @@ __sz ukarch_ectx_align(void)
 	return ECTX_ALIGN;
 }
 
-void ukarch_ectx_sanitize(struct ukarch_ectx *state __maybe_unused)
+void do_ectx_sanitize(struct ukarch_ectx *state __maybe_unused)
 {
 	UK_ASSERT(state);
 	UK_ASSERT(IS_ALIGNED((__uptr) state, ECTX_ALIGN));
@@ -78,7 +78,7 @@ void ukarch_ectx_init(struct ukarch_ectx *state)
 	ukarch_ectx_store(state);
 }
 
-void ukarch_ectx_store(struct ukarch_ectx *state)
+void do_ectx_store(struct ukarch_ectx *state)
 {
 	UK_ASSERT(state);
 	UK_ASSERT(IS_ALIGNED((__uptr) state, ECTX_ALIGN));
@@ -86,10 +86,14 @@ void ukarch_ectx_store(struct ukarch_ectx *state)
 	save_extregs(state);
 }
 
-void ukarch_ectx_load(struct ukarch_ectx *state)
+void do_ectx_load(struct ukarch_ectx *state)
 {
 	UK_ASSERT(state);
 	UK_ASSERT(IS_ALIGNED((__uptr) state, ECTX_ALIGN));
 
 	restore_extregs(state);
 }
+
+void (*ukarch_ectx_sanitize)(struct ukarch_ectx *state) = do_ectx_sanitize;
+void (*ukarch_ectx_load)(struct ukarch_ectx *state) = do_ectx_load;
+void (*ukarch_ectx_store)(struct ukarch_ectx *state) = do_ectx_store;

--- a/arch/x86/x86_64/execenv.S
+++ b/arch/x86/x86_64/execenv.S
@@ -41,7 +41,7 @@ ENTRY(ukarch_execenv_load)
 	 * of execenv.
 	 */
 	addq	$(__REGS_SIZEOF + UKARCH_SYSCTX_SIZE), %rdi
-	call	ukarch_ectx_load
+	call	*ukarch_ectx_load(%rip)
 	/**
 	 * As stated previously, after function calls, %r12 preserved value of
 	 * execenv pointer so restore that into %rdi.

--- a/include/uk/arch/ctx.h
+++ b/include/uk/arch/ctx.h
@@ -487,7 +487,7 @@ __sz ukarch_ectx_align(void);
  * @param state
  *   Reference to extended context
  */
-void ukarch_ectx_sanitize(struct ukarch_ectx *state);
+extern void (*ukarch_ectx_sanitize)(struct ukarch_ectx *state);
 
 /**
  * Initializes an extended context so that it can be loaded
@@ -505,7 +505,7 @@ void ukarch_ectx_init(struct ukarch_ectx *state);
  * @param state
  *   Reference to extended context to save to
  */
-void ukarch_ectx_store(struct ukarch_ectx *state);
+extern void (*ukarch_ectx_store)(struct ukarch_ectx *state);
 
 /**
  * Restores a given extended context on the currently executing CPU.
@@ -513,7 +513,7 @@ void ukarch_ectx_store(struct ukarch_ectx *state);
  * @param state
  *   Reference to extended context to restore
  */
-void ukarch_ectx_load(struct ukarch_ectx *state);
+extern void (*ukarch_ectx_load)(struct ukarch_ectx *state);
 
 /**
  * Loads a given execution environment on the currently executing CPU.

--- a/plat/common/x86/syscall.S
+++ b/plat/common/x86/syscall.S
@@ -230,14 +230,14 @@ ENTRY(_ukplat_syscall)
 	 * header is not dirty.
 	 */
 	addq	$(__REGS_SIZEOF + UKARCH_SYSCTX_SIZE), %rdi
-	call	ukarch_ectx_sanitize
+	call	*ukarch_ectx_sanitize(%rip)
 	/**
 	 * After function calls, %rsp preserved value of execenv pointer so
 	 * restore that into %rdi.
 	 */
 	movq	%rsp, %rdi
 	addq	$(__REGS_SIZEOF + UKARCH_SYSCTX_SIZE), %rdi
-	call	ukarch_ectx_store
+	call	*ukarch_ectx_store(%rip)
 
 	/**
 	 * After function calls, %rsp preserved value of execenv pointer so
@@ -282,7 +282,7 @@ ENTRY(_ukplat_syscall)
 	 * of execenv.
 	 */
 	addq	$(__REGS_SIZEOF + UKARCH_SYSCTX_SIZE), %rdi
-	call	ukarch_ectx_load
+	call	*ukarch_ectx_load(%rip)
 
 	/**
 	 * As stated previously, after function calls, %rsp preserved value of


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

During the initialization of the extended context we would, depending on the result of CPUID, set alignment, size and corresponding store/restore methods of this context. The latter, we would set to the value of an enum which we would afterwards use to decide which of the methods to use when storing/restoring. Change this so that we directly invoke such methods instead doing a switch case.

`NOTE`: I could not use the builtins because of `ectx.c` being marked as `|isr`