### PR TITLE
lib/posix-*: Fix missing/unneeded dependencies

### DIFF
--- a/lib/posix-fdio/Config.uk
+++ b/lib/posix-fdio/Config.uk
@@ -1,5 +1,6 @@
 config LIBPOSIX_FDIO
 	bool "posix-fdio: File I/O and control"
+	select LIBUKATOMIC
 	select LIBUKFILE
 	select LIBPOSIX_FDTAB
 	select LIBPOSIX_FDTAB_LEGACY_SHIM

--- a/lib/posix-fdtab/Config.uk
+++ b/lib/posix-fdtab/Config.uk
@@ -1,5 +1,6 @@
 menuconfig LIBPOSIX_FDTAB
 	bool "posix-fdtab: File descriptor table"
+	select LIBUKATOMIC
 	select LIBUKFILE
 
 if LIBPOSIX_FDTAB

--- a/lib/posix-pipe/Config.uk
+++ b/lib/posix-pipe/Config.uk
@@ -1,6 +1,7 @@
 menuconfig LIBPOSIX_PIPE
 	bool "posix-pipe: Support for pipes"
 	select LIBPOSIX_FDIO
+	select LIBUKATOMIC
 
 if LIBPOSIX_PIPE
 	config LIBPOSIX_PIPE_SIZE_ORDER

--- a/lib/posix-poll/Config.uk
+++ b/lib/posix-poll/Config.uk
@@ -2,6 +2,7 @@ config LIBPOSIX_POLL
 	bool "posix-poll: Support for file polling"
 	select LIBPOSIX_FDIO
 	select LIBPOSIX_FDTAB
+	select LIBUKATOMIC
 	select LIBUKTIMECONV
 	select LIBUKFILE_CHAINUPDATE
 	select LIBNOLIBC if !HAVE_LIBC

--- a/lib/posix-timerfd/Config.uk
+++ b/lib/posix-timerfd/Config.uk
@@ -1,6 +1,7 @@
 config LIBPOSIX_TIMERFD
 	bool "posix-timerfd: Support for timerfd files"
 	select LIBPOSIX_FDIO
+	select LIBUKATOMIC
 	select LIBUKLOCK
 	select LIBUKLOCK_MUTEX
 	select LIBUKTIMECONV

--- a/lib/posix-timerfd/Config.uk
+++ b/lib/posix-timerfd/Config.uk
@@ -2,7 +2,5 @@ config LIBPOSIX_TIMERFD
 	bool "posix-timerfd: Support for timerfd files"
 	select LIBPOSIX_FDIO
 	select LIBUKATOMIC
-	select LIBUKLOCK
-	select LIBUKLOCK_MUTEX
 	select LIBUKTIMECONV
 	select LIBUKSCHED

--- a/lib/posix-timerfd/timerfd.c
+++ b/lib/posix-timerfd/timerfd.c
@@ -14,7 +14,6 @@
 #include <uk/posix-fd.h>
 #include <uk/posix-fdtab.h>
 #include <uk/posix-timerfd.h>
-#include <uk/mutex.h>
 #include <uk/sched.h>
 #include <uk/timeutil.h>
 #include <uk/syscall.h>

--- a/lib/ukfile/Config.uk
+++ b/lib/ukfile/Config.uk
@@ -5,6 +5,7 @@ config LIBUKFILE
 	select LIBUKLOCK_MUTEX
 	select LIBUKLOCK_RWLOCK
 	select LIBUKSCHED
+	select LIBNOLIBC if !HAVE_LIBC
 
 # Hidden, selected by core components when required
 config LIBUKFILE_CHAINUPDATE

--- a/lib/ukfile/Config.uk
+++ b/lib/ukfile/Config.uk
@@ -1,5 +1,6 @@
 config LIBUKFILE
 	bool "ukfile: Common support for files"
+	select LIBUKATOMIC
 	select LIBUKLOCK
 	select LIBUKLOCK_MUTEX
 	select LIBUKLOCK_RWLOCK


### PR DESCRIPTION
### Description of changes

This changeset fixes a number of missing or unneeded Kconfig dependencies. See individual commits for details.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A