### PR TITLE
drivers/xen/console: Update nolibc dependency

### DIFF
--- a/drivers/xen/console/Config.uk
+++ b/drivers/xen/console/Config.uk
@@ -1,7 +1,7 @@
 menuconfig LIBXEN_CONSOLE
 	bool "Hypervisor console"
 	select LIBUKCONSOLE
-	select LIBNOLIBC
+	select LIBNOLIBC if !HAVE_LIBC
 	depends on PLAT_XEN
 	help
 		Driver for the Xen hypervisor console


### PR DESCRIPTION
Xen console dependency on nolibc in `Config.uk` (`select LIBNOLIBC`) causes conflict with the `plat/xen/Config.uk` configuration (`select LIBNOLIBC if !HAVE_LIBC`) when a libc (such as Musl) is used.

The dependency must consider both using nolibc and using a libc (such as Musl). Update dependency to select nolibc only when a libc is absent.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [`xen`]
 - Application(s): [`app-nginx`]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Update configuration causing dependency issue in `Config.uk`: `select LIBNOLIBC if !HAVE_LIBC`.