### PR TITLE
lib/ukfile: Remove padding from struct uk_statx

### DIFF
--- a/lib/ukfile/include/uk/file/statx.h
+++ b/lib/ukfile/include/uk/file/statx.h
@@ -13,7 +13,7 @@
  * Linux-compatible `statx` structure for use in syscalls, along with
  * definitions of bit flags.
  *
- * Layout taken from statx(2) man page with paddings from musl v1.2.3.
+ * Layout taken from statx(2) man page cross-checked with musl v1.2.3.
  * Flag values taken from Linux headers v6.5.6 (include/uapi/linux/stat.h).
  */
 
@@ -44,7 +44,6 @@ struct uk_statx {
 	uint64_t stx_mnt_id;
 	uint32_t stx_dio_mem_align;
 	uint32_t stx_dio_offset_align;
-	uint64_t _spare[12];
 };
 
 /* Bits used in stx_mask */


### PR DESCRIPTION
### Description of changes

This change removes the padding fields from uk_statx, minimizing memory waste when allocating inside the kernel.
Syscalls never reveal these kernel structs, and userspace allocates a struct statx dictated by its libc.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A