### PR TITLE
drivers/xen: Select XEN_GNTTAB as dependency when used

### DIFF
--- a/drivers/xen/net/Config.uk
+++ b/drivers/xen/net/Config.uk
@@ -1,6 +1,7 @@
 config LIBXEN_NETFRONT
 	bool "Xenbus Netfront Driver"
 	select LIBXEN_XENBUS
+	depends on XEN_GNTTAB
 	depends on PLAT_XEN
 	depends on LIBUKNETDEV
 	help

--- a/plat/xen/Config.uk
+++ b/plat/xen/Config.uk
@@ -44,7 +44,7 @@ config XEN_PV_BUILD_P2M
 
 config XEN_GNTTAB
 	bool "Grant table support"
-	default y if XEN_PV
+	default y if (XEN_PV || ARCH_ARM_64)
 	depends on (ARCH_X86_64 || ARCH_ARM_64)
 	select LIBXEN_XENBUS
 	select LIBUKALLOC


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`
 - Platform(s): `xen`
 - Application(s): `c-http` / see issue

### Description of changes

Select `XEN_GNTTAB` for each driver that uses it and remove the default `y` for `x86_64`.
Now grant tables will be selected by the drivers or by the user if there is any need for them in the app itself.

GitHub-Fixes: #1511 
