### PR TITLE
plat/kvm/arm64: Do not unmask PSTATE.D on IRQ entry

### DIFF
--- a/plat/kvm/arm/exceptions.S
+++ b/plat/kvm/arm/exceptions.S
@@ -270,7 +270,7 @@ el1_sync:
 .align 6
 el1_irq:
 	SAVE_REGS 1
-	msr daifclr, #(8 | 4 | 1)
+	msr daifclr, #4 /* Unmask SError */
 	mov x0, sp
 	bl trap_el1_irq
 	RESTORE_REGS


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Enabling PSTATE.D at IRQ entry results into nested debug exceptions. This is incorrect as the context restored on IRQ exit invalidates any changes to the context made by the debug exception's handler.

Also remove the unmasking of PSTATE.F as at the present we don't deal with FIQs.
