### PR TITLE
{plat,arch}: Align exception handling stacks among architectures

### DIFF
--- a/plat/common/arm/lcpu.c
+++ b/plat/common/arm/lcpu.c
@@ -46,15 +46,15 @@
 #define CPU_ID_MASK 0xff00ffffffUL
 
 /*
- *  CPU_EXCEPT_STACK_SIZE  CPU_EXCEPT_STACK_SIZE
- * <---------------------><--------------------->
- * |============================================|
- * |                     |                      |
- * |       trap stack    |        IRQ stack     |
- * |                     |                      |
- * |=============================================
- *                       ^
- *                     SP_EL0
+ *  CPU_EXCEPT_STACK_SIZE  CPU_EXCEPT_STACK_SIZE  CPU_EXCEPT_STACK_SIZE
+ *<--------------------><---------------------><-------------------->
+ *|=================================================================|
+ *|                     |                     |                     |
+ *|     crit stack      |       trap stack    |        IRQ stack    |
+ *|                     |                     |                     |
+ *|=================================================================|
+ * ^
+ * SP_EL0/lcpu_except_stack
  *
  * Why do we need separate stacks for IRQ and traps?
  * We could use a single stack for exceptions, but in that case when we have a
@@ -67,11 +67,13 @@
  * Why can one stack not corrupt the other/Why is trap stack before IRQ stack?
  * During a trap IRQs are disabled. So only the trap stack could potentially
  * corrupt the IRQ stack if they were the other way around. The ordering of the
- * stacks is made so that this cannot happen.
+ * stacks is made so that this cannot happen. Same thing goes for the crit
+ * stack as a crit exception may happen during a trap.
  *
  */
 static __align(UKARCH_SP_ALIGN)
