### PR TITLE
lib/vfscore: Do not interpret device pointer as string

### DIFF
--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -864,8 +864,7 @@ static void vfscore_autoumount(const struct uk_term_ctx *tctx __unused)
 	int rc;
 
 	uk_list_for_each_entry_reverse(mp, &mount_list, mnt_list) {
-		uk_pr_info("Unmounting %s (%s)...\n", mp->m_path,
-			   mp->m_dev ? mp->m_dev : "none");
+		uk_pr_info("Unmounting %s (%p)...\n", mp->m_path, mp->m_dev);
 		/* For now, flags = 0 is enough. */
 		rc = VFS_UNMOUNT(mp, 0);
 		if (unlikely(rc))


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

With GCC 14 using different pointer types in a ternary operator is by default an error. While this was incorrect before, it was not noticed.
