### PR TITLE
plat/xen: Use -lgcc for Xen ARM64 builds with fp emulation

### DIFF
--- a/plat/kvm/Linker.uk
+++ b/plat/kvm/Linker.uk
@@ -16,11 +16,11 @@ endif
 ifeq ($(CONFIG_KVM_BOOT_PROTO_EFI_STUB),y)
 KVM_LDFLAGS-y += -Wl,--entry=uk_efi_entry64
 KVM_LDFLAGS-y += -Wl,-m,aarch64elf
-KVM_LINK_LIBGCC_FLAG := -lgcc
+KVM_LDLIBS-y += -lgcc
 else
 KVM_LDFLAGS-y += -Wl,--entry=_libkvmplat_entry
 KVM_LDFLAGS-y += -Wl,-m,aarch64elf
-KVM_LINK_LIBGCC_FLAG := -lgcc
+KVM_LDLIBS-y += -lgcc
 endif
 endif
 
@@ -59,8 +59,8 @@ $(KVM_DEBUG_IMAGE): $(KVM_ALIBS) $(KVM_ALIBS-y) $(KVM_OLIBS) $(KVM_OLIBS-y) \
 			-Wl$(comma)--start-group \
 			$(KVM_ALIBS) $(KVM_ALIBS-y) \
 			$(UK_ALIBS) $(UK_ALIBS-y) \
-			$(KVM_LINK_LIBGCC_FLAG) \
 			-Wl$(comma)--end-group \
+			$(KVM_LDLIBS) $(KVM_LDLIBS-y) \
 			$(LDFLAGS) $(LDFLAGS-y) \
 			$(KVM_LD_SCRIPT_FLAGS) \
 			-o $@)

--- a/plat/xen/Linker.uk
+++ b/plat/xen/Linker.uk
@@ -1,5 +1,7 @@
 ifeq (x86_64,$(CONFIG_UK_ARCH))
 XEN_LDFLAGS-y += -Wl,-m,elf_x86_64
+else ifeq (arm64,$(CONFIG_UK_ARCH))
+XEN_LINK_LIBGCC_FLAG := -lgcc
 endif
 
 ##
@@ -37,6 +39,7 @@ $(XEN_DEBUG_IMAGE): $(XEN_ALIBS) $(XEN_ALIBS-y) $(XEN_OLIBS) $(XEN_OLIBS-y) \
 			-Wl$(comma)--start-group \
 			$(XEN_ALIBS) $(XEN_ALIBS-y) \
 			$(UK_ALIBS) $(UK_ALIBS-y) \
+			$(XEN_LINK_LIBGCC_FLAG) \
 			-Wl$(comma)--end-group \
 			-o $(XEN_IMAGE).ld.o)
 	$(call build_cmd,OBJCOPY,,$(XEN_IMAGE).o,\

--- a/plat/xen/Linker.uk
+++ b/plat/xen/Linker.uk
@@ -1,7 +1,8 @@
 ifeq (x86_64,$(CONFIG_UK_ARCH))
 XEN_LDFLAGS-y += -Wl,-m,elf_x86_64
 else ifeq (arm64,$(CONFIG_UK_ARCH))
-XEN_LINK_LIBGCC_FLAG := -lgcc
+XEN_LDFLAGS-y += -Wl,-m,aarch64elf
+XEN_LDLIBS-y += -lgcc
 endif
 
 ##
@@ -39,8 +40,8 @@ $(XEN_DEBUG_IMAGE): $(XEN_ALIBS) $(XEN_ALIBS-y) $(XEN_OLIBS) $(XEN_OLIBS-y) \
 			-Wl$(comma)--start-group \
 			$(XEN_ALIBS) $(XEN_ALIBS-y) \
 			$(UK_ALIBS) $(UK_ALIBS-y) \
-			$(XEN_LINK_LIBGCC_FLAG) \
 			-Wl$(comma)--end-group \
+			$(XEN_LDLIBS) $(XEN_LDLIBS-y) \
 			-o $(XEN_IMAGE).ld.o)
 	$(call build_cmd,OBJCOPY,,$(XEN_IMAGE).o,\
 		$(OBJCOPY) -w -G xenos_* -G _libxenplat_zimageboot \


### PR DESCRIPTION
Define `XEN_LINK_LIBGCC_FLAG` to link with `-lgcc`. This is required for routines for floating point emulation.

GitHub-Fixes: #1524

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [`arm64`]
 - Platform(s): [`xen`]
 - Application(s): [`nginx`]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
