### PR TITLE
lib/vfscore: Fix missing syscall declaration

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -1695,6 +1695,9 @@ UK_SYSCALL_R_DEFINE(int, lstat, const char*, pathname, struct stat*, st)
 	return __lxstat_helper(1, pathname, st);
 }
 
+/* The fstat syscall is no longer implemented here; need to declare */
+long uk_syscall_r_fstat(long dirfd, long st);
+
 static int __fxstatat_helper(int ver __unused, int dirfd, const char *pathname,
 		struct stat *st, int flags)
 {


### PR DESCRIPTION
### Description of changes

This change adds a declaration for `uk_syscall_r_fstat` as this syscall is no longer implemented in vfscore and thus no longer implicitly declared, previously causing a build warning.
GCC 14 and Clang no longer accept implicitly declared functions and will error out in such situations.

Fixes https://github.com/unikraft/unikraft/issues/1555.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A
