### PR TITLE
drivers/ukbus/pci: Map PCI regions at runtime

### DIFF
--- a/drivers/ukbus/pci/arch/arm64/pci_bus.c
+++ b/drivers/ukbus/pci/arch/arm64/pci_bus.c
@@ -51,6 +51,7 @@
  */
 
 #include <string.h>
+#include <uk/errptr.h>
 #include <uk/print.h>
 #include <uk/plat/common/cpu.h>
 #include <uk/bus/pci.h>
@@ -90,6 +91,15 @@ static int arch_pci_driver_add_device(struct pci_driver *drv,
 	memcpy(&dev->id, devid, sizeof(dev->id));
 	memcpy(&dev->addr, addr,  sizeof(dev->addr));
 	dev->drv = drv;
+
+#if CONFIG_PAGING
+	/* TODO Properly query the BAR size */
+	base = uk_bus_pf_devmap(base, __PAGE_SIZE);
+	if (unlikely(PTRISERR(base))) {
+		uk_pr_err("Could not map device (%d)\n", PTR2ERR(base));
+		return PTR2ERR(base);
+	}
+#endif /* CONFIG_PAGING */
 
 	dev->base = base;
 	dev->irq = irq;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This series updates `uk_bus_pf_devmap()` to handle large MMIO regions of devices like PCI in a performant way, and updates the PCI driver to map MMIO regions on runtime when paging is enabled.