### PR TITLE
lib/uklibparam: Refactor parameter registration

### DIFF
--- a/lib/uklibparam/Makefile.uk
+++ b/lib/uklibparam/Makefile.uk
@@ -5,6 +5,4 @@ CINCLUDES-y	+= -I$(LIBUKLIBPARAM_BASE)/include
 CXXINCLUDES-y	+= -I$(LIBUKLIBPARAM_BASE)/include
 
 LIBUKLIBPARAM_SRCS-y += $(LIBUKLIBPARAM_BASE)/parser.c
-
-# Push linker script to each library for making the section available
-EACHOLIB_SRCS-$(CONFIG_LIBUKLIBPARAM) += $(LIBUKLIBPARAM_BASE)/libparam.lds.S|uklibparam
+LIBUKLIBPARAM_SRCS-y += $(LIBUKLIBPARAM_BASE)/libparam.lds.S

--- a/lib/uklibparam/exportsyms.uk
+++ b/lib/uklibparam/exportsyms.uk
@@ -1,2 +1,1 @@
 uk_libparam_parse
-_uk_libparam_libsec_register

--- a/lib/uklibparam/libparam.lds.S
+++ b/lib/uklibparam/libparam.lds.S
@@ -1,12 +1,17 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2024, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+
 #include <uk/libparam.h>
 
 SECTIONS {
 	. = ALIGN(8);
+	PROVIDE(UK_LIBPARAM_PARAMSECTION_STARTSYM = .);
 	.UK_LIBPARAM_PARAMSECTION_NAME : {
-		PROVIDE(UK_LIBPARAM_PARAMSECTION_STARTSYM = .);
-		KEEP(*(.UK_LIBPARAM_PARAMSECTION_NAME))
-		KEEP(*(.UK_LIBPARAM_PARAMSECTION_NAME.*))
-		PROVIDE(UK_LIBPARAM_PARAMSECTION_ENDSYM = .);
+		KEEP(*(SORT_BY_NAME(UK_LIBPARAM_PARAM_NAMEPREFIX*)));
 	}
+	PROVIDE(UK_LIBPARAM_PARAMSECTION_ENDSYM = .);
 }
 INSERT AFTER .rodata


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Remove UK_CTORS registration to allow libukparam parsing to be executed during early init. Parameters now are registerd into a global section similarly to inittab. This additionally fixes a limitation of the previous registration mechanism where all parameters had to be registered from a single file.