### PR TITLE
drivers/virtio: Implement LRO and RX buffer merging

### DIFF
--- a/drivers/virtio/include/virtio/virtqueue.h
+++ b/drivers/virtio/include/virtio/virtqueue.h
@@ -66,8 +66,6 @@ struct virtqueue {
 	virtqueue_callback_t vq_callback;
 	/* Next entry of the queue */
 	UK_TAILQ_ENTRY(struct virtqueue) next;
-	/* EVENT_IDX notification suppression is used */
-	__u8 uses_event_idx;
 	/* Private data structure used by the driver of the queue */
 	void *priv;
 };
@@ -137,17 +135,6 @@ int virtqueue_ring_interrupt(void *obj);
  *	The negotiated feature set.
  */
 __u64 virtqueue_feature_negotiate(__u64 feature_set);
-
-/**
- * Check if host notification is enabled.
- *
- * @param vq
- *	Reference to the virtqueue.
- * @return
- *	Returns 1, host needs notification on new descriptors.
- *		0, otherwise.
- */
-int virtqueue_notify_enabled(struct virtqueue *vq);
 
 /**
  * Remove the user buffer from the virtqueue.
@@ -272,22 +259,7 @@ int virtqueue_intr_enable(struct virtqueue *vq);
  * @param vq
  *      Reference to the virtual queue.
  */
-static inline void virtqueue_host_notify(struct virtqueue *vq)
-{
-	UK_ASSERT(vq);
-
-	/*
-	 * Before notifying the virtio backend on the host we should make sure
-	 * that the virtqueue index update operation happened. Note that this
-	 * function is declared as inline.
-	 */
-	mb();
-
-	if (vq->vq_notify_host && virtqueue_notify_enabled(vq)) {
-		uk_pr_debug("notify queue %d\n", vq->queue_id);
-		vq->vq_notify_host(vq->vdev, vq->queue_id);
-	}
-}
+void virtqueue_host_notify(struct virtqueue *vq);
 
 #ifdef __cplusplus
 }

--- a/drivers/virtio/net/virtio_net.c
+++ b/drivers/virtio/net/virtio_net.c
@@ -596,8 +596,13 @@ static int virtio_netdev_rxq_dequeue(struct virtio_net_device *vndev,
 		*netbuf = NULL;
 		return rxq->nb_desc;
 	}
-	if (unlikely((len < (__u32)virtio_net_hdr_size(vndev) + UK_ETH_HDR_UNTAGGED_LEN) ||
-		     len > VIRTIO_PKT_BUFFER_LEN(vndev))) {
+	if (unlikely((len < (__u32)virtio_net_hdr_size(vndev) +
+			    UK_ETH_HDR_UNTAGGED_LEN) ||
+		     (!(vndev->vdev->features &
+			(1ULL << VIRTIO_NET_F_GUEST_TSO4) ||
+			vndev->vdev->features &
+			(1ULL << VIRTIO_NET_F_GUEST_TSO6)) &&
+		      (len > VIRTIO_PKT_BUFFER_LEN(vndev))))) {
 		uk_pr_err("Received invalid packet size: %"__PRIu32"\n", len);
 		return -EINVAL;
 	}
@@ -1096,6 +1101,32 @@ static int virtio_netdev_feature_negotiate(struct uk_netdev *n,
 	host_features = virtio_feature_get(vndev->vdev);
 
 	/**
+	 * Large Receive Offload
+	 * NOTE: This allows the host to send packets larger than MTU. The
+	 *       network stack needs to be able to handle such packets.
+	 *       We only enable this if we have also support for mergeable RX
+	 *       buffers, otherwise we would have to either allocate huge
+	 *       buffers (wasting space for smaller buffers) or use many small
+	 *       descriptors (needing indirect descriptors and putting a large
+	 *       burden on the allocator).
+	 */
+	if (conf->lro) {
+		if (unlikely(!VIRTIO_FEATURE_HAS(vndev->vdev->features,
+						 VIRTIO_NET_F_GUEST_CSUM) ||
+			     !VIRTIO_FEATURE_HAS(vndev->vdev->features,
+						 VIRTIO_NET_F_MRG_RXBUF))) {
+			rc = -EINVAL;
+			goto err_negotiate_feature;
+		}
+		if (VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_GUEST_TSO4))
+			VIRTIO_FEATURE_SET(vndev->vdev->features,
+					   VIRTIO_NET_F_GUEST_TSO4);
+		if (VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_GUEST_TSO6))
+			VIRTIO_FEATURE_SET(vndev->vdev->features,
+					   VIRTIO_NET_F_GUEST_TSO6);
+	}
+
+	/**
 	 * Announce our enabled driver features back to the backend device
 	 */
 	virtio_feature_set(vndev->vdev);
