### PR TITLE
include/uk/arch: Add kernel `__bool` type

### DIFF
--- a/include/uk/arch/types.h
+++ b/include/uk/arch/types.h
@@ -257,6 +257,10 @@ typedef struct {
 	__u32 counter;
 } __atomic;
 
+typedef _Bool __bool;
+#define __true (1)
+#define __false (0)
+
 #else /* __ASSEMBLY__ */
 
 #if (defined __C_IS_8)


### PR DESCRIPTION
This commits adds a kernel-internal `__bool` type to express booleans. Using `__bool` instead of, say, `int` is a good way to document APIs in code. 

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;


### Base target

 - Architecture(s):  N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
