### PR TITLE
arch: Add exception context escape trampolines ctx creation

### DIFF
--- a/arch/arm/arm64/ctx.S
+++ b/arch/arm/arm64/ctx.S
@@ -105,6 +105,17 @@ ENTRY(_ctx_arm_call2)
 	ldr x30, [sp], #16
 	ret
 
+ENTRY(_ctx_arm_call3)
+#if !__OMIT_FRAMEPOINTER__
+	mov x29, xzr /* reset frame pointer */
+#endif /* !__OMIT_FRAMEPOINTER__ */
+	ldr x2, [sp], #16
+	ldr x1, [sp], #16
+	ldr x0, [sp], #16
+	/* jump to entrance function left on stack */
+	ldr x30, [sp], #16
+	ret
+
 /*
  * Switch context on the current LCPU.
  */

--- a/arch/arm/ctx.c
+++ b/arch/arm/ctx.c
@@ -60,16 +60,16 @@ void ukarch_ctx_init(struct ukarch_ctx *ctx,
 	UK_ASSERT(ip);			/* IP == NULL would cause a crash */
 	UK_ASSERT(!keep_regs && sp);	/* stack is needed for clearing regs */
 
-	_sp = ukarch_rstack_push(sp, (long) ip);
+	_sp = ukarch_rstack_push(sp, (long)ip);
 	if (keep_regs) {
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_arm_call0);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_arm_call0);
 	} else {
-		_sp = ukarch_rstack_push(_sp, (long) _ctx_arm_call0);
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_arm_clearregs);
+		_sp = ukarch_rstack_push(_sp, (long)_ctx_arm_call0);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_arm_clearregs);
 	}
 
 	uk_pr_debug("ukarch_ctx %p: start:%p sp:%p\n",
-		    ctx, (void *) ip, (void *) sp);
+		    ctx, (void *)ip, (void *)sp);
 }
 
 void ukarch_ctx_init_entry0(struct ukarch_ctx *ctx,
@@ -85,14 +85,14 @@ void ukarch_ctx_init_entry0(struct ukarch_ctx *ctx,
 
 	_sp = ukarch_rstack_push(sp, (long) entry);
 	if (keep_regs) {
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_arm_call0);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_arm_call0);
 	} else {
-		_sp = ukarch_rstack_push(_sp, (long) _ctx_arm_call0);
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_arm_clearregs);
+		_sp = ukarch_rstack_push(_sp, (long)_ctx_arm_call0);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_arm_clearregs);
 	}
 
 	uk_pr_debug("ukarch_ctx %p: entry:%p(), sp:%p\n",
-		    ctx, entry, (void *) sp);
+		    ctx, entry, (void *)sp);
 }
 
 void ukarch_ctx_init_entry1(struct ukarch_ctx *ctx,
@@ -106,17 +106,17 @@ void ukarch_ctx_init_entry1(struct ukarch_ctx *ctx,
 	UK_ASSERT(entry);		/* NULL as func will cause a crash */
 	UK_ASSERT(!(sp & UKARCH_SP_ALIGN_MASK)); /* sp properly aligned? */
 
-	_sp = ukarch_rstack_push(sp, (long) entry);
+	_sp = ukarch_rstack_push(sp, (long)entry);
 	_sp = ukarch_rstack_push(_sp, arg);
 	if (keep_regs) {
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_arm_call1);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_arm_call1);
 	} else {
-		_sp = ukarch_rstack_push(_sp, (long) _ctx_arm_call1);
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_arm_clearregs);
+		_sp = ukarch_rstack_push(_sp, (long)_ctx_arm_call1);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_arm_clearregs);
 	}
 
 	uk_pr_debug("ukarch_ctx %p: entry:%p(%lx), sp:%p\n",
-		    ctx, entry, arg, (void *) sp);
+		    ctx, entry, arg, (void *)sp);
 }
 
 void ukarch_ctx_init_entry2(struct ukarch_ctx *ctx,
@@ -130,16 +130,16 @@ void ukarch_ctx_init_entry2(struct ukarch_ctx *ctx,
 	UK_ASSERT(entry);		/* NULL as func will cause a crash */
 	UK_ASSERT(!(sp & UKARCH_SP_ALIGN_MASK)); /* sp properly aligned? */
 
-	_sp = ukarch_rstack_push(sp, (long) entry);
+	_sp = ukarch_rstack_push(sp, (long)entry);
 	_sp = ukarch_rstack_push(_sp, arg0);
 	_sp = ukarch_rstack_push(_sp, arg1);
 	if (keep_regs) {
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_arm_call2);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_arm_call2);
 	} else {
-		_sp = ukarch_rstack_push(_sp, (long) _ctx_arm_call2);
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_arm_clearregs);
+		_sp = ukarch_rstack_push(_sp, (long)_ctx_arm_call2);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_arm_clearregs);
 	}
 
 	uk_pr_debug("ukarch_ctx %p: entry:%p(%lx, %lx), sp:%p\n",
-		    ctx, entry, arg0, arg1, (void *) sp);
+		    ctx, entry, arg0, arg1, (void *)sp);
 }

