### PR TITLE
lib/vfscore: Ensure we return symlink target on `namei_resolve`

### DIFF
--- a/lib/vfscore/lookup.c
+++ b/lib/vfscore/lookup.c
@@ -142,6 +142,15 @@ namei_resolve(const char *path, struct dentry **dpp, char *realpath)
 		dp = dentry_lookup(mp, node);
 		if (dp) {
 			/* vnode is already active. */
+
+			/* If this dentry is a symlink then we should try to
+			 * return the final target. Otherwise the *_no_follow
+			 * variants of this function should've been called
+			 * instead.
+			 */
+			if (dp->d_vnode->v_type == VLNK)
+				goto dp_is_symlink;
+
 			*dpp = dp;
 			goto out;
 		}
@@ -210,6 +219,7 @@ namei_resolve(const char *path, struct dentry **dpp, char *realpath)
 			ddp = dp;
 
 			if (dp->d_vnode->v_type == VLNK) {
+dp_is_symlink:
 				error = namei_follow_link(dp, node, name, fp, mountpoint_len);
 				if (error) {
 					drele(dp);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The `namei_resolve` method is different from its `*_no_follow` variants as in it is supposed to follow the symbolic links and eventually return the dentry of the final symlink target. However, if the first dentry hit in the cache is a symlink, we no longer check if it is a symlink or not and simply return it. To fix this, simply add a check: if current dentry pointer is a symlink, jump to the symlink logic.

To reproduce this may be hard, as it requires parallelism (just concurrency on a single CPU system won't work):
- thread 1 is following symlink/readlink or any other function that may involve holding a reference to the dentry of a symlink
- at the same time, thread 2 does an openat() on the symlink and because a reference is still being held on the symlink it will be found as a dentry in the cache (lib/vfscore/lookup.c:143) and thus be returned immediately, without checking whether it is a symlink or not. The normal behavior of openat would have been to follow the symlink until the final target is reached, however this way the openat() ends up being done on the dentry of the symlink instead.