### PR TITLE
lib/vfscore: Fix renameat function in vfscore

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1372,7 +1372,7 @@ UK_SYSCALL_R_DEFINE(int, renameat,
 		vn_unlock(vp);
 		fdrop(fp);
 	} else {
-		strlcpy(src, newpath, PATH_MAX);
+		strlcpy(dest, newpath, PATH_MAX);
 	}
 
 	return sys_rename(src, dest);


### PR DESCRIPTION
In the renameat function, 'dest' variable is declared but not initialized, leading to unexpected behaviour. Fix by making sure 'dest' is being set in the else branch by replacing "src" with "dest" in the strlcpy function.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
