### PR TITLE
lib/uknofault: Add on-demand paging disabled read/write operations

### DIFF
--- a/lib/uknofault/include/uk/nofault.h
+++ b/lib/uknofault/include/uk/nofault.h
@@ -115,6 +115,37 @@ __sz uk_nofault_memcpy(char *dst, const char *src, __sz len,
 	   (uk_nofault_memcpy((char *)(ptr), (const char *)&_v, sizeof(_v), 0)\
 		== sizeof(_v)); })
 
+/**
+ * Tries to read the value from a given pointer with on-demand paging disabled
+ *
+ * @param var
+ *   Variable to read the value into
+ * @param ptr
+ *   Memory address to read from
+ *
+ * @return
+ *   non-zero value on success, 0 otherwise
+ */
+#define uk_nofault_try_read_nopaging(v, ptr)				\
+	(uk_nofault_memcpy((char *)&(v), (const char *)(ptr), sizeof(v),\
+			   UK_NOFAULTF_NOPAGING) == sizeof(v))
+
+/**
+ * Tries to write a value to the given pointer with on-demand paging disabled
+ *
+ * @param value
+ *   Value that should be written
+ * @param ptr
+ *   Memory address to write to
+ *
+ * @return
+ *   non-zero value on success, 0 otherwise
+ */
+#define uk_nofault_try_write_nopaging(value, ptr)			\
+	({ typeof(value) _v = (value);					\
+	   (uk_nofault_memcpy((char *)(ptr), (const char *)&_v, sizeof(_v),\
+			      UK_NOFAULTF_NOPAGING) == sizeof(_v)); })
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Implement the equivalent of uk_nofault_try_read/uk_nofault_try_write but with paging disabled.
