### PR TITLE
build: Use different progress flags based on the wget version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -679,7 +679,11 @@ GZIP		:= gzip
 TAR		:= tar
 UNZIP		:= unzip -qq -u
 GIT		:= git
-WGET		:= wget
+ifneq (,$(findstring Wget2,$(shell wget --version)))
+WGET := wget -q --force-progress --progress=bar
+else
+WGET := wget -q --show-progress --progress=bar
+endif
 PYTHON          := python3
 SHA1SUM		:= sha1sum -b
 SHA256SUM	:= sha256sum -b

--- a/support/build/Makefile.rules
+++ b/support/build/Makefile.rules
@@ -527,7 +527,7 @@ endef
 define fetchas =
 $(BUILD_DIR)/$(1)/$(3):
 	$(call verbose_cmd,WGET,$(1)':' $(2), \
-	 $(WGET) -q --show-progress --progress=bar -O $(BUILD_DIR)/$(1)/$(3) $(2) || \
+	 $(WGET) -O $(BUILD_DIR)/$(1)/$(3) $(2) || \
 	 $(RM) $(BUILD_DIR)/$(1)/$(3))
 
 $(call _chksum_origin,$(1),$(BUILD_DIR)/$(1)/$(3),$(BUILD_DIR)/$(1)/.chksum)
@@ -541,8 +541,8 @@ endef
 define fetchas2 =
 $(BUILD_DIR)/$(1)/$(4):
 	$(call verbose_cmd,WGET,$(1)':' $(2) [retry-with: $(3)], \
-	 $(WGET) -q --show-progress --progress=bar -O $(BUILD_DIR)/$(1)/$(4) $(2) || \
-	 $(WGET) -q --show-progress --progress=bar -O $(BUILD_DIR)/$(1)/$(4) $(3) || \
+	 $(WGET) -O $(BUILD_DIR)/$(1)/$(4) $(2) || \
+	 $(WGET) -O $(BUILD_DIR)/$(1)/$(4) $(3) || \
 	 $(RM) $(BUILD_DIR)/$(1)/$(4))
 
 $(call _chksum_origin,$(1),$(BUILD_DIR)/$(1)/$(4),$(BUILD_DIR)/$(1)/.chksum)


### PR DESCRIPTION
The Unikraft build system uses the `--show-progress` flag for Wget1. This flag has been renamed to `--force-progress` in Wget2. That's why we need to check the version of Wget before using either one of the flags. There's a list of CLI changes from Wget1 to Wget2 here:

https://gitlab.com/gnuwget/wget2/-/wikis/Home

I originally opened this as [an issue on kraftkit](https://github.com/unikraft/unikraft/issues/1458) because I first got an issue with these flags using kraftkit.

I checked if these flags work by building nginx from the app catalog with my Wget2 as installed by my distro and Wget1.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

GitHub-Fixes: #1458