### PR TITLE
lib/ukvmem/arch/arm: Fix `error_code` build error with correct `esr`

### DIFF
--- a/lib/ukvmem/arch/arm/pagefault64.c
+++ b/lib/ukvmem/arch/arm/pagefault64.c
@@ -44,10 +44,10 @@ static int vmem_arch_pagefault(void *data)
 		vas = uk_vas_get_active();
 		if (unlikely(vas && !(vas->flags & UK_VAS_FLAG_NO_PAGING)))
 			uk_pr_crit("Cannot handle %s page fault at 0x%"
-				   __PRIvaddr" (ec: 0x%x): %s (%d).\n",
+				   __PRIvaddr" (ec: 0x%lx): %s (%d).\n",
 				   faultstr[faulttype &
 					    UK_VMA_FAULT_ACCESSTYPE],
-				   vaddr, ctx->error_code, strerror(-rc), -rc);
+				   vaddr, ctx->esr, strerror(-rc), -rc);
 
 		return UK_EVENT_NOT_HANDLED;
 	}


### PR DESCRIPTION
Commit 4d973417284a ("lib/ukvmem/arch: Do not print error message if demand paging disabled") introduced a build error by copy-pasting the change from x86 to Arm. This is incorrect as the trap context from Arm does not have the `error_code` but the `esr` field instead. Fix this by using using the corect field.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
