### PR TITLE
plat/xen: Remove UKPLAT_MEMRF_MAP from arm/setup64

### DIFF
--- a/plat/xen/arm/setup64.c
+++ b/plat/xen/arm/setup64.c
@@ -186,7 +186,7 @@ static inline void _get_cmdline(struct ukplat_bootinfo *bi)
 	}
 
 	cmdline = ukplat_memregion_alloc(cmdline_len, UKPLAT_MEMRT_CMDLINE,
-					 UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP);
+					 UKPLAT_MEMRF_READ);
 	if (!cmdline)
 		UK_CRASH("Could not allocate command-line memory");
 
@@ -267,7 +267,7 @@ static int _init_mem(struct ukplat_bootinfo *const bi, paddr_t physical_offset)
 	    .pg_off = 0,
 	    .pg_count = (max_pfn_p - start_pfn_p),
 	    .type = UKPLAT_MEMRT_FREE,
-	    .flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_WRITE | UKPLAT_MEMRF_MAP,
+	    .flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_WRITE,
 	};
 #if CONFIG_UKPLAT_MEMRNAME
 	memcpy(mrd.name, "heap", sizeof(mrd.name) - 1);
@@ -284,7 +284,7 @@ static int _init_mem(struct ukplat_bootinfo *const bi, paddr_t physical_offset)
 	    .pg_off = 0,
 	    .pg_count = PAGE_COUNT(fdt_size),
 	    .type = UKPLAT_MEMRT_DEVICETREE,
-	    .flags = UKPLAT_MEMRF_READ | UKPLAT_MEMRF_MAP,
+	    .flags = UKPLAT_MEMRF_READ,
 	};
 #if CONFIG_UKPLAT_MEMRNAME
 	memcpy(mrd.name, "dtb", sizeof(mrd.name) - 1);


### PR DESCRIPTION
Remove UKPLAT_MEMRF_MAP to fix a regression when allocating the cmdline memreg on arm/setup64.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [`xen`]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Remove UKPLAT_MEMRF_MAP to fix a regression when allocating the memregs on arm/setup64.