### PR TITLE
uk/plat: Mark MRD validation flags variable in macro as maybe unused

### DIFF
--- a/include/uk/plat/memory.h
+++ b/include/uk/plat/memory.h
@@ -147,11 +147,11 @@ struct ukplat_memregion_desc {
  */
 #define UK_ASSERT_VALID_MRD_FLAGS(mrd)					\
 	do {								\
-		__u16 flags_all = UKPLAT_MEMRF_READ    |		\
-				  UKPLAT_MEMRF_WRITE   |		\
-				  UKPLAT_MEMRF_EXECUTE |		\
-				  UKPLAT_MEMRF_UNMAP   |		\
-				  UKPLAT_MEMRF_MAP;			\
+		__u16 flags_all __maybe_unused = UKPLAT_MEMRF_READ    |	\
+						 UKPLAT_MEMRF_WRITE   |	\
+						 UKPLAT_MEMRF_EXECUTE |	\
+						 UKPLAT_MEMRF_UNMAP   |	\
+						 UKPLAT_MEMRF_MAP;	\
 									\
 		UK_ASSERT(((mrd)->flags & flags_all) == (mrd)->flags);	\
 	} while (0)


### PR DESCRIPTION
There may be unused warnings for this variable in builds that do not have assertions enabled. Therefore, make it so that it does not generate such warnings if assertions are disabled.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