--- a/arch/arm/ctx.c
+++ b/arch/arm/ctx.c
@@ -38,6 +38,7 @@
 #if CONFIG_LIBUKDEBUG
 #include <uk/assert.h>
 #include <uk/print.h>
+#include <uk/isr/string.h>
 #else /* !CONFIG_LIBUKDEBUG */
 #define UK_ASSERT(..) do {} while (0)
 #define uk_pr_debug(..) do {} while (0)
@@ -170,4 +171,49 @@ void ukarch_ctx_init_entry3(struct ukarch_ctx *ctx,
 
 	uk_pr_debug("ukarch_ctx %p: entry:%p(%lx, %lx, %lx), sp:%p\n",
 		    ctx, entry, arg0, arg1, arg2, (void *)sp);
+}
+
+static void ehtrampo_dispatcher(struct ukarch_execenv *ee,
+				ukarch_ehtrampo_entry entry, long arg)
+{
+	UK_ASSERT(ee);
+
+	(*entry)(ee, arg);
+	ukarch_execenv_load((long)ee);
+}
+
+void ukarch_ctx_init_ehtrampo(struct ukarch_ctx *ctx,
+			      struct __regs *r,
+			      __uptr sp,
+			      ukarch_ehtrampo_entry entry, long arg)
+{
+	struct ukarch_execenv *ee;
+
+	UK_ASSERT(ctx);
+	UK_ASSERT(r);
+	UK_ASSERT(sp);			/* a stack is needed */
+	UK_ASSERT(entry);		/* NULL as func will cause a crash */
+	UK_ASSERT(IS_ALIGNED(sp, UKARCH_EXECENV_END_ALIGN));
+
+	sp -= ALIGN_UP(sizeof(*ee), UKARCH_EXECENV_END_ALIGN);
+	ee = (struct ukarch_execenv *)sp;
+
+	ukarch_ectx_sanitize((struct ukarch_ectx *)&ee->ectx);
+	ukarch_ectx_store((struct ukarch_ectx *)&ee->ectx);
+
+	ukarch_sysctx_store(&ee->sysctx);
+
+	/*
+	 * NOTE: Order is important. We save the registers after ectx.
+	 * As the compiler could implement this using memcpy(), we run
+	 * the risk of corrupting the ectx before we had a chance to save it.
+	 */
+	ee->regs = *r;
+
+	sp = ukarch_rstack_push(sp, (long)ehtrampo_dispatcher);
+	sp = ukarch_rstack_push(sp, (long)ee);
+	sp = ukarch_rstack_push(sp, (long)entry);
+	sp = ukarch_rstack_push(sp, (long)arg);
+
+	ukarch_ctx_init_bare(ctx, sp, (long)_ctx_arm_call3);
 }

--- a/arch/arm/ctx.c
+++ b/arch/arm/ctx.c
@@ -217,3 +217,18 @@ void ukarch_ctx_init_ehtrampo(struct ukarch_ctx *ctx,
 
 	ukarch_ctx_init_bare(ctx, sp, (long)_ctx_arm_call3);
 }
