### PR TITLE
lib/uklock: Overhaul ukmutex

### DIFF
--- a/lib/uklock/Config.uk
+++ b/lib/uklock/Config.uk
@@ -30,6 +30,15 @@ if LIBUKLOCK
 		help
 			Enable mutex based synchornization
 
+	config LIBUKLOCK_MUTEX_ATOMIC
+		bool "Use atomic operations for mutex"
+		depends on LIBUKLOCK_MUTEX
+		default y
+		help
+			Use atomic operations for mutex implementation.
+			Disabling this can potentially improve the performance
+			of mutex if they are no used in an SMP environment.
+
 	config LIBUKLOCK_MUTEX_METRICS
 		bool "Metrics for mutex objects"
 		default n

--- a/lib/uklock/exportsyms.uk
+++ b/lib/uklock/exportsyms.uk
@@ -3,6 +3,9 @@ uk_mutex_init_config
 uk_mutex_get_metrics
 _uk_mutex_metrics
 _uk_mutex_metrics_lock
+_uk_mutex_lock_wait
+_uk_mutex_unlock_wait
+_uk_mutex_trylock_wait
 uk_rwlock_init_config
 uk_rwlock_rlock
 uk_rwlock_wlock

--- a/lib/uklock/mutex.c
+++ b/lib/uklock/mutex.c
@@ -8,11 +8,14 @@ struct uk_mutex_metrics _uk_mutex_metrics = { 0 };
 __spinlock              _uk_mutex_metrics_lock;
 #endif /* CONFIG_LIBUKLOCK_MUTEX_METRICS */
 
+/* We need the lower bits for our mutex flags */
+UK_CTASSERT(__alignof(struct uk_thread) >= 4);
+
 void uk_mutex_init_config(struct uk_mutex *m, unsigned int flags)
 {
 	m->lock_count = 0;
 	m->flags = flags;
-	m->owner = NULL;
+	m->lock = _UK_MUTEX_UNOWNED;
 	uk_waitq_init(&m->wait);
 
 #ifdef CONFIG_LIBUKLOCK_MUTEX_METRICS
@@ -20,6 +23,82 @@ void uk_mutex_init_config(struct uk_mutex *m, unsigned int flags)
 	_uk_mutex_metrics.active_unlocked++;
 	ukarch_spin_unlock(&_uk_mutex_metrics_lock);
 #endif /* CONFIG_LIBUKLOCK_MUTEX_METRICS */
+}
+
+void _uk_mutex_lock_wait(struct uk_mutex *m, __uptr tid, __uptr v)
+{
+	__uptr tmp;
+
+	/* If the owner is the current thread, just increment the lock count */
+	if (unlikely(uk_mutex_is_recursive(m) &&
+		     (tid & ~_UK_MUTEX_STATE_MASK) ==
+		     (v & ~_UK_MUTEX_STATE_MASK))) {
+		UK_ASSERT(m->lock_count > 0);
+		m->lock_count++;
+		return;
+	}
+
+	UK_ASSERT(tid != (v & ~_UK_MUTEX_STATE_MASK));
+
+	for (;;) {
+		if (v == _UK_MUTEX_UNOWNED) {
+			if (_uk_mutex_lock_fetch(m, &v, tid))
+				break;
+			continue;
+		}
+
+		UK_ASSERT(v != _UK_MUTEX_UNOWNED);
+
+		if ((v & _UK_MUTEX_CONTESTED) == 0 &&
+		    !__atomic_compare_exchange_n(&m->lock, &v,
+						 v | _UK_MUTEX_CONTESTED,
+						 0,
+						 __ATOMIC_SEQ_CST,
+						 __ATOMIC_SEQ_CST)) {
+			continue;
+		}
+
+		/* From this point, we know that the other side will also go
+		 * through the waitq spinlock.
+		 * Wait until something changed, and retry locking the mutex.
+		 */
+		uk_waitq_wait_event(
+			&m->wait,
+			(tmp = __atomic_load_n(&m->lock, __ATOMIC_RELAXED)) !=
+			v);
+
+		v = tmp;
+	}
+
+	UK_ASSERT(m->lock_count == 0);
+	m->lock_count = 1;
+}
+
+int _uk_mutex_trylock_wait(struct uk_mutex *m, __uptr tid, __uptr v)
+{
+	/* If the owner is the current thread, just increment the lock count */
+	if (unlikely(uk_mutex_is_recursive(m) &&
+		     (tid & ~_UK_MUTEX_STATE_MASK) ==
+		     (v & ~_UK_MUTEX_STATE_MASK))) {
+		UK_ASSERT(m->lock_count > 0);
+		m->lock_count++;
+
+#ifdef CONFIG_LIBUKLOCK_MUTEX_METRICS
+		ukarch_spin_lock(&_uk_mutex_metrics_lock);
+		_uk_mutex_metrics.total_ok_trylocks++;
+		ukarch_spin_unlock(&_uk_mutex_metrics_lock);
+#endif /* CONFIG_LIBUKLOCK_MUTEX_METRICS */
+
+		return 1;
+	}
+
+	return 0;
+}
+
+void _uk_mutex_unlock_wait(struct uk_mutex *m)
+{
+	__atomic_store_n(&m->lock, _UK_MUTEX_UNOWNED, __ATOMIC_RELEASE);
+	uk_waitq_wake_up(&m->wait);
 }
 
 #ifdef CONFIG_LIBUKLOCK_MUTEX_METRICS


### PR DESCRIPTION
- Make inlined part smaller and move heavy slow path into source file.
- Use more fine-grained atomic operations.
- Only use waitq for contested mutexes. This is inspired by how FreeBSD implements mutexes. This avoids having to disable interrupts and lock the waitq spinlock.

This substantially improves the performance for SMP usages. However, this PR does not make the underlying wait queue SMP-safe.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
