### PR TITLE
plat/common/x86: Sanitize the ECTX slot on syscall entry

### DIFF
--- a/plat/common/x86/syscall.S
+++ b/plat/common/x86/syscall.S
@@ -225,7 +225,17 @@ ENTRY(_ukplat_syscall)
 	 * Store execenv's stored ECTX which resides at offset:
 	 * sizeof(struct __regs) + sizeof(struct ukarch_sysctx) from beginning
 	 * of execenv.
+	 *
+	 * NOTE: Always sanitize the ECTX slot first to ensure that the XSAVE
+	 * header is not dirty.
 	 */
+	addq	$(__REGS_SIZEOF + UKARCH_SYSCTX_SIZE), %rdi
+	call	ukarch_ectx_sanitize
+	/**
+	 * After function calls, %rsp preserved value of execenv pointer so
+	 * restore that into %rdi.
+	 */
+	movq	%rsp, %rdi
 	addq	$(__REGS_SIZEOF + UKARCH_SYSCTX_SIZE), %rdi
 	call	ukarch_ectx_store
 


### PR DESCRIPTION
Commit c716bcca4822 ("{lib,arch,plat}: Redo syscall ctx's and swapgs logic"), following a rework of architecture specific contexts and syscall entries, by mistake removed the ECTX sanitization at the beginning of system calls. This can result in #GP on x86 if the XSAVE header happens to be dirty. Thus, bring this sanitization back.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
