### PR TITLE
lib/posix-environ: Deduplicate env variables during boot

### DIFF
--- a/lib/nolibc/include/unistd.h
+++ b/lib/nolibc/include/unistd.h
@@ -98,6 +98,8 @@ int dup2(int oldfd, int newfd);
 int dup3(int oldfd, int newfd, int flags);
 int unlink(const char *pathname);
 off_t lseek(int fd, off_t offset, int whence);
+int chdir(const char *path);
+int fchdir(int fd);
 int rmdir(const char *pathname);
 #endif
 

--- a/lib/ukstreambuf/include/uk/streambuf.h
+++ b/lib/ukstreambuf/include/uk/streambuf.h
@@ -263,7 +263,8 @@ __sz uk_streambuf_memcpy(struct uk_streambuf *sb, const void *src, __sz len);
  * NOTE: Instead of truncating, this function returns `__NULL` if there is not
  *       enough space left on the corresponding buffer.
  * HINT: With `uk_streambuf_reserve(sb, 1)`, the seek position can be moved
- *       further by one byte, afterwards.
+ *       further by one byte, afterwards (use 2 for
+ *       `UK_STREAMBUF_C_TERMSHIFT`).
  *
  * @param sb Streambuf object
  * @param len Number of bytes to reserve


### PR DESCRIPTION
This PR includes fixes for properly support PR [#75](https://github.com/unikraft/app-elfloader/pull/75) at app-elfloader. Most importantly, the PR introduces uniquifying environment variables during boot which finally enables overwriting compiled-in environment variables with the kernel parameter `env.vars`.