### PR TITLE
lib/posix-unixsocket: Add support for destination in `sendmsg`

### DIFF
--- a/lib/posix-unixsocket/unixsock.c
+++ b/lib/posix-unixsocket/unixsock.c
@@ -841,7 +841,7 @@ ssize_t unix_socket_sendmsg(posix_sock *file,
 	uk_file_wlock(wpipe);
 	ret = uk_file_write(wpipe, msg->msg_iov, msg->msg_iovlen, 0,
 			    data->type != SOCK_STREAM ? O_DIRECT : 0);
-	uk_file_wunlock(data->wpipe);
+	uk_file_wunlock(wpipe);
 	/* We ignore ancillary data for now */
 
 	/* 0-length datagrams will be silently lost; warn */


### PR DESCRIPTION
### Description of changes

This PR adds support for specifying a destination address in calls to `sendmsg` & friends on connectionless unix sockets.
As part of this development, a bug with mismatched lock/unlock files was triggered and fixed as a prerequisite commit.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration
Test snippet (minimal helloworld config; ensure `CONFIG_LIBPOSIX_UNIXSOCKET=y`):

```c
int main(void)
{
	ssize_t r;
	struct sockaddr_un addr = {
		.sun_family = AF_UNIX,
		.sun_path = "\0testsock"
	};
	const size_t alen = offsetof(struct sockaddr_un, sun_path) + 9 + 1;

	int sv = socket(AF_UNIX, SOCK_DGRAM|SOCK_NONBLOCK, 0);
	printf("%d\n", errno);
	assert(sv >= 0);
	r = bind(sv, (struct sockaddr *)&addr, alen);
	assert(!r);

	int cl = socket(AF_UNIX, SOCK_DGRAM|SOCK_NONBLOCK, 0);
	printf("%d\n", errno);
	assert(cl >= 0);

	r = sendto(cl, "Hello World!", 12, 0, (struct sockaddr *)&addr, alen);
	if (r != 12)
		printf("Send err %d\n", errno);
	else
		puts("Send OK");

	char buf[64];
	r = recv(sv, buf, sizeof(buf), 0);
	if (r >= 0) {
		printf("Received %zd bytes\n", r);
		buf[r] = 0;
		puts(buf);
	} else {
		printf("Recv err %d\n", errno);
	}

	close(sv);
	close(cl);
	return 0;
}
```

Prints errors for both send and recv w/o PR:
```
SeaBIOS (version 1.16.3-2.fc40)
Booting from ROM..Powered by
o.   .o       _ _               __ _
Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
oOo oOO| | | | |   (| | | (_) |  _) :_
 OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
               Telesto 0.16.3~74dcc6a0f
0
0
Send err 107
Recv err 11
```
with PR works OK:
```
SeaBIOS (version 1.16.3-2.fc40)
Booting from ROM..Powered by
o.   .o       _ _               __ _
Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
oOo oOO| | | | |   (| | | (_) |  _) :_
 OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
               Telesto 0.16.3~93b801866
0
0
Send OK
Received 12 bytes
Hello World!
```