### PR TITLE
plat/kvm/arm: Do not check for system calls on IRQ entry 

### DIFF
--- a/plat/kvm/arm/exceptions.S
+++ b/plat/kvm/arm/exceptions.S
@@ -113,6 +113,7 @@
 	/* Store old SP previously saved into x0 */
 	str     x0, [sp, #-16]
 
+.if \except_type == TYPE_TRAP
 	/* Is this trap a system call? */
 	mrs	x0, esr_el1
 	and	x0, x0, #ESR_EC_MASK
@@ -192,6 +193,7 @@
 	ldr	x0, [x0, #LCPU_AUXSP_OFFSET]
 	str	x0, [sp, #UKARCH_EXECENV_SIZE]
 	b	1f
+.endif
 0:
 	sub	sp, sp, #__TRAP_STACK_SIZE
 1:


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): `arm`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Make sure that IRQ entries to not check for a SVC trap.           
Otherwise this could cause issues for example in scenarios such as
those when the IRQ happens during syscall entry, which would make 
the IRQ entry think it's a SVC.                                   

Depends-on: #1348 