### PR TITLE
plat/kvm_x86: ASLR for Unikraft

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -120,6 +120,12 @@ config OPTIMIZE_PIE
 		space by a loader. Some loaders even assume that kernel entrance is
 		relocatable (e.g., EFI).
 
+config RANDOMIZE_BASE_ADDRESS
+	bool "Randomize Base Address"
+	default n
+	help
+		Randomizez the base address of the executable.
+
 choice
 	prompt "Debug information level"
 	default DEBUG_SYMBOLS_LVL3

--- a/Makefile
+++ b/Makefile
@@ -819,7 +819,15 @@ $(BUILD_DIR)/uk-gdb.py: $(SCRIPTS_DIR)/uk-gdb.py
 
 gdb_helpers: $(GDB_HELPER_LINKS) $(BUILD_DIR)/uk-gdb.py
 
-all: images gdb_helpers
+ifeq ($(CONFIG_RANDOMIZE_BASE_ADDRESS),y)
+randomize-base-address:
+	$(eval BASE_ADDRESS := $(shell $(SCRIPTS_DIR)/ASLR/base_address.py --file_path $(CONFIG_UK_BASE)/plat/kvm/x86/multiboot.S))
+else
+randomize-base-address:
+
+endif
+
+all: randomize-base-address images gdb_helpers
 ################################################################################
 # Cleanup rules
 ################################################################################

--- a/include/uk/plat/memory.h
+++ b/include/uk/plat/memory.h
@@ -368,6 +368,17 @@ struct uk_alloc *ukplat_memallocator_get(void);
 void *ukplat_memregion_alloc(__sz size, int type, __u16 flags);
 
 /**
+ * Loops through all the free memory regions and randomly choses a place
+ * to allocate the stack.
+ * @param size
+ *   The size to allocate. Will be rounded up to next multiple of page size.
+ *
+ * @return
+ *   A pointer to the allocated stack on success, NULL otherwise.
+ */
+void *stackmemory_aslr_palloc(__sz size);
+
+/**
  * Initializes the memory mapping based on the platform or architecture defined
  * unmapping memory region descriptor (named `bpt_unmap_mrd`). Based on this
  * descriptor, the function surrounds the kernel image with the unmappings,

--- a/lib/ukrandom/chacha.c
+++ b/lib/ukrandom/chacha.c
@@ -214,7 +214,9 @@ __u32 uk_swrand_randr(void)
 	unsigned long iflags;
 	__u32 ret;
 
+	#ifndef CONFIG_RUNTIME_ASLR
 	UK_ASSERT(!ukplat_lcpu_irqs_disabled());
+	#endif
 
 	iflags = ukplat_lcpu_save_irqf();
 	ret = uk_swrand_randr_r(&uk_swrand_def);

--- a/lib/ukrandom/exportsyms.uk
+++ b/lib/ukrandom/exportsyms.uk
@@ -2,3 +2,4 @@ getrandom
 uk_syscall_e_getrandom
 uk_syscall_r_getrandom
 uk_random_fill_buffer
+ASLR_early_uk_random_init

--- a/lib/ukrandom/include/uk/random.h
+++ b/lib/ukrandom/include/uk/random.h
@@ -47,6 +47,13 @@ extern "C" {
  */
 void uk_random_fill_buffer(void *buf, __sz buflen);
 
+#ifdef CONFIG_RUNTIME_ASLR
+/**
+ * Early random init function used for ASLR
+ */
+void ASLR_early_uk_random_init(void);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/ukrandom/random.c
+++ b/lib/ukrandom/random.c
@@ -69,4 +69,11 @@ static int uk_random_init(struct uk_init_ctx *ictx __unused)
 	return uk_swrand_init();
 }
 
+#ifdef CONFIG_RUNTIME_ASLR
+void ASLR_early_uk_random_init(void)
+{
+	uk_random_init(0x0);
+}
+#else /* CONFIG_RUNTIME_ASLR */
 uk_early_initcall(uk_random_init, 0);
+#endif

--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -171,4 +171,22 @@ endif
 
 endmenu
 
+menu "Memory security"
+
+config LINK_ASLR
+	bool "Libraries ASLR activation"
+	default n
+	select RANDOMIZE_BASE_ADDRESS
+	help
+		Activates the ASLR, it consists in modifying the lib addresses during linking time in order
+		to have different microlibs memory layouts.
+
+config RUNTIME_ASLR
+	bool "Heap/stack ASLR activation"
+	default n
+	select LIBUKSWRAND
+	help
+		Activates the ASLR, it consists in modifying the heap/stack addresses when booting the kernel.
+endmenu
+
 endif

