### PR TITLE
lib/syscall_shim: Update syscall numbers to 6.8

### DIFF
--- a/lib/syscall_shim/arch/arm/syscall.h.in
+++ b/lib/syscall_shim/arch/arm/syscall.h.in
@@ -398,6 +398,15 @@
 #define __NR_landlock_create_ruleset	444
 #define __NR_landlock_add_rule	445
 #define __NR_landlock_restrict_self	446
+#define __NR_process_mrelease	448
+#define __NR_futex_waitv	449
+#define __NR_cachestat		451
+#define __NR_fchmodat2		452
+#define __NR_futex_wake		454
+#define __NR_futex_wait		455
+#define __NR_futex_requeue	456
+#define __NR_statmount		457
+#define __NR_listmount		458
 
 #define __ARM_NR_breakpoint	0x0f0001
 #define __ARM_NR_cacheflush	0x0f0002

--- a/lib/syscall_shim/arch/arm64/syscall.h.in
+++ b/lib/syscall_shim/arch/arm64/syscall.h.in
@@ -300,3 +300,14 @@
 #define __NR_landlock_create_ruleset	444
 #define __NR_landlock_add_rule	445
 #define __NR_landlock_restrict_self	446
+#define __NR_memfd_secret	447
+#define __NR_process_mrelease	448
+#define __NR_futex_waitv	449
+#define __NR_set_mempolicy_home_node	450
+#define __NR_cachestat		451
+#define __NR_fchmodat2		452
+#define __NR_futex_wake		454
+#define __NR_futex_wait		455
+#define __NR_futex_requeue	456
+#define __NR_statmount		457
+#define __NR_listmount		458

--- a/lib/syscall_shim/arch/x86_64/syscall.h.in
+++ b/lib/syscall_shim/arch/x86_64/syscall.h.in
@@ -356,4 +356,15 @@
 #define __NR_landlock_create_ruleset	444
 #define __NR_landlock_add_rule	445
 #define __NR_landlock_restrict_self	446
-
+#define __NR_memfd_secret	447
+#define __NR_process_mrelease	448
+#define __NR_futex_waitv	449
+#define __NR_set_mempolicy_home_node	450
+#define __NR_cachestat		451
+#define __NR_fchmodat2		452
+#define __NR_map_shadow_stack	453
+#define __NR_futex_wake		454
+#define __NR_futex_wait		455
+#define __NR_futex_requeue	456
+#define __NR_statmount		457
+#define __NR_listmount		458


### PR DESCRIPTION
### Description of changes

This change adds numbers for new syscalls introduced since Linux 5.14, up to and including Linux 6.8.
No syscall implementations are actually included, this only makes `syscall_shim` recognize the syscall names & numbers.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A
