### PR TITLE
lib/nolibc: Provide fd functions without vfscore

### DIFF
--- a/lib/nolibc/include/unistd.h
+++ b/lib/nolibc/include/unistd.h
@@ -99,7 +99,25 @@ int dup3(int oldfd, int newfd, int flags);
 int unlink(const char *pathname);
 off_t lseek(int fd, off_t offset, int whence);
 int rmdir(const char *pathname);
-#endif
+#else /* !CONFIG_LIBVFSCORE */
+
+#if CONFIG_LIBPOSIX_FDTAB
+int close(int fd);
+int dup(int oldfd);
+int dup2(int oldfd, int newfd);
+int dup3(int oldfd, int newfd, int flags);
+
+#if CONFIG_LIBPOSIX_FDIO
+ssize_t write(int fd, const void *buf, size_t count);
+ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
+ssize_t read(int fd, void *buf, size_t count);
+ssize_t pread(int fd, void *buf, size_t count, off_t offset);
+int fsync(int fd);
+off_t lseek(int fd, off_t offset, int whence);
+#endif /* CONFIG_LIBPOSIX_FDIO */
+#endif /* CONFIG_LIBPOSIX_FDTAB */
+
+#endif /* !CONFIG_LIBVFSCORE */
 
 #if CONFIG_LIBUKSIGNAL
 unsigned int alarm(unsigned int seconds);


### PR DESCRIPTION
### Description of changes

This change makes nolibc provide file descriptor-related functions in `unistd.h` when the corresponding syscalls are provided by posix-fd* libraries, even without vfscore selected.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Configure with `libposix-fdtab` and/or `libposix-fdio` but without `vfscore`. Corresponding libc functions should remain declared in `unistd.h`.