### PR TITLE
lib/posix-{process, sysinfo}: Take fdtab size from `posix-fdtab` instead of vfscore

### DIFF
--- a/lib/posix-process/deprecated.c
+++ b/lib/posix-process/deprecated.c
@@ -41,9 +41,6 @@
 #include <uk/print.h>
 #include <uk/syscall.h>
 #include <uk/arch/limits.h>
-#if CONFIG_LIBVFSCORE
-#include <vfscore/file.h>
-#endif
 
 #define UNIKRAFT_SID      0
 #define UNIKRAFT_PGID     0
@@ -329,7 +326,7 @@ UK_LLSYSCALL_R_DEFINE(int, prlimit64, int, pid, unsigned int, resource,
 	case RLIMIT_STACK:
 	case RLIMIT_AS:
 		break;
-#if CONFIG_LIBVFSCORE
+#if CONFIG_LIBPOSIX_FDTAB
 	case RLIMIT_NOFILE:
 		break;
 #endif
@@ -368,10 +365,10 @@ UK_LLSYSCALL_R_DEFINE(int, prlimit64, int, pid, unsigned int, resource,
 		old_limit->rlim_max = RLIM_INFINITY;
 		break;
 
-#if CONFIG_LIBVFSCORE
+#if CONFIG_LIBPOSIX_FDTAB
 	case RLIMIT_NOFILE:
-		old_limit->rlim_cur = FDTABLE_MAX_FILES;
-		old_limit->rlim_max = FDTABLE_MAX_FILES;
+		old_limit->rlim_cur = CONFIG_LIBPOSIX_FDTAB_MAXFDS;
+		old_limit->rlim_max = CONFIG_LIBPOSIX_FDTAB_MAXFDS;
 		break;
 #endif
 

--- a/lib/posix-sysinfo/sysinfo.c
+++ b/lib/posix-sysinfo/sysinfo.c
@@ -46,11 +46,6 @@
 #include <uk/falloc.h>
 #endif /* CONFIG_HAVE_PAGING */
 
-#if CONFIG_LIBVFSCORE
-/* For FDTABLE_MAX_FILES. */
-#include <vfscore/file.h>
-#endif
-
 /**
  * The Unikraft `struct utsname` structure.
  *
@@ -152,9 +147,9 @@ long sysconf(int name)
 	}
 #endif /* CONFIG_HAVE_PAGING */
 
-#if CONFIG_LIBVFSCORE
+#if CONFIG_LIBPOSIX_FDTAB
 	if (name == _SC_OPEN_MAX)
-		return FDTABLE_MAX_FILES;
+		return CONFIG_LIBPOSIX_FDTAB_MAXFDS;
 #endif
 
 	return 0;


### PR DESCRIPTION
### Description of changes

This PR fixes an oversight of the migration of the file descriptor table from vfscore into its own lib: `prlimit` and `sysconf` now report the fdtab size based on the configured value in `posix-fdtab`, instead of the old hard-coded constant in `vfscore`.

In addition, the availability of `RLIMIT_NOFILE` and `_SC_OPEN_MAX`, is now correctly conditioned by `posix-fdtab` and not vfscore.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A