### PR TITLE
plat/common: Fix wrong `vbase` of legacy video memory area

### DIFF
--- a/plat/common/include/uk/plat/common/memory.h
+++ b/plat/common/include/uk/plat/common/memory.h
@@ -152,7 +152,7 @@ ukplat_memregion_list_insert_legacy_hi_mem(struct ukplat_memregion_list *list)
 	rc = ukplat_memregion_list_insert(list,
 			&(struct ukplat_memregion_desc){
 				.pbase = X86_VIDEO_MEM_START,
-				.vbase = X86_VIDEO_MEM_LEN,
+				.vbase = X86_VIDEO_MEM_START,
 				.pg_off = 0,
 				.len = X86_VIDEO_MEM_LEN,
 				.pg_count = PAGE_COUNT(X86_VIDEO_MEM_LEN),


### PR DESCRIPTION
Commit a001e41f607c ("plat/common/x86: Increase legacy high regions granularity") used the wrong value for the vbase, using by mistake the length of the region instead of its start. Fix this.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
