### PR TITLE
lib/posix-poll: Add option to yield on wait

### DIFF
--- a/lib/posix-poll/Config.uk
+++ b/lib/posix-poll/Config.uk
@@ -1,7 +1,18 @@
-config LIBPOSIX_POLL
+menuconfig LIBPOSIX_POLL
 	bool "posix-poll: Support for file polling"
 	select LIBPOSIX_FDIO
 	select LIBPOSIX_FDTAB
 	select LIBUKTIMECONV
 	select LIBUKFILE_CHAINUPDATE
 	select LIBNOLIBC if !HAVE_LIBC
+
+if LIBPOSIX_POLL
+	config LIBPOSIX_POLL_YIELD
+		bool "Always yield execution on wait"
+		help
+			Always yield execution at the beginning of wait functions, ensuring that other
+			threads can make progress even if there are pending events available.
+			This can improve compatibility with some applications that assume
+			starvation-free scheduling, and would otherwise live-lock.
+
+endif

--- a/lib/posix-poll/epoll.c
+++ b/lib/posix-poll/epoll.c
@@ -531,6 +531,10 @@ int uk_sys_epoll_pwait2(const struct uk_file *epf, struct epoll_event *events,
 		deadline = 0;
 	}
 
+#if CONFIG_LIBPOSIX_POLL_YIELD
+	uk_sched_yield();
+#endif /* CONFIG_LIBPOSIX_POLL_YIELD */
+
 	while (uk_file_poll_until(epf, UKFD_POLLIN, deadline)) {
 		int lvlev = 0;
 		int nout = 0;


### PR DESCRIPTION
### Description of changes

This change adds a Kconfig option, LIBPOSIX_POLL_YIELD, that when set ensures that execution is yielded at the beginning of every call to epoll_wait (as well as select and poll).
This can aid compatibility with apps that assume a starvation-free scheduler.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A