### PR TITLE
support/qemu-guest: Enable RDRAND, RDSEED for x86 TCG

### DIFF
--- a/support/scripts/qemu-guest
+++ b/support/scripts/qemu-guest
@@ -792,7 +792,7 @@ case "$ARG_MACHINETYPE" in
 		QEMU_BASE_ARGS+=("host,+x2apic,-pmu")
 	else
 		QEMU_BASE_ARGS+=("-cpu")
-		QEMU_BASE_ARGS+=("qemu64,-vmx,-svm,+x2apic,+pdpe1gb")
+		QEMU_BASE_ARGS+=("qemu64,-vmx,-svm,+x2apic,+pdpe1gb,+rdrand,+rdseed")
 	fi
 	;;
 "x86q35")
@@ -806,7 +806,7 @@ case "$ARG_MACHINETYPE" in
 		QEMU_BASE_ARGS+=("host,+x2apic,-pmu")
 	else
 		QEMU_BASE_ARGS+=("-cpu")
-		QEMU_BASE_ARGS+=("qemu64,-vmx,-svm,+x2apic,+pdpe1gb")
+		QEMU_BASE_ARGS+=("qemu64,-vmx,-svm,+x2apic,+pdpe1gb,+rdrand,+rdseed")
 	fi
 	;;
 *)


### PR DESCRIPTION
QEMU's TCG for x86 can emulate `rdrand` and `rdseed` instructions as long as specified via `-cpu` parameter and QEMU 8.1.3 or newer is used. Due to recent requirements introduced with `lib/ukrandom` (see PR #1008, PR #1451), we request `rdseed` and `rdrand` when using TCG.