### PR TITLE
lib/posix-pipe: Fix ref leak on pipe creation

### DIFF
--- a/lib/posix-pipe/pipe.c
+++ b/lib/posix-pipe/pipe.c
@@ -433,6 +433,8 @@ int uk_sys_pipe(int pipefd[2], int flags)
 	if (unlikely(r < 0))
 		goto err_close;
 
+	uk_file_release(pipes[0]);
+	uk_file_release(pipes[1]);
 	pipefd[0] = rpipe;
 	pipefd[1] = r;
 	return  0;


### PR DESCRIPTION
### Description of changes

Previously uk_sys_pipe would return pipe files with one too many references counted, leading to pipes never closing and leaking memory. This change corrects this oversight by releasing the raw pipe files after they have been entered into the fdtab.

In brief:
- new files get created with a refcount of 1 -- necessary to ensure destructors _always_ run
- creating a new open file description takes a ref on the file -- this is normal
- `uk_sys_pipe` forgot to release the raw reference

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]

### Additional configuration

N/A