-UKPLAT_PER_LCPU_ARRAY_DEFINE(__u8, lcpu_irqntrap_sp, CPU_EXCEPT_STACK_SIZE * 2);
+UKPLAT_PER_LCPU_ARRAY_DEFINE(__u8, lcpu_except_stack,
+			     CPU_EXCEPT_STACK_SIZE * 3);
 
 __lcpuid lcpu_arch_id(void)
 {
@@ -112,7 +114,7 @@ extern struct _gic_dev *gic;
 
 int lcpu_arch_init(struct lcpu *this_lcpu)
 {
-	__uptr irqntrap_sp;
+	__uptr except_sp;
 	int ret = 0;
 
 	/* Initialize the interrupt controller for non-bsp cores */
@@ -124,9 +126,9 @@ int lcpu_arch_init(struct lcpu *this_lcpu)
 
 	SYSREG_WRITE64(tpidr_el1, (__uptr)this_lcpu);
 
-	irqntrap_sp = (__uptr)&ukplat_per_lcpu_array_current(lcpu_irqntrap_sp,
-							CPU_EXCEPT_STACK_SIZE);
-	SYSREG_WRITE64(sp_el0, irqntrap_sp);
+	except_sp = (__uptr)&lcpu_except_stack[this_lcpu->idx *
+					       CPU_EXCEPT_STACK_SIZE * 3];
+	SYSREG_WRITE64(sp_el0, except_sp);
 
 	return ret;
 }

--- a/plat/kvm/arm/exceptions.S
+++ b/plat/kvm/arm/exceptions.S
@@ -32,6 +32,10 @@
 #include <uk/plat/config.h>
 #include <uk/arch/ctx.h>
 
+#define TYPE_CRIT				0
+#define TYPE_TRAP				1
+#define TYPE_IRQ				2
+
 .macro EXCHANGE_SP_WITH_X0
 	add sp, sp, x0	// new_sp = sp + x0
 	sub x0, sp, x0	// new_x0 = new_sp - x0 = sp + x0 - x0 = sp
@@ -69,7 +73,7 @@
 	EXCHANGE_SP_WITH_X0
 .endm
 
-.macro SAVE_REGS, is_irq
+.macro SAVE_REGS, except_type
 	/* Use TPIDRRO_EL0 as scratch register. It is fine to do so because
 	 * it will always hold a value the application can't modify and we will
 	 * always be able to restore it to its desired known value anytime we
@@ -77,25 +81,33 @@
 	 */
 	msr     tpidrro_el0, x0
 
-	/* Fetch middle of `lcpu_irqntrap_sp`:
-	 *  CPU_EXCEPT_STACK_SIZE  CPU_EXCEPT_STACK_SIZE
-	 * <---------------------><--------------------->
-	 * |============================================|
-	 * |                     |                      |
-	 * |       trap stack    |        IRQ stack     |
-	 * |                     |                      |
-	 * |=============================================
-	 *                       ^
-	 *                     SP_EL0
+	/* Fetch `lcpu_except_stack` of LCPU:
+	 *  CPU_EXCEPT_STACK_SIZE  CPU_EXCEPT_STACK_SIZE  CPU_EXCEPT_STACK_SIZE
+	 *<--------------------><---------------------><-------------------->
+	 *|=================================================================|
+	 *|                     |                     |			    |
+	 *|	crit stack      |       trap stack    |        IRQ stack    |
+	 *|                     |                     |                     |
+	 *|=================================================================|
+	 * ^
+	 * SP_EL0/lcpu_except_stack
 	 */
 	mrs     x0, sp_el0
 
 	/* Make it so that SP contains SP_EL0 and x0 contains old SP */
 	EXCHANGE_SP_WITH_X0
 
-.if \is_irq != 0
-	/* If we are an IRQ, use the IRQ stack instead. */
+.if \except_type == TYPE_CRIT
+	/* If we are a crit, use the crit stack. */
 	add     sp, sp, #CPU_EXCEPT_STACK_SIZE
+.endif
+.if \except_type == TYPE_TRAP
+	/* If we are a trap, use the trap stack. */
+	add     sp, sp, #CPU_EXCEPT_STACK_SIZE * 2
+.endif
+.if \except_type == TYPE_IRQ
+	/* If we are an IRQ, use the IRQ stack. */
+	add     sp, sp, #CPU_EXCEPT_STACK_SIZE * 3
 .endif
 
 	/* Store old SP previously saved into x0 */
@@ -261,7 +273,7 @@
  */
 .align 6
 el1_sync:
-	SAVE_REGS 0
+	SAVE_REGS TYPE_TRAP
 	mov x0, sp
 	mrs x1, far_el1
 	bl trap_el1_sync
@@ -269,7 +281,7 @@ el1_sync:
 
 .align 6
 el1_irq:
-	SAVE_REGS 1
+	SAVE_REGS TYPE_IRQ
 	msr daifclr, #4 /* Unmask SError */
 	mov x0, sp
 	bl trap_el1_irq
@@ -284,7 +296,7 @@ el1_irq:
 #define el_invalid(name, reason, el)	\
 .align 6;				\
 name##_invalid:				\
-	SAVE_REGS 0;			\
+	SAVE_REGS TYPE_CRIT;		\
 	mov x0, sp;			\
 	mov x1, el;			\
 	mov x2, #(reason);		\

--- a/plat/kvm/x86/traps.c
+++ b/plat/kvm/x86/traps.c
@@ -56,19 +56,33 @@
  *  ├──────────────────┤  │  │        .         │    │                  ▼ │ │
  *  │   tss  segment   ├──┘  │        .         │    └─┬──────────────────┘ │
  *  └──────────────────┘     └──────────────────┘      └────────────────────┘
+ *
+ *  CPU_EXCEPT_STACK_SIZE  CPU_EXCEPT_STACK_SIZE  CPU_EXCEPT_STACK_SIZE
+ *<--------------------><---------------------><-------------------->
+ *|=================================================================|
+ *|                     |                     |                     |
+ *|     crit stack      |       trap stack    |        IRQ stack    |
+ *|                     |                     |                     |
+ *|=================================================================|
+ * ^
+ * lcpu_except_stack
+ *
+ * Why can one stack not corrupt the other/Why is trap stack before IRQ stack?
+ * During a trap IRQs are disabled. So only the trap stack could potentially
+ * corrupt the IRQ stack if they were the other way around. The ordering of the
+ * stacks is made so that this cannot happen. Same thing goes for the crit
+ * stack as a crit exception may happen during a trap.
+ *
  */
-__align(UKARCH_SP_ALIGN) /* IST1 */
-char cpu_intr_stack[CONFIG_UKPLAT_LCPU_MAXCOUNT][CPU_EXCEPT_STACK_SIZE];
-__align(UKARCH_SP_ALIGN) /* IST2 */
-char cpu_trap_stack[CONFIG_UKPLAT_LCPU_MAXCOUNT][CPU_EXCEPT_STACK_SIZE];
-__align(UKARCH_SP_ALIGN) /* IST3 */
-char cpu_crit_stack[CONFIG_UKPLAT_LCPU_MAXCOUNT][CPU_EXCEPT_STACK_SIZE];
+static __align(UKARCH_SP_ALIGN) /* IST{1, 2, 3} */
+UKPLAT_PER_LCPU_ARRAY_DEFINE(__u8, lcpu_except_stack,
+			     3 * CPU_EXCEPT_STACK_SIZE);
 
 static __align(8)
-struct tss64 cpu_tss[CONFIG_UKPLAT_LCPU_MAXCOUNT];
+UKPLAT_PER_LCPU_DEFINE(struct tss64, cpu_tss);
 
 static __align(8)
-struct seg_desc32 cpu_gdt64[CONFIG_UKPLAT_LCPU_MAXCOUNT][GDT_NUM_ENTRIES];
+UKPLAT_PER_LCPU_ARRAY_DEFINE(struct seg_desc32, cpu_gdt64, GDT_NUM_ENTRIES);
 
 static void gdt_init(__lcpuidx idx)
 {
@@ -118,11 +132,11 @@ static void tss_init(__lcpuidx idx)
 	struct seg_desc64 *tss_desc;
 
 	cpu_tss[idx].ist[0] =
-		(__u64) &cpu_intr_stack[idx][sizeof(cpu_intr_stack[idx])];
+		(__u64)&lcpu_except_stack[idx][CPU_EXCEPT_STACK_SIZE * 3];
 	cpu_tss[idx].ist[1] =
-		(__u64) &cpu_trap_stack[idx][sizeof(cpu_trap_stack[idx])];
+		(__u64)&lcpu_except_stack[idx][CPU_EXCEPT_STACK_SIZE * 2];
 	cpu_tss[idx].ist[2] =
-		(__u64) &cpu_crit_stack[idx][sizeof(cpu_crit_stack[idx])];
+		(__u64)&lcpu_except_stack[idx][CPU_EXCEPT_STACK_SIZE];
 
 	tss_desc = (void *) &cpu_gdt64[idx][GDT_DESC_TSS_LO];
 	tss_desc->limit_lo	= sizeof(cpu_tss[idx]);
@@ -190,14 +204,14 @@ void traps_table_init(void)
 	idt_fillgate(TRAP_##name, ASM_TRAP_SYM(name), ist)
 
 	FILL_TRAP_GATE(divide_error,	2);
-	FILL_TRAP_GATE(debug,		3); /* runs on IST3 (cpu_crit_stack) */
-	FILL_TRAP_GATE(nmi,		3); /* runs on IST3 (cpu_crit_stack) */
-	FILL_TRAP_GATE(int3,		3); /* runs on IST3 (cpu_crit_stack) */
+	FILL_TRAP_GATE(debug,		3); /* on IST3 (lcpu_except_stack) */
+	FILL_TRAP_GATE(nmi,		3); /* on IST3 (lcpu_except_stack) */
+	FILL_TRAP_GATE(int3,		3); /* on IST3 (lcpu_except_stack) */
 	FILL_TRAP_GATE(overflow,	2);
 	FILL_TRAP_GATE(bounds,		2);
 	FILL_TRAP_GATE(invalid_op,	2);
 	FILL_TRAP_GATE(no_device,	2);
-	FILL_TRAP_GATE(double_fault,	3); /* runs on IST3 (cpu_crit_stack) */
+	FILL_TRAP_GATE(double_fault,	3); /* on IST3 (lcpu_except_stack) */
 
 	FILL_TRAP_GATE(invalid_tss,	2);
 	FILL_TRAP_GATE(no_segment,	2);
@@ -207,12 +221,12 @@ void traps_table_init(void)
 
 	FILL_TRAP_GATE(coproc_error,	2);
 	FILL_TRAP_GATE(alignment_check,	2);
-	FILL_TRAP_GATE(machine_check,	3); /* runs on IST3 (cpu_crit_stack) */
+	FILL_TRAP_GATE(machine_check,	3); /* on IST3 (lcpu_except_stack) */
 	FILL_TRAP_GATE(simd_error,	2);
 	FILL_TRAP_GATE(virt_error,	2);
 
 	/*
-	 * Load IRQ vectors. All IRQs run on IST1 (cpu_intr_stack).
+	 * Load IRQ vectors. All IRQs run on IST1 (lcpu_except_stack).
 	 */
 #define FILL_IRQ_GATE(num, ist)						\
 	extern void cpu_irq_##num(void);				\


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Make it so that both ARM64 and x86_64 have their exception stacks
unified:
- three exception stacks: IRQ, trap, crit
- all three contiguous part of the same huge array