### PR TITLE
lib/ukboot: Fix unused variable warning in boot.c

### DIFF
--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -463,7 +463,7 @@ exit:
 static inline int do_main(int argc, char *argv[])
 {
 	uk_ctor_func_t *ctorfn;
-#if CONFIG_LIBPOSIX_ENVIRON
+#if CONFIG_LIBPOSIX_ENVIRON && CONFIG_LIBUKDEBUG_PRINTK_INFO
 	char **envp;
 #endif /* CONFIG_LIBPOSIX_ENVIRON */
 	int ret;


### PR DESCRIPTION
Added CONFIG_LIBUKDEBUG_PRINTK_INFO check for envp declaration

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Application(s): nginx 1.25


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
