### PR TITLE
build: Allow fetching into directory outside build directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,20 @@ $(if $(BUILD_DIR),, $(error could not create directory "$(_O)"))
 BUILD_DIR := $(realpath $(patsubst %/,%,$(patsubst %.,%,$(BUILD_DIR))))
 override O := $(BUILD_DIR)
 
+# parameter F: FETCH_BASE ###
+ifneq ("$(origin F)", "command line")
+_F := $(BUILD_DIR)
+else
+ifeq ("$(filter /%,$(F))", "")
+$(error Path to fetch directory (F) is not absolute)
+endif
+_F := $(realpath $(dir $(F)))/$(notdir $(F))
+endif
+FETCH_BASE := $(shell mkdir -p $(_F) && cd $(_F) >/dev/null && pwd)
+$(if $(FETCH_BASE),, $(error could not create directory "$(_F)"))
+FETCH_BASE := $(realpath $(patsubst %/,%,$(patsubst %.,%,$(FETCH_BASE))))
+override F := $(FETCH_BASE)
+
 # parameter C: UK_CONFIG ###
 # Use C variable if set on the command line, otherwise use $(A)/.config;
 ifneq ("$(origin C)", "command line")
@@ -222,6 +236,7 @@ $(call verbose_info,* External platforms: [ $(EPLAT_DIR) ])
 $(call verbose_info,* External libraries: [ $(ELIB_DIR) ])
 $(call verbose_info,* Import excludes:    [ $(IMPORT_EXCLUDEDIRS) ])
 $(call verbose_info,* Build output:       $(BUILD_DIR))
+$(call verbose_info,* Fetch base:         $(FETCH_BASE))
 
 build_dir_make  := 0
 ifneq ($(BUILD_DIR),$(UK_BASE))
@@ -1218,6 +1233,7 @@ endif
 	@echo '                           2 => like 1 and warn about undefined build variables'
 	@echo '  C=[PATH]               - path to .config configuration file'
 	@echo '  O=[PATH]               - path to build output (will be created if it does not exist)'
+	@echo '  F=[PATH]               - path to store fetched files (will be created if it does not exist)'
 	@echo '  A=[PATH]               - path to Unikraft application'
 	@echo '  N=[NAME]               - use NAME as image name instead the one found in the configuration'
 	@echo '                           (note: the name in the configuration file is not overwritten)'

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -525,13 +525,14 @@ endef
 # (without path!) is specified
 # fetchas $1:libname,$2:url,$3:target_fname(no_path!)
 define fetchas =
-$(BUILD_DIR)/$(1)/$(3):
+$(FETCH_BASE)/$(1)/$(3):
 	$(call verbose_cmd,WGET,$(1)':' $(2), \
-	 $(WGET) -q --show-progress --progress=bar -O $(BUILD_DIR)/$(1)/$(3) $(2) || \
-	 $(RM) $(BUILD_DIR)/$(1)/$(3))
+	 mkdir -p $(FETCH_BASE)/$(1) && \
+	 $(WGET) -q --show-progress --progress=bar -O $(FETCH_BASE)/$(1)/$(3) $(2) || \
+	 $(RM) $(FETCH_BASE)/$(1)/$(3))
 
-$(call _chksum_origin,$(1),$(BUILD_DIR)/$(1)/$(3),$(BUILD_DIR)/$(1)/.chksum)
-$(call unarchive,$(1),$(BUILD_DIR)/$(1)/$(3),$(BUILD_DIR)/$(1)/.chksum)
+$(call _chksum_origin,$(1),$(FETCH_BASE)/$(1)/$(3),$(BUILD_DIR)/$(1)/.chksum)
+$(call unarchive,$(1),$(FETCH_BASE)/$(1)/$(3),$(BUILD_DIR)/$(1)/.chksum)
 
 UK_FETCH-y += $(BUILD_DIR)/$(1)/.chksum
 endef
@@ -541,12 +542,13 @@ endef
 define fetchas2 =
 $(BUILD_DIR)/$(1)/$(4):
 	$(call verbose_cmd,WGET,$(1)':' $(2) [retry-with: $(3)], \
-	 $(WGET) -q --show-progress --progress=bar -O $(BUILD_DIR)/$(1)/$(4) $(2) || \
-	 $(WGET) -q --show-progress --progress=bar -O $(BUILD_DIR)/$(1)/$(4) $(3) || \
-	 $(RM) $(BUILD_DIR)/$(1)/$(4))
+	 mkdir -p $(FETCH_BASE)/$(1) && \
+	 $(WGET) -q --show-progress --progress=bar -O $(FETCH_BASE)/$(1)/$(4) $(2) || \
+	 $(WGET) -q --show-progress --progress=bar -O $(FETCH_BASE)/$(1)/$(4) $(3) || \
+	 $(RM) $(FETCH_BASE)/$(1)/$(4))
 
-$(call _chksum_origin,$(1),$(BUILD_DIR)/$(1)/$(4),$(BUILD_DIR)/$(1)/.chksum)
-$(call unarchive,$(1),$(BUILD_DIR)/$(1)/$(4),$(BUILD_DIR)/$(1)/.chksum)
+$(call _chksum_origin,$(1),$(FETCH_BASE)/$(1)/$(4),$(BUILD_DIR)/$(1)/.chksum)
+$(call unarchive,$(1),$(FETCH_BASE)/$(1)/$(4),$(BUILD_DIR)/$(1)/.chksum)
 
 UK_FETCH-y += $(BUILD_DIR)/$(1)/.chksum
 endef


### PR DESCRIPTION
Introduce an additional path (`F`, `FETCH_BASE`) that is used for fetch targets for the builds.

There are multiple motivations for using a distinct fetch base directory:
- Reusing downloads shared by multiple builds (eg. musl).
- Allow building without internet access (with populated fetch base).

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

Build the application with the desired target directory, for example:
```
make F=$(pwd)/../fetch-base
```

For testing purposes, fetching with wget can be disabled as following:
```
# instead of wget, call false, which always fails
make F=$(pwd)/../fetch-base WGET=false
```


### Description of changes

Before, the buildsystem fetched archives into `$BUILD_DIR/$LIBNAME`. With this commit, archives are fetched into `$FETCH_BASE/$LIBNAME`. By default, `$FETCH_BASE` is set to `$BUILD_DIR`, resulting in the same behaviour as before.

Further details:
- Checksums are checked same as before.
- Incorrect checksums lead to the build failing, no retry.
- `$FETCH_BASE` does not have an effect on `clone` rules.