### PR TITLE
Fix calloc uses in vfscore

### DIFF
--- a/lib/vfscore/dentry.c
+++ b/lib/vfscore/dentry.c
@@ -69,7 +69,7 @@ struct dentry *
 dentry_alloc(struct dentry *parent_dp, struct vnode *vp, const char *path)
 {
 	struct mount *mp = vp->v_mount;
-	struct dentry *dp = (struct dentry*)calloc(sizeof(*dp), 1);
+	struct dentry *dp = calloc(1, sizeof(*dp));
 
 	if (!dp) {
 		return NULL;

--- a/lib/vfscore/mount.c
+++ b/lib/vfscore/mount.c
@@ -161,7 +161,7 @@ UK_SYSCALL_R_DEFINE(int, mount, const char*, dev, const char*, dir,
 	/*
 	 * Create VFS mount entry.
 	 */
-	mp = calloc(1, sizeof(struct mount));
+	mp = calloc(1, sizeof(*mp));
 	if (!mp) {
 		error = ENOMEM;
 		goto err1;

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -192,7 +192,7 @@ sys_open(char *path, int flags, mode_t mode, struct vfscore_file **fpp)
 		}
 	}
 
-	fp = calloc(sizeof(struct vfscore_file), 1);
+	fp = calloc(1, sizeof(*fp));
 	if (!fp) {
 		error = ENOMEM;
 		goto out_unlock;
@@ -280,10 +280,10 @@ sys_read(struct vfscore_file *fp, const struct iovec *iov, size_t niov,
 	 *  zeros the iov_len fields when it reads from disk, so we
 	 *  have to copy iov. "
 	 */
-	copy_iov = calloc(sizeof(struct iovec), niov);
+	copy_iov = calloc(niov, sizeof(*copy_iov));
 	if (!copy_iov)
 		return ENOMEM;
-	memcpy(copy_iov, iov, sizeof(struct iovec)*niov);
+	memcpy(copy_iov, iov, sizeof(*copy_iov) * niov);
 
 	uio.uio_iov = copy_iov;
 	uio.uio_iovcnt = niov;
@@ -329,7 +329,7 @@ sys_write(struct vfscore_file *fp, const struct iovec *iov, size_t niov,
 	 *  iov_len fields when it writes to disk, so we have to copy iov.
 	 */
 	/* std::vector<iovec> copy_iov(iov, iov + niov); */
-	copy_iov = calloc(sizeof(struct iovec), niov);
+	copy_iov = calloc(niov, sizeof(*copy_iov));
 	if (!copy_iov)
 		return ENOMEM;
 	memcpy(copy_iov, iov, sizeof(struct iovec)*niov);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

I was grepping through the codebase looking into the malloc like function calls and saw some "calloc" calls in lib/vfscore where the arguments were reversed. Per 'man calloc', the first parameter should be the number of elements and the second parameter should be the size of a single element i.e., the "sizeof(...)" argument should be the second argument.

This PR has 2 types of changes:
1. It fixes the places that had calloc arguments reversed (~~the niov ones look like they might cause real bugs~~ probably won't. searching on google seems to suggest they would allocate the same amount of memory so wouldn't cause any bugs.)
2. Also it uses sizeof(variable) instead of sizeof(struct) for consistency with the codebase  