### PR TITLE
scripts/checkpatch: Do not warn about symbolic permissions

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -6,4 +6,5 @@
 --ignore NEW_TYPEDEFS
 --ignore FILE_PATH_CHANGES
 --ignore OBSOLETE
+--ignore SYMBOLIC_PERMS
 --max-line-length=80


### PR DESCRIPTION
This PR switches the checkpatch warning for symbolic permissions off (Examples are `S_IXUSR`, `S_IFREG`). Such a warning makes sense for a Linux kernel but less for us: We normally compile our kernel code together with a fully featured libc and even bind application logic directly to kernel code. We do not have the classical user-/kernel- code separation and rather prefer using symbolic values over numeric values.