### PR TITLE
lib/nolibc: Compile string.c with -O3

### DIFF
--- a/lib/nolibc/Makefile.uk
+++ b/lib/nolibc/Makefile.uk
@@ -33,6 +33,7 @@ LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/stdio.c
 LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/ctype.c
 LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/stdlib.c
 LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/string.c
+LIBNOLIBC_STRING_FLAGS-$(CONFIG_OPTIMIZE_PERF) += -O3
 LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/musl-imported/src/string/strsignal.c
 LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/musl-imported/src/string/strstr.c
 LIBNOLIBC_SRCS-y += $(LIBNOLIBC_BASE)/musl-imported/src/signal/psignal.c


### PR DESCRIPTION
### Description of changes

This change makes nolibc's string.c compile with -O3 optimizations when optimizing for performance. This gives compilers more freedom to better optimize the often-used mem* and str* functions.



### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration
Compile with `CONFIG_OPTIMIZE_PERF` with & without this patch. Disassemble the produced `string.o` and examine e.g., `memcpy`.