### PR TITLE
lib/ukrandom: Improve boot and diagnostic messages

### DIFF
--- a/drivers/ukrandom/lcpu/arch/arm64/random.c
+++ b/drivers/ukrandom/lcpu/arch/arm64/random.c
@@ -120,7 +120,7 @@ struct uk_random_driver_ops *device_init(void)
 
 	rndr = (isar >> ID_AA64ISAR0_EL1_RNDR_SHIFT) & ID_AA64ISAR0_EL1_RNDR_MASK;
 	if (unlikely(!rndr)) {
-		uk_pr_err("FEAT_RNG not available on this CPU\n");
+		uk_pr_debug("FEAT_RNG not available on this CPU\n");
 		return ERR2PTR(-ENOTSUP);
 	}
 

--- a/drivers/ukrandom/lcpu/arch/x86_64/random.c
+++ b/drivers/ukrandom/lcpu/arch/x86_64/random.c
@@ -135,7 +135,7 @@ struct uk_random_driver_ops *device_init(void)
 
 	ukarch_x86_cpuid(1, 0, &eax, &ebx, &ecx, &edx);
 	if (unlikely(!(ecx & X86_CPUID1_ECX_RDRAND))) {
-		uk_pr_err("RDRAND not available on this CPU\n");
+		uk_pr_debug("RDRAND not available on this CPU\n");
 		return ERR2PTR(-ENOTSUP);
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Since initialization of `libukrandom` is driver-centric, drivers that fail to probe can't know if the library can be initialize by another driver. Because of that, issuing an error message may be misleading. Demote the severity of probe error messages to `debug`, to prevent the misinterpretation of error messages when another source of entropy is  used.

Have `libukrandom` print an info message about the CSPRNG's seed source.
    
Add debug messages for improved diagnostics on cmdline and dtb init, as well as when drivers are ignored if libukrandom has been initialized already.
    
Add a warning when seeding via the cmdline and dtb to make sure that the user is aware that these are potentially insecure methods.

## Examples

In the examples below notice the severity of each message.

### The seed is set at the cmdline
```
Booting from ROM..[    0.000000] Info: [libukconsole] <console.c @  176> Registered con0: COM1, flags: IO
[    0.000000] Info: [libukconsole] <console.c @  176> Registered con1: VGA, flags: -O
[    0.000000] Warn: [libukrandom] <chacha.c @  226> Passing the seed via the cmdline is potentially insecure
[    0.000000] Info: [libukrandom] <chacha.c @  227> Initializing the random number generator...
[    0.000000] Info: [libukrandom] <random.c @  117> CSPRNG seed source: cmdline
[    0.000000] dbg:  [libukrandom] <random.c @   87> CSPRNG already initialized, ignoring driver CPU
```

### The seed is set by the CPU driver
```
Booting from ROM..[    0.000000] Info: [libukconsole] <console.c @  176> Registered con0: COM1, flags: IO
[    0.000000] Info: [libukconsole] <console.c @  176> Registered con1: VGA, flags: -O
[    0.000000] dbg:  [libukrandom] <chacha.c @  222> Seed not set in the cmdline
[    0.000000] Info: [libukrandom] <chacha.c @  246> Initializing the random number generator...
[    0.000000] Info: [libukrandom] <random.c @   96> CSPRNG seed source: CPU
```