### PR TITLE
include/uk/errptr: Fix `NULL` being an error pointer

### DIFF
--- a/include/uk/errptr.h
+++ b/include/uk/errptr.h
@@ -47,7 +47,7 @@
  */
 #ifndef PTRISERR
 #define PTRISERR(ptr)					\
-	((__sptr)(ptr) <= 0				\
+	((__sptr)(ptr) < 0				\
 	 && (__sptr)(ptr) >= -(__sptr)(MAXERRNO))
 #endif
 

--- a/lib/ukblkdev/include/uk/blkdev.h
+++ b/lib/ukblkdev/include/uk/blkdev.h
@@ -278,7 +278,7 @@ static inline int uk_blkdev_queue_intr_enable(struct uk_blkdev *dev,
 	UK_ASSERT(dev->dev_ops);
 	UK_ASSERT(dev->_data);
 	UK_ASSERT(queue_id < CONFIG_LIBUKBLKDEV_MAXNBQUEUES);
-	UK_ASSERT(!PTRISERR(dev->_queue[queue_id]));
+	UK_ASSERT(dev->_queue[queue_id] && !PTRISERR(dev->_queue[queue_id]));
 
 	if (unlikely(!dev->dev_ops->queue_intr_enable))
 		return -ENOTSUP;
@@ -306,7 +306,7 @@ static inline int uk_blkdev_queue_intr_disable(struct uk_blkdev *dev,
 	UK_ASSERT(dev->dev_ops);
 	UK_ASSERT(dev->_data);
 	UK_ASSERT(queue_id < CONFIG_LIBUKBLKDEV_MAXNBQUEUES);
-	UK_ASSERT(!PTRISERR(dev->_queue[queue_id]));
+	UK_ASSERT(dev->_queue[queue_id] && !PTRISERR(dev->_queue[queue_id]));
 
 	if (unlikely(!dev->dev_ops->queue_intr_disable))
 		return -ENOTSUP;

--- a/lib/uknetdev/include/uk/netdev.h
+++ b/lib/uknetdev/include/uk/netdev.h
@@ -400,7 +400,8 @@ static inline int uk_netdev_rxq_intr_enable(struct uk_netdev *dev,
 	UK_ASSERT(dev->_data);
 	UK_ASSERT(dev->_data->state == UK_NETDEV_RUNNING);
 	UK_ASSERT(queue_id < CONFIG_LIBUKNETDEV_MAXNBQUEUES);
-	UK_ASSERT(!PTRISERR(dev->_rx_queue[queue_id]));
+	UK_ASSERT(dev->_rx_queue[queue_id] &&
+		  !PTRISERR(dev->_rx_queue[queue_id]));
 
 	if (unlikely(!dev->ops->rxq_intr_enable))
 		return -ENOTSUP;
@@ -428,7 +429,8 @@ static inline int uk_netdev_rxq_intr_disable(struct uk_netdev *dev,
 	UK_ASSERT(dev->_data);
 	UK_ASSERT(dev->_data->state == UK_NETDEV_RUNNING);
 	UK_ASSERT(queue_id < CONFIG_LIBUKNETDEV_MAXNBQUEUES);
-	UK_ASSERT(!PTRISERR(dev->_rx_queue[queue_id]));
+	UK_ASSERT(dev->_rx_queue[queue_id] &&
+		  !PTRISERR(dev->_rx_queue[queue_id]));
 
 	if (unlikely(!dev->ops->rxq_intr_disable))
 		return -ENOTSUP;
@@ -480,7 +482,8 @@ static inline int uk_netdev_rx_one(struct uk_netdev *dev, uint16_t queue_id,
 	UK_ASSERT(dev->rx_one);
 	UK_ASSERT(queue_id < CONFIG_LIBUKNETDEV_MAXNBQUEUES);
 	UK_ASSERT(dev->_data->state == UK_NETDEV_RUNNING);
-	UK_ASSERT(!PTRISERR(dev->_rx_queue[queue_id]));
+	UK_ASSERT(dev->_rx_queue[queue_id] &&
+		  !PTRISERR(dev->_rx_queue[queue_id]));
 	UK_ASSERT(pkt);
 
 
@@ -549,7 +552,8 @@ static inline int uk_netdev_tx_one(struct uk_netdev *dev, uint16_t queue_id,
 	UK_ASSERT(dev->tx_one);
 	UK_ASSERT(queue_id < CONFIG_LIBUKNETDEV_MAXNBQUEUES);
 	UK_ASSERT(dev->_data->state == UK_NETDEV_RUNNING);
-	UK_ASSERT(!PTRISERR(dev->_tx_queue[queue_id]));
+	UK_ASSERT(dev->_tx_queue[queue_id] &&
+		  !PTRISERR(dev->_tx_queue[queue_id]));
 	UK_ASSERT(pkt);
 
 	ret = dev->tx_one(dev, dev->_tx_queue[queue_id], pkt);

--- a/lib/uknetdev/netdev.c
+++ b/lib/uknetdev/netdev.c
@@ -533,7 +533,7 @@ int uk_netdev_rxq_configure(struct uk_netdev *dev, uint16_t queue_id,
 		return -EINVAL;
 
 	/* Make sure that we are not initializing this queue a second time */
-	if (!PTRISERR(dev->_rx_queue[queue_id]))
+	if (dev->_rx_queue[queue_id] && !PTRISERR(dev->_rx_queue[queue_id]))
 		return -EBUSY;
 
 	err = _create_event_handler(rx_conf->callback, rx_conf->callback_cookie,
@@ -576,7 +576,7 @@ int uk_netdev_txq_configure(struct uk_netdev *dev, uint16_t queue_id,
 		return -EINVAL;
 
 	/* Make sure that we are not initializing this queue a second time */
-	if (!PTRISERR(dev->_tx_queue[queue_id]))
+	if (dev->_tx_queue[queue_id] && !PTRISERR(dev->_tx_queue[queue_id]))
 		return -EBUSY;
 
 	dev->_tx_queue[queue_id] = dev->ops->txq_configure(dev, queue_id,


### PR DESCRIPTION
### Description of changes

Previously, `PTRISERR` would be true for NULL, breaking the convention of error pointers that `PTR2ERR` returns a negative error code for any pointer for which `PTRISERR` is true. This would add a subtle corner case where errors could be silently ignored when converting from errptr to integer return code.
This change fixes this oversight. Code using `PTRISERR` ambiguously or to erroneously check for NULL is also fixed.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration
N/A