+
+void ukarch_ctx_jump(struct ukarch_ctx *ctx)
+{
+	UK_ASSERT(ctx);
+
+	__asm__ __volatile__(
+		"mov	sp, %0\n"
+		"br	%1\n"
+		:
+		: "r" (ctx->sp), "r" (ctx->ip)
+		:
+	);
+
+	__builtin_unreachable();
+}

--- a/arch/x86/ctx.c
+++ b/arch/x86/ctx.c
@@ -47,6 +47,7 @@ void _ctx_x86_clearregs(void);
 void _ctx_x86_call0(void);
 void _ctx_x86_call1(void);
 void _ctx_x86_call2(void);
+void _ctx_x86_call3(void);
 
 void ukarch_ctx_init(struct ukarch_ctx *ctx,
 		     __uptr sp, int keep_regs,
@@ -159,4 +160,32 @@ void ukarch_ctx_init_entry2(struct ukarch_ctx *ctx,
 
 	uk_pr_debug("ukarch_ctx %p: entry:%p(%lx, %lx), sp:%p\n",
 		    ctx, entry, arg0, arg1, (void *)sp);
+}
+
+void ukarch_ctx_init_entry3(struct ukarch_ctx *ctx,
+			    __uptr sp, int keep_regs,
+			    ukarch_ctx_entry3 entry,
+			    long arg0, long arg1, long arg2)
+{
+	__uptr _sp;
+
+	UK_ASSERT(ctx);
+	UK_ASSERT(sp);			/* a stack is needed */
+	UK_ASSERT(entry);		/* NULL as func will cause a crash */
+	UK_ASSERT(!(sp & UKARCH_SP_ALIGN_MASK)); /* sp properly aligned? */
+
+	sp  = ukarch_rstack_push(sp, (__u64)0x0); /* SystemV call convention */
+	_sp = ukarch_rstack_push(sp, (long)entry);
+	_sp = ukarch_rstack_push(_sp, arg0);
+	_sp = ukarch_rstack_push(_sp, arg1);
+	_sp = ukarch_rstack_push(_sp, arg2);
+	if (keep_regs) {
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_x86_call3);
+	} else {
+		_sp = ukarch_rstack_push(_sp, (long)_ctx_x86_call3);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_x86_clearregs);
+	}
+
+	uk_pr_debug("ukarch_ctx %p: entry:%p(%lx, %lx, %lx), sp:%p\n",
+		    ctx, entry, arg0, arg1, arg2, (void *)sp);
 }

