### PR TITLE
libs/vfscore: Fix dirent64 warning

### DIFF
--- a/lib/posix-fdio/fdctl.c
+++ b/lib/posix-fdio/fdctl.c
@@ -6,6 +6,10 @@
 
 /* Internal syscalls for file control operations */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <sys/ioctl.h>
 
 #include <uk/atomic.h>

--- a/lib/posix-poll/epoll.c
+++ b/lib/posix-poll/epoll.c
@@ -4,6 +4,10 @@
  * You may not use this file except in compliance with the License.
  */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <errno.h>
 
 #include <uk/atomic.h>

--- a/lib/ramfs/ramfs_vfsops.c
+++ b/lib/ramfs/ramfs_vfsops.c
@@ -30,6 +30,10 @@
  * SUCH DAMAGE.
  */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <errno.h>
 
 #define _BSD_SOURCE

--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -37,6 +37,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>


### PR DESCRIPTION
Current Musl-based builds generate warnings related to dirent64 definition. Define _LARGEFILE64_SOURCE early so it prevents the warning from happening.
