### PR TITLE
plat/kvm/x86: Add early COM1 init/print for CPU init errors

### DIFF
--- a/plat/kvm/include/kvm-x86/serial_console.h
+++ b/plat/kvm/include/kvm-x86/serial_console.h
@@ -22,8 +22,36 @@
 #ifndef __KVM_SERIAL_CONSOLE__
 #define __KVM_SERIAL_CONSOLE__
 
+#define COM1 0x3f8
+
+#define COM1_DATA (COM1 + 0)
+#define COM1_INTR (COM1 + 1)
+#define COM1_CTRL (COM1 + 3)
+#define COM1_STATUS (COM1 + 5)
+
+/* only when DLAB is set */
+#define COM1_DIV_LO (COM1 + 0)
+#define COM1_DIV_HI (COM1 + 1)
+
+/* baudrate divisor */
+#define COM1_BAUDDIV_HI 0x00
+
+#if CONFIG_KVM_SERIAL_BAUD_19200
+#define COM1_BAUDDIV_LO 0x04
+#elif CONFIG_KVM_SERIAL_BAUD_38400
+#define COM1_BAUDDIV_LO 0x03
+#elif CONFIG_KVM_SERIAL_BAUD_57600
+#define COM1_BAUDDIV_LO 0x02
+#else /* default, CONFIG_KVM_SERIAL_BAUD_115200 */
+#define COM1_BAUDDIV_LO 0x01
+#endif
+
+#define DLAB 0x80
+#define PROT 0x03 /* 8N1 (8 bits, no parity, one stop bit) */
+
+#if !__ASSEMBLY__
 void _libkvmplat_init_serial_console(void);
 void _libkvmplat_serial_putc(char a);
 int  _libkvmplat_serial_getc(void);
-
+#endif /* !__ASSEMBLY__ */
 #endif /* __KVM_SERIAL_CONSOLE__ */

--- a/plat/kvm/x86/lcpu_helpers.S
+++ b/plat/kvm/x86/lcpu_helpers.S
@@ -37,6 +37,7 @@
 #ifndef __PLAT_KVM_X86_LCPU_HELPERS_S__
 #define __PLAT_KVM_X86_LCPU_HELPERS_S__
 
+#include <kvm-x86/serial_console.h>
 #include <uk/arch/lcpu.h>
 
 /**
@@ -150,4 +151,71 @@ ldmxcsr_rval_addr:
 	movq	%rdi, %rcx
 .endm
 
+/**
+ * Super basic enable macro for the widely available COM1 UART port. Can be run
+ * in any mode.
+ *
+ * @clobbers: RAX, RDX
+ */
+.macro LCPU_EARLY_COM1_INIT
+	/* Disable all IRQs */
+	xorl	%eax, %eax
+	movw	$COM1_INTR, %dx
+	outb	%al, (%dx)
+
+	/* Enable DLAB: Begin setting the baudrate divisor */
+	movb	$DLAB, %al
+	movw	$COM1_CTRL, %dx
+	outb	%al, (%dx)
+
+	/* Set low byte of the two byte divisor */
+	movb	$COM1_BAUDDIV_LO, %al
+	movw	$COM1_DIV_LO, %dx
+	outb	%al, (%dx)
+
+	/* Set high byte of the two byte divisor */
+	movb	$COM1_BAUDDIV_HI, %al
+	movw	$COM1_DIV_HI, %dx
+	outb	%al, (%dx)
+
+	/* 8 bits, no parity, one stop bit */
+	movb	$PROT, %al
+	movw	$COM1_CTRL, %dx
+	outb	%al, (%dx)
+.endm
+
+/**
+ * Super basic early printing to widely available COM1 UART port. Must be run
+ * in 64-bit mode of long mode at least so that we can use RIP-relative
+ * addressing.
+ *
+ * @param str: Address of C-string
+ * @clobbers: RAX, RDX, RSI
+ */
+.macro LCPU_EARLY_COM1_PRINT str:req
+	/* RSI = str */
+	leaq	\str(%rip), %rsi
+0:
+	/* TX queue must be empty */
+	movw	$COM1_STATUS, %dx
+	inb	(%dx), %al
+	andb	$0x20, %al
+	jz	0b
+
+	/* Fetch current character */
+	movb	0(%rsi), %al
+
+	/* Is it the NULL terminator? Then we are done printing the C-string. */
+	test	%al, %al
+	jz	1f
+
+	/* Send the current character out the COM1 data port */
+	movw	$COM1_DATA, %dx
+	outb	%al, (%dx)
+
+	/* Go to next character */
+	incq	%rsi
+	jmp	0b
+1:
+.endm
 #endif /* __PLAT_KVM_X86_LCPU_HELPERS_S__ */

