### PR TITLE
arch/arm64: Update asm constraints in mte_insert_random_tag()

### DIFF
--- a/arch/arm/arm64/include/uk/asm/mte.h
+++ b/arch/arm/arm64/include/uk/asm/mte.h
@@ -67,9 +67,9 @@ static inline __u64 mte_insert_random_tag(__u64 addr)
 {
 	__u64 reg;
 
-	__asm__ __volatile__("gmi	%x0, %x1, xzr\n"
-			     "irg	%x1, %x1, %x0\n"
-			     : "=r"(reg) : "r" (addr));
+	__asm__ __volatile__("gmi	%0, %1, xzr\n"
+			     "irg	%1, %1, %0\n"
+			     : "=&r"(reg), "+r" (addr));
 	return addr;
 }
 
@@ -83,7 +83,7 @@ static inline __u64 mte_load_alloc(__u64 addr)
 {
 	__u64 tag;
 
-	__asm__ __volatile__ ("ldg	%x0, [%x1]\n"
+	__asm__ __volatile__ ("ldg	%0, [%1]\n"
 			      : "=&r" (tag) : "r"(addr));
 	return tag;
 }
@@ -96,7 +96,7 @@ static inline __u64 mte_load_alloc(__u64 addr)
  */
 static inline void mte_store_alloc(__u64 addr)
 {
-	__asm__ __volatile__ ("stg	%x0, [%x0]"
+	__asm__ __volatile__ ("stg	%0, [%0]\n"
 			      : : "r"(addr) : "memory");
 }
 


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Update constraints of inline asm in mte_insert_random tag() to prevent GCC from using the same register for input and output.

Update all MTE inline asm to use positional parameters.

CC: @StefanJum 