### PR TITLE
lib/posix-timerfd: Fix counter on subsequent reads

### DIFF
--- a/lib/posix-timerfd/timerfd.c
+++ b/lib/posix-timerfd/timerfd.c
@@ -27,6 +27,7 @@ static const char TIMERFD_VOLID[] = "timerfd_vol";
 struct timerfd_node {
 	struct itimerspec set;
 	__u64 val;
+	__u64 total;
 	clockid_t clkid;
 	struct uk_thread *upthread;
 };
@@ -97,12 +98,11 @@ static __nsec _timerfd_update(const struct uk_file *f)
 	deadline = now + st.next;
 
 	/* Update val & events */
-	if (st.exp != d->val) {
-		d->val = st.exp;
-		if (st.exp)
-			uk_file_event_set(f, UKFD_POLLIN);
-		else
-			uk_file_event_clear(f, UKFD_POLLIN);
+	UK_ASSERT(st.exp >= d->total);
+	if (st.exp > d->total) {
+		d->val += st.exp - d->total;
+		d->total = st.exp;
+		uk_file_event_set(f, UKFD_POLLIN);
 	}
 	return deadline;
 }
@@ -119,6 +119,7 @@ static void _timerfd_set(struct timerfd_node *d, const struct itimerspec *set)
 		/* Arm */
 		d->set.it_value = set->it_value;
 		d->set.it_interval = set->it_interval;
+		d->total = 0;
 		uk_thread_wake(d->upthread);
 	}
 }


### PR DESCRIPTION
### Description of changes

The internal counter of a timerfd is returned on read() and reset to 0, and should be increased by 1 for every subsequent expiration. A logic error in the current code makes every update set the counter to the total expirations rather than since last read, leading to subsequent successful reads returning wrong counts.
This change fixes this error.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A