### PR TITLE
drivers/ukintctlr: Replace libc types with unikraft defined

### DIFF
--- a/drivers/ukintctlr/gic/gic-v2.c
+++ b/drivers/ukintctlr/gic/gic-v2.c
@@ -83,27 +83,27 @@ static const char * const gic_device_list[] __maybe_unused = {
 };
 
 /* Inline functions to access GICC & GICD registers */
-static inline void write_gicd8(uint64_t offset, uint8_t val)
+static inline void write_gicd8(__u64 offset, __u8 val)
 {
 	ioreg_write8(GIC_DIST_REG(gicv2_drv, offset), val);
 }
 
-static inline void write_gicd32(uint64_t offset, uint32_t val)
+static inline void write_gicd32(__u64 offset, __u32 val)
 {
 	ioreg_write32(GIC_DIST_REG(gicv2_drv, offset), val);
 }
 
-static inline uint32_t read_gicd32(uint64_t offset)
+static inline __u32 read_gicd32(__u64 offset)
 {
 	return ioreg_read32(GIC_DIST_REG(gicv2_drv, offset));
 }
 
-static inline void write_gicc32(uint64_t offset, uint32_t val)
+static inline void write_gicc32(__u64 offset, __u32 val)
 {
 	ioreg_write32(GIC_CPU_REG(gicv2_drv, offset), val);
 }
 
-static inline uint32_t read_gicc32(uint64_t offset)
+static inline __u32 read_gicc32(__u64 offset)
 {
 	return ioreg_read32(GIC_CPU_REG(gicv2_drv, offset));
 }
@@ -125,7 +125,7 @@ static void gicv2_enable_cpuif(void)
  *    may not support all levels. For example, if only 128 levels are supported
  *    every two levels (e.g., 0 and 1) map to the same effective value
  */
