### PR TITLE
plat/xen: Fix implicit int cast build error

### DIFF
--- a/plat/xen/arm/setup64.c
+++ b/plat/xen/arm/setup64.c
@@ -173,7 +173,7 @@ static inline void _get_cmdline(struct ukplat_bootinfo *bi)
 
 	UK_ASSERT(bi);
 
-	bi->cmdline = CONFIG_UK_NAME;
+	bi->cmdline = (__uptr)CONFIG_UK_NAME;
 	bi->cmdline_len = sizeof(CONFIG_UK_NAME) - 1;
 
 	fdtchosen = fdt_path_offset(HYPERVISOR_dtb, "/chosen");
@@ -181,7 +181,7 @@ static inline void _get_cmdline(struct ukplat_bootinfo *bi)
 		fdtcmdline = fdt_getprop(HYPERVISOR_dtb, fdtchosen, "bootargs",
 					 &len);
 		if (fdtcmdline) {
-			bi->cmdline = fdtcmdline;
+			bi->cmdline = (__uptr)fdtcmdline;
 			bi->cmdline_len = len;
 		}
 	}


### PR DESCRIPTION
Building xen on arm64 with Clang would fail due to an implicit cast from char * to __uptr.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `arm64`
 - Platform(s): `xen`
 - Application(s): [e.g. `app-python3` or N/A]

### Description of changes

Builds on `xen/arm64` using `clang` would fail due to an implicit cast. This PR makes the cast explicit.