### PR TITLE
arch/x86: Use the ISR-safe variant for ectx string operations

### DIFF
--- a/arch/Config.uk
+++ b/arch/Config.uk
@@ -7,11 +7,14 @@ choice
 	  Select the target CPU architecture.
 
 config ARCH_X86_64
-       bool "x86 compatible (64 bits)"
+	bool "x86 compatible (64 bits)"
+	select LIBISRLIB
 config ARCH_ARM_64
-       bool "Armv8 compatible (64 bits)"
+	bool "Armv8 compatible (64 bits)"
+	select LIBISRLIB
 config ARCH_ARM_32
-       bool "Armv7 compatible (32 bits)"
+	bool "Armv7 compatible (32 bits)"
+	select LIBISRLIB
 
 endchoice
 

--- a/arch/arm/ectx.c
+++ b/arch/arm/ectx.c
@@ -41,7 +41,7 @@
 #include <uk/essentials.h>
 #include <uk/assert.h>
 #include <uk/print.h>
-#include <string.h> /* memset */
+#include <uk/isr/string.h> /* memset_isr */
 #include <arm/cpu.h>
 
 __sz ukarch_ectx_size(void)
@@ -74,7 +74,7 @@ void ukarch_ectx_init(struct ukarch_ectx *state)
 	/* Initialize extregs area:
 	 * Zero out and then save a valid layout to it.
 	 */
-	memset(state, 0, sizeof(struct fpsimd_state));
+	memset_isr(state, 0, sizeof(struct fpsimd_state));
 	ukarch_ectx_store(state);
 }
 

--- a/arch/x86/ectx.c
+++ b/arch/x86/ectx.c
@@ -41,7 +41,7 @@
 #include <uk/assert.h>
 #include <uk/print.h>
 #include <uk/hexdump.h>
-#include <string.h> /* memset */
+#include <uk/isr/string.h> /* memset_isr */
 
 enum x86_save_method {
 	X86_SAVE_NONE = 0,
@@ -147,7 +147,7 @@ void ukarch_ectx_init(struct ukarch_ectx *state)
 	/* Initialize extregs area:
 	 * Zero out and then save a valid layout to it.
 	 */
-	memset(state, 0, ectx_size);
+	memset_isr(state, 0, ectx_size);
 	ukarch_ectx_store(state);
 }
 
@@ -212,7 +212,7 @@ void ukarch_ectx_assert_equal(struct ukarch_ectx *state)
 	current = (struct ukarch_ectx *)ALIGN_UP((__uptr)ectxbuf, ectx_align);
 	ukarch_ectx_init(current);
 
-	if (memcmp(current, state, ectx_size) != 0) {
+	if (memcmp_isr(current, state, ectx_size) != 0) {
 		uk_pr_crit("Modified ECTX detected!\n");
 		uk_pr_crit("Current:\n");
 		uk_hexdumpk(KLVL_CRIT, current, ectx_size,


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes
`ectx.c` is marked as an `isr` variant, so it should probably use the ISR-safe version of memcmp and memset.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
