### PR TITLE
lib/posix-poll: Fix missing epoll file locking

### DIFF
--- a/lib/posix-poll/epoll.c
+++ b/lib/posix-poll/epoll.c
@@ -357,9 +357,11 @@ void eventpoll_notify_close(struct vfscore_file *fp)
 
 		UK_ASSERT(ent->legacy);
 		sf.vfile = ent->vf;
+		uk_file_wlock(leg->epf);
 		entp = epoll_find(leg->epf, ent->fd, 1, sf);
 		UK_ASSERT(*entp == ent);
 		epoll_entry_del(leg->epf, entp);
+		uk_file_wunlock(leg->epf);
 	}
 }
 #endif /* CONFIG_LIBVFSCORE */


### PR DESCRIPTION
### Description of changes

This fix adds missing epoll file locking/unlocking in eventpoll_notify_close, which is called by legacy vfscore files on close in order to remove them from the monitored list.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A