### PR TITLE
lib/ukboot: Fix configuration of no "no scheduler"

### DIFF
--- a/lib/ukboot/Config.uk
+++ b/lib/ukboot/Config.uk
@@ -81,7 +81,14 @@ if LIBUKBOOT
 	bool
 	default n
 
-	choice LIBUKBOOT_INITALLOC
+	# Hidden option that indicates that allocator is initialized
+	# We do this here in order to allow specifying dependecies to
+	# the allocator choice
+	config LIBUKBOOT_INITALLOC
+	bool
+	default y if !LIBUKBOOT_INITNOALLOC
+
+	choice
 	prompt "Initialize memory allocator"
 	default LIBUKBOOT_INITBBUDDY
 
@@ -117,7 +124,7 @@ if LIBUKBOOT
 		depends on LIBTLSF_INCLUDED
 		select LIBTLSF
 
-		config LIBUKBOOT_NOALLOC
+		config LIBUKBOOT_INITNOALLOC
 		bool "None"
 
 	endchoice
@@ -126,21 +133,21 @@ if LIBUKBOOT
 	hex "Heap base address"
 	default 0x400000000
 	depends on HAVE_PAGING
-	depends on !LIBUKBOOT_NOALLOC
+	depends on LIBUKBOOT_INITALLOC
 
 	# Hidden configuration option that specifies that scheduling should be
 	# initialized. The check for !LIBUKBOOT_INITNOSCHED is not sufficient, as
-	# the option is also not available if LIBUKBOOT_NOALLOC is set. The
+	# the option is also not available if !LIBUKBOOT_INITALLOC is set. The
 	# reason is the dependency of the choice. This would incorrectly mean
 	# that a scheduler is being initialized.
 	config LIBUKBOOT_INITSCHED
 	bool
-	default y if !LIBUKBOOT_NOALLOC && !LIBUKBOOT_INITNOSCHED
+	default y if LIBUKBOOT_INITALLOC && !LIBUKBOOT_INITNOSCHED
 
 	choice
 	prompt "Initialize scheduler"
 	default LIBUKBOOT_INITSCHEDCOOP
-	depends on !LIBUKBOOT_NOALLOC
+	depends on LIBUKBOOT_INITALLOC
 
 		config LIBUKBOOT_INITSCHEDCOOP
 		bool "Cooperative scheduler"
@@ -155,7 +162,7 @@ if LIBUKBOOT
 
 	config LIBUKBOOT_MAINTHREAD
 	bool "Run application main in own thread"
-	depends on LIBUKBOOT_INITSCHED && !LIBUKBOOT_NOALLOC
+	depends on LIBUKBOOT_INITSCHED && LIBUKBOOT_INITALLOC
 	select LIBUKLOCK
 	select LIBUKLOCK_SEMAPHORE
 	help
@@ -183,9 +190,9 @@ if LIBUKBOOT
 
 	config LIBUKBOOT_ALLOCSTACK
 	bool
-	default y if !LIBUKBOOT_NOALLOC
+	default y if LIBUKBOOT_INITALLOC
 	select LIBUKALLOCSTACK
-	depends on !LIBUKBOOT_NOALLOC
+	depends on LIBUKBOOT_INITALLOC
 
 if LIBUKBOOT_ALLOCSTACK
 		config LIBUKBOOT_ALLOCSTACK_PREMAP_ORDER

--- a/lib/ukboot/Config.uk
+++ b/lib/ukboot/Config.uk
@@ -128,7 +128,16 @@ if LIBUKBOOT
 	depends on HAVE_PAGING
 	depends on !LIBUKBOOT_NOALLOC
 
-	choice LIBUKBOOT_INITSCHED
+	# Hidden configuration option that specifies that scheduling should be
+	# initialized. The check for !LIBUKBOOT_INITNOSCHED is not sufficient, as
+	# the option is also not available if LIBUKBOOT_NOALLOC is set. The
+	# reason is the dependency of the choice. This would incorrectly mean
+	# that a scheduler is being initialized.
+	config LIBUKBOOT_INITSCHED
+	bool
+	default y if !LIBUKBOOT_NOALLOC && !LIBUKBOOT_INITNOSCHED
+
+	choice
 	prompt "Initialize scheduler"
 	default LIBUKBOOT_INITSCHEDCOOP
 	depends on !LIBUKBOOT_NOALLOC
