### PR TITLE
lib/posix-time: [draft] implement POSIX-timer API

### DIFF
--- a/lib/nolibc/musl-imported/include/signal.h
+++ b/lib/nolibc/musl-imported/include/signal.h
@@ -129,6 +129,17 @@ struct sigevent {
 	int              sigev_notify;	/* Notification type */
 	int              sigev_signo;	/* Signal number */
 	union sigval     sigev_value;	/* Signal value */
+
+	void 		   (*sigev_notify_function)(union sigval); 
+		/* Function used for thread notification
+			      (SIGEV_THREAD) */
+	
+	void 			*sigev_notify_attributes;
+		/* Attributes for notification thread
+	  			  (SIGEV_THREAD) */
+	
+	pid_t 			 sigev_notify_thread_id;
+		/* ID of thread to signal (SIGEV_THREAD_ID) */
 };
 
 /* TODO: not used - defined just for v8 */

--- a/lib/nolibc/musl-imported/include/signal.h
+++ b/lib/nolibc/musl-imported/include/signal.h
@@ -119,7 +119,6 @@ int sigaddset(sigset_t *set, int signo);
 int sigdelset(sigset_t *set, int signo);
 int sigismember(const sigset_t *set, int signo);
 
-/* TODO: not used - defined just for newlib */
 union sigval {
 	int    sival_int;	/* Integer signal value */
 	void  *sival_ptr;	/* Pointer signal value */

--- a/lib/posix-time/timer.c
+++ b/lib/posix-time/timer.c
@@ -29,49 +29,216 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#include "uk/alloc.h"
+#include "uk/arch/lcpu.h"
+#include "uk/bitops.h"
+#include <sys/time.h>
 
 #include <errno.h>
 #include <time.h>
+#include <signal.h>
+#include <stdio.h>
+
 #include <uk/essentials.h>
 #include <uk/print.h>
+#include <uk/sched.h>
+#include <uk/timeutil.h>
 #include <uk/syscall.h>
+#include <uk/plat/time.h>
+#include <uk/assert.h>
 
+#define SIGEV_NONE 0
+#define SIGEV_SIGNAL 1
+#define SIGEV_THREAD 2
+
+struct timer_alloc {
+	clockid_t clockid;
+	struct uk_alloc *alloc;
+	struct sigevent *sigev;
+	struct itimerspec *spec;
+};
+
+/* Linked list */
+
+struct timer_list {
+	struct uk_alloc *alloc;
+	struct timer_list *next;
+	struct timer_alloc *t;
+};
+
+static struct timer_list *timer_list_head = NULL;
+
+static int __alloc_list_elem(struct timer_alloc *t,
+			     struct timer_list **new_elem)
+{
+	struct uk_alloc *a = uk_alloc_get_default();
+	*new_elem = uk_malloc(a, sizeof(struct timer_list *));
+
+	if (unlikely(!new_elem))
+		return -ENOMEM;
+
+	(*new_elem)->alloc = a;
+	(*new_elem)->next = NULL;
+	(*new_elem)->t = t;
+
+	return 0;
+}
+
+static int __push_timer(struct timer_list *head, struct timer_alloc *t)
+{
+	if (head == NULL) {
+		if (__alloc_list_elem(t, &head))
+			return -ENOMEM;
+
+	} else {
+		if (head->next == NULL) {
+			struct timer_list *new_elem;
+
+			if (__alloc_list_elem(t, &new_elem))
+				return -ENOMEM;
+			
+			uk_printk(KLVL_CRIT, "push timer\n");
+
+			head->next = new_elem;
+		} else {
+			return __push_timer(head->next, t);
+		}
+	}
+
+	return 0;
+}
+
+/* Removes timer from timer data structure and frees t_alloc */
+static int __delete_timer(struct timer_list *elem, struct timer_list *parent,
+			  timer_t timerid)
+{
+	if (elem == NULL) {
+		return -EINVAL;
+
+	} else {
+		if (elem->t == timerid) {
+			if (parent == NULL) {
+				timer_list_head = elem->next;
+			} else {
+				parent->next = elem->next;
+			}
+
+			uk_free(elem->alloc, elem);
+			uk_free(elem->t->alloc, elem->t);
+			return 0;
+
+		} else {
+			return __delete_timer(elem->next, elem, timerid);
+		}
+	}
+
+	return 0;
+}
+
+static __noreturn void __timer_updatefn(void *timerid)
+{
+	struct timer_alloc *t_alloc = (struct timer_alloc *)timerid;
+	uk_printk(KLVL_CRIT, "timer updated\n");
+}
+
+static void __timer_thread_destroyedfn()
+{
+	uk_printk(KLVL_CRIT, "timer destroyed\n");
+}
 
 UK_SYSCALL_R_DEFINE(int, timer_create, clockid_t, clockid,
-		    struct sigevent *__restrict, sevp,
-		    timer_t *__restrict, timerid)
+		    struct sigevent *__restrict, sevp, timer_t *__restrict,
+		    timerid)
+{
+
+	/* Check Signal event valid */
+
+	switch (sevp->sigev_notify) {
+	case SIGEV_NONE:
+	case SIGEV_SIGNAL: {
+		struct timer_alloc *t_alloc;
+
+		struct uk_alloc *a = uk_alloc_get_default();
+		t_alloc = uk_malloc(a, sizeof(struct timer_alloc *));
+
+		if (unlikely(!t_alloc))
+			return -ENOMEM;
+
+		t_alloc->alloc = a;
+		t_alloc->sigev = sevp;
+		t_alloc->clockid = clockid;
+		t_alloc->spec = NULL;
+
+		if (unlikely(__push_timer(timer_list_head, t_alloc))) {
+			return -ENOMEM;
+		}
+
+
+		*timerid = t_alloc;
+		return 0;
+	}
+
+	/* Thread events not implemented yet */
+	default: {
+		return -ENOTSUP;
+	}
+	}
+}
+
+UK_SYSCALL_R_DEFINE(int, timer_delete, timer_t, timerid)
 {
 	UK_WARN_STUBBED();
 	return -ENOTSUP;
 }
 
