### PR TITLE
lib/syscall-shim: Do not dereference optional clone() parameters

### DIFF
--- a/lib/syscall_shim/uk_prsyscall.c
+++ b/lib/syscall_shim/uk_prsyscall.c
@@ -1220,21 +1220,39 @@ static void pr_syscall(struct uk_streambuf *sb, int fmtf,
 
 #ifdef HAVE_uk_syscall_clone
 	case SYS_clone:
+		do {
+			unsigned long pt_tid_parent_ref;
+			unsigned long pt_tid_child_ref;
+			unsigned long flags;
+
+			flags = (unsigned long)va_arg(args, long);
+
+			if (flags & CLONE_PARENT_SETTID)
+				pt_tid_parent_ref = PT_VADDR | PT_REF;
+			else
+				pt_tid_parent_ref = PT_VADDR;
+
+			if (flags & CLONE_CHILD_SETTID)
+				pt_tid_child_ref = PT_VADDR | PT_REF;
+			else
+				pt_tid_child_ref = PT_VADDR;
+
 #if CONFIG_ARCH_X86_64
-		VPR_SYSCALL(sb, fmtf, syscall_num, args, rc >= 0,
-			    PT_CLONEFLAGS,
-			    PT_VADDR, /* sp */
-			    PT_TID | PT_REF, /* ref to parent tid */
-			    PT_TID | PT_REF, /* ref to child tid */
-			    PT_VADDR /* tlsp */);
+			VPR_SYSCALL(sb, fmtf, syscall_num, args, rc >= 0,
+				    PT_CLONEFLAGS,
+				    PT_VADDR, /* sp */
+				    pt_tid_parent_ref, /* ref to parent tid */
+				    pt_tid_child_ref,  /* ref to child tid */
+				    PT_VADDR /* tlsp */);
 #else /* !CONFIG_ARCH_X86_64 */
-		VPR_SYSCALL(sb, fmtf, syscall_num, args, rc >= 0,
-			    PT_CLONEFLAGS,
-			    PT_VADDR, /* sp */
-			    PT_TID | PT_REF, /* ref to parent tid */
-			    PT_VADDR, /* tlsp */
-			    PT_TID | PT_REF /* ref to child tid */);
+			VPR_SYSCALL(sb, fmtf, syscall_num, args, rc >= 0,
+				    PT_CLONEFLAGS,
+				    PT_VADDR, /* sp */
+				    pt_tid_parent_ref, /* ref to parent tid */
+				    PT_VADDR, /* tlsp */
+				    pt_tid_child_ref); /* ref to child tid */
 #endif /* !CONFIG_ARCH_X86_64 */
+		} while (0);
 		PR_SYSRET(sb, fmtf, PT_TID, rc);
 		break;
 #endif /* HAVE_uk_syscall_clone */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]

### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The `parent_tid` parameter of `clone()` is used to instruct the kernel where to store the child TID in parent's memory. Similarly, the `child_tid` is used to instruct the kernel where to store the child TID in the child's memory. Both parameters are optional, and are interpreted conditionally to whether the CLONE_CHILD_SETTID and CLONE_PARENT_SETTID flags are set, respectively.
    
Do not interpret these options as PT_REF, as the pointer will not be valid if the caller does not set corresponding flags.