--- a/arch/x86/ctx.c
+++ b/arch/x86/ctx.c
@@ -59,16 +59,16 @@ void ukarch_ctx_init(struct ukarch_ctx *ctx,
 	UK_ASSERT(ip);			/* NULL as IP will cause a crash */
 	UK_ASSERT(!keep_regs && sp);	/* a stack is needed when clearing */
 
-	_sp = ukarch_rstack_push(sp, (long) ip);
+	_sp = ukarch_rstack_push(sp, (long)ip);
 	if (keep_regs) {
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_x86_call0);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_x86_call0);
 	} else {
-		_sp = ukarch_rstack_push(_sp, (long) _ctx_x86_call0);
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_x86_clearregs);
+		_sp = ukarch_rstack_push(_sp, (long)_ctx_x86_call0);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_x86_clearregs);
 	}
 
 	uk_pr_debug("ukarch_ctx %p: start:%p sp:%p\n",
-		    ctx, (void *) ip, (void *) sp);
+		    ctx, (void *)ip, (void *)sp);
 }
 
 void ukarch_ctx_init_entry0(struct ukarch_ctx *ctx,
@@ -97,17 +97,17 @@ void ukarch_ctx_init_entry0(struct ukarch_ctx *ctx,
 	 *       do not require any alignments and will pass any sp offsets
 	 *       through.
 	 */
-	sp  = ukarch_rstack_push(sp, (__u64) 0x0);
-	_sp = ukarch_rstack_push(sp, (long) entry);
+	sp  = ukarch_rstack_push(sp, (__u64)0x0);
+	_sp = ukarch_rstack_push(sp, (long)entry);
 	if (keep_regs) {
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_x86_call0);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_x86_call0);
 	} else {
-		_sp = ukarch_rstack_push(_sp, (long) _ctx_x86_call0);
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_x86_clearregs);
+		_sp = ukarch_rstack_push(_sp, (long)_ctx_x86_call0);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_x86_clearregs);
 	}
 
 	uk_pr_debug("ukarch_ctx %p: entry:%p(), sp:%p\n",
-		    ctx, entry, (void *) sp);
+		    ctx, entry, (void *)sp);
 }
 
 void ukarch_ctx_init_entry1(struct ukarch_ctx *ctx,
@@ -121,18 +121,18 @@ void ukarch_ctx_init_entry1(struct ukarch_ctx *ctx,
 	UK_ASSERT(entry);		/* NULL as func will cause a crash */
 	UK_ASSERT(!(sp & UKARCH_SP_ALIGN_MASK)); /* sp properly aligned? */
 
-	sp  = ukarch_rstack_push(sp, (__u64) 0x0); /* SystemV call convention */
-	_sp = ukarch_rstack_push(sp, (long) entry);
+	sp  = ukarch_rstack_push(sp, (__u64)0x0); /* SystemV call convention */
+	_sp = ukarch_rstack_push(sp, (long)entry);
 	_sp = ukarch_rstack_push(_sp, arg);
 	if (keep_regs) {
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_x86_call1);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_x86_call1);
 	} else {
-		_sp = ukarch_rstack_push(_sp, (long) _ctx_x86_call1);
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_x86_clearregs);
+		_sp = ukarch_rstack_push(_sp, (long)_ctx_x86_call1);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_x86_clearregs);
 	}
 
 	uk_pr_debug("ukarch_ctx %p: entry:%p(%lx), sp:%p\n",
-		    ctx, entry, arg, (void *) sp);
+		    ctx, entry, arg, (void *)sp);
 }
 
 void ukarch_ctx_init_entry2(struct ukarch_ctx *ctx,
@@ -146,17 +146,17 @@ void ukarch_ctx_init_entry2(struct ukarch_ctx *ctx,
 	UK_ASSERT(entry);		/* NULL as func will cause a crash */
 	UK_ASSERT(!(sp & UKARCH_SP_ALIGN_MASK)); /* sp properly aligned? */
 
-	sp  = ukarch_rstack_push(sp, (__u64) 0x0); /* SystemV call convention */
-	_sp = ukarch_rstack_push(sp, (long) entry);
+	sp  = ukarch_rstack_push(sp, (__u64)0x0); /* SystemV call convention */
+	_sp = ukarch_rstack_push(sp, (long)entry);
 	_sp = ukarch_rstack_push(_sp, arg0);
 	_sp = ukarch_rstack_push(_sp, arg1);
 	if (keep_regs) {
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_x86_call2);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_x86_call2);
 	} else {
-		_sp = ukarch_rstack_push(_sp, (long) _ctx_x86_call2);
-		ukarch_ctx_init_bare(ctx, _sp, (long) _ctx_x86_clearregs);
+		_sp = ukarch_rstack_push(_sp, (long)_ctx_x86_call2);
+		ukarch_ctx_init_bare(ctx, _sp, (long)_ctx_x86_clearregs);
 	}
 
 	uk_pr_debug("ukarch_ctx %p: entry:%p(%lx, %lx), sp:%p\n",
-		    ctx, entry, arg0, arg1, (void *) sp);
+		    ctx, entry, arg0, arg1, (void *)sp);
 }

--- a/arch/x86/ctx.c
+++ b/arch/x86/ctx.c
@@ -37,6 +37,7 @@
 #if CONFIG_LIBUKDEBUG
 #include <uk/assert.h>
 #include <uk/print.h>
+#include <uk/isr/string.h>
 #else /* !CONFIG_LIBUKDEBUG */
 #define UK_ASSERT(..) do {} while (0)
 #define uk_pr_debug(..) do {} while (0)
