### PR TITLE
lib/ukcpio: Add `syscall_shim` dep and use `uk_syscall_do`

### DIFF
--- a/lib/ukcpio/Config.uk
+++ b/lib/ukcpio/Config.uk
@@ -7,4 +7,5 @@ config LIBUKCPIO
 	# ukcpio.
 	depends on LIBVFSCORE
 	select LIBNOLIBC if !HAVE_LIBC
+	select LIBSYSCALL_SHIM
 	default n


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Since the CPIO library depends on having the `uk_syscall_r_` symbols 
exported by the VFSCore library, which can only do so if the         
`syscall_shim` library is enabled, add a dependency to this said     
library.                                                             
                                                                     
This will be undone in the near future by the deprecation of VFSCore,
but for now do this so we don't break builds that use CPIO without   
`syscall_shim`.                                                      
                                                                     
Since `uk_syscall_r_` symbols tend to also invoke the system call enter
and exit tables if the `syscall_shim` library is enabled, replace such 
calls with the `uk_syscall_do_` symbol variant which does not involve  
any tables.                                                            
                                                                       
Depends-on: #1277 