### PR TITLE
lib/posix-fdio: Add internal implementations of futime(n)s

### DIFF
--- a/lib/posix-fdio/Config.uk
+++ b/lib/posix-fdio/Config.uk
@@ -2,5 +2,7 @@ config LIBPOSIX_FDIO
 	bool "posix-fdio: File I/O and control"
 	select LIBUKATOMIC
 	select LIBUKFILE
+	select LIBPOSIX_TIME
+	select LIBUKTIMECONV
 	select LIBPOSIX_FDTAB
 	select LIBPOSIX_FDTAB_LEGACY_SHIM

--- a/lib/posix-fdio/fdstat.c
+++ b/lib/posix-fdio/fdstat.c
@@ -9,8 +9,15 @@
 #include <string.h>
 
 #include <uk/posix-fdio.h>
+#include <uk/posix-time.h>
+#include <uk/timeutil.h>
 
 #include "fdio-impl.h"
+
+#define statx_time(ts) ((struct uk_statx_timestamp){ \
+	.tv_sec = (ts).tv_sec, \
+	.tv_nsec = (ts).tv_nsec \
+})
 
 static inline
 dev_t nums2dev(__u32 major, __u32 minor)
@@ -116,4 +123,64 @@ int uk_sys_fchown(struct uk_ofile *of, uid_t owner, gid_t group)
 	if (iolock)
 		uk_file_wunlock(of->file);
 	return r;
+}
+
+int uk_sys_futimens(struct uk_ofile *of, const struct timespec *times)
+{
+	int r;
+	unsigned int mask;
+	struct uk_statx sx;
+	struct timespec t;
+	const int iolock = _SHOULD_LOCK(of->mode);
+
+	/* TODO: check if uid is root or file owner for custom times */
+
+	if (!times ||
+	    times[0].tv_nsec == UTIME_NOW || times[1].tv_nsec == UTIME_NOW) {
+		r = uk_sys_clock_gettime(CLOCK_REALTIME, &t);
+		if (unlikely(r)) {
+			UK_ASSERT(r < 0);
+			/* The futime(n)s manpages do not specify an error case
+			 * for failing to get the current time, and failure of
+			 * the above call may indicate a misconfigured kernel.
+			 * Print a warning before erroring out.
+			 */
+			uk_pr_warn("Failed to get current time: %d\n", r);
+			return r;
+		}
+	}
+
+	if (!times) {
+		mask = UK_STATX_ATIME | UK_STATX_MTIME;
+		sx.stx_atime = statx_time(t);
+		sx.stx_mtime = statx_time(t);
+	} else {
+		mask = 0;
+		if (times[0].tv_nsec != UTIME_OMIT) {
+			mask |= UK_STATX_ATIME;
+			if (times[0].tv_nsec == UTIME_NOW)
+				sx.stx_atime = statx_time(t);
+			else
+				sx.stx_atime = statx_time(times[0]);
+		}
+		if (times[1].tv_nsec != UTIME_OMIT) {
+			mask |= UK_STATX_MTIME;
+			if (times[1].tv_nsec == UTIME_NOW)
+				sx.stx_mtime = statx_time(t);
+			else
+				sx.stx_mtime = statx_time(times[1]);
+		}
+	}
+
+	if (iolock)
+		uk_file_wlock(of->file);
+	r = uk_file_setstat(of->file, mask, &sx);
+	if (iolock)
+		uk_file_wunlock(of->file);
+	return r;
+}
+
+int uk_sys_futimes(struct uk_ofile *of, const struct timeval *tv)
+{
+	return uk_sys_futimens(of, tv ? &uk_time_spec_from_val(tv) : NULL);
 }

--- a/lib/posix-fdio/fdstat.c
+++ b/lib/posix-fdio/fdstat.c
@@ -25,8 +25,7 @@ void timecpy(struct timespec *d, const struct uk_statx_timestamp *s)
 	d->tv_nsec = s->tv_nsec;
 }
 
-static inline
-void statx_cpyout(struct stat *s, const struct uk_statx *sx)
+void uk_fdio_statx_cpyout(struct stat *s, const struct uk_statx *sx)
 {
 	unsigned int mask = sx->stx_mask;
 
@@ -79,7 +78,7 @@ int uk_sys_fstat(struct uk_ofile *of, struct stat *statbuf)
 	r = uk_sys_fstatx(of, UK_STATX_BASIC_STATS, &statx);
 	if (unlikely(r))
 		return r;
-	statx_cpyout(statbuf, &statx);
+	uk_fdio_statx_cpyout(statbuf, &statx);
 	return 0;
 }
 

--- a/lib/posix-fdio/include/uk/posix-fdio.h
+++ b/lib/posix-fdio/include/uk/posix-fdio.h
@@ -13,6 +13,18 @@
 
 #include <uk/posix-fd.h>
 
+/* Utils */
+
+/**
+ * Copy info out of a struct statx and into a struct stat.
+ *
+ * Fields whose bits are present in `statxbuf->stx_mask` will be copied over,
+ * all others will be left untouched.
+ */
+void uk_fdio_statx_cpyout(struct stat *statbuf,
+			  const struct uk_statx *statxbuf);
+
+/* Internal syscalls */
 /* I/O */
 
 ssize_t uk_sys_preadv(struct uk_ofile *of, const struct iovec *iov, int iovcnt,

--- a/lib/posix-fdio/include/uk/posix-fdio.h
+++ b/lib/posix-fdio/include/uk/posix-fdio.h
@@ -10,6 +10,7 @@
 #define __UK_POSIX_FDIO_H__
 
 #include <sys/stat.h>
+#include <sys/time.h>
 
 #include <uk/posix-fd.h>
 
@@ -66,6 +67,10 @@ int uk_sys_fstatx(struct uk_ofile *of, unsigned int mask,
 int uk_sys_fchmod(struct uk_ofile *of, mode_t mode);
 
 int uk_sys_fchown(struct uk_ofile *of, uid_t owner, gid_t group);
+
+int uk_sys_futimes(struct uk_ofile *of, const struct timeval *tv);
+
+int uk_sys_futimens(struct uk_ofile *of, const struct timespec *times);
 
 /* Control */
 


### PR DESCRIPTION
### Description of changes

This changeset adds internal API (`uk_sys_*`) implementations of the `futimes` and `futimens` operations on file references, as well as exposing the statx-to-stat field conversions used by `posix-fdio` for use in related code (specifically, `*at`-type operations that can target either open files or VFS paths).

(Binary) syscalls fall outside the scope of this PR, due to how Linux ties both of these operations to VFS-specific syscalls: `futimesat` and `utimensat`, respectively. Since these target the VFS they must remain in `vfscore` for now.

Permissions checking is also out of scope, it is to be handled File/VFS-wide by a single later PR.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A
