### PR TITLE
plat/arm, lib/nolibc: Add fixes for ARM

### DIFF
--- a/lib/nolibc/include/sys/stat.h
+++ b/lib/nolibc/include/sys/stat.h
@@ -30,6 +30,7 @@ extern "C" {
  * is different.
  */
 
+#ifdef CONFIG_ARCH_X86_64
 struct stat {
 	dev_t st_dev;
 	ino_t st_ino;
@@ -49,6 +50,28 @@ struct stat {
 	struct timespec st_ctim;
 	long unused[3];
 };
+#else		/* ARM64 */
+struct stat {
+	dev_t st_dev;
+	ino_t st_ino;
+	unsigned int st_nlink;
+
+	mode_t st_mode;
+	uid_t st_uid;
+	gid_t st_gid;
+	dev_t st_rdev;
+	dev_t __pad1;
+	long st_size;
+	int st_blksize;
+	int __pad2;
+	long st_blocks;
+
+	struct timespec st_atim;
+	struct timespec st_mtim;
+	struct timespec st_ctim;
+	int __glibc_reserved[2];
+};
+#endif
 
 #define st_atime st_atim.tv_sec
 #define st_mtime st_mtim.tv_sec

--- a/plat/common/arm/traps_arm64.c
+++ b/plat/common/arm/traps_arm64.c
@@ -240,7 +240,13 @@ static int arm64_syscall_adapter(void *data)
 	/* Save system context state */
 	ukarch_sysctx_store(&execenv->sysctx);
 
+	/* Enable IRQs */
+	ukplat_lcpu_enable_irq();
+
 	ukplat_syscall_handler((struct uk_syscall_ctx *)execenv);
+
+	/* Disable IRQs */
+	ukplat_lcpu_disable_irq();
 
 	/* Restore system context state */
 	ukarch_sysctx_load(&execenv->sysctx);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`ARM`]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

* Add `struct stat` for ARM Architecture
* Enable IRQs before entering a syscall and disable them on exit. Without this, blocking syscalls `yield` with interrupts disabled and the scheduler causes an `UK_CRASH`.


Signed-off-by: Robert Zamfir <georobi.016@gmail.com>

 