--- a/plat/kvm/Linker.uk
+++ b/plat/kvm/Linker.uk
@@ -47,6 +47,54 @@ KVM_LD_SCRIPT_FLAGS := $(addprefix -Wl$(comma)-dT$(comma),\
 KVM_LD_SCRIPT_FLAGS += $(addprefix -Wl$(comma)-T$(comma),\
 			$(KVM_LD_SCRIPT-y) $(EXTRA_LD_SCRIPT-y))
 
+KVM_LD_SCRIPT_FLAGS_ASLR := $(addprefix -Wl$(comma)-dT$(comma),\
+			 $(UK_PLAT_KVM_DEF_LDS_ASLR))
+KVM_LD_SCRIPT_FLAGS_ASLR += $(addprefix -Wl$(comma)-T$(comma),\
+			$(KVM_LD_SCRIPT-y) $(EXTRA_LD_SCRIPT-y))
+
+ASLR_LIBS += $(foreach P,$(UK_PLATS) $(UK_PLATS-y),\
+		$(if $(call qstrip,$($(call uc,$(P))_LIBS) $($(call uc,$(P))_LIBS-y)),\
+		$(foreach L,$($(call uc,$(P))_LIBS) $($(call uc,$(P))_LIBS-y), \
+		$(if $(call qstrip,$($(call vprefix_lib,$(L),SRCS)) $($(call vprefix_lib,$(L),SRCS-y))), \
+		$(L) \
+		)))) \
+		$(UK_LIBS) $(UK_LIBS-y)
+
+ASLR_args += --file_path=$(UK_PLAT_KVM_DEF_LDS) \
+	--lib_list="$(ASLR_LIBS)" --output_path=$(UK_PLAT_KVM_DEF_LDS_ASLR) --base_addr=$(BASE_ADDRESS)
+
+ifeq (y,$(CONFIG_LINK_ASLR))
+$(KVM_DEBUG_IMAGE): $(KVM_ALIBS) $(KVM_ALIBS-y) $(KVM_OLIBS) $(KVM_OLIBS-y) \
+		    $(UK_ALIBS) $(UK_ALIBS-y) $(UK_OLIBS) $(UK_OLIBS-y)
+
+	$(call build_cmd,ASLR,,ASLR,\
+		$(SCRIPTS_DIR)/ASLR/ASLR.py \
+			$(ASLR_args))
+
+	$(call build_cmd,LD,,$(KVM_IMAGE).ld.o,\
+	       $(LD) -r $(LIBLDFLAGS) $(LIBLDFLAGS-y) \
+			$(KVM_LDFLAGS) $(KVM_LDFLAGS-y) \
+			$(KVM_OLIBS) $(KVM_OLIBS-y) \
+			$(UK_OLIBS) $(UK_OLIBS-y) \
+			-Wl$(comma)--start-group \
+			$(KVM_ALIBS) $(KVM_ALIBS-y) \
+			$(UK_ALIBS) $(UK_ALIBS-y) \
+			$(KVM_LINK_LIBGCC_FLAG) \
+			-Wl$(comma)--end-group \
+			-o $(KVM_IMAGE).ld.o)
+
+	$(call build_cmd,OBJCOPY,,$(KVM_IMAGE).o,\
+		$(OBJCOPY) -w \
+			$(KVM_IMAGE).ld.o $(KVM_IMAGE).o)
+
+	$(call build_cmd,LD,,$@,\
+	       $(LD) $(LDFLAGS) $(LDFLAGS-y) \
+		     $(KVM_LDFLAGS) $(KVM_LDFLAGS-y) \
+		     $(KVM_LD_SCRIPT_FLAGS_ASLR)\
+		     -L$(BUILD_DIR) \
+		     -o $@)
+	$(call build_bootinfo,$@)
+else
 $(KVM_DEBUG_IMAGE): $(KVM_ALIBS) $(KVM_ALIBS-y) $(KVM_OLIBS) $(KVM_OLIBS-y) \
 		    $(UK_ALIBS) $(UK_ALIBS-y) $(UK_OLIBS) $(UK_OLIBS-y) \
 		    $(KVM_LD_SCRIPT-y) $(EXTRA_LD_SCRIPT-y) \
@@ -64,6 +112,8 @@ $(KVM_DEBUG_IMAGE): $(KVM_ALIBS) $(KVM_ALIBS-y) $(KVM_OLIBS) $(KVM_OLIBS-y) \
 			$(LDFLAGS) $(LDFLAGS-y) \
 			$(KVM_LD_SCRIPT_FLAGS) \
 			-o $@)
