### PR TITLE
lib/ukalloc: Fix build with clang when MEMTAG is enabled

### DIFF
--- a/lib/ukalloc/alloc.c
+++ b/lib/ukalloc/alloc.c
@@ -189,7 +189,7 @@ void uk_free_ifpages(struct uk_alloc *a, void *ptr)
 		return;
 
 #ifdef CONFIG_HAVE_MEMTAG
-	metadata = uk_get_metadata((void *)((uint64_t)ptr & ~MTE_TAG_MASK));
+	metadata = uk_get_metadata((void *)((__u64)ptr & ~MTE_TAG_MASK));
 	size = metadata->size;
 #else
 	metadata = uk_get_metadata(ptr);


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Replace cast to `uint64_t` with `__u64` to fix building with clang when memory tagging is enabled.