### PR TITLE
plat/xen: Fix implicit conversion on return type

### DIFF
--- a/drivers/xen/net/netfront.c
+++ b/drivers/xen/net/netfront.c
@@ -778,7 +778,7 @@ static void netfront_info_get(struct uk_netdev *n,
 	dev_info->features = UK_NETDEV_F_RXQ_INTR | UK_NETDEV_F_PARTIAL_CSUM;
 }
 
-static const void *netfront_einfo_get(struct uk_netdev *n,
+static const char *netfront_einfo_get(struct uk_netdev *n,
 		enum uk_netdev_einfo_type einfo_type)
 {
 	struct netfront_dev *nfdev;


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `xen`
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Clang throws an error when trying to implicitly convert from `const void*` to `const char *`.

To reproduce/test
```
export COMPILER=clang-18
make
```

