### PR TITLE
lib/ukvmem/arch: Do not print error message if demand paging disabled

### DIFF
--- a/lib/ukvmem/arch/arm/pagefault64.c
+++ b/lib/ukvmem/arch/arm/pagefault64.c
@@ -11,6 +11,7 @@
 #include <uk/arch/types.h>
 #include <uk/print.h>
 #include <uk/config.h>
+#include <string.h>
 
 static int vmem_arch_pagefault(void *data)
 {
@@ -21,6 +22,7 @@ static int vmem_arch_pagefault(void *data)
 	};
 	unsigned int faulttype;
 	unsigned long dfsc;
+	struct uk_vas *vas;
 	int rc;
 
 	if (ctx->esr & ARM64_PF_ESR_WnR)
@@ -39,10 +41,13 @@ static int vmem_arch_pagefault(void *data)
 
 	rc = vmem_pagefault(vaddr, faulttype, ctx->regs);
 	if (unlikely(rc < 0)) {
-		uk_pr_crit("Cannot handle %s page fault at 0x%"__PRIvaddr
-			   " (ec: 0x%lx): %d\n",
-			   faultstr[faulttype & UK_VMA_FAULT_ACCESSTYPE],
-			   vaddr, ctx->esr, rc);
+		vas = uk_vas_get_active();
+		if (unlikely(vas && !(vas->flags & UK_VAS_FLAG_NO_PAGING)))
+			uk_pr_crit("Cannot handle %s page fault at 0x%"
+				   __PRIvaddr" (ec: 0x%x): %s (%d).\n",
+				   faultstr[faulttype &
+					    UK_VMA_FAULT_ACCESSTYPE],
+				   vaddr, ctx->error_code, strerror(-rc), -rc);
 
 		return UK_EVENT_NOT_HANDLED;
 	}

--- a/lib/ukvmem/arch/x86_64/pagefault.c
+++ b/lib/ukvmem/arch/x86_64/pagefault.c
@@ -11,6 +11,7 @@
 #include <uk/arch/types.h>
 #include <uk/print.h>
 #include <uk/config.h>
+#include <string.h>
 
 static int vmem_arch_pagefault(void *data)
 {
@@ -20,6 +21,7 @@ static int vmem_arch_pagefault(void *data)
 		"read", "write", "exec"
 	};
 	unsigned int faulttype;
+	struct uk_vas *vas;
 	int rc;
 
 	if (ctx->error_code & X86_PF_EC_WR)
@@ -35,11 +37,14 @@ static int vmem_arch_pagefault(void *data)
 		faulttype |= UK_VMA_FAULT_MISCONFIG;
 
 	rc = vmem_pagefault(vaddr, faulttype, ctx->regs);
-	if (unlikely(rc < 0)) {
-		uk_pr_crit("Cannot handle %s page fault at 0x%"__PRIvaddr
-			   " (ec: 0x%x): %d\n",
-			   faultstr[faulttype & UK_VMA_FAULT_ACCESSTYPE],
-			   vaddr, ctx->error_code, rc);
+	if (rc < 0) {
+		vas = uk_vas_get_active();
+		if (unlikely(vas && !(vas->flags & UK_VAS_FLAG_NO_PAGING)))
+			uk_pr_crit("Cannot handle %s page fault at 0x%"
+				   __PRIvaddr" (ec: 0x%x): %s (%d).\n",
+				   faultstr[faulttype &
+					    UK_VMA_FAULT_ACCESSTYPE],
+				   vaddr, ctx->error_code, strerror(-rc), -rc);
 
 		return UK_EVENT_NOT_HANDLED;
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

In cases such as those of `lib/uknofault`, pafe faults may actually be intentional. So, to avoid unnecessarily throwing out error messages, check if on-demand paging was disabled prior to faulting.