-static void gicv2_set_threshold_priority(uint32_t priority)
+static void gicv2_set_threshold_priority(__u32 priority)
 {
 	/* GICC_PMR allocate 1 byte for each IRQ */
 	UK_ASSERT(priority <= GICC_PMR_PRIO_MAX);
@@ -138,7 +138,7 @@ static void gicv2_set_threshold_priority(uint32_t priority)
  * @return the ID of the signaled interrupt in bits [0..9] and for SGIs in
  *    a multiprocessor system the originating CPU's ID in bits [10..12]
  */
-static uint32_t gicv2_ack_irq(void)
+static __u32 gicv2_ack_irq(void)
 {
 	return read_gicc32(GICC_IAR);
 }
@@ -154,7 +154,7 @@ static uint32_t gicv2_ack_irq(void)
  *    the ID of the CPU that requested the interrupt in bits [10..12]. Must
  *    correspond to the last value read with ack_irq()
  */
-static void gicv2_eoi_irq(uint32_t eoir)
+static void gicv2_eoi_irq(__u32 eoir)
 {
 	write_gicc32(GICC_EOIR, eoir);
 }
@@ -169,10 +169,10 @@ static void gicv2_eoi_irq(uint32_t eoir)
  * @param targetlist an 8-bit bitmap with 1 bit per CPU 0-7. A `1` bit
  *    indicates that the SGI should be forwarded to the respective CPU
  */
-static void gicv2_sgi_gen(uint32_t sgintid, enum sgi_filter targetfilter,
-			  uint8_t targetlist)
+static void gicv2_sgi_gen(__u32 sgintid, enum sgi_filter targetfilter,
+			  __u8 targetlist)
 {
-	uint32_t val;
+	__u32 val;
 
 	UK_ASSERT(sgintid <= GICD_SGI_MAX_INITID);
 	UK_ASSERT(targetfilter < GICD_SGI_FILTER_MAX);
@@ -199,7 +199,7 @@ static void gicv2_sgi_gen(uint32_t sgintid, enum sgi_filter targetfilter,
  * @param targetlist an 8-bit bitmap with 1 bit per CPU 0-7. A `1` bit
  *    indicates that the SGI should be forwarded to the respective CPU
  */
-void gicv2_sgi_gen_to_list(uint32_t sgintid, uint8_t targetlist)
+void gicv2_sgi_gen_to_list(__u32 sgintid, __u8 targetlist)
 {
 	unsigned long irqf;
 
@@ -211,16 +211,16 @@ void gicv2_sgi_gen_to_list(uint32_t sgintid, uint8_t targetlist)
 /**
  * Forward the SGI to the CPU specified by cpuid.
  */
-static void gicv2_sgi_gen_to_cpu(uint8_t sgintid, uint32_t cpuid)
+static void gicv2_sgi_gen_to_cpu(__u8 sgintid, __u32 cpuid)
 {
-	gicv2_sgi_gen_to_list((uint32_t) sgintid, (uint8_t) (1 << (cpuid % 8)));
+	gicv2_sgi_gen_to_list((__u32) sgintid, (__u8) (1 << (cpuid % 8)));
 }
 
 /**
  * Forward the SGI to all CPU interfaces except the one of the processor that
  * requested the interrupt.
  */
-void gicv2_sgi_gen_to_others(uint32_t sgintid)
+void gicv2_sgi_gen_to_others(__u32 sgintid)
 {
 	unsigned long irqf;
 
@@ -233,7 +233,7 @@ void gicv2_sgi_gen_to_others(uint32_t sgintid)
  * Forward the SGI only to the CPU interface of the processor that requested
  * the interrupt.
  */
-void gicv2_sgi_gen_to_self(uint32_t sgintid)
+void gicv2_sgi_gen_to_self(__u32 sgintid)
 {
 	gicv2_sgi_gen(sgintid, GICD_SGI_FILTER_TO_SELF, 0);
 }
@@ -245,13 +245,13 @@ void gicv2_sgi_gen_to_self(uint32_t sgintid)
  * @param targetlist an 8-bit bitmap with 1 bit per CPU 0-7. A `1` bit
  *    indicates that the SGI should be forwarded to the respective CPU
  */
-static void gicv2_set_irq_target(uint32_t irq, uint32_t targetlist)
+static void gicv2_set_irq_target(__u32 irq, __u32 targetlist)
 {
 	UK_ASSERT(irq >= GIC_SPI_BASE && irq <= GIC_MAX_IRQ);
 	UK_ASSERT(targetlist <= __U8_MAX);
 
 	dist_lock(gicv2_drv);
-	write_gicd8(GICD_ITARGETSR(irq), (uint8_t)targetlist);
+	write_gicd8(GICD_ITARGETSR(irq), (__u8)targetlist);
 	dist_unlock(gicv2_drv);
 }
 
@@ -264,7 +264,7 @@ static void gicv2_set_irq_target(uint32_t irq, uint32_t targetlist)
  *    (e.g., 0 and 1) map to the same effective value. Lower values correspond
  *    to higher priority
  */
-static void gicv2_set_irq_prio(uint32_t irq, uint8_t priority)
+static void gicv2_set_irq_prio(__u32 irq, __u8 priority)
 {
 	UK_ASSERT(irq <= GIC_MAX_IRQ);
 
@@ -278,7 +278,7 @@ static void gicv2_set_irq_prio(uint32_t irq, uint8_t priority)
  *
  * @param irq interrupt number [0..GIC_MAX_IRQ]
  */
-static void gicv2_enable_irq(uint32_t irq)
+static void gicv2_enable_irq(__u32 irq)
 {
 	UK_ASSERT(irq <= GIC_MAX_IRQ);
 
@@ -292,7 +292,7 @@ static void gicv2_enable_irq(uint32_t irq)
  *
  * @param irq interrupt number [0..GIC_MAX_IRQ]
  */
-static void gicv2_disable_irq(uint32_t irq)
+static void gicv2_disable_irq(__u32 irq)
 {
 	UK_ASSERT(irq <= GIC_MAX_IRQ);
 
@@ -327,9 +327,9 @@ static void gicv2_disable_dist(void)
  * @param trigger trigger type (UK_INTCTLR_IRQ_TRIGGER_*)
  */
 static
-void gicv2_set_irq_trigger(uint32_t irq, enum uk_intctlr_irq_trigger trigger)
+void gicv2_set_irq_trigger(__u32 irq, enum uk_intctlr_irq_trigger trigger)
 {
-	uint32_t val, mask, oldmask;
+	__u32 val, mask, oldmask;
 
 	UK_ASSERT(irq >= GIC_PPI_BASE && irq <= GIC_MAX_IRQ);
 	UK_ASSERT(trigger == UK_INTCTLR_IRQ_TRIGGER_EDGE ||
@@ -364,7 +364,7 @@ EXIT_UNLOCK:
 
 static void gicv2_handle_irq(struct __regs *regs)
 {
-	uint32_t stat, irq;
+	__u32 stat, irq;
 
 	do {
 		stat = gicv2_ack_irq();
@@ -396,8 +396,8 @@ static void gicv2_handle_irq(struct __regs *regs)
 
 static void gicv2_init_dist(void)
 {
-	uint32_t val, cpuif_number, irq_number;
-	uint32_t i;
+	__u32 val, cpuif_number, irq_number;
+	__u32 i;
 
 	/* Turn off distributor */
 	gicv2_disable_dist();
@@ -441,7 +441,7 @@ static void gicv2_init_dist(void)
 
 static void gicv2_init_cpuif(void)
 {
-	uint32_t i;
+	__u32 i;
 
 	/* Set priority threshold to the lowest to make all IRQs visible to
 	 * the CPU interface. Note: Higher priority corresponds to a lower

--- a/drivers/ukintctlr/gic/include/uk/intctlr/gic-v2.h
+++ b/drivers/ukintctlr/gic/include/uk/intctlr/gic-v2.h
@@ -297,7 +297,7 @@ enum sgi_filter {
  * @param target an 8-bit bitmap with 1 bit per CPU 0-7. A `1` bit
  *    indicates that the SGI should be forwarded to the respective CPU
  */
-void gicv2_sgi_gen_to_list(uint32_t sgintid, uint8_t target);
+void gicv2_sgi_gen_to_list(__u32 sgintid, __u8 target);
 
 /**
  * Forward the SGI to all CPU interfaces except that of the processor
@@ -305,7 +305,7 @@ void gicv2_sgi_gen_to_list(uint32_t sgintid, uint8_t target);
  *
  * @param sgintid the SGI ID [0-15]
  */
-void gicv2_sgi_gen_to_others(uint32_t sgintid);
+void gicv2_sgi_gen_to_others(__u32 sgintid);
 
 /**
  * Forward the SGI only to the CPU interface of the processor
@@ -313,7 +313,7 @@ void gicv2_sgi_gen_to_others(uint32_t sgintid);
  *
  * @param sgintid the SGI ID [0-15]
  */
-void gicv2_sgi_gen_to_self(uint32_t sgintid);
+void gicv2_sgi_gen_to_self(__u32 sgintid);
 
 /**
  * Probe device tree or ACPI for GICv2

--- a/drivers/ukintctlr/gic/include/uk/intctlr/gic.h
+++ b/drivers/ukintctlr/gic/include/uk/intctlr/gic.h
@@ -30,7 +30,6 @@
 #ifndef __UK_INTCTLR_GIC_H__
 #define __UK_INTCTLR_GIC_H__
 
-#include <stdint.h>
 #include <uk/config.h>
 #include <uk/intctlr.h>
 #include <uk/plat/spinlock.h>
@@ -71,24 +70,24 @@ struct _gic_operations {
 	/** Initialize GIC controller */
 	int (*initialize)(void);
 	/** Acknowledging IRQ */
-	uint32_t (*ack_irq)(void);
+	__u32 (*ack_irq)(void);
 	/** Finish interrupt handling */
-	void (*eoi_irq)(uint32_t irq);
+	void (*eoi_irq)(__u32 irq);
 	/** Enable IRQ */
-	void (*enable_irq)(uint32_t irq);
+	void (*enable_irq)(__u32 irq);
 	/** Disable IRQ */
-	void (*disable_irq)(uint32_t irq);
+	void (*disable_irq)(__u32 irq);
 	/** Set IRQ trigger type */
-	void (*set_irq_trigger)(uint32_t irq,
+	void (*set_irq_trigger)(__u32 irq,
 				enum uk_intctlr_irq_trigger trigger);
 	/** Set priority for IRQ */
-	void (*set_irq_prio)(uint32_t irq, uint8_t priority);
+	void (*set_irq_prio)(__u32 irq, __u8 priority);
 	/** Set IRQ affinity (or "target" for GICv2) */
-	void (*set_irq_affinity)(uint32_t irq, uint32_t affinity);
+	void (*set_irq_affinity)(__u32 irq, __u32 affinity);
 	/** Handle IRQ */
 	void (*handle_irq)(struct __regs *regs);
 	/** Send a SGI to the specifiec core */
-	void (*gic_sgi_gen)(uint8_t sgintid, uint32_t cpuid);
+	void (*gic_sgi_gen)(__u8 sgintid, __u32 cpuid);
 };
 
 /** GIC controller structure */
@@ -96,24 +95,24 @@ struct _gic_dev {
 	/** GIC hardware version */
 	GIC_HW_VER version;
 	/** Indicates if GIC is present */
-	uint8_t is_present;
+	__u8 is_present;
 	/** Probe status */
-	uint8_t is_probed;
+	__u8 is_probed;
 	/** GIC status */
-	uint8_t is_initialized;
+	__u8 is_initialized;
 	/** Distributor base address */
-	uint64_t dist_mem_addr;
+	__u64 dist_mem_addr;
 	/** Distributor memory size */
-	uint64_t dist_mem_size;
+	__u64 dist_mem_size;
 	union {
 		/**
 		 * CPU Interface base address. This field is used only by
 		 * GICv2 driver since in versions above the CPU interface
 		 * is accessed through system registers (not memory mapped)
 		 */
-		uint64_t cpuif_mem_addr;
+		__u64 cpuif_mem_addr;
 		/** Redistributor's base address (GICv3) */
-		uint64_t rdist_mem_addr;
+		__u64 rdist_mem_addr;
 	};
 	union {
 		/**
@@ -121,9 +120,9 @@ struct _gic_dev {
 		 * GICv2 driver since in versions above the CPU interface
 		 * is accessed through system registers (not memory mapped)
 		 */
-		uint64_t cpuif_mem_size;
+		__u64 cpuif_mem_size;
 		/** Redistributor's memory size (GICv3) */
-		uint64_t rdist_mem_size;
+		__u64 rdist_mem_size;
 	};
 #ifdef CONFIG_HAVE_SMP
 	/** Pointer to the lock for distributor access */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Some files inside Unikraft use libc data types. This PR changes those data types with Unikraft-specific data types, inside drivers/ukintctlr.