@@ -139,14 +148,14 @@ if LIBUKBOOT
 		help
 		  Initialize ukschedcoop as cooperative scheduler on the boot CPU.
 
-		config LIBUKBOOT_NOSCHED
+		config LIBUKBOOT_INITNOSCHED
 		bool "None"
 
 	endchoice
 
 	config LIBUKBOOT_MAINTHREAD
 	bool "Run application main in own thread"
-	depends on !LIBUKBOOT_NOSCHED && !LIBUKBOOT_NOALLOC
+	depends on LIBUKBOOT_INITSCHED && !LIBUKBOOT_NOALLOC
 	select LIBUKLOCK
 	select LIBUKLOCK_SEMAPHORE
 	help

--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -103,9 +103,9 @@
 #include <uk/errptr.h>
 #include "banner.h"
 
-#if CONFIG_LIBUKBOOT_NOSCHED
+#if !CONFIG_LIBUKBOOT_INITSCHED
 #include <uk/plat/common/lcpu.h>
-#endif /* CONFIG_LIBUKBOOT_NOSCHED */
+#endif /* !CONFIG_LIBUKBOOT_INITSCHED */
 
 #if CONFIG_LIBUKINTCTLR
 #include <uk/intctlr.h>
@@ -387,7 +387,7 @@ void ukplat_entry(int argc, char *argv[])
 	uk_pr_info("Initialize platform time...\n");
 	ukplat_time_init();
 
-#if !CONFIG_LIBUKBOOT_NOSCHED
+#if CONFIG_LIBUKBOOT_INITSCHED
 	uk_pr_info("Initialize scheduling...\n");
 #if CONFIG_LIBUKBOOT_INITSCHEDCOOP
 	s = uk_schedcoop_create(a, sa, auxsa, a);
@@ -395,7 +395,7 @@ void ukplat_entry(int argc, char *argv[])
 	if (unlikely(!s))
 		UK_CRASH("Failed to initialize scheduling\n");
 	uk_sched_start(s);
-#endif /* !CONFIG_LIBUKBOOT_NOSCHED */
+#endif /* CONFIG_LIBUKBOOT_INITSCHED */
 
 	ictx.cmdline.argc = argc;
 	ictx.cmdline.argv = argv;

--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -270,7 +270,7 @@ void ukplat_entry(int argc, char *argv[])
 #if CONFIG_LIBUKALLOC
 	struct uk_alloc *a = NULL, *sa = NULL, *auxsa = NULL;
 #endif
-#if !CONFIG_LIBUKBOOT_NOALLOC
+#if CONFIG_LIBUKBOOT_INITALLOC
 	void *tls = NULL;
 #endif
 #if CONFIG_LIBUKSCHED
@@ -324,7 +324,7 @@ void ukplat_entry(int argc, char *argv[])
 	}
 #endif /* CONFIG_LIBUKLIBPARAM */
 
-#if !CONFIG_LIBUKBOOT_NOALLOC
+#if CONFIG_LIBUKBOOT_INITALLOC
 	uk_pr_info("Initialize memory allocator...\n");
 
 	a = heap_init();
@@ -374,7 +374,7 @@ void ukplat_entry(int argc, char *argv[])
 		UK_CRASH("Failed to allocate the auxiliary stack\n");
 	/* Activate auxiliary stack */
 	ukplat_lcpu_set_auxsp(ukarch_gen_sp(auxstack, AUXSTACK_SIZE));
-#endif /* !CONFIG_LIBUKBOOT_NOALLOC */
+#endif /* CONFIG_LIBUKBOOT_INITALLOC */
 
 #if CONFIG_LIBUKINTCTLR
 	uk_pr_info("Initialize the IRQ subsystem...\n");


### PR DESCRIPTION
### Description of changes

This PR fixes the KConfig configuration of "no scheduler" with `lib/ukboot`. Previously, scheduler initialization code was still compiled in even if no scheduling was selected. This happened if at the same time no allocator was configured as well.

Please note that this PR fixes only the configuration handling in `lib/ukboot`. I noticed a crash within one of the registered inittab functions if no scheduler was initialized. There is also an assertion failure if `lib/ukboot` is configured without allocator initialization (system does not boot without an allocator assigned to the platform libraries). Both need fixing with corresponding subsystem PRs and taking re-arch into account.