+endif
+
 ifeq ($(CONFIG_OPTIMIZE_PIE),y)
 	$(call build_uk_reloc,$@)
 endif

--- a/plat/kvm/Makefile.uk
+++ b/plat/kvm/Makefile.uk
@@ -25,6 +25,9 @@ LIBKVMPLAT_CXXFLAGS            += -DKVMPLAT -DUK_USE_SECTION_SEGMENTS
 ## Default Linker script
 ifeq ($(CONFIG_ARCH_X86_64),y)
 UK_PLAT_KVM_DEF_LDS            := $(CONFIG_UK_BASE)/plat/kvm/x86/link64.lds.S
+ifeq ($(CONFIG_LINK_ASLR),y)
+UK_PLAT_KVM_DEF_LDS_ASLR := $(BUILD_DIR)/libkvmplat/link64_ASLR.lds
+endif
 else
 ifeq ($(CONFIG_ARCH_ARM_64),y)
 UK_PLAT_KVM_DEF_LDS            := $(CONFIG_UK_BASE)/plat/kvm/arm/link64.lds.S

--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -24,6 +24,10 @@
 #include <uk/plat/common/sections.h>
 #include <uk/plat/common/bootinfo.h>
 
+#ifdef CONFIG_RUNTIME_ASLR
+#include <uk/random.h>
+#endif
+
 static char *cmdline;
 static __sz cmdline_len;
 
@@ -95,9 +99,16 @@ void _ukplat_entry(struct lcpu *lcpu, struct ukplat_bootinfo *bi)
 		UK_CRASH("Cmdline init failed: %d\n", rc);
 
 	/* Allocate boot stack */
+	#ifdef CONFIG_RUNTIME_ASLR
+	ASLR_early_uk_random_init();
+
+	bstack = stackmemory_aslr_palloc(__STACK_SIZE);
+	#else /* CONFIG_RUNTIME_ASLR */
 	bstack = ukplat_memregion_alloc(__STACK_SIZE, UKPLAT_MEMRT_STACK,
 					UKPLAT_MEMRF_READ |
 					UKPLAT_MEMRF_WRITE);
+	#endif /* CONFIG_RUNTIME_ASLR */
+
 	if (unlikely(!bstack))
 		UK_CRASH("Boot stack alloc failed\n");
 

