### PR TITLE
 lib/posix-process: Define kernel internal `exit_group`

### DIFF
--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -580,23 +580,28 @@ UK_LLSYSCALL_R_DEFINE(int, exit, int, status)
 	return -EFAULT;
 }
 
-UK_LLSYSCALL_R_DEFINE(int, exit_group, int, status)
+static int pprocess_exit(int status __unused)
 {
 	uk_posix_process_kill(uk_thread_current()); /* won't return */
 	UK_CRASH("sys_exit_group() unexpectedly returned\n");
 	return -EFAULT;
 }
 
+UK_LLSYSCALL_R_DEFINE(int, exit_group, int, status)
+{
+	return pprocess_exit(status);
+}
+
 #if UK_LIBC_SYSCALLS
 __noreturn void exit(int status)
 {
-	uk_syscall_r_exit_group(status);
+	pprocess_exit(status);
 	UK_CRASH("sys_exit_group() unexpectedly returned\n");
 }
 
 __noreturn void exit_group(int status)
 {
-	uk_syscall_r_exit_group(status);
+	pprocess_exit(status);
 	UK_CRASH("sys_exit_group() unexpectedly returned\n");
 }
 #endif /* UK_LIBC_SYSCALLS */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Add the kernel internal variant of `exit_group`, `pprocess_exit`. This allows kernel internal code to call this system call's logic without having the syscall shim wrapper logic intervene.