### PR TITLE
plat/xen: Fix Arm setup to work with new Xen console

### DIFF
--- a/plat/xen/arm/setup64.c
+++ b/plat/xen/arm/setup64.c
@@ -339,9 +339,6 @@ void _libxenplat_armentry(void *dtb_pointer, paddr_t physical_offset)
 	/* Set up events. */
 	init_events();
 
-	/* Do early init */
-	uk_boot_early_init(bi);
-
 	/* Initialize logical boot CPU */
 	r = lcpu_init(lcpu_get_bsp());
 	if (unlikely(r))
@@ -358,9 +355,8 @@ void _libxenplat_armentry(void *dtb_pointer, paddr_t physical_offset)
 	get_console();
 	get_xenbus();
 
-	prepare_console();
-	/* Init console */
-	init_console();
+	/* Do early init */
+	uk_boot_early_init(bi);
 
 	uk_boot_entry();
 }


### PR DESCRIPTION
This fixes a regression introduced in the `ukconsole` changes. The recent updates to the Xen console drivers removed the `prepare_console()` and `init_console()` functions in favor of calling the same code through the early init tab.

Fixes: #1506 

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms; (Only checked if it builds)
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`
 - Platform(s): `xen`
 - Application(s): N/A