### PR TITLE
lib/ukcpio: Consistently overwrite existing destination

### DIFF
--- a/lib/ukcpio/cpio.c
+++ b/lib/ukcpio/cpio.c
@@ -58,6 +58,59 @@ int uk_syscall_r_utime(const char *, const struct utimbuf *);
 int uk_syscall_r_mkdir(const char *, mode_t);
 int uk_syscall_r_symlink(const char *, const char *);
 int uk_syscall_r_stat(const char *, struct stat *);
+int uk_syscall_r_unlinkat(int, const char *, int);
+int uk_syscall_r_rename(const char *, const char *);
+
+static int
+try_rm_nonempty_dir(const char *path)
+{
+	/* rm -rf is nontrivial and costly, so we rename for speed */
+	/* TODO: revisit if efficient recursive dir removal is available */
+	int r;
+	char newpath[PATH_MAX];
+	char *newend = newpath + strlcpy(newpath, path, PATH_MAX);
+
+	if (unlikely(newend - newpath + 2 > PATH_MAX)) {
+		uk_pr_err("Cannot rename %s, path too long\n", path);
+		return -ENAMETOOLONG;
+	}
+	strcpy(newend, ".0");
+	r = uk_syscall_r_rename(path, newpath);
+	uk_pr_info("Rename '%s' to '%s': %d\n", path, newpath, r);
+	return r;
+}
+
+static int
+try_remove(const char *path)
+{
+	int r;
+
+	r = uk_syscall_r_unlinkat(AT_FDCWD, path, 0);
+	uk_pr_info("Unlink %s: %d\n", path, r);
+	if (!r || r == -ENOENT)
+		return 0;
+
+	r = uk_syscall_r_unlinkat(AT_FDCWD, path, AT_REMOVEDIR);
+	uk_pr_info("Rmdir %s: %d\n", path, r);
+	if (!r || r == -ENOENT)
+		return 0;
+	return try_rm_nonempty_dir(path);
+}
+
+static int
+write_file(int fd, const char *contents, size_t len)
+{
+	while (len) {
+		ssize_t written = uk_syscall_r_write(fd, contents, len);
+
+		if (unlikely(written < 0))
+			return written;
+		UK_ASSERT(len >= (size_t)written);
+		contents += written;
+		len -= written;
+	}
+	return 0;
+}
 
 static enum ukcpio_error
 extract_file(const char *path, const char *contents, size_t len,
@@ -70,39 +123,44 @@ extract_file(const char *path, const char *contents, size_t len,
 
 	uk_pr_info("Extracting %s (%zu bytes)\n", path, len);
 
-	fd = uk_syscall_r_open(path, O_CREAT | O_WRONLY | O_TRUNC, 0);
-	if (fd < 0) {
+	fd = uk_syscall_r_open(path, O_CREAT | O_WRONLY | O_EXCL, 0);
+	if (unlikely(fd == -EEXIST)) {
+		uk_pr_info("Path exists, trying removal\n");
+		err = try_remove(path);
+		if (unlikely(err))
+			/* Not fatal, following open may still succeed */
+			uk_pr_warn("%s: Path cleanup failed: %s (%d)\n",
+				   path, strerror(-err), -err);
+		fd = uk_syscall_r_open(path, O_CREAT | O_WRONLY | O_TRUNC, 0);
+	}
+	if (unlikely(fd < 0)) {
 		uk_pr_err("%s: Failed to create file: %s (%d)\n",
 			  path, strerror(-fd), -fd);
 		ret = -UKCPIO_FILE_CREATE_FAILED;
 		goto out;
 	}
 
-	while (len) {
-		ssize_t written = uk_syscall_r_write(fd, contents, len);
-
-		if (written < 0) {
-			err = written;
-			uk_pr_err("%s: Failed to load content: %s (%d)\n",
-				  path, strerror(-err), -err);
-			ret = -UKCPIO_FILE_WRITE_FAILED;
-			goto close_out;
-		}
-		UK_ASSERT(len >= (size_t)written);
-		contents += written;
-		len -= written;
+	err = write_file(fd, contents, len);
+	if (unlikely(err)) {
+		uk_pr_err("%s: Failed to load content: %s (%d)\n",
+			  path, strerror(-err), -err);
+		ret = -UKCPIO_FILE_WRITE_FAILED;
+		goto close_out;
 	}
 
-	if ((err = uk_syscall_r_chmod(path, mode)))
+	err = uk_syscall_r_chmod(path, mode);
+	if (unlikely(err))
 		uk_pr_warn("%s: Failed to chmod: %s (%d)\n",
 			   path, strerror(-err), -err);
 
-	if ((err = uk_syscall_r_utime(path, &times)))
+	err = uk_syscall_r_utime(path, &times);
+	if (unlikely(err))
 		uk_pr_warn("%s: Failed to set modification time: %s (%d)",
 			   path, strerror(-err), -err);
 
 close_out:
-	if ((err = uk_syscall_r_close(fd))) {
+	err = uk_syscall_r_close(fd);
+	if (unlikely(err)) {
 		uk_pr_err("%s: Failed to close file: %s (%d)\n",
 			  path, strerror(-err), -err);
 		if (!ret)
@@ -119,26 +177,40 @@ extract_dir(const char *path, mode_t mode)
 
 	uk_pr_info("Creating directory %s\n", path);
 	r = uk_syscall_r_mkdir(path, mode);
-	if (r == -EEXIST) {
+	if (unlikely(r == -EEXIST)) {
 		struct stat pstat;
 
+		uk_pr_info("Path exists, checking type\n");
 		r = uk_syscall_r_stat(path, &pstat);
-		if (r < 0) {
+		if (unlikely(r < 0)) {
+			uk_pr_warn("%s: Cannot stat path: %s (%d)\n",
+				   path, strerror(-r), -r);
 			r = -EEXIST;
 			goto err_out;
 		}
 		if (!S_ISDIR(pstat.st_mode)) {
-			r = -EEXIST;
-			goto err_out;
+			/* Path exists but is not dir; remove & try again */
+			uk_pr_info("Path exists and not dir, trying removal\n");
+			r = try_remove(path);
+			if (unlikely(r)) {
+				uk_pr_warn("%s: Path cleanup failed: %s (%d)\n",
+					   path, strerror(-r), -r);
+				goto err_out;
+			}
+			r = uk_syscall_r_mkdir(path, mode);
+			if (unlikely(r))
+				goto err_out;
+			else
+				return UKCPIO_SUCCESS;
 		}
 
 		/* Directory already exists, set mode only */
+		uk_pr_info("Path exists and is dir, doing chmod\n");
 		r = uk_syscall_r_chmod(path, mode);
-		if (r < 0) {
+		if (unlikely(r < 0))
 			uk_pr_warn("%s: Failed to chmod: %s (%d)\n",
 				   path, strerror(-r), -r);
-		}
-	} else if (r < 0) {
+	} else if (unlikely(r < 0)) {
 		goto err_out;
 	}
 	return UKCPIO_SUCCESS;
@@ -161,12 +233,64 @@ extract_symlink(const char *path, const char *contents, size_t len)
 	target[len] = 0;
 
 	uk_pr_info("%s: Target is %s\n", path, target);
-	if ((r = uk_syscall_r_symlink(target, path))) {
-		uk_pr_err("%s: Failed to create symlink: %s (%d)\n",
-			  path, strerror(-r), -r);
-		return -UKCPIO_SYMLINK_FAILED;
+	r = uk_syscall_r_symlink(target, path);
+	if (r == -EEXIST) {
+		uk_pr_info("Path exists, trying removal\n");
+		r = try_remove(path);
+		if (!r)
+			r = uk_syscall_r_symlink(target, path);
 	}
-	return UKCPIO_SUCCESS;
+	if (likely(!r))
+		return UKCPIO_SUCCESS;
+
+	uk_pr_err("%s: Failed to create symlink: %s (%d)\n",
+		  path, strerror(-r), -r);
+	return -UKCPIO_SYMLINK_FAILED;
+}
+
+static enum ukcpio_error
+extract_section(const struct uk_cpio_header **headerp, char *fullpath,
+		const char *eof, size_t prefixlen)
+{
+	const struct uk_cpio_header *header = *headerp;
+	uint32_t mode = UKCPIO_U32FIELD(header->mode);
+	uint32_t filesize = UKCPIO_U32FIELD(header->filesize);
+	uint32_t namesize = UKCPIO_U32FIELD(header->namesize);
+	uint32_t mtime = UKCPIO_U32FIELD(header->mtime);
+	const char *fname = UKCPIO_FILENAME(header);
+	const char *data = UKCPIO_DATA(header, namesize);
+	enum ukcpio_error err;
+
+	if (unlikely(fname + namesize > eof)) {
+		uk_pr_err("File name exceeds archive bounds at %p\n", header);
+		return -UKCPIO_MALFORMED_INPUT;
+	}
+	if (unlikely(data + filesize > eof)) {
+		uk_pr_err("File exceeds archive bounds: %s\n", fname);
+		return -UKCPIO_MALFORMED_INPUT;
+	}
+
+	/* namesize includes trailing NUL */
+	if (unlikely(prefixlen + namesize > PATH_MAX)) {
+		uk_pr_err("Resulting path too long: %s\n", fname);
+		return -UKCPIO_MALFORMED_INPUT;
+	}
+	memcpy(fullpath + prefixlen, fname, namesize);
+
+	err = UKCPIO_SUCCESS;
+
+	if (UKCPIO_IS_DIR(mode))
+		err = extract_dir(fullpath, mode & 0777);
+	else if (UKCPIO_IS_FILE(mode))
+		err = extract_file(fullpath, data, filesize,
+				   mode & 0777, mtime);
+	else if (UKCPIO_IS_SYMLINK(mode))
+		err = extract_symlink(fullpath, data, filesize);
+	else
+		uk_pr_warn("File %s unknown mode %o\n", fullpath, mode);
+
+	*headerp = UKCPIO_NEXT(header, namesize, filesize);
+	return err;
 }
 
 /**
@@ -189,60 +313,20 @@ process_section(const struct uk_cpio_header **headerp, char *fullpath,
 {
 	const struct uk_cpio_header *header = *headerp;
 
-	if ((char *)header >= eof || UKCPIO_FILENAME(header) > eof) {
+	if (unlikely((char *)header >= eof ||
+		     UKCPIO_FILENAME(header) > eof)) {
 		uk_pr_err("Truncated CPIO header at %p", header);
 		return -UKCPIO_INVALID_HEADER;
 	}
-	if (!ukcpio_valid_magic(header)) {
+	if (unlikely(!ukcpio_valid_magic(header))) {
 		uk_pr_err("Bad magic number in CPIO header at %p\n", header);
 		return -UKCPIO_INVALID_HEADER;
 	}
-
-	if (UKCPIO_ISLAST(header)) {
+	if (unlikely(UKCPIO_ISLAST(header))) {
 		*headerp = NULL;
 		return UKCPIO_SUCCESS;
-	} else {
-		uint32_t mode = UKCPIO_U32FIELD(header->mode);
-		uint32_t filesize = UKCPIO_U32FIELD(header->filesize);
-		uint32_t namesize = UKCPIO_U32FIELD(header->namesize);
-		uint32_t mtime = UKCPIO_U32FIELD(header->mtime);
-		const char *fname = UKCPIO_FILENAME(header);
-		const char *data = UKCPIO_DATA(header, namesize);
-		enum ukcpio_error err;
-
-		if (fname + namesize > eof) {
-			uk_pr_err("File name exceeds archive bounds at %p\n",
-				  header);
-			return -UKCPIO_MALFORMED_INPUT;
-		}
-		if (data + filesize > eof) {
-			uk_pr_err("File exceeds archive bounds: %s\n", fname);
-			return -UKCPIO_MALFORMED_INPUT;
-		}
-
-		/* namesize includes trailing NUL */
-		if (prefixlen + namesize > PATH_MAX) {
-			uk_pr_err("Resulting path too long: %s\n", fname);
-			return -UKCPIO_MALFORMED_INPUT;
-		}
-		memcpy(fullpath + prefixlen, fname, namesize);
-
-		err = UKCPIO_SUCCESS;
-
-		if (UKCPIO_IS_DIR(mode)) {
-			err = extract_dir(fullpath, mode & 0777);
-		} else if (UKCPIO_IS_FILE(mode)) {
-			err = extract_file(fullpath, data, filesize,
-					   mode & 0777, mtime);
-		} else if (UKCPIO_IS_SYMLINK(mode)) {
-			err = extract_symlink(fullpath, data, filesize);
-		} else {
-			uk_pr_warn("File %s unknown mode %o\n", fullpath, mode);
-		}
-
-		*headerp = UKCPIO_NEXT(header, namesize, filesize);
-		return err;
 	}
+	return extract_section(headerp, fullpath, eof, prefixlen);
 }
 
 enum ukcpio_error
@@ -256,9 +340,10 @@ ukcpio_extract(const char *dest, const void *buf, size_t buflen)
 	if (dest == NULL)
 		return -UKCPIO_NODEST;
 
-	if ((destlen = strlcpy(pathbuf, dest, PATH_MAX)) > PATH_MAX - 1)
+	destlen = strlcpy(pathbuf, dest, PATH_MAX);
+	if (unlikely(destlen > PATH_MAX - 1))
 		return -UKCPIO_NODEST;
-	if (pathbuf[destlen-1] != '/') {
+	if (pathbuf[destlen - 1] != '/') {
 		pathbuf[destlen++] = '/';
 		pathbuf[destlen] = 0;
 	}

--- a/lib/ukcpio/cpio.c
+++ b/lib/ukcpio/cpio.c
@@ -229,8 +229,7 @@ process_section(const struct uk_cpio_header **headerp, char *fullpath,
 
 		err = UKCPIO_SUCCESS;
 
-		/* Skip "." as dest is already there */
-		if (UKCPIO_IS_DIR(mode) && strcmp(".", fname)) {
+		if (UKCPIO_IS_DIR(mode)) {
 			err = extract_dir(fullpath, mode & 0777);
 		} else if (UKCPIO_IS_FILE(mode)) {
 			err = extract_file(fullpath, data, filesize,

--- a/lib/ukcpio/include/uk/cpio.h
+++ b/lib/ukcpio/include/uk/cpio.h
@@ -35,10 +35,102 @@
 #define __UK_CPIO_H__
 
 #include <stddef.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern C {
 #endif /* __cplusplus */
+
+/*
+ * Currently only supports BSD new-style cpio archive format.
+ */
+#define UKCPIO_MAGIC_NEWC "070701"
+#define UKCPIO_MAGIC_CRC  "070702"
+#define UKCPIO_FILE_TYPE_MASK    0170000
+#define UKCPIO_DIRECTORY_BITS    040000
+#define UKCPIO_FILE_BITS         0100000
+#define UKCPIO_SYMLINK_BITS      0120000
+
+#define UKCPIO_IS_FILE_OF_TYPE(mode, bits) \
+	(((mode) & (UKCPIO_FILE_TYPE_MASK)) == (bits))
+#define UKCPIO_IS_FILE(mode) UKCPIO_IS_FILE_OF_TYPE((mode), (UKCPIO_FILE_BITS))
+#define UKCPIO_IS_DIR(mode) \
+	UKCPIO_IS_FILE_OF_TYPE((mode), (UKCPIO_DIRECTORY_BITS))
+#define UKCPIO_IS_SYMLINK(mode) \
+	UKCPIO_IS_FILE_OF_TYPE((mode), (UKCPIO_SYMLINK_BITS))
+
+struct uk_cpio_header {
+	char magic[6];
+	char inode_num[8];
+	char mode[8];
+	char uid[8];
+	char gid[8];
+	char nlink[8];
+	char mtime[8];
+	char filesize[8];
+	char major[8];
+	char minor[8];
+	char ref_major[8];
+	char ref_minor[8];
+	char namesize[8];
+	char chksum[8];
+};
+
+static inline
+int ukcpio_valid_magic(const struct uk_cpio_header *header)
+{
+	return memcmp(header->magic, UKCPIO_MAGIC_NEWC, 6) == 0 ||
+	       memcmp(header->magic, UKCPIO_MAGIC_CRC, 6) == 0;
+}
+
+/**
+ * Function to convert len digits of hexadecimal string loc
+ * to an integer.
+ *
+ * @param buf
+ *  The string character buffer.
+ * @param count
+ *  The size of the buffer.
+ * @return
+ *   The converted unsigned integer value on success.  Returns 0 on error.
+ */
+static inline
+unsigned int snhex_to_int(const char *buf, size_t count)
+{
+	unsigned int val = 0;
+	size_t i;
+
+	UK_ASSERT(buf);
+
+	for (i = 0; i < count; i++) {
+		val *= 16;
+		if (buf[i] >= '0' && buf[i] <= '9')
+			val += (buf[i] - '0');
+		else if (buf[i] >= 'A' && buf[i] <= 'F')
+			val += (buf[i] - 'A') + 10;
+		else if (buf[i] >= 'a' && buf[i] <= 'f')
+			val += (buf[i] - 'a') + 10;
+		else
+			return 0;
+	}
+	return val;
+}
+
+#define UKCPIO_ALIGN 4
+#define UKCPIO_ALIGN_UP(ptr) ((void *)ALIGN_UP((uintptr_t)(ptr), UKCPIO_ALIGN))
+
+#define UKCPIO_U32FIELD(buf) \
+	((uint32_t)snhex_to_int((buf), 8))
+#define UKCPIO_FILENAME(header) \
+	((char *)(header) + sizeof(struct uk_cpio_header))
+#define UKCPIO_DATA(header, fnlen) \
+	((char *)UKCPIO_ALIGN_UP((char *)(header) + \
+				 sizeof(struct uk_cpio_header) + (fnlen)))
+#define UKCPIO_NEXT(header, fnlen, fsize) \
+	((struct uk_cpio_header *)UKCPIO_ALIGN_UP(UKCPIO_DATA(header, fnlen) + \
+						  (fsize)))
+#define UKCPIO_ISLAST(header) \
+	(strcmp(UKCPIO_FILENAME(header), "TRAILER!!!") == 0)
 
 /**
  * Include also the case of unsupported headers


### PR DESCRIPTION
### Description of changes

Previously ukcpio would inconsistently ovewrite its destination depending on file types; notably, directories could not be overwritten by files or symlinks, and symlinks would be followed instead of overwritten by files.

This PR makes ukcpio consistently overwrite existing files/dirs/symlinks in the destination. Specifically:
- Files & symlinks whose path exists will attempt removal before retrying
- Directories whose path exists and is not a directory will attempt removal
- Directories that already exists will only have their mode bits changed

When attempting to remove a path, the following are tried, in order:
- `unlink()` -- for files & symlinks
- `rmdir()` -- for empty dirs
- `rename()` -- for non-empty dirs; this is chosen instead of recursive removal to minimize boot latency. Ideally one would not overwrite entire directory trees using an initrd anyway.

In addition, and as prerequisites, this PR also brings the following general improvements:
- Export the supported CPIO header format + accessor macros through `<uk/cpio.h>`, making it available for other Unikraft components/apps to use
- Remove special handling of `.`, as it had little benefit and produced several issues

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

Test with an embedded initrd + initrd that overwrites existing contents.
