### PR TITLE
arch/arm64: Add checks for min clang version

### DIFF
--- a/arch/arm/arm64/Makefile.uk
+++ b/arch/arm/arm64/Makefile.uk
@@ -29,15 +29,23 @@ CXXINCLUDES += -I$(CONFIG_UK_BASE)/arch/arm/arm64/include
 ifeq ($(CONFIG_ARM64_FEAT_PAUTH),y)
 # Min GCC >= 9 to avoid dealing with deprecated
 # msign-return-address here and in macros
+ifeq ($(call have_gcc),y)
 $(call error_if_gcc_version_lt,9,0)
+else
+$(call error_if_clang_version_lt,14,0)
+endif
 ARCH_REV := armv8.3-a
 BRANCH_PROTECTION := pac-ret+leaf
 endif
 
 ifeq ($(CONFIG_ARM64_FEAT_BTI),y)
+ifeq ($(call have_gcc),y)
 # Min GCC >= 10, due to buggy GCC-9.
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94697
 $(call error_if_gcc_version_lt,10,0)
+else
+$(call error_if_clang_version_lt,14,0)
+endif
 ARCH_REV := armv8.5-a
 ifeq ($(BRANCH_PROTECTION),)
 	BRANCH_PROTECTION := bti
@@ -47,15 +55,23 @@ endif
 endif
 
 ifeq ($(CONFIG_ARM64_FEAT_MTE),y)
+ifeq ($(call have_gcc),y)
 # MTE support introduced in GCC-10
 $(call error_if_gcc_version_lt,10,0)
+else
+$(call error_if_clang_version_lt,14,0)
+endif
 ARCH_REV := armv8.5-a
 ARCH_OPT := $(ARCH_OPT)+memtag
 endif
 
 ifeq ($(CONFIG_ARM64_FEAT_RNG),y)
+ifeq ($(call have_gcc),y)
 # FEAT_RNG support introduced in GCC-9
 $(call error_if_gcc_version_lt,9,0)
+else
+$(call error_if_clang_version_lt,14,0)
+endif
 ARCH_REV := armv8.5-a
 ARCH_OPT := $(ARCH_OPT)+rng
 endif


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [N/A]
 - Application(s): [N/A]

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Add conditionals for clang to fix the build when arch features are enabled. Set min clang version to 14 on all features as that is the first clang version that supports branch-protection on arm64, and for the rest of the features the only version tested.