### PR TITLE
lib/ukboot: Silence compiler warning on envp

### DIFF
--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -462,10 +462,8 @@ exit:
 
 static inline int do_main(int argc, char *argv[])
 {
+	char **envp __maybe_unused;
 	uk_ctor_func_t *ctorfn;
-#if CONFIG_LIBPOSIX_ENVIRON
-	char **envp;
-#endif /* CONFIG_LIBPOSIX_ENVIRON */
 	int ret;
 
 	/*


### PR DESCRIPTION
Make declaration of envp conditional to CONFIG_LIBUKDEBUG_PRINTK_INFO to silence a compiler warning on unused variable.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Make declaration of `envp` conditional to `CONFIG_LIBUKDEBUG_PRINTK_INFO` to silence a compiler warning on unused variable.