### PR TITLE
lib/posix-timerfd: Output correct old_value on set

### DIFF
--- a/lib/posix-timerfd/timerfd.c
+++ b/lib/posix-timerfd/timerfd.c
@@ -307,8 +307,10 @@ int uk_sys_timerfd_settime(const struct uk_file *f, int flags,
 	struct timerfd_node *d;
 	const struct itimerspec *set;
 	struct itimerspec absset;
+	struct timespec t;
 	const int disarm = !new_value->it_value.tv_sec &&
 			   !new_value->it_value.tv_nsec;
+	const int abstime = !!(flags & TFD_TIMER_ABSTIME);
 
 	if (unlikely(flags & ~TFD_TIMER_ABSTIME))
 		return -EINVAL;
@@ -317,18 +319,22 @@ int uk_sys_timerfd_settime(const struct uk_file *f, int flags,
 
 	d = f->node;
 	uk_file_wlock(f);
-	if (disarm || flags & TFD_TIMER_ABSTIME) {
+	if (old_value || !(disarm || abstime))
+		uk_sys_clock_gettime(d->clkid, &t);
+
+	if (disarm || abstime) {
 		set = new_value;
 	} else {
-		struct timespec t;
-
-		uk_sys_clock_gettime(d->clkid, &t);
 		absset.it_interval = new_value->it_interval;
 		absset.it_value = uk_time_spec_sum(&new_value->it_value, &t);
 		set = &absset;
 	}
-	if (old_value)
-		*old_value = d->set;
+	if (old_value) {
+		struct timerfd_status st = _timerfd_valnext(&d->set, &t);
+
+		old_value->it_interval = d->set.it_interval;
+		old_value->it_value = uk_time_spec_from_nsec(st.next);
+	}
 	_timerfd_set(d, set);
 	(void)_timerfd_update(f);
 	uk_file_wunlock(f);


### PR DESCRIPTION
### Description of changes

Previously settime() would output the old timerfd setting verbatim, as an absolute deadline; this contradicts timerfd_settime(2) which clearly states that old_value should be output with the same semantics as gettime() -- relative time remaining until the next expiration. This change makes settime() calculate and output this time correctly.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A
