### PR TITLE
checkpatch: Additional updates for compliance to coding style

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -3,6 +3,7 @@
 --no-tree
 --ignore ASSIGN_IN_IF
 --ignore AVOID_BUG
+--ignore C99_COMMENT_TOLERANCE
 --ignore NEW_TYPEDEFS
 --ignore FILE_PATH_CHANGES
 --ignore OBSOLETE

--- a/support/scripts/checkpatch.pl
+++ b/support/scripts/checkpatch.pl
@@ -3768,9 +3768,9 @@ sub process {
 				$checklicenseline = 2;
 			} elsif ($rawline =~ /^\+/) {
 				my $comment = "";
-				if ($realfile =~ /\.(h|s|S)$/) {
+				if ($realfile =~ /\.(c|h|s|S)$/) {
 					$comment = '/*';
-				} elsif ($realfile =~ /\.(c|rs|dts|dtsi)$/) {
+				} elsif ($realfile =~ /\.(rs|dts|dtsi)$/) {
 					$comment = '//';
 				} elsif (($checklicenseline == 2) || $realfile =~ /\.(sh|pl|py|awk|tc|yaml)$/) {
 					$comment = '#';


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR contains two changes for the updated `checkpatch` that aim to retain the current coding conventions:

### Disable `C99_COMMENT_TOLERANCE`

The latest version of `checkpatch` allows by default C99 comments with an option to revert back to the old policy. This PR retains the current convention in Unikraft to only allow block comments.

### Use block comments for SPDX identifiers in C files

The linux kernel's convention is to use inline comments for SPDX identifiers in C files for reasons related to tooling. According to https://www.kernel.org/doc/html/next/process/license-rules.html:

```
If a specific tool cannot handle the standard comment style, then the appropriate
comment mechanism which the tool accepts shall be used. This is the reason for
having the “/* */” style comment in C header files. There was build breakage observed
with generated .lds files where ‘ld’ failed to parse the C++ comment. This has been fixed by
now, but there are still older assembler tools which cannot handle C++ style comments.
```

This PR updates `checkpatch` to retain our current convention to use block comments for SPDX identifiers in C files, as at the time of writing there is no use-case of supporting legacy tools in Unikraft.