### PR TITLE
plat/kvm/x86: Fix {XSAVE,AVX,FSGSBASE} checking/enabling behavior

### DIFF
--- a/plat/kvm/x86/lcpu_start.S
+++ b/plat/kvm/x86/lcpu_start.S
@@ -323,20 +323,32 @@ ENTRY(lcpu_start64)
 #if (__AVX__ || CONFIG_HAVE_X86PKU)
 	/* Enable XSAVE feature */
 	LCPU_ENABLE_XSAVE fail
+#else /* !__AVX__ && !CONFIG_HAVE_X86PKU */
+	LCPU_ENABLE_XSAVE no_xsave
+no_xsave:
+#endif /* !__AVX__ && !CONFIG_HAVE_X86PKU */
+
 #if __AVX__
 	/* Enable AVX */
 	LCPU_ENABLE_AVX fail
-#endif /* __AVX__ */
-#endif /* __AVX__ || CONFIG_HAVE_X86PKU */
+#else /* !__AVX__ */
+	LCPU_ENABLE_AVX no_avx
+no_avx:
+#endif /* !__AVX__ */
 
 	/* Request extended CPU features */
 	movl	$7, %eax
 	xorl	%ecx, %ecx
 	cpuid
 
+#if __FSGSBASE__
 	/* Enable FS and GS base */
+	LCPU_ENABLE_FSGSBASE fail
+#else /* !__FSGSBASE__ */
 	LCPU_ENABLE_FSGSBASE no_fsgsbase
 no_fsgsbase:
+#endif /* !__FSGSBASE__ */
+
 #if CONFIG_HAVE_X86PKU
 	/* Enable memory protection keys (PKU) */
 	LCPU_ENABLE_PKU no_pku


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

During early 64-bit long mode boot entry we check for XSAVE, AVX and FSGSBASE. Make sure that we fail booting if we configured Unikraft to use these and they are not supported. However, if Unikraft is still not configured for these, but other runtimes/apps may still benefit from using them (e.g. Java using FSGSBASE), still check and try enabling them but don't fail booting if they are not supported.