### PR TITLE
 lib/posix-process: Define kernel internal `gettid`/`getppid`/`getpid`

### DIFF
--- a/lib/posix-futex/futex.c
+++ b/lib/posix-futex/futex.c
@@ -373,7 +373,7 @@ UK_POSIX_CLONE_HANDLER(CLONE_CHILD_CLEARTID, true, pfutex_child_cleartid, 0x0);
  */
 UK_LLSYSCALL_R_DEFINE(pid_t, set_tid_address, pid_t *, tid_ref)
 {
-	pid_t self_tid = uk_syscall_r_gettid();
+	pid_t self_tid = uk_sys_gettid();
 
 	if (self_tid >= 0) {
 		/* Store new reference */

--- a/lib/posix-process/exportsyms.uk
+++ b/lib/posix-process/exportsyms.uk
@@ -31,6 +31,7 @@ wait4
 waitpid
 waitid
 getpid
+uk_sys_getppid
 getppid
 uk_sys_gettid
 gettid

--- a/lib/posix-process/exportsyms.uk
+++ b/lib/posix-process/exportsyms.uk
@@ -30,6 +30,7 @@ wait3
 wait4
 waitpid
 waitid
+uk_sys_getpid
 getpid
 uk_sys_getppid
 getppid

--- a/lib/posix-process/exportsyms.uk
+++ b/lib/posix-process/exportsyms.uk
@@ -32,6 +32,7 @@ waitpid
 waitid
 getpid
 getppid
+uk_sys_gettid
 gettid
 exit
 exit_group

--- a/lib/posix-process/include/uk/process.h
+++ b/lib/posix-process/include/uk/process.h
@@ -149,6 +149,7 @@ static inline int uk_sys_setrlimit(int resource, const struct rlimit *rlim)
 
 pid_t uk_sys_gettid(void);
 pid_t uk_sys_getppid(void);
+pid_t uk_sys_getpid(void);
 
 #if CONFIG_LIBUKSCHED
 int uk_posix_process_create(struct uk_alloc *a,

--- a/lib/posix-process/include/uk/process.h
+++ b/lib/posix-process/include/uk/process.h
@@ -38,6 +38,7 @@
 #include <uk/config.h>
 #include <stdbool.h>
 #include <sys/resource.h>
+#include <sys/types.h> /* pid_t */
 #if CONFIG_LIBUKSCHED
 #include <uk/thread.h>
 #endif
@@ -145,6 +146,8 @@ static inline int uk_sys_setrlimit(int resource, const struct rlimit *rlim)
 	return uk_sys_prlimit64(0, resource,
 				DECONST(struct rlimit *, rlim), NULL);
 }
+
+pid_t uk_sys_gettid(void);
 
 #if CONFIG_LIBUKSCHED
 int uk_posix_process_create(struct uk_alloc *a,

--- a/lib/posix-process/include/uk/process.h
+++ b/lib/posix-process/include/uk/process.h
@@ -148,6 +148,7 @@ static inline int uk_sys_setrlimit(int resource, const struct rlimit *rlim)
 }
 
 pid_t uk_sys_gettid(void);
+pid_t uk_sys_getppid(void);
 
 #if CONFIG_LIBUKSCHED
 int uk_posix_process_create(struct uk_alloc *a,

--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -539,7 +539,7 @@ UK_SYSCALL_R_DEFINE(pid_t, getpid)
 	return pthread_self->process->pid;
 }
 
-UK_SYSCALL_R_DEFINE(pid_t, gettid)
+pid_t uk_sys_gettid(void)
 {
 	if (!pthread_self)
 		return -ENOTSUP;
@@ -660,7 +660,7 @@ UK_SYSCALL_R_DEFINE(int, getpid)
 	return UNIKRAFT_PID;
 }
 
-UK_SYSCALL_R_DEFINE(int, gettid)
+pid_t uk_sys_gettid(void)
 {
 	return UNIKRAFT_TID;
 }
@@ -671,3 +671,8 @@ UK_SYSCALL_R_DEFINE(pid_t, getppid)
 }
 
 #endif /* !CONFIG_LIBPOSIX_PROCESS_PIDS */
+
+UK_SYSCALL_R_DEFINE(pid_t, gettid)
+{
+	return uk_sys_gettid();
+}

--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -548,7 +548,7 @@ pid_t uk_sys_gettid(void)
 }
 
 /* PID of parent process  */
-UK_SYSCALL_R_DEFINE(pid_t, getppid)
+pid_t uk_sys_getppid(void)
 {
 	if (!pthread_self)
 		return -ENOTSUP;
@@ -665,7 +665,7 @@ pid_t uk_sys_gettid(void)
 	return UNIKRAFT_TID;
 }
 
-UK_SYSCALL_R_DEFINE(pid_t, getppid)
+pid_t uk_sys_getppid(void)
 {
 	return UNIKRAFT_PPID;
 }
@@ -675,4 +675,9 @@ UK_SYSCALL_R_DEFINE(pid_t, getppid)
 UK_SYSCALL_R_DEFINE(pid_t, gettid)
 {
 	return uk_sys_gettid();
+}
+
+UK_SYSCALL_R_DEFINE(pid_t, getppid)
+{
+	return uk_sys_getppid();
 }

--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -530,7 +530,7 @@ pid_t ukthread2pid(struct uk_thread *thread)
 	return pthread->process->pid;
 }
 
-UK_SYSCALL_R_DEFINE(pid_t, getpid)
+pid_t uk_sys_getpid(void)
 {
 	if (!pthread_self)
 		return -ENOTSUP;
@@ -655,7 +655,7 @@ UK_POSIX_CLONE_HANDLER(CLONE_THREAD, false, pprocess_clone_thread, 0x0);
 #define UNIKRAFT_TID      1
 #define UNIKRAFT_PPID     0
 
-UK_SYSCALL_R_DEFINE(int, getpid)
+pid_t uk_sys_getpid(void)
 {
 	return UNIKRAFT_PID;
 }
@@ -680,4 +680,9 @@ UK_SYSCALL_R_DEFINE(pid_t, gettid)
 UK_SYSCALL_R_DEFINE(pid_t, getppid)
 {
 	return uk_sys_getppid();
+}
+
+UK_SYSCALL_R_DEFINE(pid_t, getpid)
+{
+	return uk_sys_getpid();
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Add the kernel internal variant of `gettid`, `uk_sys_gettid`. This  
allows kernel internal code to call this system call's logic without
having the syscall shim wrapper logic intervene.                    

While at it, also use this variant where possible, only place at the moment being in posix-futex.