### PR TITLE
plat/xen: Remove redundant memory region

### DIFF
--- a/plat/xen/x86/setup.c
+++ b/plat/xen/x86/setup.c
@@ -156,23 +156,7 @@ static int _init_mem(struct ukplat_bootinfo *const bi)
 	if (unlikely(rc < 0))
 		return rc;
 
-	mrd = (struct ukplat_memregion_desc) {
-		.pbase = __PADDR_MAX,
-		.vbase = VIRT_DEMAND_AREA,
-		.pg_off = 0,
-		.len   = DEMAND_MAP_PAGES * PAGE_SIZE,
-		.pg_count = DEMAND_MAP_PAGES,
-		.type  = UKPLAT_MEMRT_RESERVED,
-		.flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP,
-	};
-#if CONFIG_UKPLAT_MEMRNAME
-	strncpy(mrd.name, "demand", sizeof(mrd.name) - 1);
-#endif
-	rc = ukplat_memregion_list_insert(&bi->mrds, &mrd);
-	if (unlikely(rc < 0))
-		return rc;
-
-	_init_mem_demand_area((unsigned long)mrd.vbase, DEMAND_MAP_PAGES);
+	_init_mem_demand_area((unsigned long)VIRT_DEMAND_AREA, DEMAND_MAP_PAGES);
 
 	/* initrd */
 	mrd = (struct ukplat_memregion_desc){0};


### PR DESCRIPTION

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `xen`


### Description of changes
The reserved virtual address space for mappings was added in the global list of memory regions. Due to the constraint for tracked regions to be page aligned caused the max physical address to get rounded to 0x0.

This removes the region from the list, thus side stepping the requirement.

