### PR TITLE
support: Change `PYTHONCMD` to python3

### DIFF
--- a/support/kconfiglib/makefile.patch
+++ b/support/kconfiglib/makefile.patch
@@ -15,7 +15,7 @@ index 3f327e21f60e..8b7dd1292005 100644
  
 +PHONY += scriptconfig iscriptconfig kmenuconfig guiconfig dumpvarsconfig
 +
-+PYTHONCMD ?= python
++PYTHONCMD ?= python3
 +kpython := PYTHONPATH=$(srctree)/Kconfiglib:$$PYTHONPATH $(PYTHONCMD)
 +
 +ifneq ($(filter scriptconfig,$(MAKECMDGOALS)),)


### PR DESCRIPTION
Make it so that python3 is used to run scripts.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration
None.
<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes
Change makefile.patch so that python3 is used to run Python scripts. 
From what we could tell all other instances of python have been replaced by python3. 

<!--
Please provide a detailed description of the changes made in this new PR.
-->

GitHub-Fixes: #1006