@@ -188,4 +189,50 @@ void ukarch_ctx_init_entry3(struct ukarch_ctx *ctx,
 
 	uk_pr_debug("ukarch_ctx %p: entry:%p(%lx, %lx, %lx), sp:%p\n",
 		    ctx, entry, arg0, arg1, arg2, (void *)sp);
+}
+
+static void ehtrampo_dispatcher(struct ukarch_execenv *ee,
+				ukarch_ehtrampo_entry entry, long arg)
+{
+	UK_ASSERT(ee);
+
+	(*entry)(ee, arg);
+	ukarch_execenv_load((long)ee);
+}
+
+void ukarch_ctx_init_ehtrampo(struct ukarch_ctx *ctx,
+			      struct __regs *r,
+			      __uptr sp,
+			      ukarch_ehtrampo_entry entry, long arg)
+{
+	struct ukarch_execenv *ee;
+
+	UK_ASSERT(ctx);
+	UK_ASSERT(r);
+	UK_ASSERT(sp);			/* a stack is needed */
+	UK_ASSERT(entry);		/* NULL as func will cause a crash */
+	UK_ASSERT(IS_ALIGNED(sp, UKARCH_EXECENV_END_ALIGN));
+
+	sp -= ALIGN_UP(sizeof(*ee), UKARCH_EXECENV_END_ALIGN);
+	ee = (struct ukarch_execenv *)sp;
+
+	ukarch_ectx_sanitize((struct ukarch_ectx *)&ee->ectx);
+	ukarch_ectx_store((struct ukarch_ectx *)&ee->ectx);
+
+	ukarch_sysctx_store(&ee->sysctx);
+
+	/*
+	 * NOTE: Order is important. We save the registers after ectx.
+	 * As the compiler could implement this using memcpy(), we run
+	 * the risk of corrupting the ectx before we had a chance to save it.
+	 */
+	ee->regs = *r;
+
+	sp  = ukarch_rstack_push(sp, (__u64)0x0); /* SystemV call convention */
+	sp = ukarch_rstack_push(sp, (long)ehtrampo_dispatcher);
+	sp = ukarch_rstack_push(sp, (long)ee);
+	sp = ukarch_rstack_push(sp, (long)entry);
+	sp = ukarch_rstack_push(sp, (long)arg);
+
+	ukarch_ctx_init_bare(ctx, sp, (long)_ctx_x86_call3);
 }

--- a/arch/x86/ctx.c
+++ b/arch/x86/ctx.c
@@ -236,3 +236,18 @@ void ukarch_ctx_init_ehtrampo(struct ukarch_ctx *ctx,
 
 	ukarch_ctx_init_bare(ctx, sp, (long)_ctx_x86_call3);
 }
+
+void ukarch_ctx_jump(struct ukarch_ctx *ctx)
+{
+	UK_ASSERT(ctx);
+
+	__asm__ __volatile__(
+		"movq	%0, %%rsp\n"
+		"jmp	*%1\n"
+		:
+		: "r" (ctx->sp), "r" (ctx->ip)
+		:
+	);
+
+	__builtin_unreachable();
+}

--- a/arch/x86/x86_64/ctx.S
+++ b/arch/x86/x86_64/ctx.S
@@ -75,6 +75,15 @@ ENTRY(_ctx_x86_call2)
 	popq %rdi	/* load first argument from stack */
 	ret		/* jump to entrance function left on stack */
 
+ENTRY(_ctx_x86_call3)
+#if !__OMIT_FRAMEPOINTER__
+	xorq %rbp, %rbp /* reset frame pointer */
+#endif /* !__OMIT_FRAMEPOINTER__ */
+	popq %rdx	/* load third argument from stack */
+	popq %rsi	/* load second argument from stack */
+	popq %rdi	/* load first argument from stack */
+	ret		/* jump to entrance function left on stack */
+
 /*
  * Do a local context switch
  */

