### PR TITLE
lib/vfscore: Fix build warning

### DIFF
--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -632,7 +632,7 @@ static int vfscore_ukopt_mkmp(char *path)
  */
 static inline int vfscore_mount_volume(const struct vfscore_volume *vv)
 {
-	const char *path;
+	char *path;
 	int rc;
 
 	UK_ASSERT(vv);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes
Cast path variable to `(char *)` to resolve compiler warnings related to `const` qualifier discard.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
