### PR TITLE
drivers/ukbus/platform: Make UKBUS_PLATFORM_FDT conditional to parent

### DIFF
--- a/drivers/ukbus/platform/Config.uk
+++ b/drivers/ukbus/platform/Config.uk
@@ -4,6 +4,10 @@ config LIBUKBUS_PLATFORM
 	help
 		Platform bus for non-auto-discoverable devices
 
+if LIBUKBUS_PLATFORM
+
 config LIBUKBUS_PLATFORM_FDT
 	bool
 	default y if (LIBUKOFW && LIBFDT)
+
+endif


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Make UKBUS_PLATFORM_FDT conditional to UKBUS_PLATFORM to prevent that option from being available if its parent is not selected.