@@ -1292,9 +1323,12 @@ static void virtio_net_info_get(struct uk_netdev *dev,
 				struct uk_netdev_info *dev_info)
 {
 	struct virtio_net_device *vndev;
+	__u64 host_features;
 
 	UK_ASSERT(dev && dev_info);
 	vndev = to_virtionetdev(dev);
+
+	host_features = virtio_feature_get(vndev->vdev);
 
 	dev_info->max_rx_queues = vndev->max_vqueue_pairs;
 	dev_info->max_tx_queues = vndev->max_vqueue_pairs;
@@ -1307,13 +1341,15 @@ static void virtio_net_info_get(struct uk_netdev *dev,
 	dev_info->ioalign = VIRTIO_PKT_BUFFER_ALIGN;
 
 	dev_info->features = UK_NETDEV_F_RXQ_INTR
-		| (VIRTIO_FEATURE_HAS(vndev->vdev->features, VIRTIO_NET_F_CSUM)
+		| (VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_CSUM)
 		   ? UK_NETDEV_F_PARTIAL_CSUM : 0)
-		| ((VIRTIO_FEATURE_HAS(vndev->vdev->features,
-				       VIRTIO_NET_F_HOST_TSO4)
-		    || VIRTIO_FEATURE_HAS(vndev->vdev->features,
-					  VIRTIO_NET_F_GSO))
-		   ? UK_NETDEV_F_TSO4 : 0);
+		| ((VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_HOST_TSO4)
+		    || VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_GSO))
+		   ? UK_NETDEV_F_TSO4 : 0)
+		| ((VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_GUEST_TSO4)
+		    || VIRTIO_FEATURE_HAS(host_features,
+					  VIRTIO_NET_F_GUEST_TSO6)
+		   ? UK_NETDEV_F_LRO : 0));
 }
 
 static int virtio_net_start(struct uk_netdev *n)

--- a/lib/uknetdev/include/uk/netdev_core.h
+++ b/lib/uknetdev/include/uk/netdev_core.h
@@ -147,6 +147,10 @@ struct uk_hwaddr {
 #define UK_NETDEV_F_TSO4_BIT		3
 #define UK_NETDEV_F_TSO4		(1UL << UK_NETDEV_F_TSO4_BIT)
 
+/* Indicates that the network device supports receiving packets with LRO. */
+#define UK_NETDEV_F_LRO_BIT		4
+#define UK_NETDEV_F_LRO			(1UL << UK_NETDEV_F_LRO_BIT)
+
 #define uk_netdev_rxintr_supported(feature)	\
 	(feature & (UK_NETDEV_F_RXQ_INTR))
 #define uk_netdev_txintr_supported(feature)	\
@@ -185,6 +189,7 @@ struct uk_netdev_queue_info {
 struct uk_netdev_conf {
 	uint16_t nb_rx_queues;
 	uint16_t nb_tx_queues;
+	uint8_t lro; /**< If true, allow LRO. UK_NETDEV_F_LRO must be set */
 };
 
 /**


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

To test this PR you can use the corresponding LWIP PR: https://github.com/unikraft/lib-lwip/pull/53
When receiving large enough payloads via TCP, QEMU/Linux should then pass on packets size much larger than the configured MTU to the VM.

### Description of changes

This PR adds LRO support to the virtio net driver and the necessary abstraction in uknetdev. To avoid having to allocate huge buffers it also implements support for the RX buffer merge feature. This feature allows the device to join multiple receive buffers together for packets larger than the buffer size.
Because this feature triggered a bug in the event notification code, it also includes a fix for that problem.
