### PR TITLE
Log calls to the `multiboot` and `mkefi` scripts

### DIFF
--- a/plat/common/Makefile.rules
+++ b/plat/common/Makefile.rules
@@ -1,5 +1,5 @@
 define build_multiboot =
-	@$(SCRIPTS_DIR)/multiboot.py $(1)
+	$(call build_cmd,MULTIBT,,$(1).multiboot,$(SCRIPTS_DIR)/multiboot.py $(1))
 endef
 
 BINFO_FLAGS := -a $(CONFIG_UK_ARCH)
@@ -15,7 +15,7 @@ define build_bootinfo =
 endef
 
 define build_efi =
-	@$(SCRIPTS_DIR)/mkefi.py $(1)
+	$(call build_cmd,MKEFI,,$(1).efi,$(SCRIPTS_DIR)/mkefi.py $(1))
 endef
 
 define build_linux =


### PR DESCRIPTION
Use `build_cmd` to log calls to `multiboot.py` as `MULTIBT` and to `mkefi.py` as `MKEFI` instead of completely hiding them. This uses fake `.multiboot` and `.efi` extensions to avoid clashing with the first rule generating the target (ie overwriting its `.cmd` file).
Note this is already done with the `.bin` extension when generating the binary image.

For the context, I ended up writing this commit after spending at least one hour chasing what was missing in a step-by-step build of an image by hand...