### PR TITLE
arch/arm64: Fix compile error for MTE

### DIFF
--- a/arch/arm/arm64/memtag.c
+++ b/arch/arm/arm64/memtag.c
@@ -28,7 +28,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#include <uk/config.h>
+#if CONFIG_LIBNOLIBC
 #include <assert.h>
+#else
+#include <uk/assert.h>
+#endif
 #include <errno.h>
 #include <stddef.h>
 #include <uk/arch/memtag.h>


### PR DESCRIPTION
Fix compile error of MTE when enable CONFIG_LIBMUSL

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [ARM64]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->
N/A

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
N/A
