### PR TITLE
lib/posix-fdio: Move non-trivial libc syscall wrappers over from vfscore

### DIFF
--- a/lib/posix-fdio/fd-shim.c
+++ b/lib/posix-fdio/fd-shim.c
@@ -98,6 +98,16 @@ UK_LLSYSCALL_R_DEFINE(ssize_t, pread64, int, fd,
 	return r;
 }
 
+#if UK_LIBC_SYSCALLS
+ssize_t pread(int fd, void *buf, size_t count, off_t offset)
+{
+	return uk_syscall_e_pread64((long)fd, (long)buf,
+				    (long)count, (long)offset);
+}
+
+__alias(pread, pread64);
+#endif /* UK_LIBC_SYSCALLS */
+
 UK_SYSCALL_R_DEFINE(ssize_t, readv, int, fd,
 		    const struct iovec *, iov, int, iovcnt)
 {
@@ -215,6 +225,16 @@ UK_LLSYSCALL_R_DEFINE(ssize_t, pwrite64, int, fd,
 	}
 	return r;
 }
+
+#if UK_LIBC_SYSCALLS
+ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset)
+{
+	return uk_syscall_e_pwrite64((long)fd, (long)buf,
+				     (long)count, (long)offset);
+}
+
+__alias(pwrite, pwrite64);
+#endif /* UK_LIBC_SYSCALLS */
 
 UK_SYSCALL_R_DEFINE(ssize_t, writev, int, fd, const struct iovec *, iov,
 		    int, iovcnt)
@@ -356,6 +376,23 @@ UK_LLSYSCALL_R_DEFINE(int, fcntl, int, fd,
 	}
 }
 
+#if UK_LIBC_SYSCALLS
+int fcntl(int fd, int cmd, ...)
+{
+	int arg = 0;
+	va_list ap;
+
+	va_start(ap, cmd);
+	if (cmd == F_SETFD ||
+	    cmd == F_SETFL) {
+		arg = va_arg(ap, int);
+	}
+	va_end(ap);
+
+	return uk_syscall_e_fcntl(fd, cmd, arg);
+}
+#endif /* UK_LIBC_SYSCALLS */
+
 UK_LLSYSCALL_R_DEFINE(int, ioctl, int, fd, unsigned int, request, void *, arg)
 {
 	int r;
@@ -385,3 +422,17 @@ UK_LLSYSCALL_R_DEFINE(int, ioctl, int, fd, unsigned int, request, void *, arg)
 	}
 	return r;
 }
+
+#if UK_LIBC_SYSCALLS
+int ioctl(int fd, unsigned long request, ...)
+{
+	va_list ap;
+	void *arg;
+
+	va_start(ap, request);
+	arg = va_arg(ap, void *);
+	va_end(ap);
+
+	return uk_syscall_e_ioctl((long)fd, (long)request, (long)arg);
+}
+#endif /* UK_LIBC_SYSCALLS */

--- a/lib/posix-fdio/fd-shim.c
+++ b/lib/posix-fdio/fd-shim.c
@@ -3,7 +3,7 @@
  * Licensed under the BSD-3-Clause License (the "License").
  * You may not use this file except in compliance with the License.
  */
-
+#define _GNU_SOURCE
 /* Userspace shim syscalls that delegate to either posix-fdio or vfscore */
 
 #include <fcntl.h>
