### PR TITLE
lib/posix-time: Support CLOCK_REALTIME_COARSE

### DIFF
--- a/lib/posix-time/time.c
+++ b/lib/posix-time/time.c
@@ -153,6 +153,7 @@ UK_SYSCALL_R_DEFINE(int, clock_getres, clockid_t, clk_id,
 	case CLOCK_MONOTONIC:
 	case CLOCK_MONOTONIC_COARSE:
 	case CLOCK_REALTIME:
+	case CLOCK_REALTIME_COARSE:
 	case CLOCK_BOOTTIME:
 		if (tp) {
 			tp->tv_sec = 0;
@@ -188,6 +189,7 @@ UK_SYSCALL_R_DEFINE(int, clock_gettime, clockid_t, clk_id, struct timespec*, tp)
 		now = ukplat_monotonic_clock();
 		break;
 	case CLOCK_REALTIME:
+	case CLOCK_REALTIME_COARSE:
 		now = ukplat_wall_clock();
 		break;
 	default:


### PR DESCRIPTION
### Description of changes

This change adds support for CLOCK_REALTIME_COARSE as an alias to CLOCK_REALTIME.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Test by requesting `CLOCK_REALTIME_COARSE` from any of the `clock_*` syscalls.
