### PR TITLE
lib/posix-process: Define kernel internal resource limit syscalls

### DIFF
--- a/lib/posix-process/deprecated.c
+++ b/lib/posix-process/deprecated.c
@@ -37,6 +37,7 @@
 #include <string.h>
 #include <sys/prctl.h>
 #include <sys/resource.h>
+#include <uk/essentials.h>
 #include <uk/process.h>
 #include <uk/print.h>
 #include <uk/syscall.h>
@@ -302,8 +303,8 @@ UK_SYSCALL_R_DEFINE(int, prctl, int, option,
 	return 0; /* syscall has no effect */
 }
 
-UK_LLSYSCALL_R_DEFINE(int, prlimit64, int, pid, unsigned int, resource,
-		      struct rlimit *, new_limit, struct rlimit *, old_limit)
+int uk_sys_prlimit64(int pid, unsigned int resource,
+		     struct rlimit *new_limit, struct rlimit *old_limit)
 {
 	if (unlikely(pid != 0))
 		uk_pr_debug("Do not support prlimit64 on PID %u, use current process\n",
@@ -374,16 +375,20 @@ UK_LLSYSCALL_R_DEFINE(int, prlimit64, int, pid, unsigned int, resource,
 	return 0;
 }
 
+UK_LLSYSCALL_R_DEFINE(int, prlimit64, int, pid, unsigned int, resource,
+		      struct rlimit *, new_limit, struct rlimit *, old_limit)
+{
+	return uk_sys_prlimit64(pid, resource, new_limit, old_limit);
+}
+
 UK_SYSCALL_R_DEFINE(int, getrlimit, int, resource, struct rlimit *, rlim)
 {
-	return uk_syscall_r_prlimit64(0, (long) resource,
-				      (long) NULL, (long) rlim);
+	return uk_sys_getrlimit(resource, rlim);
 }
 
 UK_SYSCALL_R_DEFINE(int, setrlimit, int, resource, const struct rlimit *, rlim)
 {
-	return uk_syscall_r_prlimit64(0, (long) resource,
-				      (long) rlim, (long) NULL);
+	return uk_sys_setrlimit(resource, rlim);
 }
 
 UK_SYSCALL_R_DEFINE(int, getrusage, int, who,

--- a/lib/posix-process/exportsyms.uk
+++ b/lib/posix-process/exportsyms.uk
@@ -32,6 +32,7 @@ popen
 prctl
 uk_syscall_r_prctl
 uk_syscall_e_prctl
+uk_sys_prlimit64
 prlimit
 uk_syscall_r_prlimit64
 uk_syscall_e_prlimit64

--- a/lib/posix-process/include/uk/process.h
+++ b/lib/posix-process/include/uk/process.h
@@ -37,6 +37,7 @@
 #include <arch/clone.h>
 #include <uk/config.h>
 #include <stdbool.h>
+#include <sys/resource.h>
 #if CONFIG_LIBUKSCHED
 #include <uk/thread.h>
 #endif
@@ -130,6 +131,20 @@
 #define CLONE_CLEAR_SIGHAND	0x100000000ULL
 #endif
 #endif /* CONFIG_LIBPOSIX_PROCESS_CLONE */
+
+int uk_sys_prlimit64(int pid, unsigned int resource,
+		     struct rlimit *new_limit, struct rlimit *old_limit);
+
+static inline int uk_sys_getrlimit(int resource, struct rlimit *rlim)
+{
+	return uk_sys_prlimit64(0, resource, NULL, rlim);
+}
+
+static inline int uk_sys_setrlimit(int resource, const struct rlimit *rlim)
+{
+	return uk_sys_prlimit64(0, resource,
+				DECONST(struct rlimit *, rlim), NULL);
+}
 
 #if CONFIG_LIBUKSCHED
 int uk_posix_process_create(struct uk_alloc *a,


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Add the kernel internal variants of `prlimit64`, `getrlimit` and
`setrlimit`: `uk_sys_prlimit64`, `uk_sys_getrlimit` and
`uk_sys_setrlimit` respectively.
This allows kernel internal code to call these system calls' logic
without having the syscall shim wrapper logic intervene.

Note how only `uk_sys_prlimit64` has been added to `exportsyms.uk`
since the others are defined as inline.