--- a/plat/kvm/x86/lcpu_start.S
+++ b/plat/kvm/x86/lcpu_start.S
@@ -2,11 +2,13 @@
 /*
  * Authors: Marc Rittinghaus <marc.rittinghaus@kit.edu>
  *          Cristian Vijelie <cristianvijelie@gmail.com>
+ *          Sergiu Moga <sergiu@unikraft.io>
  *
  * Copyright (c) 2022, Karlsruhe Institute of Technology (KIT)
  *                     All rights reserved.
  * Copyright (c) 2022, University POLITEHNICA of Bucharest.
  *                     All rights reserved.
+ * Copyright (c) 2024, Unikraft GmbH. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -391,7 +393,16 @@ jump_to_entry:
 	 */
 	jmp	*%rax
 
+.pushsection .rodata
+lcpu_start64_fail_msg:
+.string "\nCRIT: Failed to boot on unsupported CPU: An extension is missing.\n"
+.popsection
+
 fail:
+	/* Briefly initialize COM1 and print error message */
+	LCPU_EARLY_COM1_INIT
+	LCPU_EARLY_COM1_PRINT lcpu_start64_fail_msg
+
 	movl	$LCPU_STATE_HALTED, LCPU_STATE_OFFSET(%rbp)
 
 fail_loop:

--- a/plat/kvm/x86/serial_console.c
+++ b/plat/kvm/x86/serial_console.c
@@ -29,33 +29,6 @@
 #include <kvm-x86/serial_console.h>
 #include <x86/cpu.h>
 
-#define COM1 0x3f8
-
-#define COM1_DATA (COM1 + 0)
-#define COM1_INTR (COM1 + 1)
-#define COM1_CTRL (COM1 + 3)
-#define COM1_STATUS (COM1 + 5)
-
-/* only when DLAB is set */
-#define COM1_DIV_LO (COM1 + 0)
-#define COM1_DIV_HI (COM1 + 1)
-
-/* baudrate divisor */
-#define COM1_BAUDDIV_HI 0x00
-
-#if CONFIG_KVM_SERIAL_BAUD_19200
-#define COM1_BAUDDIV_LO 0x04
-#elif CONFIG_KVM_SERIAL_BAUD_38400
-#define COM1_BAUDDIV_LO 0x03
-#elif CONFIG_KVM_SERIAL_BAUD_57600
-#define COM1_BAUDDIV_LO 0x02
-#else /* default, CONFIG_KVM_SERIAL_BAUD_115200 */
-#define COM1_BAUDDIV_LO 0x01
-#endif
-
-#define DLAB 0x80
-#define PROT 0x03 /* 8N1 (8 bits, no parity, one stop bit) */
-
 void _libkvmplat_init_serial_console(void)
 {
 	outb(COM1_INTR, 0x00);  /* Disable all interrupts */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Usually early boot failures tend to be very confusing since there is no message printed. To ease figuring out what went wrong, implement a very basic early initialization macro for the COM1 port as well as a corresponding printing macro that can be used before having a stack.

As a first use case of these newly added macros, print an error message when failing early CPU features initialization, right before halting the system.