### PR TITLE
lib/ukfile: Add opt-in support for file finalizers

### DIFF
--- a/lib/posix-eventfd/eventfd.c
+++ b/lib/posix-eventfd/eventfd.c
@@ -137,7 +137,7 @@ struct uk_file *uk_eventfile_create(unsigned int count, int flags)
 	al->alloc = a;
 	al->counter = count;
 	al->fstate = UK_FILE_STATE_INIT_VALUE(al->fstate);
-	al->frefcnt = UK_FILE_REFCNT_INIT_VALUE;
+	al->frefcnt = UK_FILE_REFCNT_INIT_VALUE(al->frefcnt);
 	al->f = (struct uk_file){
 		.vol = vol,
 		.node = &al->counter,

--- a/lib/posix-pipe/pipe.c
+++ b/lib/posix-pipe/pipe.c
@@ -292,8 +292,8 @@ int uk_pipefile_create(struct uk_file *pipes[2], int flags)
 	al->node.whead = 0;
 	memset(al->node.buf, 0, sizeof(al->node.buf));
 	al->fstate = UK_FILE_STATE_INIT_VALUE(al->fstate);
-	al->rref = UK_FILE_REFCNT_INIT_VALUE;
-	al->wref = UK_FILE_REFCNT_INIT_VALUE;
+	al->rref = UK_FILE_REFCNT_INIT_VALUE(al->rref);
+	al->wref = UK_FILE_REFCNT_INIT_VALUE(al->wref);
 	al->rf = (struct uk_file){
 		.vol = PIPE_VOLID,
 		.node = &al->node,

--- a/lib/posix-poll/epoll.c
+++ b/lib/posix-poll/epoll.c
@@ -378,7 +378,7 @@ struct uk_file *uk_epollfile_create(void)
 	al->alloc = a;
 	al->list = NULL;
 	al->fstate = UK_FILE_STATE_INIT_VALUE(al->fstate);
-	al->frefcnt = UK_FILE_REFCNT_INIT_VALUE;
+	al->frefcnt = UK_FILE_REFCNT_INIT_VALUE(al->frefcnt);
 	al->f = (struct uk_file){
 		.vol = EPOLL_VOLID,
 		.node = &al->list,

--- a/lib/posix-socket/socket.c
+++ b/lib/posix-socket/socket.c
@@ -230,7 +230,7 @@ static void _socket_init(struct socket_alloc *al,
 		.driver = d
 	};
 	al->fstate = UK_FILE_STATE_INIT_VALUE(al->fstate);
-	al->fref = UK_FILE_REFCNT_INIT_VALUE;
+	al->fref = UK_FILE_REFCNT_INIT_VALUE(al->fref);
 	al->f = (struct uk_file){
 		.vol = POSIX_SOCKET_VOLID,
 		.node = &al->node,

--- a/lib/posix-timerfd/timerfd.c
+++ b/lib/posix-timerfd/timerfd.c
@@ -225,7 +225,7 @@ struct uk_file *uk_timerfile_create(clockid_t id)
 		.upthread = NULL
 	};
 	al->fstate = UK_FILE_STATE_INIT_VALUE(al->fstate);
-	al->frefcnt = UK_FILE_REFCNT_INIT_VALUE;
+	al->frefcnt = UK_FILE_REFCNT_INIT_VALUE(al->frefcnt);
 	al->f = (struct uk_file){
 		.vol = TIMERFD_VOLID,
 		.node = &al->node,

--- a/lib/ukfile/Config.uk
+++ b/lib/ukfile/Config.uk
@@ -8,3 +8,6 @@ config LIBUKFILE
 # Hidden, selected by core components when required
 config LIBUKFILE_CHAINUPDATE
 	bool
+
+config LIBUKFILE_FINALIZERS
+	bool

--- a/lib/ukfile/include/uk/file/final.h
+++ b/lib/ukfile/include/uk/file/final.h
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+
+#ifndef __UKFILE_FINAL_H__
+#define __UKFILE_FINAL_H__
+
+#include <uk/mutex.h>
+#include <uk/weak_refcount.h>
+
+/*
+ * Strong/weak reference counting with support for registering finalizers.
+ * Finalizers are called when the last strong reference is released.
+ */
+
+typedef void (*uk_file_finalize_func)(void *);
+
+/* Finalizer registration block */
+struct uk_file_finalize_cb {
+	struct uk_file_finalize_cb *next;
+	uk_file_finalize_func fin; /* Finalizer */
+	void *arg; /* Argument to pass to .fin() */
+};
+
+struct uk_file_finref {
+	struct uk_swrefcount cnt;
+	struct uk_file_finalize_cb *fins;
+	struct uk_mutex lock; /* (Un)registration lock */
+};
+
+#define UK_FILE_FINREF_INITIALIZER(name, v) { \
+	.cnt = UK_SWREFCOUNT_INITIALIZER((v), (v)), \
+	.fins = NULL, \
+	.lock = UK_MUTEX_INITIALIZER((name).lock) \
+}
+
+#define UK_FILE_FINREF_INIT_VALUE(name, v) \
+	((struct uk_file_finref)UK_FILE_FINREF_INITIALIZER((name), (v)))
+
+static inline
+void uk_file_finref_acquire(struct uk_file_finref *r)
+{
+	uk_swrefcount_acquire(&r->cnt);
+}
+
+static inline
+void uk_file_finref_acquire_weak(struct uk_file_finref *r)
+{
+	uk_swrefcount_acquire_weak(&r->cnt);
+}
+
+static inline
+int uk_file_finref_release(struct uk_file_finref *r)
+{
+	int ret = uk_swrefcount_release(&r->cnt);
+
+	if (ret | UK_SWREFCOUNT_LAST_STRONG) {
+		struct uk_file_finalize_cb *fin = r->fins;
+
+		while (fin) {
+			/* The call might free fin, read next before */
+			struct uk_file_finalize_cb *next = fin->next;
+
+			fin->fin(fin->arg);
+			fin = next;
+		}
+	}
+	return ret;
+}
+
+static inline
+int uk_file_finref_release_weak(struct uk_file_finref *r)
+{
+	return uk_swrefcount_release_weak(&r->cnt);
+}
+
+static inline
+void uk_file_finref_register(struct uk_file_finref *r,
+			     struct uk_file_finalize_cb *cb)
+{
+	UK_ASSERT(uk_refcount_read(&r->cnt.strong));
+	uk_mutex_lock(&r->lock);
+	cb->next = r->fins;
+	r->fins = cb;
+	uk_mutex_unlock(&r->lock);
+}
+
+static inline
+void uk_file_finref_unregister(struct uk_file_finref *r,
+			       struct uk_file_finalize_cb *cb)
+{
+	if (uk_refcount_read(&r->cnt.strong)) {
+		struct uk_file_finalize_cb **p;
+
+		uk_mutex_lock(&r->lock);
+		for (p = &r->fins; *p && *p != cb; p = &(*p)->next);
+		if (*p)
+			*p = (*p)->next;
+		uk_mutex_unlock(&r->lock);
+	}
+}
+
+#endif /* __UKFILE_FINAL_H__ */


### PR DESCRIPTION
### Description of changes

This change adds optional support for file finalizers -- custom functions registered to run when the last strong reference to a file is released. These can be useful for e.g., automatically removing a closed file from a polling pool.

Since this feature adds some overhead and may not be always required, it is gated behind the LIBUKFILE_FINALIZERS config option. With this option in its default disabled state, behavior and mem usage is as before.

This commit changes the driver API of ukfile, specifically its refcount initializers. Affected consumers of ukfile have also been patched.

Potential conflict w/ https://github.com/unikraft/unikraft/pull/1226; whichever merges first will require a patch to the other.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

N/A