-UK_SYSCALL_R_DEFINE(int, timer_delete,
-		    timer_t, timerid)
-{
-	UK_WARN_STUBBED();
-	return -ENOTSUP;
-}
-
-UK_SYSCALL_R_DEFINE(int, timer_settime,
-		    timer_t, timerid,
-		    int, flags,
+UK_SYSCALL_R_DEFINE(int, timer_settime, timer_t, timerid, int, flags,
 		    const struct itimerspec *__restrict, new_value,
 		    struct itimerspec *__restrict, old_value)
 {
-	UK_WARN_STUBBED();
-	return -ENOTSUP;
+	struct timer_alloc *t_alloc = (struct timer_alloc *)timerid;
+	uk_printk(KLVL_CRIT, "set time of timer\n");
+
+	if (!new_value) {
+		// TODO: disarm timer
+		uk_printk(KLVL_CRIT, "disarm timer\n");
+		return 0;
+	}
+
+	if (new_value->it_value.tv_sec < 0 || new_value->it_value.tv_nsec < 0
+	    || new_value->it_value.tv_nsec > 999999999) {
+		return -EINVAL;
+	}
+
+	if (old_value) {
+		old_value->it_value = t_alloc->spec->it_value;
+		old_value->it_interval = t_alloc->spec->it_interval;
+	}
+
+	uk_printk(KLVL_CRIT, "start thread\n");
+
+
+	struct uk_thread *ut = uk_sched_thread_create_fn1(
+	    uk_sched_current(), __timer_updatefn, &t_alloc, 0x0, 0x0, false,
+	    false, "timer_update_thread", NULL, __timer_thread_destroyedfn);
+
+	if (unlikely(!ut)) {
+		__delete_timer(timer_list_head, NULL, t_alloc);
+		return -ENODEV;
+	}
+
+	uk_sched_dumpk_threads(KLVL_CRIT, uk_sched_current());
+
+	return 0;
 }
 
-UK_SYSCALL_R_DEFINE(int, timer_gettime,
-		    timer_t, timerid,
-		    struct itimerspec *, curr_value)
+UK_SYSCALL_R_DEFINE(int, timer_gettime, timer_t, timerid, struct itimerspec *,
+		    curr_value)
 {
 	UK_WARN_STUBBED();
 	return -ENOTSUP;
 }
 
-UK_SYSCALL_R_DEFINE(int, timer_getoverrun,
-		    timer_t, timerid)
+UK_SYSCALL_R_DEFINE(int, timer_getoverrun, timer_t, timerid)
 {
 	UK_WARN_STUBBED();
 	return -ENOTSUP;

--- a/lib/posix-time/timer.c
+++ b/lib/posix-time/timer.c
@@ -109,13 +109,12 @@ static struct uk_timer *get_timer(timer_t timerid)
 static void timer_disarm(struct uk_thread *thread)
 {
 	uk_thread_terminate(thread);
-	uk_printk(KLVL_CRIT, "timer disairmed\n");
 }
 
 /* Called when timer expires */
 static void expire(struct uk_timer *timer)
 {
-	uk_printk(KLVL_CRIT, "expired\n");
+	uk_printk(KLVL_CRIT, "Expired\n");
 
 	switch(timer->sigev.sigev_notify) {
 		case SIGEV_NONE: 
@@ -201,12 +200,9 @@ static __nsec _get_next_deadline(struct uk_timer *timer, struct timespec *now)
 	timer->exp_cnt = status.exp_cnt;
 
 	if (!status.next) {
-
-		uk_printk(KLVL_CRIT, "n\n");
 		return 0;
 	}
 
-	uk_printk(KLVL_CRIT, "next %lu\n", status.next);
 	return ukplat_monotonic_clock() + status.next;
 }
 
@@ -232,7 +228,6 @@ static __noreturn void __timer_update_thread(void *timerid)
 		}
 
 		deadline = _get_next_deadline(timer, &now);
-		uk_printk(KLVL_CRIT, "deadline: %lu\n", deadline);
 
 		if (deadline) {
 			uk_thread_block_until(uk_thread_current(), deadline);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [] Tested your changes against relevant architectures and platforms;
 - [] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Hello, I have been working on #1204 and I wanted to get some feedback and give an update since this is my first time working on a Unikernel.

So far I have implemented all five timer syscalls although there are still some TODOs left:

- Thread safety: Acquire / Release rw lock on timer list
- Unit tests

 
Since the sigaction syscall seems to be stubbed as well, any SIGEV other than SIGEV_THREAD does not do anything at the moment. I've skipped SIGEV_THREAD_ID for now too.

Feedback would be appreciated! 
