### PR TITLE
lib/vfscore: Use `uk_syscall_do` for syscall delegation

### DIFF
--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -236,10 +236,11 @@ int openat(int dirfd, const char *pathname, int flags, ...)
 LFS64(openat);
 #endif /* UK_LIBC_SYSCALLS */
 
-UK_SYSCALL_DEFINE(int, creat, const char*, pathname, mode_t, mode)
+UK_SYSCALL_R_DEFINE(int, creat, const char*, pathname, mode_t, mode)
 {
-	return uk_syscall_e_open((long int) pathname,
-		O_CREAT|O_WRONLY|O_TRUNC, mode);
+	return uk_syscall_do_open((long int)pathname,
+				  O_CREAT | O_WRONLY | O_TRUNC,
+				  mode);
 }
 
 #ifdef creat64


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Since `uk_syscall_r_` symbols tend to also invoke the system call enter
and exit tables if the `syscall_shim` library is enabled, replace such 
calls with the `uk_syscall_do_` symbol variant which does not involve  
any tables.                                                            

