### PR TITLE
lib/posix-timerfd: Validate settime argument

### DIFF
--- a/lib/posix-timerfd/timerfd.c
+++ b/lib/posix-timerfd/timerfd.c
@@ -306,6 +306,18 @@ int uk_sys_timerfd_create(clockid_t id, int flags)
 
 #endif /* CONFIG_LIBPOSIX_FDTAB */
 
+/**
+ * Return non-zero if `val` contains either negative or non-canonical times.
+ */
+static inline
+int timerfd_check_settime(const struct itimerspec *val)
+{
+	return !uk_time_spec_canonical(&val->it_value) ||
+	       !uk_time_spec_canonical(&val->it_interval) ||
+	       !uk_time_spec_positive(&val->it_value) ||
+	       !uk_time_spec_positive(&val->it_interval);
+}
+
 int uk_sys_timerfd_settime(const struct uk_file *f, int flags,
 			   const struct itimerspec *new_value,
 			   struct itimerspec *old_value)
@@ -319,6 +331,8 @@ int uk_sys_timerfd_settime(const struct uk_file *f, int flags,
 	if (unlikely(flags & ~TFD_TIMER_ABSTIME))
 		return -EINVAL;
 	if (unlikely(f->vol != TIMERFD_VOLID))
+		return -EINVAL;
+	if (unlikely(timerfd_check_settime(new_value)))
 		return -EINVAL;
 
 	d = f->node;

--- a/lib/uktimeconv/include/uk/timeutil.h
+++ b/lib/uktimeconv/include/uk/timeutil.h
@@ -39,6 +39,24 @@
 	.tv_usec = ukarch_time_nsec_to_usec((ts)->tv_nsec) \
 })
 
+/**
+ * Return non-zero if `t` is canonical (nanoseconds in [0, 999999999] range).
+ */
+static inline
+int uk_time_spec_canonical(const struct timespec *t)
+{
+	return t->tv_nsec >= 0 && t->tv_nsec < 1000000000;
+}
+
+/**
+ * Return non-zero if canonical `t` represents zero or positive time.
+ */
+static inline
+int uk_time_spec_positive(const struct timespec *t)
+{
+	return t->tv_sec >= 0;
+}
+
 static inline
 __snsec uk_time_spec_nsecdiff(const struct timespec *t1,
 			      const struct timespec *t2)


### PR DESCRIPTION
### Description of changes

This change adds a validation check on the `new_value` argument to settime(), refusing to work with negative times and non-canonical timespec values.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A
