### PR TITLE
plat/common/x86: Use `X86_VIDEO_MEM_START` for SIPI vector allocation

### DIFF
--- a/plat/common/include/uk/plat/common/memory.h
+++ b/plat/common/include/uk/plat/common/memory.h
@@ -200,7 +200,8 @@ ukplat_memregion_alloc_sipi_vect(void)
 							  UKPLAT_MEMRT_RESERVED,
 							  UKPLAT_MEMRF_READ  |
 							  UKPLAT_MEMRF_WRITE);
-	if (unlikely(!x86_start16_addr || x86_start16_addr >= X86_HI_MEM_START))
+	if (unlikely(!x86_start16_addr ||
+		     x86_start16_addr >= X86_VIDEO_MEM_START))
 		return -ENOMEM;
 
 	return 0;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Commit a001e41f607c ("plat/common/x86: Increase legacy high regions granularity") changed the definitions of some x86 memregion related macro-definitions. By mistake it forgot to adapt the `ukplat_memregion_alloc_sipi_vect` function which was using one them. This was not caught at the time as it required one to have SMP enabled in order to get the build error.