@@ -367,13 +367,39 @@ UK_LLSYSCALL_R_DEFINE(int, fcntl, int, fd,
 #if UK_LIBC_SYSCALLS
 int fcntl(int fd, int cmd, ...)
 {
-	int arg = 0;
+	intptr_t arg = 0;
 	va_list ap;
 
 	va_start(ap, cmd);
-	if (cmd == F_SETFD ||
-	    cmd == F_SETFL) {
+	switch (cmd) {
+	case F_DUPFD:
+	case F_DUPFD_CLOEXEC:
+	case F_SETFD:
+	case F_SETFL:
+	case F_SETOWN:
+	case F_SETSIG:
+	case F_SETLEASE:
+	case F_NOTIFY:
+	case F_SETPIPE_SZ:
+	case F_ADD_SEALS:
 		arg = va_arg(ap, int);
+		break;
+	case F_SETLK:
+	case F_SETLKW:
+	case F_GETLK:
+	case F_OFD_SETLK:
+	case F_OFD_SETLKW:
+	case F_OFD_GETLK:
+	case F_GETOWN_EX:
+	case F_SETOWN_EX:
+	case F_GET_RW_HINT:
+	case F_SET_RW_HINT:
+	case F_GET_FILE_RW_HINT:
+	case F_SET_FILE_RW_HINT:
+		arg = (intptr_t)va_arg(ap, void *);
+		break;
+	default:
+		break;
 	}
 	va_end(ap);
 

--- a/lib/posix-fdio/fd-shim.c
+++ b/lib/posix-fdio/fd-shim.c
@@ -76,8 +76,8 @@ UK_SYSCALL_R_DEFINE(ssize_t, preadv, int, fd, const struct iovec *, iov,
 #undef pread64
 #endif
 
-UK_LLSYSCALL_R_DEFINE(ssize_t, pread64, int, fd,
-		      void *, buf, size_t, count, off_t, offset)
+UK_SYSCALL_R_DEFINE(ssize_t, pread64, int, fd,
+		    void *, buf, size_t, count, off_t, offset)
 {
 	ssize_t r;
 	union uk_shim_file sf;
@@ -99,13 +99,7 @@ UK_LLSYSCALL_R_DEFINE(ssize_t, pread64, int, fd,
 }
 
 #if UK_LIBC_SYSCALLS
-ssize_t pread(int fd, void *buf, size_t count, off_t offset)
-{
-	return uk_syscall_e_pread64((long)fd, (long)buf,
-				    (long)count, (long)offset);
-}
-
-__alias(pread, pread64);
+__alias(pread64, pread);
 #endif /* UK_LIBC_SYSCALLS */
 
 UK_SYSCALL_R_DEFINE(ssize_t, readv, int, fd,
@@ -204,8 +198,8 @@ UK_SYSCALL_R_DEFINE(ssize_t, pwritev, int, fd, const struct iovec*, iov,
 #undef pwrite64
 #endif
 
-UK_LLSYSCALL_R_DEFINE(ssize_t, pwrite64, int, fd,
-		      const void *, buf, size_t, count, off_t, offset)
+UK_SYSCALL_R_DEFINE(ssize_t, pwrite64, int, fd,
+		    const void *, buf, size_t, count, off_t, offset)
 {
 	ssize_t r;
 	union uk_shim_file sf;
@@ -227,13 +221,7 @@ UK_LLSYSCALL_R_DEFINE(ssize_t, pwrite64, int, fd,
 }
 
 #if UK_LIBC_SYSCALLS
-ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset)
-{
-	return uk_syscall_e_pwrite64((long)fd, (long)buf,
-				     (long)count, (long)offset);
-}
-
-__alias(pwrite, pwrite64);
+__alias(pwrite64, pwrite);
 #endif /* UK_LIBC_SYSCALLS */
 
 UK_SYSCALL_R_DEFINE(ssize_t, writev, int, fd, const struct iovec *, iov,
@@ -430,7 +418,7 @@ int ioctl(int fd, unsigned long request, ...)
 	void *arg;
 
 	va_start(ap, request);
-	arg = va_arg(ap, void *);
+	arg = va_arg(ap, void*);
 	va_end(ap);
 
 	return uk_syscall_e_ioctl((long)fd, (long)request, (long)arg);

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -397,16 +397,6 @@ ssize_t vfscore_pread64(struct vfscore_file *fp,
 	return bytes;
 }
 
-#if UK_LIBC_SYSCALLS
-ssize_t pread(int fd, void *buf, size_t count, off_t offset)
-{
-	return uk_syscall_e_pread64((long) fd, (long) buf,
-				    (long) count, (long) offset);
-}
-
-LFS64(pread);
-#endif /* UK_LIBC_SYSCALLS */
-
 UK_TRACEPOINT(trace_vfs_readv, "%p %#x %#x", void *, const struct iovec*,
 	      int);
 UK_TRACEPOINT(trace_vfs_readv_ret, "%#x", ssize_t);
@@ -576,16 +566,6 @@ ssize_t vfscore_pwrite64(struct vfscore_file *fp, const void *buf,
 	return bytes;
 }
 
-#if UK_LIBC_SYSCALLS
-ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset)
-{
-	return uk_syscall_e_pwrite64((long) fd, (long) buf,
-				     (long) count, (long) offset);
-}
-
-LFS64(pwrite);
-#endif /* UK_LIBC_SYSCALLS */
-
 UK_TRACEPOINT(trace_vfs_writev, "%p %#x %d", void *, const struct iovec*, int);
 UK_TRACEPOINT(trace_vfs_writev_ret, "%#x", ssize_t);
 UK_TRACEPOINT(trace_vfs_writev_err, "%d", int);
@@ -647,20 +627,6 @@ ssize_t vfscore_write(struct vfscore_file *fp, const void *buf, size_t count)
 		trace_vfs_write_ret(bytes);
 	return bytes;
 }
-
-#if UK_LIBC_SYSCALLS
-int ioctl(int fd, unsigned long int request, ...)
-{
-	va_list ap;
-	void *arg;
-
-	va_start(ap, request);
-	arg = va_arg(ap, void*);
-	va_end(ap);
-
-	return uk_syscall_e_ioctl((long) fd, (long) request, (long) arg);
-}
-#endif /* UK_LIBC_SYSCALLS */
 
 UK_TRACEPOINT(trace_vfs_fsync, "%d", int);
 UK_TRACEPOINT(trace_vfs_fsync_ret, "");
@@ -1998,23 +1964,6 @@ out_errno:
 	trace_vfs_fcntl_err(error);
 	return -error;
 }
-
-#if UK_LIBC_SYSCALLS
-int fcntl(int fd, int cmd, ...)
-{
-	int arg = 0;
-	va_list ap;
-
-	va_start(ap, cmd);
-	if (cmd == F_SETFD ||
-	    cmd == F_SETFL) {
-		arg = va_arg(ap, int);
-	}
-	va_end(ap);
-
-	return uk_syscall_e_fcntl(fd, cmd, arg);
-}
-#endif /* UK_LIBC_SYSCALLS */
 
 UK_TRACEPOINT(trace_vfs_access, "\"%s\" 0%0o", const char*, int);
 UK_TRACEPOINT(trace_vfs_access_ret, "");


### PR DESCRIPTION
### Description of changes

This changeset moves the implementations of non-trivial libc wrapper functions for file-related syscalls from vfscore into posix-fdio, where these syscalls are actually implemented, fixing an oversight of the original posix-fdio work.
In addition, two improvements are made to the handling of these functions:
- pread/pwrite(64) aliasing is now simpler
- VA args are correctly fetched for every known fcntl command, whether supported or not

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A; this change should be transparent to user code