### PR TITLE
plat/xen/arm: Set pg_count parameter for mrd regions

### DIFF
--- a/plat/xen/arm/setup64.c
+++ b/plat/xen/arm/setup64.c
@@ -264,6 +264,8 @@ static int _init_mem(struct ukplat_bootinfo *const bi, paddr_t physical_offset)
 	    .vbase = vaddr,
 	    .pbase = (__paddr_t)vaddr,
 	    .len = (max_pfn_p - start_pfn_p) << PAGE_SHIFT,
+	    .pg_off = 0,
+	    .pg_count = (max_pfn_p - start_pfn_p),
 	    .type = UKPLAT_MEMRT_FREE,
 	    .flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_WRITE | UKPLAT_MEMRF_MAP,
 	};
@@ -279,6 +281,8 @@ static int _init_mem(struct ukplat_bootinfo *const bi, paddr_t physical_offset)
 	    .vbase = (__vaddr_t)HYPERVISOR_dtb,
 	    .pbase = (__paddr_t)HYPERVISOR_dtb,
 	    .len = fdt_size,
+	    .pg_off = 0,
+	    .pg_count = PAGE_COUNT(fdt_size),
 	    .type = UKPLAT_MEMRT_DEVICETREE,
 	    .flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP,
 	};


### PR DESCRIPTION

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s): `arm64`
 - Platform(s): `xen`
 - Application(s): N/A

### Additional configuration

### Description of changes

Set pg_count in _init_mem call to fix assertion failure on start:

<memory.c @   82> Assertion failure: (mrd)->pg_count * 0x1000UL == (mrd)->len

This assertion checks for mrd->pg_count parameter that was introduced in the following commit:
ad52a90f (uk/plat/memory: Introduce `pg_off` and `pg_count` memregion fields, 2023-10-28)
