### PR TITLE
lib/posix-unixsocket: Fix NULL deref crash

### DIFF
--- a/lib/posix-unixsocket/unixsock.c
+++ b/lib/posix-unixsocket/unixsock.c
@@ -714,7 +714,7 @@ ssize_t unix_socket_recvfrom(posix_sock *file, void *restrict buf,
 	};
 	struct msghdr msg = {
 		.msg_name = from,
-		.msg_namelen = *fromlen,
+		.msg_namelen = fromlen ? *fromlen : 0,
 		.msg_iov = &iov,
 		.msg_iovlen = 1,
 		.msg_control = NULL,
@@ -723,7 +723,7 @@ ssize_t unix_socket_recvfrom(posix_sock *file, void *restrict buf,
 	};
 	ssize_t ret = unix_socket_recvmsg(file, &msg, flags);
 
-	if (ret >= 0)
+	if (fromlen && ret >= 0)
 		*fromlen = msg.msg_namelen;
 	return ret;
 }


### PR DESCRIPTION
### Description of changes

Previously `unix_socket_recvfrom` would not check its `fromlen` argument before dereferencing it, even though the API allows for it to be NULL. This change fixes this oversight, eliminating a potential crash.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Test: call `recvfrom()` on a unix socket with NULL for `src_addr`.