### PR TITLE
lib/posix-timerfd: Fix update thread double free and add update thread dtor

### DIFF
--- a/lib/posix-timerfd/timerfd.c
+++ b/lib/posix-timerfd/timerfd.c
@@ -176,8 +176,6 @@ static void timerfd_release(const struct uk_file *f, int what)
 		uk_file_rlock(f);
 		uk_thread_terminate(d->upthread);
 		uk_file_runlock(f);
-		/* Collect thread */
-		uk_thread_release(d->upthread);
 	}
 	if (what & UK_FILE_RELEASE_OBJ) {
 		struct timerfd_alloc *al;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Whenever a timer fd is released, the thread associated with its update
function is also released through a combination of `uk_thread_terminate`
and `uk_thread_release`. However, if the released thread is different
from the current thread then `uk_thread_terminate` also calls
`uk_thread_release` on its own, leading to a double free. This is always
the case as the release function is impossible to be called from the
update function.

Therefore, fix this by deleting the explicit call to `uk_thread_release`
and rely on the one implicitly called by `uk_thread_terminate`.

On the other hand, with future introduction of posix-signals, we will
have to compensate for the fact that some subsystems end up terminating
threads without being timerfd aware.

For example, posix-process may try to terminate all threads of a
given process without being aware that a thread may have open fd's.
In this case, a closed thread with an open timerfd results in the
timerfd still holding a reference to the released thread to terminate
it when it is closed, resulting in a double termination or memory
corruption.

Fix this by adding a destructor that, when called, uses the `priv` field
of `struct uk_thread`, initially assigned to the timerfd structure
holding this reference, to mark this reference as NULL so that double
termination is avoided.

