### PR TITLE
plat/kvm/x86: Add dependency to ukbitops

### DIFF
--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -6,6 +6,7 @@ menuconfig PLAT_KVM
 	select LIBUKALLOC
 	select LIBUKTIMECONV
 	select LIBNOLIBC if !HAVE_LIBC
+	select LIBUKBITOPS if ARCH_X86_64
 	select HAVE_FDT if ARCH_ARM_64
 	imply LIBFDT if ARCH_ARM_64
 	imply LIBUKOFW if ARCH_ARM_64


### PR DESCRIPTION
### Description of changes

This change adds a Kconfig dependency on ukbitops to the x86 KVM platform code, as it is needed by tscclock.c.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A