### PR TITLE
lib/posix-socket: Expose internal socket syscalls

### DIFF
--- a/lib/posix-socket/exportsyms.uk
+++ b/lib/posix-socket/exportsyms.uk
@@ -52,3 +52,8 @@ uk_syscall_r_sendto
 socketpair
 uk_syscall_e_socketpair
 uk_syscall_r_socketpair
+uk_socket_create
+uk_socketpair_create
+uk_socket_accept
+uk_sys_socket
+uk_sys_socketpair

--- a/lib/posix-socket/include/uk/socket.h
+++ b/lib/posix-socket/include/uk/socket.h
@@ -40,6 +40,8 @@
 #ifndef __UK_SOCKET__
 #define __UK_SOCKET__
 
+#include <sys/socket.h>
+
 struct posix_socket_driver;
 
 struct posix_socket_node {
@@ -57,5 +59,21 @@ struct posix_socket_node {
 #endif /* !CONFIG_LIBPOSIX_SOCKET_PRINT_ERRORS */
 
 #include <uk/socket_driver.h>
+
+struct uk_file *uk_socket_create(int family, int type, int protocol);
+
+int uk_socketpair_create(int family, int type, int protocol,
+			 const struct uk_file *sv[2]);
+
+const struct uk_file *uk_socket_accept(const struct uk_file *sock, int blocking,
+				       struct sockaddr *addr,
+				       socklen_t *addr_len, int flags);
+
+int uk_sys_socket(int family, int type, int protocol);
+
+int uk_sys_socketpair(int family, int type, int protocol, int sv[2]);
+
+int uk_sys_accept(const struct uk_file *sock, int blocking,
+		  struct sockaddr *addr, socklen_t *addr_len, int flags);
 
 #endif /* __UK_SOCKET__ */

--- a/lib/posix-socket/socket.c
+++ b/lib/posix-socket/socket.c
@@ -310,20 +310,18 @@ UK_SYSCALL_R_DEFINE(int, socket, int, family, int, type, int, protocol)
 	return ret;
 }
 
-
-int uk_sys_accept(const struct uk_file *sock, int blocking,
-		  struct sockaddr *addr, socklen_t *addr_len, int flags)
+const struct uk_file *uk_socket_accept(const struct uk_file *sock, int blocking,
+				       struct sockaddr *addr,
+				       socklen_t *addr_len, int flags)
 {
-	int fd;
 	void *new_data;
 	struct socket_alloc *al;
 	struct socket_alloc *al_listener __maybe_unused;
-	unsigned int mode = SOCKET_MODE;
 	struct posix_socket_node *n = (struct posix_socket_node *)sock->node;
 
 	al = uk_malloc(n->driver->allocator, sizeof(*al));
 	if (unlikely(!al))
-		return -ENOMEM;
+		return ERR2PTR(-ENOMEM);
 
 	for (;;) {
 		uk_file_rlock(sock);
@@ -336,7 +334,7 @@ int uk_sys_accept(const struct uk_file *sock, int blocking,
 	}
 	if (unlikely(PTRISERR(new_data))) {
 		uk_free(n->driver->allocator, al);
-		return PTR2ERR(new_data);
+		return new_data;
 	}
 
 	_socket_init(al, n->driver, new_data);
@@ -348,12 +346,29 @@ int uk_sys_accept(const struct uk_file *sock, int blocking,
 	uk_socket_evd_raddr_set(&al->evd, addr, (addr_len ? *addr_len : 0));
 #endif /* CONFIG_LIBPOSIX_SOCKET_EVENTS */
 
+	return &al->f;
+}
+
+int uk_sys_accept(const struct uk_file *sock, int blocking,
+		  struct sockaddr *addr, socklen_t *addr_len, int flags)
+{
+	int fd;
+	const struct uk_file *sockfile;
+	unsigned int mode = SOCKET_MODE;
+	struct socket_alloc *al __maybe_unused;
+
+	al = __containerof(sock, struct socket_alloc, f);
+
+	sockfile = uk_socket_accept(sock, blocking, addr, addr_len, flags);
+	if (unlikely(PTRISERR(sockfile)))
+		return PTR2ERR(sockfile);
+
 	if (flags & SOCK_NONBLOCK)
 		mode |= O_NONBLOCK;
 	if (flags & SOCK_CLOEXEC)
 		mode |= O_CLOEXEC;
-	fd = uk_fdtab_open(&al->f, mode);
-	uk_file_release(&al->f);
+	fd = uk_fdtab_open(sockfile, mode);
+	uk_file_release(sockfile);
 	if (fd >= 0)
 		uk_socket_event_raise(&al->evd, ACCEPT);
 	return fd;


### PR DESCRIPTION
### Description of changes

This change exposes Unikraft-internal syscalls that create sockets. Both versions returning raw uk_files as well as opened file descriptors are provided.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration
N/A