### PR TITLE
arch/: Replace libc types with Unikraft defined

### DIFF
--- a/arch/arm/arm64/include/uk/asm/lcpu.h
+++ b/arch/arm/arm64/include/uk/asm/lcpu.h
@@ -192,7 +192,7 @@ unsigned char tcr_ips_bits[] = {32, 36, 40, 42, 44, 48, 52};
 
 #if !__ASSEMBLY__
 
-#include <stdint.h>
+#include <uk/arch/types.h>
 
 /*
  * Change this structure must update TRAP_STACK_SIZE at the same time.
@@ -200,22 +200,22 @@ unsigned char tcr_ips_bits[] = {32, 36, 40, 42, 44, 48, 52};
  */
 struct __regs {
 	/* Generic Purpose registers, from x0 ~ x29 */
-	uint64_t x[30];
+	__u64 x[30];
 
 	/* Link Register (x30) */
-	uint64_t lr;
+	__u64 lr;
 
 	/* Exception Link Register */
-	uint64_t elr_el1;
+	__u64 elr_el1;
 
 	/* Processor State Register */
-	uint64_t spsr_el1;
+	__u64 spsr_el1;
 
 	/* Exception Status Register */
-	uint64_t esr_el1;
+	__u64 esr_el1;
 
 	/* Stack Pointer */
-	uint64_t sp;
+	__u64 sp;
 
 	/* Padding to make sure this structure is 16-byte aligned */
 	__u8 pad[__REGS_PAD_SIZE];
@@ -229,13 +229,13 @@ UK_CTASSERT(sizeof(struct __regs) == __REGS_SIZEOF);
  */
 struct __callee_saved_regs {
 	/* Callee-saved registers, from x19 ~ x28 */
-	uint64_t callee[10];
+	__u64 callee[10];
 
 	/* Frame Point Register (x29) */
-	uint64_t fp;
+	__u64 fp;
 
 	/* Link Register (x30) */
-	uint64_t lr;
+	__u64 lr;
 };
 
 UK_CTASSERT(sizeof(struct __callee_saved_regs) == __CALLEE_SAVED_SIZE);
@@ -280,7 +280,7 @@ UK_CTASSERT(sizeof(struct __callee_saved_regs) == __CALLEE_SAVED_SIZE);
 
 /* Macros to access system registers */
 #define SYSREG_READ(reg)					\
-({	uint64_t val;						\
+({	__u64 val;						\
 	__asm__ __volatile__("mrs %0, " __STRINGIFY(reg)	\
 			: "=r" (val));				\
 	val;							\
@@ -288,11 +288,11 @@ UK_CTASSERT(sizeof(struct __callee_saved_regs) == __CALLEE_SAVED_SIZE);
 
 #define SYSREG_WRITE(reg, val)					\
 ({	__asm__ __volatile__("msr " __STRINGIFY(reg) ", %0"	\
-			: : "r" ((uint64_t)(val)));		\
+			: : "r" ((__u64)(val)));		\
 })
 
 #define SYSREG_READ32(reg)					\
-({	uint32_t val;						\
+({	__u64 val;						\
 	__asm__ __volatile__("mrs %0, " __STRINGIFY(reg)	\
 			: "=r" (val));				\
 	val;							\
@@ -300,7 +300,7 @@ UK_CTASSERT(sizeof(struct __callee_saved_regs) == __CALLEE_SAVED_SIZE);
 
 #define SYSREG_WRITE32(reg, val)				\
 ({	__asm__ __volatile__("msr " __STRINGIFY(reg) ", %0"	\
-			: : "r" ((uint32_t)(val)));		\
+			: : "r" ((__u32)(val)));		\
 })
 
 #define SYSREG_READ64(reg)			SYSREG_READ(reg)
@@ -312,57 +312,57 @@ UK_CTASSERT(sizeof(struct __callee_saved_regs) == __CALLEE_SAVED_SIZE);
  * addressing mode which will cause crash when running in hyper mode
  * unless they will be decoded by hypervisor.
  */
-static inline uint8_t ioreg_read8(const volatile uint8_t *address)
+static inline __u8 ioreg_read8(const volatile __u8 *address)
 {
-	uint8_t value;
+	__u8 value;
 
 	__asm__ __volatile__("ldrb %w0, [%1]" : "=r"(value) : "r"(address));
 	return value;
 }
 
-static inline uint16_t ioreg_read16(const volatile uint16_t *address)
+static inline __u16 ioreg_read16(const volatile __u16 *address)
 {
-	uint16_t value;
+	__u16 value;
 
 	__asm__ __volatile__("ldrh %w0, [%1]" : "=r"(value) : "r"(address));
 	return value;
 }
 
-static inline uint32_t ioreg_read32(const volatile uint32_t *address)
+static inline __u32 ioreg_read32(const volatile __u32 *address)
 {
-	uint32_t value;
+	__u32 value;
 
 	__asm__ __volatile__("ldr %w0, [%1]" : "=r"(value) : "r"(address));
 	return value;
 }
 
-static inline uint64_t ioreg_read64(const volatile uint64_t *address)
+static inline __u64 ioreg_read64(const volatile __u64 *address)
 {
-	uint64_t value;
+	__u64 value;
 
 	__asm__ __volatile__("ldr %0, [%1]" : "=r"(value) : "r"(address));
 	return value;
 }
 
-static inline void ioreg_write8(const volatile uint8_t *address, uint8_t value)
+static inline void ioreg_write8(const volatile __u8 *address, __u8 value)
 {
 	__asm__ __volatile__("strb %w0, [%1]" : : "rZ"(value), "r"(address));
 }
 
-static inline void ioreg_write16(const volatile uint16_t *address,
-				 uint16_t value)
+static inline void ioreg_write16(const volatile __u16 *address,
+				 __u16 value)
 {
 	__asm__ __volatile__("strh %w0, [%1]" : : "rZ"(value), "r"(address));
 }
 
-static inline void ioreg_write32(const volatile uint32_t *address,
-				 uint32_t value)
+static inline void ioreg_write32(const volatile __u32 *address,
+				 __u32 value)
 {
 	__asm__ __volatile__("str %w0, [%1]" : : "rZ"(value), "r"(address));
 }
 
-static inline void ioreg_write64(const volatile uint64_t *address,
-				 uint64_t value)
+static inline void ioreg_write64(const volatile __u64 *address,
+				 __u64 value)
 {
 	__asm__ __volatile__("str %0, [%1]" : : "rZ"(value), "r"(address));
 }


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A

<!--
### Additional configuration


Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Replace libc data types with Unikraft defined, to make `arch/` independent of libc

<!--
Please provide a detailed description of the changes made in this new PR.
-->
