### PR TITLE
#1229 - Add macro for "mkmp" mount option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@
 	·
 	<a href="https://github.com/unikraft/unikraft/issues/new?assignees=&labels=kind%2Fenhancement&projects=&template=project_backlog.yml">Feature Request</a>
 	·
-	<a href="https://unikraft.org/discord">Join Our Discord</a>
-	·
 	<a href="https://x.com/UnikraftSDK">X.com</a>
+   ·
+	<a href="https://unikraft.org/discord">Join Our Discord</a>
 </p>
 
 <br />

--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -56,17 +56,18 @@
 #include <uk/argparse.h>
 
 #define LIBVFSCORE_MOUNTOPTS_SEP				','
-#define LIBVFSCORE_FSTAB_VOLUME_ARGS_SEP			':'
+#define LIBVFSCORE_FSTAB_VOLUME_ARGS_SEP		':'
 #define LIBVFSCORE_FSTAB_UKOPTS_ARGS_SEP \
 	LIBVFSCORE_MOUNTOPTS_SEP
 
 #define LIBVFSCORE_EXTRACT_DRV					"extract"
-#define LIBVFSCORE_EXTRACT_DEV_INITRD0				"initrd0"
-#define LIBVFSCORE_EXTRACT_DEV_EMBEDDED				"embedded"
+#define LIBVFSCORE_EXTRACT_DEV_INITRD0			"initrd0"
+#define LIBVFSCORE_EXTRACT_DEV_EMBEDDED			"embedded"
+#define LIBVFSCORE_INITRD_OPT_MKMP				"mkmp"
 
 #define LIBVFSCORE_UKOPT_MKMP					(0x1 << 0)
 #define LIBVFSCORE_UKOPT_IFINITRD0				(0x1 << 1)
-#define LIBVFSCORE_UKOPT_IFNOINITRD0				(0x1 << 2)
+#define LIBVFSCORE_UKOPT_IFNOINITRD0			(0x1 << 2)
 
 struct vfscore_volume {
 	/* Volume source device */
@@ -727,7 +728,7 @@ static unsigned int vfscore_volume_parse_ukopts(char *ukopts)
 			continue; /* empty option */
 		}
 
-		if (!strcmp(opt, "mkmp")) {
+		if (!strcmp(opt, LIBVFSCORE_INITRD_OPT_MKMP)) {
 			ret |= LIBVFSCORE_UKOPT_MKMP;
 			continue;
 		}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ X ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ X ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ X ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

N/A

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

We created the macro LIBVFSCORE_INITRD_OPT_MKMP for the string "mkmp" mount option in lib/vfscore/automount.c and replaced the single instance of "mkmp" with the macro. Our only concern is we were not able to test our changes because our terminals could not recognize "sh" while following [these guidelines](https://unikraft.org/docs/contributing/docs#building-the-website).