--- a/support/scripts/ASLR/ASLR.py
+++ b/support/scripts/ASLR/ASLR.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024, Unikraft GmbH and The Unikraft Authors.
+# Licensed under the BSD-3-Clause License (the "License").
+# You may not use this file except in compliance with the License.
+
+from Analyzer import Analyzer
+import sys
+from random import SystemRandom
+import argparse
+import re
+import random
+import copy
+
+def library_region(sysRand,libListOrigin,debug):
+	"""
+	In : A random engine, the list of libraries contained in the executable and a debug boolean.
+	Returns a randomized version of the libListOrigin with padding and shuffled micro libs.
+	"""
+	libList = libListOrigin.copy()
+	newRegions = ""
+	while len(libList) != 0:
+		padding = '. = . + 0x'+''.join('{:02X}'.format(sysRand.randint(0,65536)))+";\n"
+		nextLib = sysRand.choice(libList)
+		libList.remove(nextLib)
+		newRegions += "  " + padding
+		newRegions += nextLib+".o (.text);\n"
+
+	return newRegions
+
+def swap_regions(table):
+	"""
+	In : Takes a table of symbols from the linker file, and randomizez the order of the regions and segments.
+	Return a swapped version of the linker script's regions and segments.
+	"""
+
+	for index in range(1,3):
+		region_index = []
+		indices_dict = {}
+		for i, item in enumerate(table):
+			if isinstance(item, list):
+				if item[1] == index:
+					region_index.append(i)
+			if len(item) == 3:
+				key = tuple(item[2]) if isinstance(item[2], list) else item[2]
+				if key not in indices_dict:
+					indices_dict[key] = [i]
+				else:
+					indices_dict[key].append(i)
+
+		if indices_dict != {}:
+			for key, value in indices_dict.items():
+				tmp_shuffle = copy.deepcopy(value)
+				random.shuffle(tmp_shuffle)
+
+				tmp_table = copy.deepcopy(table)
+				for i, item in enumerate(value):
+					tmp_table[value[i]] = table[tmp_shuffle[i]]
+				table = tmp_table
+		else:
+			tmp_shuffle = copy.deepcopy(region_index)
+			random.shuffle(tmp_shuffle)
+
+			tmp_table = copy.deepcopy(table)
+			for i, item in enumerate(region_index):
+				tmp_table[region_index[i]] = table[tmp_shuffle[i]]
+		table = tmp_table
+
+	return table
+
+def randomize_phdrs(file_content):
+    # Use regular expression to find lines between '{' and '}'
+    pattern = re.compile(r'{(.*?)}', re.DOTALL)
+
+    def randomize(match):
+        # Split the lines inside the braces
+        lines = match.group(1).strip().split('\n')
+        # Randomize the order of lines
+        random.shuffle(lines)
+        # Join the lines back together
+        return '{\n' + '\n'.join(lines) + '\n}'
+
+    # Apply the randomize function to each match
+    result = pattern.sub(randomize, file_content, count=1)
+
+    return result
+
+def print_back(openFile,output,table,debug):
+	"""
+	In : openFile is the linker script to modify,
+		 output the file in which the programs writes,
+		 table is the table containing the modified linker script,
+		 debug a boolean
+	Writes back the modified linker script into the file openFile.
+	"""
+	writeFile = open(output,"w")
+	if not writeFile:
+		print("[ASLR] {Error} Can't open the output file.",file=sys.stderr)
+		sys.exit()
+	# Clears the file and save headers
+	openFile.seek(0)
+	headers = openFile.read().split("SECTIONS\n{\n")
+
+	new_phdrs = randomize_phdrs(headers[0])
+
+	# Writes back randomized phdrs
+	writeFile.write(new_phdrs+"SECTIONS\n{\n")
+
+	# Write back the sections
+	for element in table:
+		if isinstance(element, list):
+			writeFile.write(element[0] + "\n")
+		else:
+			writeFile.write(element + "\n")
+
+	writeFile.close()
+	return 0
+
+def extract_libs(string,onlyLibs):
+	"""
+	In : string, a string
+	onlyLibs, a boolean
+	"""
+	wordList = []
+	returnList = []
+	if string is not None:
+		wordList = string.split()
+
+	if onlyLibs:
+		for libs in wordList:
+			if not libs.startswith("lib"):
+				continue
+			else:
+				if isinstance(libs, list):
+					print("[ERROR] - the lib list contains something unexpected")
+					sys.exit()
+				returnList.append(libs)
+		return returnList
+	else:
+		return wordList
+
+def main(openFile,output,debug,libList,baseAddr):
+	analyzer = Analyzer(openFile)
+	table = analyzer.analyze()
+	sysRand = SystemRandom()
+
+	# Randomize the library list inside the .text region
+	for i, line in enumerate(table):
+		if ".text" in line:
+			newLibs = library_region(sysRand, libList, debug)
+			table[i] = table[i].replace("*(.text)", newLibs + "*(.text)")
+			break
+
+	# Swap memory regions
+	table = swap_regions(table)
+
+	# Change the base address in the table
+	table[0] = baseAddr
+
+	print_back(openFile,output,table,debug)
+
+	return 0
+
+if __name__ == '__main__':
+	#Gets back the path of the linker script to modify
+	parser = argparse.ArgumentParser(prog="Unikraft ASLR, linker script implementation")
+
+	parser.add_argument('--base_addr', dest='baseAddr', default='', help="ASLR's base address")
+
+	parser.add_argument('--file_path', dest='path', default='./', help="Path leading to the file.")
+
+	parser.add_argument('--output_path', dest='output', default='./', help="Path and name of the file to create.")
+
+	parser.add_argument('--lib_list', dest='build', default=None, help="All the libs in the ELF file.")
+
+	parser.add_argument('--debug', dest='debug', default='False',
+		help="Prints on the standard input debug information.")
+
+	params , _ = parser.parse_known_args(sys.argv[1:])
+
+	# If no baseAddr is passed, generate a random one
+	if params.baseAddr == "":
+		params.baseAddr = '{:02X}'.format(SystemRandom().randint(1048576,1048576*4))
+
+	baseAddr = '. = 0x' + ''.join(params.baseAddr) + ";"
+
+	openFile = open(params.path,"r+")
+	if openFile is None:
+		print("[ASLR] {Error} Couldn't open the file, path may be wrong.")
+		sys.exit()
+
+	libList = extract_libs(params.build,False)
+	if len(libList) == 0:
+		print("[ASLR] {Error} No lib list given to the program abort.",file=sys.stderr)
+		sys.exit()
+	main(openFile,params.output,params.debug,libList,baseAddr)
+	openFile.close()

