### PR TITLE
lib/ukfile: Add try acquire operation

### DIFF
--- a/lib/ukfile/include/uk/file.h
+++ b/lib/ukfile/include/uk/file.h
@@ -183,6 +183,7 @@ typedef struct uk_file_finref uk_file_refcnt;
 
 #define uk_file_refcnt_acquire		uk_file_finref_acquire
 #define uk_file_refcnt_acquire_weak	uk_file_finref_acquire_weak
+#define uk_file_refcnt_try_acquire	uk_file_finref_try_acquire
 #define uk_file_refcnt_release		uk_file_finref_release
 #define uk_file_refcnt_release_weak	uk_file_finref_release_weak
 
@@ -196,6 +197,7 @@ typedef struct uk_swrefcount uk_file_refcnt;
 
 #define uk_file_refcnt_acquire		uk_swrefcount_acquire
 #define uk_file_refcnt_acquire_weak	uk_swrefcount_acquire_weak
+#define uk_file_refcnt_try_acquire	uk_swrefcount_try_acquire
 #define uk_file_refcnt_release		uk_swrefcount_release
 #define uk_file_refcnt_release_weak	uk_swrefcount_release_weak
 
@@ -266,6 +268,12 @@ static inline
 void uk_file_acquire_weak(const struct uk_file *f)
 {
 	uk_file_refcnt_acquire_weak(f->refcnt);
+}
+
+static inline
+int uk_file_try_acquire(const struct uk_file *f)
+{
+	return uk_file_refcnt_try_acquire(f->refcnt);
 }
 
 static inline

--- a/lib/ukfile/include/uk/file/final.h
+++ b/lib/ukfile/include/uk/file/final.h
@@ -52,6 +52,12 @@ void uk_file_finref_acquire_weak(struct uk_file_finref *r)
 }
 
 static inline
+int uk_file_finref_try_acquire(struct uk_file_finref *r)
+{
+	return uk_swrefcount_try_acquire(&r->cnt);
+}
+
+static inline
 int uk_file_finref_release(struct uk_file_finref *r)
 {
 	return uk_swrefcount_release(&r->cnt);


### PR DESCRIPTION
### Description of changes

This change adds a try_acquire operation on files which allows callers holding a weakref to attempt to take a strong ref.
This call may fail if no other strongrefs are currently held (and thus finalizers and the destructor are scheduled to run).

As a prerequisite, this adds a `try_acquire()` operation to the `<uk/weak_refcount.h>` API.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A