### PR TITLE
include/uk/arch: Define bool types for cpp compilers

### DIFF
--- a/include/uk/arch/types.h
+++ b/include/uk/arch/types.h
@@ -257,9 +257,15 @@ typedef struct {
 	__u32 counter;
 } __atomic;
 
+#ifdef __cplusplus
+typedef bool __bool;
+#define __true (true)
+#define __false (false)
+#else
 typedef _Bool __bool;
 #define __true (1)
 #define __false (0)
+#endif /* __cplusplus */
 
 #else /* __ASSEMBLY__ */
 


### PR DESCRIPTION
If compiling using a cpp compiler, define `_Bool`, as it is a C built-in type and cpp compilers do not recognize it. Also, depending on the cpp version, define `bool`, `true` and `false` if needed.

The logic is copied from `stdbool.h`.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Application(s): `app-helloworld-cpp`
