### PR TITLE
lib/ukvmem: Fix dependency and test scripts

### DIFF
--- a/lib/ukvmem/Config.uk
+++ b/lib/ukvmem/Config.uk
@@ -5,6 +5,7 @@ menuconfig LIBUKVMEM
 	select LIBUKALLOC
 	select LIBISRLIB
 	select PAGING
+	select LIBUKNOFAULT
 	help
 		This library implements virtual address management by
 		providing methods for working with virtual address space

--- a/lib/ukvmem/tests/test_vmem.c
+++ b/lib/ukvmem/tests/test_vmem.c
@@ -639,7 +639,7 @@ UK_TESTCASE(ukvmem, test_vma_stack)
 
 	/* Probe the entire stack */
 	len = probe_r(va1 - UK_VMA_STACK_BOTTOM_GUARD_SIZE,
-		      VMEM_STACKSIZE + STACK_GUARDS_SIZE);
+		      VMEM_STACKSIZE + UK_VMA_STACK_GUARDS_SIZE);
 	UK_TEST_EXPECT_SNUM_EQ(len, VMEM_STACKSIZE);
 
 	rc = uk_vma_map_stack(vas, &va2, VMEM_STACKSIZE, 0,
@@ -662,7 +662,7 @@ UK_TESTCASE(ukvmem, test_vma_stack)
 
 	/* Probe the entire stack */
 	len = probe_r(va2 - UK_VMA_STACK_BOTTOM_GUARD_SIZE,
-		      VMEM_STACKSIZE + STACK_GUARDS_SIZE);
+		      VMEM_STACKSIZE + UK_VMA_STACK_GUARDS_SIZE);
 	UK_TEST_EXPECT_SNUM_EQ(len, VMEM_STACKSIZE);
 
 	/* Try to unmap only some part of the stack */
@@ -675,7 +675,7 @@ UK_TESTCASE(ukvmem, test_vma_stack)
 
 	/* But we should be able to change attributes for the whole VMA */
 	rc = uk_vma_set_attr(vas, va2 - UK_VMA_STACK_BOTTOM_GUARD_SIZE,
-			     VMEM_STACKSIZE + STACK_GUARDS_SIZE, PROT_R, 0);
+			     VMEM_STACKSIZE + UK_VMA_STACK_GUARDS_SIZE, PROT_R, 0);
 	UK_TEST_EXPECT_ZERO(rc);
 
 	vas_clean(vas);


### PR DESCRIPTION
- Add `uknofault` as dependency as it is needed for testing
- Update obsolete variable names in `test_vmem.c`

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): N/A

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes
This change adds `uknofault` as a dependent library for `ukvmem` because it is needed for testing purposes. It also updates `STACK_GUARDS_SIZE` to `UK_VMA_STACK_GUARDS_SIZE` in accordance with changes in `vma_types.h`.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
