### PR TITLE
lib/uktest: Introduce `FIX ME` assertion in `uktest`

### DIFF
--- a/lib/uktest/Config.uk
+++ b/lib/uktest/Config.uk
@@ -29,4 +29,8 @@ config LIBUKTEST_TEST_MYSELF
 	bool "Run self-test to check sanity"
 	default n
 
+config LIBUKTEST_STRICT_MODE
+	bool "Count failing FIX_ME tests"
+	default n
+
 endif # LIBUKTEST

--- a/lib/uktest/myself.c
+++ b/lib/uktest/myself.c
@@ -75,6 +75,19 @@ UK_TESTCASE(uktest_myself_testsuite, uktest_test_sanity)
 	// Expect the left-hand long integer to be less than or equal the right
 	UK_TEST_EXPECT_SNUM_LE(1, 1);
 	UK_TEST_EXPECT_SNUM_LE(1, 2);
+
+	// Expect FIX_ME tests to pass regardless of success or failure
+	UK_FIXME_EXPECT(1);
+	UK_FIXME_EXPECT(0);
+
+	UK_FIXME_EXPECT_NOT_NULL(1);
+	UK_FIXME_EXPECT_NOT_NULL(0);
+
+	UK_FIXME_EXPECT_ZERO(0);
+	UK_FIXME_EXPECT_ZERO(1);
+
+	UK_FIXME_EXPECT_SNUM_EQ(1, 1);
+	UK_FIXME_EXPECT_SNUM_EQ(1, 0);
 }
 
 UK_TESTSUITE_AT_CTORCALL_PRIO(uktest_myself_testsuite, NULL, 0);

--- a/lib/uktest/test.c
+++ b/lib/uktest/test.c
@@ -141,6 +141,14 @@ _uk_test_compute_assert_stats(struct uk_testcase *esac,
 		case UK_TEST_ASSERT_FAIL:
 			out->fail++;
 			break;
+		case UK_TEST_ASSERT_OMITTED_FAIL:
+#ifdef CONFIG_LIBUKTEST_STRICT_MODE
+			out->fail++;
+			break;
+#endif
+		case UK_TEST_ASSERT_OMITTED_SUCCESS:
+			out->success++;
+			break;
 		}
 	}
 }


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

- `CONFIG_LIBUKTEST_STRICT_MODE=y`

### Description of changes

This PR attempts to address #1027 , which introduces a new `FIX ME` assertion to downgrade known failing tests. Tests marked as `FIX_ME` will show up as `OMITTED` in the testing logs, and will be counted toward the overall failure count only if the strict mode config is turned on.

An example output log is below:
<img width="838" alt="image" src="https://github.com/unikraft/unikraft/assets/37784817/ff920999-f690-4dcb-a4c9-abdd70d95c42">

GitHub-Closes: #1027