### PR TITLE
lib/posix-fdio: Fix wrong computation of dev_t

### DIFF
--- a/lib/nolibc/musl-imported/include/sys/sysmacros.h
+++ b/lib/nolibc/musl-imported/include/sys/sysmacros.h
@@ -1,0 +1,15 @@
+#ifndef _SYS_SYSMACROS_H
+#define _SYS_SYSMACROS_H
+
+#define major(x) \
+	((unsigned)( (((x)>>31>>1) & 0xfffff000) | (((x)>>8) & 0x00000fff) ))
+#define minor(x) \
+	((unsigned)( (((x)>>12) & 0xffffff00) | ((x) & 0x000000ff) ))
+
+#define makedev(x,y) ( \
+        (((x)&0xfffff000ULL) << 32) | \
+	(((x)&0x00000fffULL) << 8) | \
+        (((y)&0xffffff00ULL) << 12) | \
+	(((y)&0x000000ffULL)) )
+
+#endif

--- a/lib/posix-fdio/fdstat.c
+++ b/lib/posix-fdio/fdstat.c
@@ -7,6 +7,7 @@
 /* Internal syscalls for manipulating file metadata */
 
 #include <string.h>
+#include <sys/sysmacros.h>
 
 #include <uk/posix-fdio.h>
 #include <uk/posix-time.h>
@@ -20,12 +21,6 @@
 })
 
 static inline
-dev_t nums2dev(__u32 major, __u32 minor)
-{
-	return ((dev_t)major << 32) | minor;
-}
-
-static inline
 void timecpy(struct timespec *d, const struct uk_statx_timestamp *s)
 {
 	d->tv_sec = s->tv_sec;
@@ -37,8 +32,8 @@ void uk_fdio_statx_cpyout(struct stat *s, const struct uk_statx *sx)
 	unsigned int mask = sx->stx_mask;
 
 	memset(s, 0, sizeof(*s));
-	s->st_dev = nums2dev(sx->stx_dev_major, sx->stx_dev_minor);
-	s->st_rdev = nums2dev(sx->stx_rdev_major, sx->stx_rdev_minor);
+	s->st_dev = makedev(sx->stx_dev_major, sx->stx_dev_minor);
+	s->st_rdev = makedev(sx->stx_rdev_major, sx->stx_rdev_minor);
 	s->st_blksize = sx->stx_blksize;
 	if (mask & UK_STATX_INO)
 		s->st_ino = sx->stx_ino;


### PR DESCRIPTION
### Description of changes

Previously posix-fdio would compute the value of a dev_t from a major/minor number pair wrong by naive bit shifting. The correct computation is more involved and should use `makedev()` as defined in `<sys/sysmacros.h>`.
This PR fixes this oversight, making `fstat()` output correct.

As a prerequisite, this also imports `<sys/sysmacros.h>` from musl v1.2.4.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A