### PR TITLE
plat/common/arm: Check for QARMA3 support in pauth_init()

### DIFF
--- a/arch/arm/arm64/include/uk/asm/arch.h
+++ b/arch/arm/arm64/include/uk/asm/arch.h
@@ -179,6 +179,10 @@
 #define ID_AA64ISAR1_EL1_APA_SHIFT		4
 #define ID_AA64ISAR1_EL1_APA_MASK		0xf
 
+/* ID_AA64ISAR2_EL1: AArch64 Instruction Set Attributes Register 2 */
+#define ID_AA64ISAR2_EL1_APA3_SHIFT		12
+#define ID_AA64ISAR2_EL1_APA3_MASK		0xf
+
 /* ID_AA64PFR1_EL1: AArch64 Processor Feature Register 1 */
 #define ID_AA64PFR1_EL1_NMI_SHIFT		_AC(32, UL)
 #define ID_AA64PFR1_EL1_NMI_MASK		_AC(0xf, UL)

--- a/plat/common/arm/pauth.c
+++ b/plat/common/arm/pauth.c
@@ -31,6 +31,7 @@
 #include <arm/arm64/cpu.h>
 #include <arm/arm64/pauth.h>
 #include <errno.h>
+#include <stdbool.h>
 #include <uk/arch/types.h>
 #include <uk/assert.h>
 #include <uk/essentials.h>
@@ -39,7 +40,8 @@
 #include <uk/arch/random.h>
 #endif /* CONFIG_HAVE_RANDOM */
 
-static void ukplat_pauth_gen_key(__u64 *key_hi, __u64 *key_lo)
+static inline
+void ukplat_pauth_gen_key(__u64 *key_hi, __u64 *key_lo)
 {
 	int ret;
 
@@ -56,22 +58,36 @@ static void ukplat_pauth_gen_key(__u64 *key_hi, __u64 *key_lo)
 		UK_CRASH("Could not generate PAuth key\n");
 }
 
-int __no_pauth ukplat_pauth_init(void)
+/* Check if pointer authentication is available.
+ *
+ * This checks whether either QARMA or an IMPLEMENTATION DEFINED
+ * algorithm is used.
+ */
+static inline bool pauth_supported(void)
 {
+	__u64 apa3, apa, api;
 	__u64 reg;
-	__u64 apa, api;
-	__u64 key_hi, key_lo;
 
-	/* Check if pointer authentication is available.
-	 *
-	 * This checks whether either QARMA or an IMPLEMENTATION DEFINED
-	 * algorithm is used. If the platform supports PAuth, one of
-	 * the two must be present.
-	 */
 	reg = SYSREG_READ(ID_AA64ISAR1_EL1);
 	apa = (reg >> ID_AA64ISAR1_EL1_APA_SHIFT) & ID_AA64ISAR1_EL1_APA_MASK;
 	api = (reg >> ID_AA64ISAR1_EL1_API_SHIFT) & ID_AA64ISAR1_EL1_API_MASK;
-	if (unlikely(!apa && !api))
+	if (apa || api)
+		return true;
+
+	reg = SYSREG_READ(ID_AA64ISAR2_EL1);
+	apa3 = (reg >> ID_AA64ISAR2_EL1_APA3_SHIFT) & ID_AA64ISAR2_EL1_APA3_MASK;
+	if (apa3)
+		return true;
+
+	return false;
+}
+
+int __no_pauth ukplat_pauth_init(void)
+{
+	__u64 key_hi, key_lo;
+	__u64 reg;
+
+	if (unlikely(!pauth_supported()))
 		return -ENOTSUP;
 
 	/* Program instruction Key A */


### PR DESCRIPTION



<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Add definitions `ID_AA64ISAR2_EL1.APA3` and update pauth_init() to additionally query `APA3` (QARMA3) when checking if PAuth is enabled.