### PR TITLE
plat: Set HAVE_RANDOM at the platform

### DIFF
--- a/arch/arm/arm64/Config.uk
+++ b/arch/arm/arm64/Config.uk
@@ -203,7 +203,7 @@ endif
 
 config ARM64_FEAT_RNG
 	bool "Armv8.5 Random Number Generator"
-	select HAVE_RANDOM
+	default y if HAVE_RANDOM
 	help
 	  This enables the hardware RNG functionality provided by the
 	  processor. The architecture specifies that this is implemented

--- a/arch/x86/x86_64/Config.uk
+++ b/arch/x86/x86_64/Config.uk
@@ -92,7 +92,7 @@ menu "Processor Features"
 
 config X86_64_HAVE_RANDOM
 	bool "Processor-generated randomness"
-	select HAVE_RANDOM
+	default y if HAVE_RANDOM
 	help
 	  Enable processor-generated randomness. This uses the RDRAND / RDSEED
 	  instructions provided by Intel's DRNG technology.

--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -19,6 +19,7 @@ menuconfig PLAT_KVM
 	imply LIBVIRTIO_9P if LIBUK9P
 	imply LIBVIRTIO_NET if LIBUKNETDEV
 	imply LIBVIRTIO_BLK if LIBUKBLKDEV
+	imply LIBUKRANDOM if HAVE_RANDOM
 	help
 		Create a Unikraft image that runs as a KVM guest
 
@@ -98,11 +99,13 @@ config KVM_VMM_QEMU
 	imply LIBUKRTC_PL031
 	select HAVE_PCI
 	select HAVE_MMIO
+	select HAVE_RANDOM
 
 config KVM_VMM_FIRECRACKER
 	bool "Firecracker"
 	select KVM_BOOT_PROTO_LXBOOT
 	select HAVE_MMIO
+	select HAVE_RANDOM
 	select VIRTIO_MMIO_LINUX_COMPAT_CMDLINE
 	imply LIBUKTTY_NS16550 if ARCH_ARM_64
 	imply LIBUKINTCTLR_GICV3 if ARCH_ARM_64

--- a/plat/xen/Config.uk
+++ b/plat/xen/Config.uk
@@ -13,11 +13,13 @@ menuconfig PLAT_XEN
        select LIBUKRELOC if OPTIMIZE_PIE
        imply LIBUKOFW if ARCH_ARM_64
        select HAVE_INTCTLR
+       select HAVE_RANDOM
        imply LIBUKINTCTLR_GICV3 if ARCH_ARM_64
        imply LIBXEN_NETFRONT if LIBUKNETDEV
        imply LIBXEN_9PFRONT if LIBUK9P
        imply LIBXEN_BLKFRONT if LIBUKBLKDEV
-      help
+       imply LIBUKRANDOM if HAVE_RANDOM
+       help
                 Create a Unikraft image that runs as a Xen guest
 
 if (PLAT_XEN)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`, `x86_64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This patch-set updates the config dependencies of the `ukarch_random` API to enable the feature conditionally to the platform's capabilties, and enables `HAVE_RANDOM` on QEMU and Firecracker.