### PR TITLE
drivers/ukbus: Replace libc types with unikraft defined

### DIFF
--- a/drivers/ukbus/pci/arch/arm64/pci_bus.c
+++ b/drivers/ukbus/pci/arch/arm64/pci_bus.c
@@ -115,8 +115,8 @@ int arch_pci_probe(struct uk_alloc *pha)
 	struct pci_address addr;
 	struct pci_device_id devid;
 	struct pci_driver *drv;
-	uint32_t bus;
-	uint8_t dev;
+	__u32 bus;
+	__u8 dev;
 	int irq, pin = 0;
 	__u64 base;
 	int found_pci_device = 0;

--- a/drivers/ukbus/pci/arch/x86_64/pci_bus.c
+++ b/drivers/ukbus/pci/arch/x86_64/pci_bus.c
@@ -58,7 +58,7 @@
 
 #define PCI_CONF_READ(type, ret, a, s)					\
 	do {								\
-		uint32_t _conf_data;					\
+		__u32 _conf_data;					\
 		outl(PCI_CONFIG_ADDR, (a) | PCI_CONF_##s);		\
 		_conf_data = ((inl(PCI_CONFIG_DATA) >> PCI_CONF_##s##_SHFT) \
 			      & PCI_CONF_##s##_MASK);			\
@@ -70,7 +70,7 @@ static inline int pci_driver_add_device(struct pci_driver *drv,
 					struct pci_device_id *devid)
 {
 	struct pci_device *dev;
-	uint32_t config_addr;
+	__u32 config_addr;
 	int ret;
 
 	UK_ASSERT(drv != NULL);
@@ -94,8 +94,8 @@ static inline int pci_driver_add_device(struct pci_driver *drv,
 	config_addr = (PCI_ENABLE_BIT)
 			| (addr->bus << PCI_BUS_SHIFT)
 			| (addr->devid << PCI_DEVICE_SHIFT);
-	PCI_CONF_READ(uint16_t, &dev->base, config_addr, IOBAR);
-	PCI_CONF_READ(uint8_t, &dev->irq, config_addr, IRQ);
+	PCI_CONF_READ(__u16, &dev->base, config_addr, IOBAR);
+	PCI_CONF_READ(__u8, &dev->irq, config_addr, IRQ);
 
 	ret = drv->add_dev(dev);
 	if (ret < 0) {
@@ -108,14 +108,14 @@ static inline int pci_driver_add_device(struct pci_driver *drv,
 	return 0;
 }
 
-static void probe_bus(uint32_t);
+static void probe_bus(__u32);
 
 /* Probe a function. Return 1 if the function does not exist in the device, 0
  * otherwise.
  */
-static int probe_function(uint32_t bus, uint32_t device, uint32_t function)
+static int probe_function(__u32 bus, __u32 device, __u32 function)
 {
-	uint32_t config_addr, config_data, secondary_bus;
+	__u32 config_addr, config_data, secondary_bus;
 	struct pci_address addr;
 	struct pci_device_id devid;
 	struct pci_driver *drv;
@@ -142,17 +142,17 @@ static int probe_function(uint32_t bus, uint32_t device, uint32_t function)
 	/* These I/O reads could be batched, but it practice this does not
 	 * appear to make the code more performant.
 	 */
-	PCI_CONF_READ(uint32_t, &devid.class_id,
+	PCI_CONF_READ(__u32, &devid.class_id,
 			config_addr, CLASS_ID);
-	PCI_CONF_READ(uint32_t, &devid.sub_class_id,
+	PCI_CONF_READ(__u32, &devid.sub_class_id,
 			config_addr, SUBCLASS_ID);
-	PCI_CONF_READ(uint16_t, &devid.vendor_id,
+	PCI_CONF_READ(__u16, &devid.vendor_id,
 			config_addr, VENDOR_ID);
-	PCI_CONF_READ(uint16_t, &devid.device_id,
+	PCI_CONF_READ(__u16, &devid.device_id,
 			config_addr, DEVICE_ID);
-	PCI_CONF_READ(uint16_t, &devid.subsystem_device_id,
+	PCI_CONF_READ(__u16, &devid.subsystem_device_id,
 			config_addr, SUBSYS_ID);
-	PCI_CONF_READ(uint16_t, &devid.subsystem_vendor_id,
+	PCI_CONF_READ(__u16, &devid.subsystem_vendor_id,
 			config_addr, SUBSYSVEN_ID);
 
 	uk_pr_info("PCI %02x:%02x.%02x (%04x %04x:%04x): ",
@@ -173,7 +173,7 @@ static int probe_function(uint32_t bus, uint32_t device, uint32_t function)
 
 	/* 0x06 = Bridge Device, 0x04 = PCI-to-PCI bridge */
 	if ((devid.class_id == 0x06) && (devid.sub_class_id == 0x04)) {
-		PCI_CONF_READ(uint32_t, &secondary_bus,
+		PCI_CONF_READ(__u32, &secondary_bus,
 				config_addr, SECONDARY_BUS);
 		probe_bus(secondary_bus);
 	}
@@ -184,16 +184,16 @@ static int probe_function(uint32_t bus, uint32_t device, uint32_t function)
 /* Recursive PCI enumeration: this function is called recursively by
  * probe_function upon discovering PCI-to-PCI bridges.
  */
-static void probe_bus(uint32_t bus)
+static void probe_bus(__u32 bus)
 {
-	uint32_t config_addr, device, header_type, function = 0;
+	__u32 config_addr, device, header_type, function = 0;
 
 	for (device = 0; device < PCI_MAX_DEVICES; ++device) {
 		if (!probe_function(bus, device, function))
 			continue;
 
 		config_addr = (PCI_ENABLE_BIT);
-		PCI_CONF_READ(uint32_t, &header_type,
+		PCI_CONF_READ(__u32, &header_type,
 				config_addr, HEADER_TYPE);
 
 		/* Is this a multi-function device? */
@@ -208,14 +208,14 @@ static void probe_bus(uint32_t bus)
 
 int arch_pci_probe(struct uk_alloc *pha)
 {
-	uint32_t config_addr, function, header_type, vendor_id;
+	__u32 config_addr, function, header_type, vendor_id;
 
 	uk_pr_debug("Probe PCI\n");
 
 	ph.a = pha;
 
 	config_addr = (PCI_ENABLE_BIT);
-	PCI_CONF_READ(uint32_t, &header_type,
+	PCI_CONF_READ(__u32, &header_type,
 			config_addr, HEADER_TYPE);
 
 	if ((header_type & PCI_HEADER_TYPE_MSB_MASK) == 0) {
@@ -227,7 +227,7 @@ int arch_pci_probe(struct uk_alloc *pha)
 			config_addr = (PCI_ENABLE_BIT) |
 					(function << PCI_FUNCTION_SHIFT);
 
-			PCI_CONF_READ(uint32_t, &vendor_id,
+			PCI_CONF_READ(__u32, &vendor_id,
 					config_addr, VENDOR_ID);
 
 			if (vendor_id == PCI_INVALID_ID)

--- a/drivers/ukbus/pci/include/uk/bus/pci.h
+++ b/drivers/ukbus/pci/include/uk/bus/pci.h
@@ -64,7 +64,6 @@
 #ifndef __UK_BUS_PCI_H__
 #define __UK_BUS_PCI_H__
 
-#include <stdint.h>
 #include <stddef.h>
 #include <uk/bus.h>
 #include <uk/alloc.h>
@@ -81,17 +80,17 @@ extern "C" {
  */
 struct pci_device_id {
 	/**< Class ID or PCI_CLASS_ANY_ID. */
-	uint32_t class_id;
+	__u32 class_id;
 	/**< Sub class ID or PCI_CLASS_ANY_ID. */
-	uint32_t sub_class_id;
+	__u32 sub_class_id;
 	/**< Vendor ID or PCI_ANY_ID. */
-	uint16_t vendor_id;
+	__u16 vendor_id;
 	/**< Device ID or PCI_ANY_ID. */
-	uint16_t device_id;
+	__u16 device_id;
 	/**< Subsystem vendor ID or PCI_ANY_ID. */
-	uint16_t subsystem_vendor_id;
+	__u16 subsystem_vendor_id;
 	/**< Subsystem device ID or PCI_ANY_ID. */
-	uint16_t subsystem_device_id;
+	__u16 subsystem_device_id;
 };
 
 /** Any PCI device identifier (vendor, device, ...) */
@@ -124,13 +123,13 @@ struct pci_device_id {
  */
 struct pci_address {
 	/**< Device domain */
-	uint32_t domain;
+	__u32 domain;
 	/**< Device bus */
-	uint8_t bus;
+	__u8 bus;
 	/**< Device ID */
-	uint8_t devid;
+	__u8 devid;
 	/**< Device function. */
-	uint8_t function;
+	__u8 function;
 };
 
 struct pci_device;

--- a/drivers/ukbus/pci/pci_ecam.c
+++ b/drivers/ukbus/pci/pci_ecam.c
@@ -100,11 +100,11 @@ int pci_generic_config_read(__u8 bus, __u8 devfn,
 	}
 
 	if (size == 1)
-		*(uint8_t *)val = ioreg_read8(addr);
+		*(__u8 *)val = ioreg_read8(addr);
 	else if (size == 2)
-		*(uint16_t *)val = ioreg_read16(addr);
+		*(__u16 *)val = ioreg_read16(addr);
 	else if (size == 4)
-		*(uint32_t *)val = ioreg_read32(addr);
+		*(__u32 *)val = ioreg_read32(addr);
 	else
 		uk_pr_err("not support size pci config read\n");
 

--- a/drivers/ukbus/pci/pci_ecam.h
+++ b/drivers/ukbus/pci/pci_ecam.h
@@ -73,7 +73,7 @@ struct pci_config_window {
 struct fdt_phandle_args {
 	int np;
 	int args_count;
-	uint32_t args[16];
+	__u32 args[16];
 };
 
 /*

--- a/drivers/ukbus/platform/include/uk/bus/platform.h
+++ b/drivers/ukbus/platform/include/uk/bus/platform.h
@@ -33,7 +33,6 @@
 #ifndef __UK_BUS_PLATFORM_H__
 #define __UK_BUS_PLATFORM_H__
 
-#include <stdint.h>
 #include <uk/bus.h>
 #include <uk/alloc.h>
 
@@ -54,7 +53,7 @@ extern "C" {
 #define UK_MAX_VIRTIO_MMIO_DEVICE (0x2)
 
 struct pf_device_id {
-	uint16_t device_id;
+	__u16 device_id;
 };
 
 struct device_match_table {
@@ -91,8 +90,8 @@ struct pf_device {
 	enum pf_device_state state;
 
 	int fdt_offset;	/* The start offset of fdt node for device */
-	uint64_t base;
-	size_t size;
+	__u64 base;
+	__sz size;
 	unsigned long irq;
 };
 UK_TAILQ_HEAD(pf_device_list, struct pf_device);

--- a/drivers/ukbus/platform/platform_bus.c
+++ b/drivers/ukbus/platform/platform_bus.c
@@ -30,7 +30,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdint.h>
 #include <string.h>
 #include <uk/print.h>
 #include <uk/plat/memory.h>
@@ -86,7 +85,7 @@ static inline struct pf_driver *pf_find_driver(const char *compatible)
 		if (!drv->match)
 			continue;
 
-		id.device_id = (uint16_t)drv->match(compatible);
+		id.device_id = (__u16)drv->match(compatible);
 		if (id.device_id >= PLATFORM_DEVICE_ID_START &&
 			id.device_id < PLATFORM_DEVICE_ID_END) {
 			if (pf_device_id_match(&id, drv->device_ids)) {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Some files inside Unikraft use libc data types. This PR changes those data types with Unikraft-specific data types, inside `drivers/ukbus`.