### PR TITLE
lib/ukfile: API improvements

### DIFF
--- a/lib/ukfile/file-nops.c
+++ b/lib/ukfile/file-nops.c
@@ -50,3 +50,9 @@ const struct uk_file_ops uk_file_nops = {
 	.setstat = uk_file_nop_setstat,
 	.ctl = uk_file_nop_ctl
 };
+
+void uk_file_static_release(const struct uk_file *f __maybe_unused,
+			    int what __unused)
+{
+	uk_pr_warn("Destructor called on static file: %p\n", f);
+}

--- a/lib/ukfile/include/uk/file.h
+++ b/lib/ukfile/include/uk/file.h
@@ -137,6 +137,26 @@ static inline void uk_file_state_wunlock(struct uk_file_state *st)
 	((struct uk_file_state)UK_FILE_STATE_INITIALIZER(name))
 
 
+static inline
+uk_pollevent uk_file_state_event_clear(struct uk_file_state *st,
+				       uk_pollevent ev)
+{
+	return uk_pollq_clear(&st->pollq, ev);
+}
+
+static inline
+uk_pollevent uk_file_state_event_set(struct uk_file_state *st, uk_pollevent ev)
+{
+	return uk_pollq_set(&st->pollq, ev);
+}
+
+static inline
+uk_pollevent uk_file_state_event_assign(struct uk_file_state *st,
+					uk_pollevent ev)
+{
+	return uk_pollq_assign(&st->pollq, ev);
+}
+
 /*
  * Reference count type used by uk_file.
  *
@@ -280,19 +300,19 @@ uk_pollevent uk_file_poll(const struct uk_file *f, uk_pollevent req)
 static inline
 uk_pollevent uk_file_event_clear(const struct uk_file *f, uk_pollevent clr)
 {
-	return uk_pollq_clear(&f->state->pollq, clr);
+	return uk_file_state_event_clear(f->state, clr);
 }
 
 static inline
 uk_pollevent uk_file_event_set(const struct uk_file *f, uk_pollevent set)
 {
-	return uk_pollq_set(&f->state->pollq, set);
+	return uk_file_state_event_set(f->state, set);
 }
 
 static inline
 uk_pollevent uk_file_event_assign(const struct uk_file *f, uk_pollevent set)
 {
-	return uk_pollq_assign(&f->state->pollq, set);
+	return uk_file_state_event_assign(f->state, set);
 }
 
 #endif /* __UKFILE_FILE_H__ */

--- a/lib/ukfile/include/uk/file.h
+++ b/lib/ukfile/include/uk/file.h
@@ -104,6 +104,26 @@ struct uk_file_state {
 	/* TODO */
 };
 
+static inline void uk_file_state_rlock(struct uk_file_state *st)
+{
+	uk_rwlock_rlock(&st->iolock);
+}
+
+static inline void uk_file_state_runlock(struct uk_file_state *st)
+{
+	uk_rwlock_runlock(&st->iolock);
+}
+
+static inline void uk_file_state_wlock(struct uk_file_state *st)
+{
+	uk_rwlock_wlock(&st->iolock);
+}
+
+static inline void uk_file_state_wunlock(struct uk_file_state *st)
+{
+	uk_rwlock_wunlock(&st->iolock);
+}
+
 /*
  * We define initializers separate from an initial values.
  * The former can only be used in (static) variable initializations, while the
@@ -218,22 +238,22 @@ void uk_file_release_weak(const struct uk_file *f)
 
 static inline void uk_file_rlock(const struct uk_file *f)
 {
-	uk_rwlock_rlock(&f->state->iolock);
+	uk_file_state_rlock(f->state);
 }
 
 static inline void uk_file_runlock(const struct uk_file *f)
 {
-	uk_rwlock_runlock(&f->state->iolock);
+	uk_file_state_runlock(f->state);
 }
 
 static inline void uk_file_wlock(const struct uk_file *f)
 {
-	uk_rwlock_wlock(&f->state->iolock);
+	uk_file_state_wlock(f->state);
 }
 
 static inline void uk_file_wunlock(const struct uk_file *f)
 {
-	uk_rwlock_wunlock(&f->state->iolock);
+	uk_file_state_wunlock(f->state);
 }
 
 /* Events & polling */

--- a/lib/ukfile/include/uk/file/nops.h
+++ b/lib/ukfile/include/uk/file/nops.h
@@ -30,4 +30,7 @@ int uk_file_nop_setstat(const struct uk_file *f,
 int uk_file_nop_ctl(const struct uk_file *f, int fam, int req,
 		    uintptr_t arg1, uintptr_t arg2, uintptr_t arg3);
 
+/* Destructor for static files; prints warning & does nothing */
+void uk_file_static_release(const struct uk_file *f, int what);
+
 #endif /* __UKFILE_FILE_NOPS_H__ */


### PR DESCRIPTION
### Description of changes

This changeset brings several improvements to the `ukfile` API:
- convenience file destructor for static files that prints a warning and does nothing
- expose I/O locking & event update operations on file state objects, in addition to files themselves; this is a stabilization of the API and a commitment to handle these aspects as part of file state going forward.

May benefit the following PR (if merged before this, will append patches here):
- https://github.com/unikraft/unikraft/pull/1226

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A