### PR TITLE
lib/uklibparam: Namespace symbols to avoid conflicts

### DIFF
--- a/lib/uklibparam/include/uk/libparam.h
+++ b/lib/uklibparam/include/uk/libparam.h
@@ -66,8 +66,16 @@ extern C {
  * A library parameter descriptor (struct uk_libparam_desc) is referencing to
  * the section's base address for iteration.
  */
-#define UK_LIBPARAM_PARAM_NAMEPREFIX          __uk_libparam_param_
-#define UK_LIBPARAM_PDATA_NAMEPREFIX          __uk_libparam_pdata_
+#define _UK_LIBPARAM_PARAM_NAMEPREFIX	    __uk_libparam_param_
+#define UK_LIBPARAM_PARAM_NAMEPREFIX					    \
+	UK_LIBPARAM_CONCAT(UK_LIBPARAM_CONCAT(_UK_LIBPARAM_PARAM_NAMEPREFIX,\
+					      UK_LIBPARAM_LIBPREFIX), _)
+
+#define _UK_LIBPARAM_PDATA_NAMEPREFIX					    \
+	__uk_libparam_pdata_
+#define UK_LIBPARAM_PDATA_NAMEPREFIX					    \
+	UK_LIBPARAM_CONCAT(UK_LIBPARAM_CONCAT(_UK_LIBPARAM_PDATA_NAMEPREFIX,\
+					      UK_LIBPARAM_LIBPREFIX), _)
 
 #define UK_LIBPARAM_PARAMSECTION_NAME       uk_libparam_params
 #define UK_LIBPARAM_PARAMSECTION_STARTSYM   \


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Namespace the `__uk_libparam_param` and `__uk_libparam_pdata` symbols exported by each library to avoid conflicts when two libraries export a parameter with the same name.
