### PR TITLE
lib/ukintctlr: Simplify the interface of ukintctlr_platform_probe()

### DIFF
--- a/drivers/ukintctlr/gic/gic-v2.c
+++ b/drivers/ukintctlr/gic/gic-v2.c
@@ -574,7 +574,6 @@ static int gicv2_do_probe(void)
 	struct ukplat_bootinfo *bi = ukplat_bootinfo_get();
 	int fdt_gic, r;
 	void *fdt;
-	struct uk_intctlr_plat_data in, out;
 
 	UK_ASSERT(bi);
 	fdt = (void *)bi->dtb;
@@ -599,15 +598,11 @@ static int gicv2_do_probe(void)
 		return r;
 	}
 
-	in.dist_addr = gicv2_drv.dist_mem_addr;
-	in.rdist_addr = gicv2_drv.cpuif_mem_addr;
-	r = uk_intctlr_plat_probe(&in, &out);
+	r = uk_intctlr_plat_probe(&gicv2_drv);
 	if (unlikely(r)) {
-		uk_pr_err("GICv3 initialization error");
+		uk_pr_err("GICv2 platform probe failed\n");
 		return r;
 	}
-	gicv2_drv.dist_mem_addr = out.dist_addr;
-	gicv2_drv.cpuif_mem_addr = out.rdist_addr;
 
 	return 0;
 }

--- a/drivers/ukintctlr/gic/gic-v3.c
+++ b/drivers/ukintctlr/gic/gic-v3.c
@@ -647,7 +647,6 @@ static int gicv3_do_probe(void)
 	struct ukplat_bootinfo *bi = ukplat_bootinfo_get();
 	int fdt_gic, r;
 	void *fdt;
-	struct uk_intctlr_plat_data in, out;
 
 	UK_ASSERT(bi);
 	fdt = (void *)bi->dtb;
@@ -683,15 +682,11 @@ static int gicv3_do_probe(void)
 		return r;
 	}
 
-	in.dist_addr = gicv3_drv.dist_mem_addr;
-	in.rdist_addr = gicv3_drv.rdist_mem_addr;
-	r = uk_intctlr_plat_probe(&in, &out);
+	r = uk_intctlr_plat_probe(&gicv3_drv);
 	if (unlikely(r)) {
-		uk_pr_err("GICv3 initialization error");
+		uk_pr_err("GICv3 platform probe failed\n");
 		return r;
 	}
-	gicv3_drv.dist_mem_addr = out.dist_addr;
-	gicv3_drv.rdist_mem_addr = out.rdist_addr;
 
 	return 0;
 }

--- a/drivers/ukintctlr/gic/include/uk/intctlr/gic.h
+++ b/drivers/ukintctlr/gic/include/uk/intctlr/gic.h
@@ -134,17 +134,6 @@ struct _gic_dev {
 	struct _gic_operations ops;
 };
 
-/** Platform specific initialization data */
-struct uk_intctlr_plat_data {
-#if defined(CONFIG_ARCH_ARM_64)
-	uint64_t dist_addr;
-	uint64_t rdist_addr;
-#elif defined(CONFIG_ARCH_ARM_32))
-	uint32_t dist_addr;
-	uint32_t rdist_addr;
-#endif /* CONFIG_ARCH_ARM_32 */
-};
-
 /**
  * Fetch data from an existing MADT's GICD table.
  *

--- a/lib/ukintctlr/include/uk/intctlr.h
+++ b/lib/ukintctlr/include/uk/intctlr.h
@@ -192,12 +192,9 @@ int uk_intctlr_irq_fdt_xlat(const void *fdt, int nodeoffset, __u32 index,
  * For example some architectures with mmu support requires address
  * mapping to access registers.
  *
- * @param in pointer to the platform data that should be interpreted by
- * the driver
- * @param out result structure to that should be interpreted by
- * the driver
+ * @param pointer to driver data. These may be updated by the platform.
  */
-int uk_intctlr_plat_probe(void *in, void *out);
+int uk_intctlr_plat_probe(void *arg);
 
 #endif /* __ASSEMBLY__ */
 

--- a/lib/ukintctlr/ukintctlr.c
+++ b/lib/ukintctlr/ukintctlr.c
@@ -312,8 +312,7 @@ int uk_intctlr_register(struct uk_intctlr_desc *intctlr)
 	return 0;
 }
 
-int __weak uk_intctlr_plat_probe(void *in __unused,
-				 void *out __unused)
+int __weak uk_intctlr_plat_probe(void *arg __unused)
 {
 	return 0;
 }

--- a/plat/xen/arm/setup64.c
+++ b/plat/xen/arm/setup64.c
@@ -198,22 +198,22 @@ static inline void _get_cmdline(struct ukplat_bootinfo *bi)
 	bi->cmdline_len = cmdline_len;
 }
 
-int uk_intctlr_plat_probe(void *in, void *out)
+int uk_intctlr_plat_probe(void *arg)
 {
-	struct uk_intctlr_plat_data *dout = (struct uk_intctlr_plat_data *)out;
-	struct uk_intctlr_plat_data *din = (struct uk_intctlr_plat_data *)in;
+	struct _gic_dev *gic = (struct _gic_dev *)arg;
 
-	if (!in || !out)
-		return -EINVAL;
+	UK_ASSERT(gic);
 
 #if defined(__arm__)
-	dout->dist_addr = to_virt((long)fdt64_ld(din->dist_addr));
-	dout->rdist_addr = to_virt((long)fdt64_ld(din->rdist_addr));
+	gic->dist_mem_addr = to_virt((long)fdt64_ld(gic->dist_mem_addr));
+	gic->rdist_mem_addr = to_virt((long)fdt64_ld(gic->rdist_mem_addr));
 #else
 	set_pgt_entry(&fixmap_pgtable[l2_pgt_idx(FIX_GIC_START)],
-		      ((din->dist_addr & L2_MASK) | BLOCK_DEV_ATTR | L2_BLOCK));
-	dout->dist_addr = (FIX_GIC_START + (din->dist_addr & L2_OFFSET));
-	dout->rdist_addr = (FIX_GIC_START + (din->rdist_addr & L2_OFFSET));
+		      ((gic->dist_mem_addr & L2_MASK) |
+			BLOCK_DEV_ATTR | L2_BLOCK));
+	gic->dist_mem_addr = (FIX_GIC_START + (gic->dist_mem_addr & L2_OFFSET));
+	gic->rdist_mem_addr = (FIX_GIC_START + (gic->rdist_mem_addr &
+						L2_OFFSET));
 #endif
 	/* Setting memory barrier to get access to mapped pages */
 	wmb();


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [`kvm`, `xen`]
 - Application(s): [N/A]

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Replace the input / output parameters of `ukintctlr_platform_probe()` with a single parameter to a mutable object. 

This fixes an issue where a call the default (stub) implementation could result into uninitialized output data.