--- a/include/uk/arch/ctx.h
+++ b/include/uk/arch/ctx.h
@@ -213,6 +213,7 @@ UK_CTASSERT(__offsetof(struct ukarch_auxspcb, uksysctx) ==
 typedef void (*ukarch_ctx_entry0)(void) __noreturn;
 typedef void (*ukarch_ctx_entry1)(long) __noreturn;
 typedef void (*ukarch_ctx_entry2)(long, long) __noreturn;
+typedef void (*ukarch_ctx_entry3)(long, long, long) __noreturn;
 
 /**
  * Initializes a context struct with stack pointer and

--- a/include/uk/arch/ctx.h
+++ b/include/uk/arch/ctx.h
@@ -341,6 +341,50 @@ void ukarch_ctx_init_entry2(struct ukarch_ctx *ctx,
 void ukarch_ctx_switch(struct ukarch_ctx *store, struct ukarch_ctx *load);
 
 /**
+ * Function that can be executed in a context where one can take
+ * exceptions or yield the current thread.
+ * After the function returns, execution will resume the state stored in
+ * the execenv argument.
+ *
+ * @param execenv
+ *   Pointer to the execution environment that the function will return to
+ * @param arg
+ *   Custom user-defined argument
+ */
+typedef void (*ukarch_ehtrampo_entry)(struct ukarch_execenv *execenv, long arg);
+
+/**
+ * Initializes a context that allows jumping from an exception handling
+ * context to a caller-defined function in a context where one can take
+ * exceptions or yield the current thread.
+ * Returning from the caller-defined function resumes execution from
+ * the place that the exception handler would resume from.
+ *
+ * After calling ukarch_ehtrampo_init() use ukarch_ctx_jmp() to jump to
+ * the target context.
+ *
+ * NOTE: This function may return with a tainted extended context.
+ *
+ * @param ctx
+ *   Reference to context to initialize
+ * @param sp
+ *   Stack pointer (required and must be aligned to `UKARCH_EXECENV_END_ALIGN`)
+ *  The stack must have enough space to store both an entire execution
+ *  environment context as well as run the user provided entry function
+ * @param r
+ *   Pointer to architecture specific general purpose registers saved on
+ *  exception handling entry
+ * @param entry
+ *   Entry function to execute (required).
+ * @param arg
+ *   The argument `entry` callback will receive
+ */
+void ukarch_ctx_init_ehtrampo(struct ukarch_ctx *ctx,
+			      struct __regs *r,
+			      __uptr sp,
+			      ukarch_ehtrampo_entry entry, long arg);
+
+/**
  * Initialize an auxiliary stack pointer. This must be always called the
  * first time you create an auxiliary stack pointer.
  *

--- a/include/uk/arch/ctx.h
+++ b/include/uk/arch/ctx.h
@@ -341,6 +341,15 @@ void ukarch_ctx_init_entry2(struct ukarch_ctx *ctx,
 void ukarch_ctx_switch(struct ukarch_ctx *store, struct ukarch_ctx *load);
 
 /**
+ * Without saving or restoring anything, directly switch to stack pointer
+ * and jump to instruction pointer stored in the context structure.
+ *
+ * @param ctx
+ *   Reference to context that shall be executed
+ */
+void ukarch_ctx_jump(struct ukarch_ctx *ctx) __noreturn;
+
+/**
  * Function that can be executed in a context where one can take
  * exceptions or yield the current thread.
  * After the function returns, execution will resume the state stored in


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Implement the ability to jump from exception handling context to an
I/O-able context from which one can return to the context that the
exception handler was supposed to return to.

Essentially by creating a return-chain into a function that creates
room on a given stack to store execution environment
(struct ukarch_execenv) which would then return to a custom entry which
would then return to a routine that would restore the aforementioned
execution environment, one is able to freely do I/O, use any registers.

The caller of ukarch_ctx_init_ehtrampoX API's will be given a context
that is guaranteed to run with IRQ's enabled and from which, upon
return, execution from the point the exception handler was supposed
to return to is resumed.
```
        ┌───────────────────┐
▲       │                   │
│       │      struct       │
│       │      execenv      │
│       │                   │
│       │                   │
│       ├───────────────────┤
│       │                   │
│       │  execenv_load(ee) │
│       │                   │
│       ├───────────────────┤
│       │ entry(ee, arg0,   │
│       │       arg1…) for  │
│       │    ehtrampo0,1,2… │
│       │    variants       │
│       │                   │
│       │                   │
│       ├───────────────────┤
│       │                   │
│       │ ehtrampo_.._store │
exec    │                   │
order   │                   │
        └───────────────────┘
```
