### PR TITLE
lib/ukfile: API: Change file offset and iovec length to size_t

### DIFF
--- a/lib/posix-eventfd/eventfd.c
+++ b/lib/posix-eventfd/eventfd.c
@@ -35,7 +35,7 @@ struct evfd_alloc {
 
 
 static ssize_t evfd_read(const struct uk_file *f,
-			 const struct iovec *iov, int iovcnt,
+			 const struct iovec *iov, size_t iovcnt,
 			 size_t off, long flags __unused)
 {
 	int semaphore;
@@ -75,7 +75,7 @@ static ssize_t evfd_read(const struct uk_file *f,
 
 
 static ssize_t evfd_write(const struct uk_file *f,
-			  const struct iovec *iov, int iovcnt,
+			  const struct iovec *iov, size_t iovcnt,
 			  size_t off, long flags __unused)
 {
 	uint64_t add;

--- a/lib/posix-eventfd/eventfd.c
+++ b/lib/posix-eventfd/eventfd.c
@@ -36,7 +36,7 @@ struct evfd_alloc {
 
 static ssize_t evfd_read(const struct uk_file *f,
 			 const struct iovec *iov, int iovcnt,
-			 off_t off, long flags __unused)
+			 size_t off, long flags __unused)
 {
 	int semaphore;
 	evfd_node n;
@@ -76,7 +76,7 @@ static ssize_t evfd_read(const struct uk_file *f,
 
 static ssize_t evfd_write(const struct uk_file *f,
 			  const struct iovec *iov, int iovcnt,
-			  off_t off, long flags __unused)
+			  size_t off, long flags __unused)
 {
 	uint64_t add;
 	evfd_node n;

--- a/lib/posix-fd/include/uk/posix-fd.h
+++ b/lib/posix-fd/include/uk/posix-fd.h
@@ -22,7 +22,7 @@ struct uk_ofile {
 	const struct uk_file *file;
 	unsigned int mode;
 	__atomic refcnt;
-	off_t pos; /* Current file read/write offset position */
+	size_t pos; /* Current file read/write offset position */
 	struct uk_mutex lock; /* Lock for modifying open file state */
 };
 

--- a/lib/posix-fdio/fdio.c
+++ b/lib/posix-fdio/fdio.c
@@ -96,7 +96,7 @@ ssize_t uk_sys_readv(struct uk_ofile *of, const struct iovec *iov, int iovcnt)
 {
 	ssize_t r;
 	long flags;
-	off_t off;
+	size_t off;
 	const struct uk_file *f;
 	int seekable;
 	int iolock;
@@ -152,7 +152,7 @@ ssize_t uk_sys_preadv2(struct uk_ofile *of, const struct iovec *iov, int iovcnt,
 		       off_t offset, int flags)
 {
 	ssize_t r;
-	off_t off;
+	size_t off;
 	long xflags;
 	const struct uk_file *f;
 	unsigned int mode;
@@ -386,8 +386,10 @@ ssize_t uk_sys_pwritev2(struct uk_ofile *of, const struct iovec *iov,
 	}
 
 	if (use_pos) {
-		if (r >= 0)
+		if (r >= 0) {
+			UK_ASSERT(off >= 0);
 			of->pos = off + r;
+		}
 		_of_unlock(of);
 	}
 

--- a/lib/posix-fdio/fdio.c
+++ b/lib/posix-fdio/fdio.c
@@ -77,7 +77,7 @@ ssize_t uk_sys_preadv(struct uk_ofile *of, const struct iovec *iov, int iovcnt,
 	for (;;) {
 		if (iolock)
 			uk_file_rlock(f);
-		r = uk_file_read(f, iov, iovcnt, offset, flags);
+		r = uk_file_read(f, iov, (size_t)iovcnt, offset, flags);
 		if (iolock)
 			uk_file_runlock(f);
 		if (!_SHOULD_BLOCK(r, mode))
@@ -124,7 +124,7 @@ ssize_t uk_sys_readv(struct uk_ofile *of, const struct iovec *iov, int iovcnt)
 
 		if (iolock)
 			uk_file_rlock(f);
-		r = uk_file_read(f, iov, iovcnt, off, flags);
+		r = uk_file_read(f, iov, (size_t)iovcnt, off, flags);
 		if (iolock)
 			uk_file_runlock(f);
 		if (!_SHOULD_BLOCK(r, mode))
@@ -192,7 +192,7 @@ ssize_t uk_sys_preadv2(struct uk_ofile *of, const struct iovec *iov, int iovcnt,
 
 		if (iolock)
 			uk_file_rlock(f);
-		r = uk_file_read(f, iov, iovcnt, off, xflags);
+		r = uk_file_read(f, iov, (size_t)iovcnt, off, xflags);
 		if (iolock)
 			uk_file_runlock(f);
 		if (!_SHOULD_BLOCK(r, mode))
@@ -237,7 +237,7 @@ ssize_t uk_sys_pwritev(struct uk_ofile *of, const struct iovec *iov, int iovcnt,
 	for (;;) {
 		if (iolock)
 			uk_file_wlock(f);
-		r = uk_file_write(f, iov, iovcnt, offset, flags);
+		r = uk_file_write(f, iov, (size_t)iovcnt, offset, flags);
 		if (iolock)
 			uk_file_wunlock(f);
 		if (!_SHOULD_BLOCK(r, mode))
@@ -292,7 +292,7 @@ ssize_t uk_sys_writev(struct uk_ofile *of, const struct iovec *iov, int iovcnt)
 		}
 
 		if (likely(off >= 0))
-			r = uk_file_write(f, iov, iovcnt, off, flags);
+			r = uk_file_write(f, iov, (size_t)iovcnt, off, flags);
 		else
 			r = off;
 
@@ -372,7 +372,7 @@ ssize_t uk_sys_pwritev2(struct uk_ofile *of, const struct iovec *iov,
 		}
 
 		if (likely(off >= 0))
-			r = uk_file_write(f, iov, iovcnt, off, xflags);
+			r = uk_file_write(f, iov, (size_t)iovcnt, off, xflags);
 		else
 			r = off;
 

--- a/lib/posix-pipe/pipe.c
+++ b/lib/posix-pipe/pipe.c
@@ -143,7 +143,7 @@ static ssize_t _iovsz(const struct iovec *iov, int iovcnt)
 
 static ssize_t pipe_read(const struct uk_file *f,
 			 const struct iovec *iov, int iovcnt,
-			 off_t off, long flags __unused)
+			 size_t off, long flags __unused)
 {
 	ssize_t toread;
 	struct pipe_node *d;
@@ -231,7 +231,7 @@ static ssize_t pipe_read(const struct uk_file *f,
 
 static ssize_t pipe_write(const struct uk_file *f,
 			  const struct iovec *iov, int iovcnt,
-			  off_t off, long flags)
+			  size_t off, long flags)
 {
 	struct pipe_node *d;
 	struct pipe_msg *tail;

--- a/lib/posix-pipe/pipe.c
+++ b/lib/posix-pipe/pipe.c
@@ -127,11 +127,11 @@ static void pipebuf_iovwrite(char *buf, pipeidx head,
 		_pipebuf_write(buf, head, (const char *)iov[i].iov_base, n);
 }
 
-static ssize_t _iovsz(const struct iovec *iov, int iovcnt)
+static ssize_t _iovsz(const struct iovec *iov, size_t iovcnt)
 {
 	size_t ret = 0;
 
-	for (int i = 0; i < iovcnt; i++)
+	for (size_t i = 0; i < iovcnt; i++)
 		if (iov[i].iov_len) {
 			if (likely(iov[i].iov_base))
 				ret += iov[i].iov_len;
@@ -142,7 +142,7 @@ static ssize_t _iovsz(const struct iovec *iov, int iovcnt)
 }
 
 static ssize_t pipe_read(const struct uk_file *f,
-			 const struct iovec *iov, int iovcnt,
+			 const struct iovec *iov, size_t iovcnt,
 			 size_t off, long flags __unused)
 {
 	ssize_t toread;
@@ -230,7 +230,7 @@ static ssize_t pipe_read(const struct uk_file *f,
 }
 
 static ssize_t pipe_write(const struct uk_file *f,
-			  const struct iovec *iov, int iovcnt,
+			  const struct iovec *iov, size_t iovcnt,
 			  size_t off, long flags)
 {
 	struct pipe_node *d;

--- a/lib/posix-socket/include/uk/socket_driver.h
+++ b/lib/posix-socket/include/uk/socket_driver.h
@@ -398,7 +398,7 @@ typedef void (*posix_socket_socketpair_post_func_t)(
  * @return The number of bytes written on success, -errno otherwise
  */
 typedef ssize_t (*posix_socket_write_func_t)(posix_sock *sock,
-		const struct iovec *iov, int iovcnt);
+		const struct iovec *iov, size_t iovcnt);
 
 /**
  * Read from a socket file descriptor.
@@ -411,7 +411,7 @@ typedef ssize_t (*posix_socket_write_func_t)(posix_sock *sock,
  * @return The number of bytes read on success, -errno otherwise
  */
 typedef ssize_t (*posix_socket_read_func_t)(posix_sock *sock,
-		const struct iovec *iov, int iovcnt);
+		const struct iovec *iov, size_t iovcnt);
 
 /**
  * Close the socket.
@@ -640,7 +640,7 @@ posix_socket_socketpair_post(struct posix_socket_driver *d,
 
 static inline ssize_t
 posix_socket_write(posix_sock *sock, const struct iovec *iov,
-		   int iovcnt)
+		   size_t iovcnt)
 {
 	struct posix_socket_driver *d = posix_sock_get_driver(sock);
 
@@ -650,7 +650,7 @@ posix_socket_write(posix_sock *sock, const struct iovec *iov,
 
 static inline ssize_t
 posix_socket_read(posix_sock *sock, const struct iovec *iov,
-		  int iovcnt)
+		  size_t iovcnt)
 {
 	struct posix_socket_driver *d = posix_sock_get_driver(sock);
 

--- a/lib/posix-socket/socket.c
+++ b/lib/posix-socket/socket.c
@@ -94,7 +94,7 @@ static struct uk_ofile *socketfd_get(int fd)
 static ssize_t
 socket_read(const struct uk_file *sock,
 	    const struct iovec *iov, int iovcnt,
-	    off_t off, long flags __unused)
+	    size_t off, long flags __unused)
 {
 	ssize_t ret;
 	struct posix_socket_driver *d;
@@ -126,7 +126,7 @@ socket_read(const struct uk_file *sock,
 static ssize_t
 socket_write(const struct uk_file *sock,
 	     const struct iovec *iov, int iovcnt,
-	     off_t off, long flags __unused)
+	     size_t off, long flags __unused)
 {
 	ssize_t ret;
 	struct posix_socket_driver *d;

--- a/lib/posix-socket/socket.c
+++ b/lib/posix-socket/socket.c
@@ -93,7 +93,7 @@ static struct uk_ofile *socketfd_get(int fd)
 
 static ssize_t
 socket_read(const struct uk_file *sock,
-	    const struct iovec *iov, int iovcnt,
+	    const struct iovec *iov, size_t iovcnt,
 	    size_t off, long flags __unused)
 {
 	ssize_t ret;
@@ -125,7 +125,7 @@ socket_read(const struct uk_file *sock,
 
 static ssize_t
 socket_write(const struct uk_file *sock,
-	     const struct iovec *iov, int iovcnt,
+	     const struct iovec *iov, size_t iovcnt,
 	     size_t off, long flags __unused)
 {
 	ssize_t ret;

--- a/lib/posix-timerfd/timerfd.c
+++ b/lib/posix-timerfd/timerfd.c
@@ -129,7 +129,7 @@ static void _timerfd_set(struct timerfd_node *d, const struct itimerspec *set)
 /* Ops */
 
 static ssize_t timerfd_read(const struct uk_file *f,
-			    const struct iovec *iov, int iovcnt,
+			    const struct iovec *iov, size_t iovcnt,
 			    size_t off, long flags __unused)
 {
 	struct timerfd_node *d;

--- a/lib/posix-timerfd/timerfd.c
+++ b/lib/posix-timerfd/timerfd.c
@@ -130,14 +130,14 @@ static void _timerfd_set(struct timerfd_node *d, const struct itimerspec *set)
 
 static ssize_t timerfd_read(const struct uk_file *f,
 			    const struct iovec *iov, int iovcnt,
-			    off_t off, long flags __unused)
+			    size_t off, long flags __unused)
 {
 	struct timerfd_node *d;
 	__u64 v;
 
 	if (unlikely(f->vol != TIMERFD_VOLID))
 		return -EINVAL;
-	if (unlikely(off != 0))
+	if (unlikely(off))
 		return -EINVAL;
 	if (unlikely(!iovcnt || iov[0].iov_len < sizeof(__u64)))
 		return -EINVAL;

--- a/lib/posix-tty/pseudo.c
+++ b/lib/posix-tty/pseudo.c
@@ -22,7 +22,8 @@ static const char VOID_VOLID[] = "void_vol";
 static const char ZERO_VOLID[] = "zero_vol";
 
 static ssize_t null_read(const struct uk_file *f __maybe_unused,
-			 const struct iovec *iov __unused, int iovcnt __unused,
+			 const struct iovec *iov __unused,
+			 size_t iovcnt __unused,
 			 size_t off __unused, long flags __unused)
 {
 	UK_ASSERT(f->vol == NULL_VOLID);
@@ -30,7 +31,8 @@ static ssize_t null_read(const struct uk_file *f __maybe_unused,
 }
 
 static ssize_t void_read(const struct uk_file *f __maybe_unused,
-			 const struct iovec *iov __unused, int iovcnt __unused,
+			 const struct iovec *iov __unused,
+			 size_t iovcnt __unused,
 			 size_t off __unused, long flags __unused)
 {
 	UK_ASSERT(f->vol == VOID_VOLID);
@@ -38,14 +40,14 @@ static ssize_t void_read(const struct uk_file *f __maybe_unused,
 }
 
 static ssize_t zero_read(const struct uk_file *f __maybe_unused,
-			 const struct iovec *iov, int iovcnt,
+			 const struct iovec *iov, size_t iovcnt,
 			 size_t off __unused, long flags __unused)
 {
 	ssize_t total = 0;
 
 	UK_ASSERT(f->vol == ZERO_VOLID);
 
-	for (int i = 0; i < iovcnt; i++) {
+	for (size_t i = 0; i < iovcnt; i++) {
 		if (unlikely(!iov[i].iov_base && iov[i].iov_len))
 			return -EFAULT;
 		memset(iov[i].iov_base, 0, iov[i].iov_len);
@@ -55,7 +57,7 @@ static ssize_t zero_read(const struct uk_file *f __maybe_unused,
 }
 
 static ssize_t null_write(const struct uk_file *f __maybe_unused,
-			  const struct iovec *iov, int iovcnt,
+			  const struct iovec *iov, size_t iovcnt,
 			  size_t off __unused, long flags __unused)
 {
 	ssize_t total = 0;
@@ -63,7 +65,7 @@ static ssize_t null_write(const struct uk_file *f __maybe_unused,
 	UK_ASSERT(f->vol == NULL_VOLID || f->vol == ZERO_VOLID ||
 		  f->vol == VOID_VOLID);
 
-	for (int i = 0; i < iovcnt; i++)
+	for (size_t i = 0; i < iovcnt; i++)
 		total += iov[i].iov_len;
 	return total;
 }

--- a/lib/posix-tty/pseudo.c
+++ b/lib/posix-tty/pseudo.c
@@ -23,7 +23,7 @@ static const char ZERO_VOLID[] = "zero_vol";
 
 static ssize_t null_read(const struct uk_file *f __maybe_unused,
 			 const struct iovec *iov __unused, int iovcnt __unused,
-			 off_t off __unused, long flags __unused)
+			 size_t off __unused, long flags __unused)
 {
 	UK_ASSERT(f->vol == NULL_VOLID);
 	return 0;
@@ -31,7 +31,7 @@ static ssize_t null_read(const struct uk_file *f __maybe_unused,
 
 static ssize_t void_read(const struct uk_file *f __maybe_unused,
 			 const struct iovec *iov __unused, int iovcnt __unused,
-			 off_t off __unused, long flags __unused)
+			 size_t off __unused, long flags __unused)
 {
 	UK_ASSERT(f->vol == VOID_VOLID);
 	return -EAGAIN;
@@ -39,7 +39,7 @@ static ssize_t void_read(const struct uk_file *f __maybe_unused,
 
 static ssize_t zero_read(const struct uk_file *f __maybe_unused,
 			 const struct iovec *iov, int iovcnt,
-			 off_t off __unused, long flags __unused)
+			 size_t off __unused, long flags __unused)
 {
 	ssize_t total = 0;
 
@@ -56,7 +56,7 @@ static ssize_t zero_read(const struct uk_file *f __maybe_unused,
 
 static ssize_t null_write(const struct uk_file *f __maybe_unused,
 			  const struct iovec *iov, int iovcnt,
-			  off_t off __unused, long flags __unused)
+			  size_t off __unused, long flags __unused)
 {
 	ssize_t total = 0;
 

--- a/lib/posix-tty/serial.c
+++ b/lib/posix-tty/serial.c
@@ -88,7 +88,7 @@ static inline __ssz _console_out(const char *buf, __sz len)
 }
 
 static ssize_t serial_read(const struct uk_file *f,
-			   const struct iovec *iov, int iovcnt,
+			   const struct iovec *iov, size_t iovcnt,
 			   size_t off, long flags __unused)
 {
 	ssize_t total = 0;
@@ -100,7 +100,7 @@ static ssize_t serial_read(const struct uk_file *f,
 	if (!uk_file_poll_immediate(f, UKFD_POLLIN))
 		return 0;
 
-	for (int i = 0; i < iovcnt; i++) {
+	for (size_t i = 0; i < iovcnt; i++) {
 		char *buf = iov[i].iov_base;
 		size_t len = iov[i].iov_len;
 		char *last;
@@ -137,7 +137,7 @@ static ssize_t serial_read(const struct uk_file *f,
 }
 
 static ssize_t serial_write(const struct uk_file *f __maybe_unused,
-			    const struct iovec *iov, int iovcnt,
+			    const struct iovec *iov, size_t iovcnt,
 			    size_t off, long flags __unused)
 {
 	ssize_t total = 0;
@@ -146,7 +146,7 @@ static ssize_t serial_write(const struct uk_file *f __maybe_unused,
 	if (unlikely(off))
 		return -ESPIPE;
 
-	for (int i = 0; i < iovcnt; i++) {
+	for (size_t i = 0; i < iovcnt; i++) {
 		char *buf = iov[i].iov_base;
 		size_t len = iov[i].iov_len;
 		int bytes_written;

--- a/lib/posix-tty/serial.c
+++ b/lib/posix-tty/serial.c
@@ -89,13 +89,13 @@ static inline __ssz _console_out(const char *buf, __sz len)
 
 static ssize_t serial_read(const struct uk_file *f,
 			   const struct iovec *iov, int iovcnt,
-			   off_t off, long flags __unused)
+			   size_t off, long flags __unused)
 {
 	ssize_t total = 0;
 
 	UK_ASSERT(f->vol == SERIAL_VOLID);
-	if (unlikely(off != 0))
-		return -EINVAL;
+	if (unlikely(off))
+		return -ESPIPE;
 
 	if (!uk_file_poll_immediate(f, UKFD_POLLIN))
 		return 0;
@@ -138,13 +138,13 @@ static ssize_t serial_read(const struct uk_file *f,
 
 static ssize_t serial_write(const struct uk_file *f __maybe_unused,
 			    const struct iovec *iov, int iovcnt,
-			    off_t off, long flags __unused)
+			    size_t off, long flags __unused)
 {
 	ssize_t total = 0;
 
 	UK_ASSERT(f->vol == SERIAL_VOLID);
-	if (unlikely(off != 0))
-		return -EINVAL;
+	if (unlikely(off))
+		return -ESPIPE;
 
 	for (int i = 0; i < iovcnt; i++) {
 		char *buf = iov[i].iov_base;

--- a/lib/posix-unixsocket/unixsock.c
+++ b/lib/posix-unixsocket/unixsock.c
@@ -887,7 +887,7 @@ ssize_t unix_socket_sendto(posix_sock *file, const void *buf,
 
 static
 ssize_t unix_socket_read(posix_sock *file,
-			 const struct iovec *iov, int iovcnt)
+			 const struct iovec *iov, size_t iovcnt)
 {
 	struct msghdr msg = {
 		.msg_name = NULL,
@@ -903,7 +903,7 @@ ssize_t unix_socket_read(posix_sock *file,
 
 static
 ssize_t unix_socket_write(posix_sock *file,
-			  const struct iovec *iov, int iovcnt)
+			  const struct iovec *iov, size_t iovcnt)
 {
 	struct msghdr msg = {
 		.msg_name = NULL,

--- a/lib/ukfile/file-nops.c
+++ b/lib/ukfile/file-nops.c
@@ -11,14 +11,14 @@
 
 ssize_t uk_file_nop_read(const struct uk_file *f __unused,
 			 const struct iovec *iov __unused, int iovcnt __unused,
-			 off_t off __unused, long flags __unused)
+			 size_t off __unused, long flags __unused)
 {
 	return -ENOSYS;
 }
 
 ssize_t uk_file_nop_write(const struct uk_file *f __unused,
 			  const struct iovec *iov __unused, int iovcnt __unused,
-			  off_t off __unused, long flags __unused)
+			  size_t off __unused, long flags __unused)
 {
 	return -ENOSYS;
 }

--- a/lib/ukfile/file-nops.c
+++ b/lib/ukfile/file-nops.c
@@ -10,14 +10,16 @@
 
 
 ssize_t uk_file_nop_read(const struct uk_file *f __unused,
-			 const struct iovec *iov __unused, int iovcnt __unused,
+			 const struct iovec *iov __unused,
+			 size_t iovcnt __unused,
 			 size_t off __unused, long flags __unused)
 {
 	return -ENOSYS;
 }
 
 ssize_t uk_file_nop_write(const struct uk_file *f __unused,
-			  const struct iovec *iov __unused, int iovcnt __unused,
+			  const struct iovec *iov __unused,
+			  size_t iovcnt __unused,
 			  size_t off __unused, long flags __unused)
 {
 	return -ENOSYS;

--- a/lib/ukfile/include/uk/file.h
+++ b/lib/ukfile/include/uk/file.h
@@ -37,7 +37,7 @@ struct uk_file;
 /* I/O */
 typedef ssize_t (*uk_file_io_func)(const struct uk_file *f,
 				   const struct iovec *iov, int iovcnt,
-				   off_t off, long flags);
+				   size_t off, long flags);
 
 /* Info (stat-like & chXXX-like) */
 typedef int (*uk_file_getstat_func)(const struct uk_file *f,
@@ -220,7 +220,7 @@ struct uk_file {
 static inline
 ssize_t uk_file_read(const struct uk_file *f,
 		     const struct iovec *iov, int iovcnt,
-		     off_t off, long flags)
+		     size_t off, long flags)
 {
 	return f->ops->read(f, iov, iovcnt, off, flags);
 }
@@ -228,7 +228,7 @@ ssize_t uk_file_read(const struct uk_file *f,
 static inline
 ssize_t uk_file_write(const struct uk_file *f,
 		      const struct iovec *iov, int iovcnt,
-		      off_t off, long flags)
+		      size_t off, long flags)
 {
 	return f->ops->write(f, iov, iovcnt, off, flags);
 }

--- a/lib/ukfile/include/uk/file.h
+++ b/lib/ukfile/include/uk/file.h
@@ -36,7 +36,7 @@ struct uk_file;
 
 /* I/O */
 typedef ssize_t (*uk_file_io_func)(const struct uk_file *f,
-				   const struct iovec *iov, int iovcnt,
+				   const struct iovec *iov, size_t iovcnt,
 				   size_t off, long flags);
 
 /* Info (stat-like & chXXX-like) */
@@ -219,7 +219,7 @@ struct uk_file {
 /* Operations inlines */
 static inline
 ssize_t uk_file_read(const struct uk_file *f,
-		     const struct iovec *iov, int iovcnt,
+		     const struct iovec *iov, size_t iovcnt,
 		     size_t off, long flags)
 {
 	return f->ops->read(f, iov, iovcnt, off, flags);
@@ -227,7 +227,7 @@ ssize_t uk_file_read(const struct uk_file *f,
 
 static inline
 ssize_t uk_file_write(const struct uk_file *f,
-		      const struct iovec *iov, int iovcnt,
+		      const struct iovec *iov, size_t iovcnt,
 		      size_t off, long flags)
 {
 	return f->ops->write(f, iov, iovcnt, off, flags);

--- a/lib/ukfile/include/uk/file/iovutil.h
+++ b/lib/ukfile/include/uk/file/iovutil.h
@@ -24,11 +24,11 @@
  * @return Number of bytes zeroed
  */
 static inline
-size_t uk_iov_zero(const struct iovec *iov, int iovcnt, size_t len,
-		   int *iovip, size_t *curp)
+size_t uk_iov_zero(const struct iovec *iov, size_t iovcnt, size_t len,
+		   size_t *iovip, size_t *curp)
 {
 	size_t ret = 0;
-	int i = *iovip;
+	size_t i = *iovip;
 	size_t cur = *curp;
 
 	UK_ASSERT(i < iovcnt);
@@ -74,11 +74,11 @@ size_t uk_iov_zero(const struct iovec *iov, int iovcnt, size_t len,
  * @return Number of bytes copied
  */
 static inline
-size_t uk_iov_scatter(const struct iovec *iov, int iovcnt, const char *buf,
-		      size_t len, int *iovip, size_t *curp)
+size_t uk_iov_scatter(const struct iovec *iov, size_t iovcnt, const char *buf,
+		      size_t len, size_t *iovip, size_t *curp)
 {
 	size_t ret = 0;
-	int i = *iovip;
+	size_t i = *iovip;
 	size_t cur = *curp;
 
 	UK_ASSERT(i < iovcnt);
@@ -126,11 +126,11 @@ size_t uk_iov_scatter(const struct iovec *iov, int iovcnt, const char *buf,
  * @return Number of bytes copied
  */
 static inline
-size_t uk_iov_gather(char *buf, const struct iovec *iov, int iovcnt,
-		     size_t len, int *iovip, size_t *curp)
+size_t uk_iov_gather(char *buf, const struct iovec *iov, size_t iovcnt,
+		     size_t len, size_t *iovip, size_t *curp)
 {
 	size_t ret = 0;
-	int i = *iovip;
+	size_t i = *iovip;
 	size_t cur = *curp;
 
 	UK_ASSERT(i < iovcnt);

--- a/lib/ukfile/include/uk/file/nops.h
+++ b/lib/ukfile/include/uk/file/nops.h
@@ -15,11 +15,11 @@ extern const struct uk_file_ops uk_file_nops;
 
 ssize_t uk_file_nop_read(const struct uk_file *f,
 			 const struct iovec *iov, int iovcnt,
-			 off_t off, long flags);
+			 size_t off, long flags);
 
 ssize_t uk_file_nop_write(const struct uk_file *f,
 			  const struct iovec *iov, int iovcnt,
-			  off_t off, long flags);
+			  size_t off, long flags);
 
 int uk_file_nop_getstat(const struct uk_file *f,
 			unsigned int mask, struct uk_statx *arg);

--- a/lib/ukfile/include/uk/file/nops.h
+++ b/lib/ukfile/include/uk/file/nops.h
@@ -14,11 +14,11 @@
 extern const struct uk_file_ops uk_file_nops;
 
 ssize_t uk_file_nop_read(const struct uk_file *f,
-			 const struct iovec *iov, int iovcnt,
+			 const struct iovec *iov, size_t iovcnt,
 			 size_t off, long flags);
 
 ssize_t uk_file_nop_write(const struct uk_file *f,
-			  const struct iovec *iov, int iovcnt,
+			  const struct iovec *iov, size_t iovcnt,
 			  size_t off, long flags);
 
 int uk_file_nop_getstat(const struct uk_file *f,


### PR DESCRIPTION
### Description of changes

Previously the ukfile API used signed integers in places where they made no logical sense: file offsets and the length of iovec arrays. These types were a design oversight, uncritically copying the Linux syscall API.

This PR makes both of these unsigned `size_t` in the internal file and socket API, reflecting their true logical intent. Furthermore, all validation of and conversion from signed values occurs in a single well-defined point -- the syscall API.

The `posix-socket` API is also changed by this PR, having the socket read/write operations take `size_t` length iovecs. This harmonizes nicely with the type used for iovcnt in the socket-native `struct msghdr`.
Builtin sockets (`posix-unixsock`) are updated.
External socket implementations require a patch:
- lwip: https://github.com/unikraft/lib-lwip/pull/61

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A