### PR TITLE
lib/ukrandom: Alternative options for seeding the CSPRNG

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -235,3 +235,10 @@ config UK_NAME
 	default UK_DEFNAME
 	help
 	  Name to be used for final image
+
+# The following are selected by libraries that provide options to bypass security.
+config CONFIG_UK_TAINT_INSECURE_CSPRNG
+	bool
+
+comment "Notice: UNIKRAFT IS CONFIGURED WITH INSECURE RANDOM NUMBER GENERATOR"
+	depends on CONFIG_UK_TAINT_INSECURE_CSPRNG

--- a/lib/ukrandom/Config.uk
+++ b/lib/ukrandom/Config.uk
@@ -6,6 +6,21 @@ menuconfig LIBUKRANDOM
 
 if LIBUKRANDOM
 
+config LIBUKRANDOM_SEED_INSECURE
+	bool "Use a fixed seed (INSECURE)"
+	select CONFIG_UK_TAINT_INSECURE_CSPRNG
+	help
+		Seed the CSPRNG with a fixed value. Enabling this option will make the
+		output of the RNG to be trivially predictable, which compromises the
+		security of the system.
+
+		This option is available for trying out Unikraft on legacy systems that
+		do not feature a TRNG.
+
+		Select this if you know what you're doing.
+
+		DO NOT USE IN PRODUCTION SYSTEMS
+
 config LIBUKRANDOM_DEVFS
 	bool "Register random, urandom, and hwrng device to devfs"
 	select LIBDEVFS

--- a/lib/ukrandom/chacha.c
+++ b/lib/ukrandom/chacha.c
@@ -157,8 +157,13 @@ int uk_swrand_init(void)
 
 	uk_pr_info("Initialize random number generator...\n");
 
+	/* It has been observed that in some x86_64 systems this loop
+	 * fails after a few iterations due to exhastion of conditioned
+	 * entropy (rdseed). Use RDRAND until we provide more flexible
+	 * options for RDSEED.
+	 */
 	for (i = 0; i < seedc; i++) {
-		ret = ukarch_random_seed_u32(&seedv[i]);
+		ret = ukarch_random_u32(&seedv[i]);
 		if (unlikely(ret)) {
 			uk_pr_err("Could not generate random seed\n");
 			return ret;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR updates the mechanisms used to seed the CSPRNG of `libukrandom`. The following changes are made:
* **Switch from `rdseed` to `rdrand` when seeding ChaCha:** This is due to the observation that on some x86_64 systems, the loop fails due to exhaustion of the conditioned entropy. In [1] Intel suggests that performance-crtical systems may use `rdrand` instead. Switch to `ukarch_random_u32()` to mitigate this risk. In the future there should be a more flexible mechanism to control seeding.
* **Introduce options to taint Unikraft:** These are options should bet set by any library that provides an option to bypass security. Upon selecting one of these options a message is printed at the main screen of Kconfig. In the future there may be additional hits for tainted builds.
* **Add option to seed the CSPRNG with a fixed value:** Add an option to seed the CSPRNG with a fixed value. The purpose of this option is for development, or running Unikraft in legacy systems that don't provide a TRNG. Enabling this option compromises the system's security and should not be used in production. Moreover, the build system marks Unikraft as tainted and libukrandom prints a banner during init.

[1] https://www.intel.com/content/www/us/en/developer/articles/guide/intel-digital-random-number-generator-drng-software-implementation-guide.html

GitHub-Depends-On: #1008 