### PR TITLE
lib/syscall_shim: Fix C++ build error with Clang

### DIFF
--- a/lib/syscall_shim/arch/arm64/include/arch/syscall_prologue.h
+++ b/lib/syscall_shim/arch/arm64/include/arch/syscall_prologue.h
@@ -60,19 +60,19 @@
 		"/* Use `struct lcpu` pointer from TPIDR_EL1 */\n\t"	\
 		"mrs	x0, tpidr_el1\n\t"				\
 		" /* Switch to per-CPU auxiliary stack */\n\t"		\
-		"ldr	x0, [x0, #"STRINGIFY(LCPU_AUXSP_OFFSET)"]\n\t"	\
-		"sub	x0, x0, #"STRINGIFY(UKARCH_AUXSPCB_SIZE)"\n\t"	\
+		"ldr	x0, [x0, #" STRINGIFY(LCPU_AUXSP_OFFSET) "]\n\t"\
+		"sub	x0, x0, #" STRINGIFY(UKARCH_AUXSPCB_SIZE) "\n\t"\
 		"ldr	x0, [x0, #"					\
-			STRINGIFY(UKARCH_AUXSPCB_OFFSETOF_CURR_FP)"]\n\t"\
+			STRINGIFY(UKARCH_AUXSPCB_OFFSETOF_CURR_FP) "]\n\t"\
 		"/* Auxiliary stack is already ECTX aligned */\n\t"	\
 		"/* Make room for `struct ukarch_execenv` */\n\t"	\
-		"sub	x0, x0, #"STRINGIFY(UKARCH_EXECENV_SIZE)"\n\t"	\
+		"sub	x0, x0, #" STRINGIFY(UKARCH_EXECENV_SIZE) "\n\t"\
 		"/* Swap x0 and (old) sp */\n\t"			\
 		"add	sp, sp, x0\n\t"					\
 		"sub	x0, sp, x0\n\t"					\
 		"sub	sp, sp, x0\n\t"					\
 		"/* Now store old sp w.r.t. `struct __regs` */\n\t"	\
-		"str	x0, [sp, #"STRINGIFY(__SP_OFFSET)"]\n\t"	\
+		"str	x0, [sp, #" STRINGIFY(__SP_OFFSET) "]\n\t"	\
 		"/* Restore x0 from scratch register TPIDRRO_EL0 */\n\t"\
 		"mrs	x0, tpidrro_el0\n\t"				\
 		"/* Now just store the rest of `struct __regs` */\n\t"	\
@@ -104,27 +104,27 @@
 		" * following a SVC.\n\t"				\
 		" */\n\t"						\
 		"mov	x22, #"						\
-			STRINGIFY(UK_SYSCALL_PROLOGUE_SPSR_EL1_SVC64_DEFAULT_VALUE)"\n\t"\
+			STRINGIFY(UK_SYSCALL_PROLOGUE_SPSR_EL1_SVC64_DEFAULT_VALUE) "\n\t"\
 		"/* Same for esr_el1, make it look like a SVC\n\t"	\
 		" * happened.\n\t"					\
 		" */\n\t"						\
 		"mov	x23, xzr\n\t"					\
-		"add	x23, x23, #"STRINGIFY(ESR_EL1_EC_SVC64)"\n\t"	\
-		"orr	x23, xzr, x23, lsl #"STRINGIFY(ESR_EC_SHIFT)"\n\t"\
-		"orr	x23, x23, #"STRINGIFY(ESR_IL)"\n\t"		\
+		"add	x23, x23, #" STRINGIFY(ESR_EL1_EC_SVC64) "\n\t"	\
+		"orr	x23, xzr, x23, lsl #" STRINGIFY(ESR_EC_SHIFT) "\n\t"\
+		"orr	x23, x23, #" STRINGIFY(ESR_IL) "\n\t"		\
 		"stp	x22, x23, [sp, #16 * 16]\n\t"			\
 		"/* ECTX at slot w.r.t. `struct ukarch_execenv` */\n\t"	\
 		"mov	x0, sp\n\t"					\
-		"add	x0, x0, #("STRINGIFY(__REGS_SIZEOF +		\
-				     UKARCH_SYSCTX_SIZE)")\n\t"		\
+		"add	x0, x0, #(" STRINGIFY(__REGS_SIZEOF +		\
+				     UKARCH_SYSCTX_SIZE) ")\n\t"	\
 		"bl	ukarch_ectx_store\n\t"				\
 		"/* SYSCTX at slot w.r.t. `struct ukarch_execenv` */\n\t"\
 		"mov	x0, sp\n\t"					\
-		"add	x0, x0, #"STRINGIFY(__REGS_SIZEOF)"\n\t"	\
+		"add	x0, x0, #" STRINGIFY(__REGS_SIZEOF) "\n\t"	\
 		"bl	ukarch_sysctx_store\n\t"			\
 		"mov	x0, sp\n\t"					\
 		"msr	daifclr, #2\n\t"				\
-		"bl	"STRINGIFY(fname)"\n\t"				\
+		"bl	" STRINGIFY(fname) "\n\t"			\
 		"/* Only restore callee preserved regs (ABI) */\n\t"	\
 		"ldr	x30, [sp, #16 * 15]\n\t"			\
 		"ldp	x28, x29, [sp, #16 * 14]\t\n"			\
