### PR TITLE
lib/posix-fdio: Allow owner/group == -1 for fchown

### DIFF
--- a/lib/posix-fdio/fdstat.c
+++ b/lib/posix-fdio/fdstat.c
@@ -101,14 +101,18 @@ int uk_sys_fchmod(struct uk_ofile *of, mode_t mode)
 int uk_sys_fchown(struct uk_ofile *of, uid_t owner, gid_t group)
 {
 	int r;
+	unsigned int mask = 0;
 	const int iolock = _SHOULD_LOCK(of->mode);
 
+	if (owner != (uid_t)-1)
+		mask |= UK_STATX_UID;
+	if (group != (gid_t)-1)
+		mask |= UK_STATX_GID;
 	if (iolock)
 		uk_file_wlock(of->file);
-	r = uk_file_setstat(of->file, UK_STATX_UID|UK_STATX_GID,
-		&(const struct uk_statx){
-			.stx_uid = owner,
-			.stx_gid = group
+	r = uk_file_setstat(of->file, mask, &(const struct uk_statx){
+		.stx_uid = owner,
+		.stx_gid = group
 	});
 	if (iolock)
 		uk_file_wunlock(of->file);


### PR DESCRIPTION
### Description of changes

This change adds support in fchown for the owner or group to be passed as -1, in which case that particular field is left unchanged. This mimimcs the behavior of Linux.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A
