### PR TITLE
drivers/virtio: Replace libc types with unikraft defined

### DIFF
--- a/drivers/virtio/9p/virtio_9p.c
+++ b/drivers/virtio/9p/virtio_9p.c
@@ -60,7 +60,7 @@ struct virtio_9p_device {
 	/* Virtqueue reference. */
 	struct virtqueue *vq;
 	/* Hw queue identifier. */
-	uint16_t hwvq_id;
+	__u16 hwvq_id;
 	/* libuk9p associated device (NULL if the device is not in use). */
 	struct uk_9pdev *p9dev;
 	/* Scatter-gather list. */
@@ -133,7 +133,7 @@ static int virtio_9p_request(struct uk_9pdev *p9dev,
 	struct virtio_9p_device *dev;
 	int rc, host_notified = 0;
 	unsigned long flags;
-	size_t read_segs, write_segs;
+	__sz read_segs, write_segs;
 	bool failed = false;
 
 	UK_ASSERT(p9dev);
@@ -173,7 +173,7 @@ static int virtio_9p_request(struct uk_9pdev *p9dev,
 	}
 
 	if (req->recv.zc_buf) {
-		uint32_t recv_size = req->recv.size + req->recv.zc_size;
+		__u32 recv_size = req->recv.size + req->recv.zc_size;
 
 		rc = uk_sglist_append(&dev->sg, req->recv.zc_buf,
 				req->recv.zc_size);
@@ -184,7 +184,7 @@ static int virtio_9p_request(struct uk_9pdev *p9dev,
 
 		/* Make eure there is sufficient space for Rerror replies. */
 		if (recv_size < UK_9P_RERROR_MAXSIZE) {
-			uint32_t leftover = UK_9P_RERROR_MAXSIZE - recv_size;
+			__u32 leftover = UK_9P_RERROR_MAXSIZE - recv_size;
 
 			rc = uk_sglist_append(&dev->sg,
 					req->recv.buf + recv_size, leftover);
@@ -235,7 +235,7 @@ static int virtio_9p_recv(struct virtqueue *vq, void *priv)
 {
 	struct virtio_9p_device *dev;
 	struct uk_9preq *req = NULL;
-	uint32_t len;
+	__u32 len;
 	int rc = 0;
 	int handled = 0;
 

--- a/drivers/virtio/blk/virtio_blk.c
+++ b/drivers/virtio/blk/virtio_blk.c
@@ -95,15 +95,15 @@ struct uk_blkdev_queue {
 	struct virtqueue *vq;
 	/* The libukblkdev queue identifier */
 	/* It is also the virtqueue identifier */
-	uint16_t lqueue_id;
+	__u16 lqueue_id;
 	/* Allocator */
 	struct uk_alloc *a;
 	/* The nr. of descriptor limit */
-	uint16_t max_nb_desc;
+	__u16 max_nb_desc;
 	/* The nr. of descriptor user configured */
-	uint16_t nb_desc;
+	__u16 nb_desc;
 	/* The flag to interrupt on the queue */
-	uint8_t intr_enabled;
+	__u8 intr_enabled;
 	/* Reference to virtio_blk_device  */
 	struct virtio_blk_device *vbd;
 	/* The scatter list and its associated fragments */
@@ -120,7 +120,7 @@ struct virtio_blkdev_request {
 	struct uk_blkreq *req;
 	struct uk_list_head free_list_head;
 	struct virtio_blk_outhdr virtio_blk_outhdr;
-	uint8_t status;
+	__u8 status;
 };
 
 static int virtio_blkdev_request_set_sglist(struct uk_blkdev_queue *queue,
@@ -130,11 +130,11 @@ static int virtio_blkdev_request_set_sglist(struct uk_blkdev_queue *queue,
 {
 	struct virtio_blk_device *vbdev;
 	struct uk_blkreq *req;
-	size_t data_size = 0;
-	size_t segment_size;
-	size_t segment_max_size;
-	size_t idx;
-	uintptr_t start_data;
+	__sz data_size = 0;
+	__sz segment_size;
+	__sz segment_max_size;
+	__sz idx;
+	__uptr start_data;
 	int rc = 0;
 
 	UK_ASSERT(queue);
@@ -142,7 +142,7 @@ static int virtio_blkdev_request_set_sglist(struct uk_blkdev_queue *queue,
 
 	req = virtio_blk_req->req;
 	vbdev = queue->vbd;
-	start_data = (uintptr_t)req->aio_buf;
+	start_data = (__uptr)req->aio_buf;
 	data_size = req->nb_sectors * sector_size;
 	segment_max_size = vbdev->max_size_segment;
 
@@ -174,7 +174,7 @@ static int virtio_blkdev_request_set_sglist(struct uk_blkdev_queue *queue,
 		}
 
 	rc = uk_sglist_append(&queue->sg, &virtio_blk_req->status,
-			sizeof(uint8_t));
+			sizeof(__u8));
 	if (unlikely(rc != 0)) {
 		uk_pr_err("Failed to append to sg list %d\n", rc);
 		goto out;
@@ -496,9 +496,9 @@ static int virtio_blkdev_queue_intr_disable(struct uk_blkdev *dev __unused,
  * This function setup the vring infrastructure.
  */
 static int virtio_blkdev_vqueue_setup(struct uk_blkdev_queue *queue,
-		uint16_t nr_desc)
+		__u16 nr_desc)
 {
-	uint16_t max_desc;
+	__u16 max_desc;
 	struct virtqueue *vq;
 
 	UK_ASSERT(queue);
@@ -533,8 +533,8 @@ static int virtio_blkdev_vqueue_setup(struct uk_blkdev_queue *queue,
 }
 
 static struct uk_blkdev_queue *virtio_blkdev_queue_setup(struct uk_blkdev *dev,
-		uint16_t queue_id,
-		uint16_t nb_desc,
+		__u16 queue_id,
+		__u16 nb_desc,
 		const struct uk_blkdev_queue_conf *queue_conf)
 {
 	struct virtio_blk_device *vbdev;
@@ -603,7 +603,7 @@ static int virtio_blkdev_queue_release(struct uk_blkdev *dev,
 }
 
 static int virtio_blkdev_queue_info_get(struct uk_blkdev *dev,
-		uint16_t queue_id,
+		__u16 queue_id,
 		struct uk_blkdev_queue_info *qinfo)
 {
 	struct virtio_blk_device *vbdev = NULL;
@@ -633,7 +633,7 @@ static int virtio_blkdev_queues_alloc(struct virtio_blk_device *vbdev,
 				    const struct uk_blkdev_conf *conf)
 {
 	int rc = 0;
-	uint16_t i = 0;
+	__u16 i = 0;
 	int vq_avail = 0;
 	__u16 qdesc_size[conf->nb_queues];
 
@@ -714,7 +714,7 @@ static int virtio_blkdev_start(struct uk_blkdev *dev)
 static int virtio_blkdev_stop(struct uk_blkdev *dev)
 {
 	struct virtio_blk_device *d;
-	uint16_t q_id;
+	__u16 q_id;
 	int rc = 0;
 
 	UK_ASSERT(dev != NULL);

--- a/drivers/virtio/mmio/virtio_mmio.c
+++ b/drivers/virtio/mmio/virtio_mmio.c
@@ -61,8 +61,8 @@
 
 static struct uk_alloc *a;
 struct virtio_mmio_device_id {
-	uint16_t device_id;
-	uint32_t vendor;
+	__u16 device_id;
+	__u32 vendor;
 };
 
 struct virtio_mmio_device {

--- a/drivers/virtio/mmio/virtio_mmio_cmdl.c
+++ b/drivers/virtio/mmio/virtio_mmio_cmdl.c
@@ -24,7 +24,7 @@ UK_LIBPARAM_PARAM_ARR_ALIAS(device, uk_libparam_devices, charp,
 			    MAX_DEV_CMDLINE, "virtio-mmio devices");
 
 /* Helper to parse numeric string with size suffix (eg "4K") into numeric */
-static char *parse_size(const char *size_str, size_t *sz)
+static char *parse_size(const char *size_str, __sz *sz)
 {
 	char *endptr;
 

--- a/drivers/virtio/pci/virtio_pci.c
+++ b/drivers/virtio/pci/virtio_pci.c
@@ -127,14 +127,14 @@ static int vpci_legacy_notify(struct virtio_dev *vdev, __u16 queue_id)
 static int virtio_pci_handle(void *arg)
 {
 	struct virtio_pci_dev *d = (struct virtio_pci_dev *) arg;
-	uint8_t isr_status;
+	__u8 isr_status;
 	struct virtqueue *vq;
 	int rc = 0;
 
 	UK_ASSERT(arg);
 
 	/* Reading the isr status is used to acknowledge the interrupt */
-	isr_status = virtio_cread8((void *)(unsigned long)d->pci_isr_addr, 0);
+	isr_status = virtio_cread8((void *)d->pci_isr_addr, 0);
 
 	if (isr_status & VIRTIO_PCI_ISR_CONFIG) {
 		/* We don't support configuration interrupt on the device */

--- a/drivers/virtio/ring/include/virtio/virtio_ring.h
+++ b/drivers/virtio/ring/include/virtio/virtio_ring.h
@@ -161,7 +161,7 @@ typedef __virtio_le16 __may_alias __virtio_le16_ma;
 #define vring_avail_event(vr) \
 	(*(__virtio_le16_ma *)&(vr)->used->ring[(vr)->num])
 
-static inline void vring_init(struct vring *vr, unsigned int num, uint8_t *p,
+static inline void vring_init(struct vring *vr, unsigned int num, __u8 *p,
 			      unsigned long align)
 {
 	vr->num = num;
@@ -169,7 +169,7 @@ static inline void vring_init(struct vring *vr, unsigned int num, uint8_t *p,
 	vr->avail = (struct vring_avail *) (p +
 			num * sizeof(struct vring_desc));
 	vr->used = (void *)
-		(((unsigned long) &vr->avail->ring[num] + sizeof(uint16_t) +
+		(((unsigned long) &vr->avail->ring[num] + sizeof(__u16) +
 			align - 1) & ~(align - 1));
 }
 
@@ -178,19 +178,19 @@ static inline unsigned int vring_size(unsigned int num, unsigned long align)
 	int size;
 
 	size = num * sizeof(struct vring_desc);
-	size += sizeof(struct vring_avail) + (num * sizeof(uint16_t)) +
-		sizeof(uint16_t);
+	size += sizeof(struct vring_avail) + (num * sizeof(__u16)) +
+		sizeof(__u16);
 	size = (size + align - 1) & ~(align - 1);
 	size += sizeof(struct vring_used) +
-	    (num * sizeof(struct vring_used_elem)) + sizeof(uint16_t);
+	    (num * sizeof(struct vring_used_elem)) + sizeof(__u16);
 	return size;
 }
 
 static inline int vring_need_event(__u16 event_idx, __u16 new_idx,
 				   __u16 old_idx)
 {
-	return (uint16_t)(new_idx - event_idx - 1) <
-		(uint16_t)(new_idx - old_idx);
+	return (__u16)(new_idx - event_idx - 1) <
+		(__u16)(new_idx - old_idx);
 }
 
 #ifdef __cplusplus

--- a/drivers/virtio/ring/virtio_ring.c
+++ b/drivers/virtio/ring/virtio_ring.c
@@ -202,7 +202,7 @@ static inline void virtqueue_detach_desc(struct virtqueue_vring *vrq,
 int virtqueue_notify_enabled(struct virtqueue *vq)
 {
 	struct virtqueue_vring *vrq;
-	uint16_t old, new;
+	__u16 old, new;
 
 	UK_ASSERT(vq);
 	vrq = to_virtqueue_vring(vq);
@@ -429,7 +429,7 @@ struct virtqueue *virtqueue_create(__u16 queue_id, __u16 nr_descs, __u16 align,
 	struct virtqueue_vring *vrq;
 	struct virtqueue *vq;
 	int rc;
-	size_t ring_size = 0;
+	__sz ring_size = 0;
 
 	UK_ASSERT(a);
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Some files inside Unikraft use libc data types. This PR changes those data types with Unikraft-specific data types, inside drivers/virtio.