@@ -134,7 +134,7 @@
 		"ldp	x20, x21, [sp, #16 * 10]\t\n"			\
 		"ldp	x18, x19, [sp, #16 * 9]\t\n"			\
 		"/* Restore rsp from where it was stored */\n\t"	\
-		"ldr	x9, [sp, #"STRINGIFY(__SP_OFFSET)"]\n\t"	\
+		"ldr	x9, [sp, #" STRINGIFY(__SP_OFFSET) "]\n\t"	\
 		"mov	sp, x9\n\t"					\
 		"ret\n\t"						\
 		::							\

--- a/lib/syscall_shim/arch/x86_64/include/arch/syscall_prologue.h
+++ b/lib/syscall_shim/arch/x86_64/include/arch/syscall_prologue.h
@@ -32,11 +32,11 @@
 		"/* Switch to the per-CPU auxiliary stack */\n\t"	\
 		"/* AMD64 SysV ABI: r11 is scratch register */\n\t"	\
 		"movq   %%rsp, %%r11\n\t"				\
-		"movq	%%gs:("STRINGIFY(LCPU_AUXSP_OFFSET)"), %%rsp\n\t"\
+		"movq	%%gs:(" STRINGIFY(LCPU_AUXSP_OFFSET) "), %%rsp\n\t"\
 		"/* Auxiliary stack is already ECTX aligned */\n\t"	\
 		"/* Make room for `struct UKARCH_EXECENV` */\n\t"	\
-		"subq	$("STRINGIFY(UKARCH_EXECENV_SIZE -		\
-				     __REGS_SIZEOF)"), %%rsp\n\t"	\
+		"subq	$(" STRINGIFY(UKARCH_EXECENV_SIZE -		\
+				     __REGS_SIZEOF)" ), %%rsp\n\t"	\
 		"/* Now build stack frame beginning with 5 pointers\n\t"\
 		" * in the classical iretq/`struct __regs` format\n\t"	\
 		" */\n\t"						\
@@ -56,7 +56,7 @@
 		" * manually set the flag.\n\t"				\
 		" */\n\t"						\
 		"pushfq\n\t"						\
-		"orq	$("STRINGIFY(X86_EFLAGS_IF)"), 0(%%rsp)\n\t"	\
+		"orq	$(" STRINGIFY(X86_EFLAGS_IF) "), 0(%%rsp)\n\t"	\
 		"/* Push code segment, GDT code segment selector:\n\t"	\
 		" * [15: 3]: Selector Index - first GDT entry\n\t"	\
 		" * [ 2: 2]: Table Indicator - GDT, table 0\n\t"	\
@@ -87,20 +87,20 @@
 		"pushq	%%r13\n\t"					\
 		"pushq	%%r14\n\t"					\
 		"pushq	%%r15\n\t"					\
-		"subq	$("STRINGIFY(__REGS_PAD_SIZE)"), %%rsp\n\t"	\
-		"/* ECTX at slot w.r.t. `struct UKARCH_EXECENV` */\n\t"\
+		"subq	$(" STRINGIFY(__REGS_PAD_SIZE) "), %%rsp\n\t"	\
+		"/* ECTX at slot w.r.t. `struct UKARCH_EXECENV` */\n\t" \
 		"movq	%%rsp, %%rdi\n\t"				\
-		"addq	$("STRINGIFY(__REGS_SIZEOF +			\
-				     UKARCH_SYSCTX_SIZE)"), %%rdi\n\t"	\
+		"addq	$(" STRINGIFY(__REGS_SIZEOF +			\
+				     UKARCH_SYSCTX_SIZE) "), %%rdi\n\t"	\
 		"call	ukarch_ectx_store\n\t"				\
 		"/* SYSCTX at slot w.r.t. `struct UKARCH_EXECENV` */\n\t"\
 		"movq	%%rsp, %%rdi\n\t"				\
-		"addq	$("STRINGIFY(__REGS_SIZEOF)"), %%rdi\n\t"	\
+		"addq	$(" STRINGIFY(__REGS_SIZEOF) "), %%rdi\n\t"	\
 		"call	ukarch_sysctx_store\n\t"			\
 		"movq	%%rsp, %%rdi\n\t"				\
 		"sti\n\t"						\
-		"call	"STRINGIFY(fname)"\n\t"				\
-		"addq	$("STRINGIFY(__REGS_PAD_SIZE)"), %%rsp\n\t"	\
+		"call	" STRINGIFY(fname) "\n\t"			\
+		"addq	$(" STRINGIFY(__REGS_PAD_SIZE) "), %%rsp\n\t"	\
 		"/* Only restore callee preserved regs (ABI) */\n\t"	\
 		"popq	%%r15\n\t"					\
 		"popq	%%r14\n\t"					\


### PR DESCRIPTION
Clang (18) requires a space between identifier and literals for preprocessor string concatenation. Otherwise, it results in build error. The error shown is: "C++11 requires a space between literal and identifier".

Add required spaces to fix the build error.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s): all
 - Platform(s): kvm
 - Application(s): C++ applications


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
