### PR TITLE
lib/ramfs: Use kernel internal `clock_gettime` variant

### DIFF
--- a/lib/ramfs/Config.uk
+++ b/lib/ramfs/Config.uk
@@ -2,3 +2,4 @@ config LIBRAMFS
 	bool "ramfs: simple RAM file system"
 	default n
 	depends on LIBVFSCORE
+	select LIBPOSIX_TIME


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Use the kernel internal variant of `clock_gettime`, `uk_sys_clock_gettime`.
This helps avoid unnecessary execution of the syscall wrappers' logic of syscall shim that would have otherwise been run through `uk_syscall_r_clock_gettime`.

Additionally, make sure to also handle errors of said syscall.

Lastly, since now RAMFS uses a definition available only through posix-time, add a dependency to it in the Config.uk. Ideally, this should have been a depends on HAVE_TIME and an imply, but seeing that currently this is the only library offering us time services, do it like this for now.