### PR TITLE
lib/posix-process: Fix off-by-one error in tid check

### DIFF
--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -110,6 +110,8 @@ static inline pid_t find_free_tid(void)
 	}
 	if (found == TIDMAP_SIZE) {
 		/* no free PID */
+		uk_pr_err("Could not allocate TID: Out of TIDs (configured max: %d)\n",
+			  CONFIG_LIBPOSIX_PROCESS_MAX_PID);
 		return -1;
 	}
 
@@ -461,7 +463,7 @@ UK_THREAD_INIT_PRIO(posix_thread_init, posix_thread_fini, UK_PRIO_EARLIEST);
 
 static inline struct posix_thread *tid2pthread(pid_t tid)
 {
-	if (tid >= CONFIG_LIBPOSIX_PROCESS_MAX_PID || tid < 0)
+	if ((__sz)tid >= ARRAY_SIZE(tid_thread) || tid < 0)
 		return NULL;
 	return tid_thread[tid];
 }


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Fix an off-by-one error in tid2pthread() that returns failure when the passed tid is the maximum allowed value.
    
Show error message when CONFIG_LIBPOSIX_PROCESS_MAX_PID is reached.
