### PR TITLE
lib/ukboot: Declare `main` as a strong symbol rather than a weak one

### DIFF
--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -110,7 +110,7 @@
 extern char **boot_argv;
 extern int boot_argc;
 
-int main(int argc, char *argv[]) __weak;
+int main(int argc, char *argv[]);
 static inline int do_main(int argc, char *argv[]);
 
 #if CONFIG_LIBUKBOOT_MAINTHREAD


### PR DESCRIPTION
When a symbol is _declared_ weak, `ld` (at least GNU `ld`) will set it to `NULL` if the symbol cannot be found in the `.o` files (even if it could find it in a `.a` library). As `do_main` calls `main` inconditionnally (ie without testing whether it is available or not), this commit makes the declaration of the symbol strong, so that the linker fails if no `main` is found.

### Context

I’ve run into this problem while using Unikraft as a new backend for MirageOS. In the standard tooling used in the Solo5 backend for MirageOS and, more broadly, what the OCaml compiler does, a generic `main` is provided by a `.a` library, along with all the rest of the runtime. To keep that workflow, I’ve had to make the declaration of `main` strong as provided by this commit and to blacklist `ukboot_main` (as the linker will choose a weak `main` from a `.o` file over a strong `main` from a `.a` file).