### PR TITLE
lib/vfscore: Fix build warning for argument declaration

### DIFF
--- a/lib/nolibc/musl-imported/include/sys/time.h
+++ b/lib/nolibc/musl-imported/include/sys/time.h
@@ -24,16 +24,16 @@ struct itimerval {
 
 int getitimer (int, struct itimerval *);
 int setitimer (int, const struct itimerval *__restrict, struct itimerval *__restrict);
-int utimes (const char *, const struct timeval *);
+int utimes (const char *, const struct timeval times[2]);
 
 #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
 struct timezone {
 	int tz_minuteswest;
 	int tz_dsttime;
 };
-int futimes(int, const struct timeval *);
-int futimesat(int, const char *, const struct timeval *);
-int lutimes(const char *, const struct timeval *);
+int futimes(int, const struct timeval times[2]);
+int futimesat(int, const char *, const struct timeval times[2]);
+int lutimes(const char *, const struct timeval times[2]);
 int settimeofday(const struct timeval *, const struct timezone *);
 int adjtime (const struct timeval *, struct timeval *);
 #define timerisset(t) ((t)->tv_sec || (t)->tv_usec)

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -2266,7 +2266,7 @@ UK_TRACEPOINT(trace_vfs_utimes, "\"%s\"", const char*);
 UK_TRACEPOINT(trace_vfs_utimes_ret, "");
 UK_TRACEPOINT(trace_vfs_utimes_err, "%d", int);
 
-int futimes(int fd, const struct timeval *times)
+int futimes(int fd, const struct timeval times[2])
 {
     return futimesat(fd, NULL, times);
 }
@@ -2404,7 +2404,7 @@ UK_SYSCALL_R_DEFINE(int, utimes, const char*, pathname,
 	return do_utimes(pathname, times, 0);
 }
 
-int lutimes(const char *pathname, const struct timeval *times)
+int lutimes(const char *pathname, const struct timeval times[2])
 {
 	return do_utimes(pathname, times, AT_SYMLINK_NOFOLLOW);
 }

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1326,7 +1326,7 @@ static void convert_timeval(struct timespec *to, const struct timeval *from)
 }
 
 int
-sys_utimes(char *path, const struct timeval *times, int flags)
+sys_utimes(char *path, const struct timeval times[2], int flags)
 {
 	int error;
 	struct dentry *dp;

--- a/lib/vfscore/vfs.h
+++ b/lib/vfscore/vfs.h
@@ -477,7 +477,7 @@ int sys_readlink(char *path, char *buf, size_t bufsize, ssize_t *size);
  *	- (0):  Completed successfully
  *	- (<0): Negative value with error code
  */
-int sys_utimes(char *path, const struct timeval *times, int flags);
+int sys_utimes(char *path, const struct timeval times[2], int flags);
 
 /**
  * Changes last access and modification times with nanoseconds


### PR DESCRIPTION
Resolve a build warning in the `vfscore` library caused by the declaration of argument 2 as a `const struct timeval *` pointer. This change ensures compatibility with the expected parameter type.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes
Changed `const struct timeval *times` parameter to `const struct timeval times[2]` in the `futimes` and `lutimes` functions to resolve the argument declaration warning.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