--- a/support/scripts/ASLR/Analyzer.py
+++ b/support/scripts/ASLR/Analyzer.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024, Unikraft GmbH and The Unikraft Authors.
+# Licensed under the BSD-3-Clause License (the "License").
+# You may not use this file except in compliance with the License.
+
+class Analyzer:
+	def __init__(self,openFile):
+		self.file = openFile
+		self.symbolTable = []
+		# A list of the sections that cause crashes if their position is changed in the link step
+		self.skippedSections = ["bss", "uk_inittab", "uk_ctortab", "intrstack"]
+
+	def __handlesLine(self,lines):
+		buffer = ""
+		section_name = ""
+
+		# fsm 1 treats the case of the regions that start with "_*" and end with "_e*".
+		# This regions are flattened into a single string as not to overlap in the next steps.
+		# For example, the following region:
+		#  _rodata = .;
+		# .rodata :
+		# {
+		# *(.rodata)
+		# *(.rodata.*)
+		# } :rodata
+		# _erodata = .;
+		# becomes:
+		#  _rodata = .; .rodata : { *(.rodata) *(.rodata.*) } :rodata _erodata = .;
+		fsm_1 = 0
+		# fsm 2 treats the case of the sections that start with "*_start" and end with "*_end"
+		# This regions are flattened into a single string as not to overlap in the next steps.
+		# For example, the following line:
+		# . = ALIGN((1 << 12)); __eh_frame_start = .; .eh_frame : { KEEP(*(.eh_frame)) KEEP(*(.eh_frame.*)) } __eh_frame_end = .; __eh_frame_hdr_start = .; .eh_frame_hdr : { KEEP(*(.eh_frame_hdr)) KEEP(*(.eh_frame_hdr.*)) } __eh_frame_hdr_end = .; __gcc_except_table_start = .; .gcc_except_table : { *(.gcc_except_table) *(.gcc_except_table.*) } __gcc_except_table_end = .;
+		# becomes:
+		# . = ALIGN((1 << 12));
+		# __eh_frame_start = .; .eh_frame : { KEEP(*(.eh_frame)) KEEP(*(.eh_frame.*)) } __eh_frame_end = .;
+		# __eh_frame_hdr_start = .; .eh_frame_hdr : { KEEP(*(.eh_frame_hdr)) KEEP(*(.eh_frame_hdr.*)) } __eh_frame_hdr_end = .;
+		# __gcc_except_table_start = .; .gcc_except_table : { *(.gcc_except_table) *(.gcc_except_table.*) } __gcc_except_table_end = .;
+		fsm_2 = 0
+
+		tmp_lines = list(map(lambda x: [substring + ";" for substring in x.split(";")[:-1]] + [x.split(";")[-1]], lines))
+		tmp_lines = [x for sub_tmp_lines in tmp_lines for x in sub_tmp_lines if x != '']
+		lines = tmp_lines
+
+		for line in lines:
+			stripped_line = line.strip()
+
+			#fsm 1
+			if stripped_line.startswith("_") and not stripped_line.startswith("_e") and not stripped_line.startswith("__"):
+				if fsm_1 != 0:
+					self.symbolTable.append(buffer)
+					buffer = ""
+				fsm_1 = 1
+
+				# Extract the region name
+				region_name = stripped_line[1:stripped_line.index(" ")]
+				buffer += line
+				continue
+
+			if fsm_1 == 1 and "_e" + region_name in line:
+				fsm_1 = 0
+				if line not in buffer:
+					buffer += line
+				if ".text" in buffer:
+					self.symbolTable.append(buffer)
+				else:
+					self.symbolTable.append([buffer, 1])
+				buffer = ""
+				continue
+
+			#fsm 2
+			if fsm_2 == 0 and "_start" in stripped_line and fsm_1 == 0:
+				buffer += line
+				fsm_2 = 1
+				continue
+
+			if fsm_2 == 1 and "_end" in stripped_line:
+				buffer += line
+				skip = False
+				for region in self.skippedSections:
+					if region in buffer:
+						skip = True
+				if skip:
+					self.symbolTable.append(buffer)
+				else:
+					self.symbolTable.append([buffer, 2, section_name])
+				buffer = ""
+				fsm_2 = 0
+				continue
+
+			if fsm_1 != 0 or fsm_2 != 0:
+				buffer += line
+			elif fsm_1 == 0 and fsm_2 == 0:
+				self.symbolTable.append(line)
+
+	def analyze(self):
+		lines = self.file.read().split("SECTIONS\n{\n")[1].split("\n")
+		self.__handlesLine(lines)
+
+		return self.symbolTable.copy()

