### PR TITLE
lib/posix-sysinfo: Use a more Linux compatible release string

### DIFF
--- a/lib/posix-sysinfo/sysinfo.c
+++ b/lib/posix-sysinfo/sysinfo.c
@@ -64,10 +64,11 @@
 static struct utsname utsname = {
 	.sysname	= "Unikraft",
 	.nodename	= "unikraft",
-	/* glibc looks into the release field to check the kernel version:
-	 * We prepend '5-' in order to be "new enough" for it.
+	/* glibc and some other applications look into the release field to
+	 * check the kernel version: We prepend a proper kernel version in order
+	 * to be "new enough" for it.
 	 */
-	.release	= "5-" STRINGIFY(UK_CODENAME),
+	.release	= "5.15.148-" STRINGIFY(UK_CODENAME),
 	.version	= STRINGIFY(UK_FULLVERSION),
 #ifdef CONFIG_ARCH_X86_64
 	.machine	= "x86_64"


### PR DESCRIPTION
Some software checks for the linux version number in the release string. Just including a '5' at the beginning is not enough in some cases. Therefore, just include some more digits.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
