### PR TITLE
include/uk: Replace libc types with Unikraft defined

### DIFF
--- a/include/uk/compat_list.h
+++ b/include/uk/compat_list.h
@@ -169,7 +169,7 @@ struct UK__qm_trace {
 
 #ifdef UK_QUEUE_MACRO_DEBUG_TRASH
 #define	UK__TRASHIT(x)		do {(x) = (void *)-1;} while (0)
-#define	UK__QMD_IS_TRASHED(x)	((x) == (void *)(intptr_t)-1)
+#define	UK__QMD_IS_TRASHED(x)	((x) == (void *)(__sptr) - 1)
 #else	/* !UK_QUEUE_MACRO_DEBUG_TRASH */
 #define	UK__TRASHIT(x)
 #define	UK__QMD_IS_TRASHED(x)	0

--- a/include/uk/plat/time.h
+++ b/include/uk/plat/time.h
@@ -35,7 +35,6 @@
 #define __UKPLAT_TIME_H__
 
 #include <uk/arch/time.h>
-#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,7 +42,7 @@ extern "C" {
 
 void ukplat_time_init(void);
 void ukplat_time_fini(void);
-uint32_t ukplat_time_get_irq(void);
+__u32 ukplat_time_get_irq(void);
 
 __nsec ukplat_time_get_ticks(void);
 __nsec ukplat_monotonic_clock(void);

--- a/plat/kvm/x86/time.c
+++ b/plat/kvm/x86/time.c
@@ -84,7 +84,7 @@ void ukplat_time_fini(void)
 {
 }
 
-uint32_t ukplat_time_get_irq(void)
+__u32 ukplat_time_get_irq(void)
 {
 	return 0;
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

<!--
### Additional configuration


Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Replace libc types with Unikraft defined, to make `include/uk/` independent of libc.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