--- a/support/scripts/ASLR/base_address.py
+++ b/support/scripts/ASLR/base_address.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024, Unikraft GmbH and The Unikraft Authors.
+# Licensed under the BSD-3-Clause License (the "License").
+# You may not use this file except in compliance with the License.
+
+import re
+from random import SystemRandom
+import argparse
+import sys
+
+def replaceBaseAddress(filePath,address):
+	regex1 = re.compile(".movl.*%edi")
+	regex2 = re.compile(".movl.*%edx")
+
+	file = open(filePath, "r")
+
+	newString = ""
+
+	for line in file.readlines():
+		detect1 = re.split(regex1,line)
+		detect2 = re.split(regex2,line)
+		if len(detect1) > 1:
+			newString += "	movl    $0x" + str(address) + ", %edi" + detect1[1]
+		elif len(detect2) > 1:
+			newString += "	movl    $0x" + str(address) + ", %edx" + detect2[1]
+		else:
+			newString += line
+	file.close()
+
+	# Write back the file, with the changed base address
+	file = open(filePath, "w")
+	file.seek(0)
+	file.write(newString)
+
+	return None
+
+if __name__ == "__main__":
+	parser = argparse.ArgumentParser(prog="Unikraft ASLR, linker script implementation")
+	parser.add_argument('--file_path', dest='path', default='', help="ASLR's base address")
+
+	params , _ = parser.parse_known_args(sys.argv[1:])
+
+	if(params.path == ""):
+		print("[BASE_ADDRESS] {Error} Couldn't find the file, path may be wrong.")
+		sys.exit()
+
+	# Generate the new random base address
+	baseAddr = '{:02X}'.format(SystemRandom().randint(1048576,1048576*4))
+
+	replaceBaseAddress(params.path, baseAddr)
+
+	# Print the address so that we can later use it in the ASLR script, via the BASE_ADDRESS env var
+	print(baseAddr)


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): x86_64
 - Platform(s): kvm
 - Application: code base and python3/3.10


### Additional configuration

 - CONFIG_LINK_ASLR=y
 - CONFIG_RUNTIME_ASLR=y
   (the last requires CONFIG_LIBUKSWRAND)
- CONFIG_RANDOMIZE_BASE_ADDRESS

### Description of changes

Add python scripts for library randomization at build-time
Add randomized base address placement for stack and heap
Continued the work from this PR: https://github.com/unikraft/unikraft/pull/492

The **ASLR.py** and **Analyzer.py** scripts are used for the build-time randomization.
**Analyzer.py** parses the 'link64.lds' file to make a symbol table that is then randomized in **ASLR.py**, resulting in the 'link64_ASLR.lds' used in the linking process.
The build-time ASLR includes:
	- PHDRS order randomization
	- .text library randomization and padding between each adjacent libraries
	- .text base address randomization
	- segment order randomization
	- section inside segments order randomization (except ”bss”, ”uk inittab”, ”uk ctortab”, and ”intrstack”)
	

`stackmemory_aslr_palloc` function is used to loop through the free memory regions and select at random a region where the stack will be put. Usually, the stack will be placed somewhere inside the region, resulting in unused space before and after the stack. This spaces will create two new memory regions that will be readded in the memory pool.
The heap is allocated later in the `heap_init` function. There are separate cases depending on the  `CONFIG_LIBUKBOOT_HEAP_BASE` flag. If the flag is enabled, the heap address is generated between the last virtual address used and 2 ** 46. If the flag is disabled, the heap address is generated somewhere inside the free memory regions, similar to how the stack base address is generated.