### PR TITLE
lib/posix-fd: Named open file descriptions

### DIFF
--- a/lib/posix-eventfd/eventfd.c
+++ b/lib/posix-eventfd/eventfd.c
@@ -21,6 +21,9 @@
 static const char EVENTFD_VOLID[] = "eventfd_vol";
 static const char EVENTFD_SEM_VOLID[] = "eventfd_semaphore_vol";
 
+#define EVENTFD_FNAME "eventfd"
+#define EVENTFD_FNAME_LEN (sizeof(EVENTFD_FNAME) - 1)
+
 #define _IS_EVFVOL(v) ((v) == EVENTFD_VOLID || (v) == EVENTFD_SEM_VOLID)
 
 typedef volatile uint64_t *evfd_node;
@@ -171,7 +174,7 @@ int uk_sys_eventfd(unsigned int count, int flags)
 		mode |= O_NONBLOCK;
 	if (flags & EFD_CLOEXEC)
 		mode |= O_CLOEXEC;
-	ret = uk_fdtab_open(evf, mode);
+	ret = uk_fdtab_open_named(evf, mode, EVENTFD_FNAME, EVENTFD_FNAME_LEN);
 	uk_file_release(evf);
 	return ret;
 }

--- a/lib/posix-fd/include/uk/posix-fd.h
+++ b/lib/posix-fd/include/uk/posix-fd.h
@@ -44,6 +44,36 @@ void uk_ofile_init(struct uk_ofile *of,
 	of->pos = 0;
 }
 
+/**
+ * Acquire a reference on open file description `of`.
+ *
+ * @param of Open file description
+ */
+static inline
+void uk_ofile_acquire(struct uk_ofile *of)
+{
+	uk_refcount_acquire(&of->refcnt);
+}
+
+/**
+ * Release a reference held on open file description `of`.
+ *
+ * Do not call directly unless you are prepared to handle cleanup after the last
+ * reference is dropped. Instead use the release function provided by the lib
+ * where you got the open file reference from.
+ *
+ * @param of Open file description
+ *
+ * @return
+ *  == 0: There are remaining references held
+ *  != 0: The last reference has just been released
+ */
+static inline
+int uk_ofile_release(struct uk_ofile *of)
+{
+	return uk_refcount_release(&of->refcnt);
+}
+
 
 /* Mode bits from fcntl.h that open files are interested in */
 #define UKFD_MODE_MASK \

--- a/lib/posix-fdtab/fdtab.c
+++ b/lib/posix-fdtab/fdtab.c
@@ -145,11 +145,11 @@ static inline void ofile_del(struct uk_fdtab *tab, struct uk_ofile *of)
 
 static inline void ofile_acq(struct uk_ofile *of)
 {
-	uk_refcount_acquire(&of->refcnt);
+	uk_ofile_acquire(of);
 }
 static inline void ofile_rel(struct uk_fdtab *tab, struct uk_ofile *of)
 {
-	if (uk_refcount_release(&of->refcnt)) {
+	if (uk_ofile_release(of)) {
 		uk_file_release(of->file);
 		ofile_del(tab, of);
 	}

--- a/lib/posix-fdtab/include/uk/posix-fdtab.h
+++ b/lib/posix-fdtab/include/uk/posix-fdtab.h
@@ -30,6 +30,68 @@
 int uk_fdtab_open(const struct uk_file *f, unsigned int mode);
 
 /**
+ * Open the file `f` with `mode` and `name` of length `len` and associate it
+ * with a file descriptor.
+ *
+ * The lifetime of `f` must cover the entirety of this function call.
+ *
+ * @param f
+ *   File to open
+ * @param mode
+ *   Mode flags to apply on the new open file description
+ * @param name
+ *   If not NULL, a copy will become the new open file description's name
+ * @param len
+ *   If name is supplied, the length of the string contained in name
+ * @return
+ *   The newly allocated file descriptor.
+ */
+int uk_fdtab_open_named(const struct uk_file *f, unsigned int mode,
+			const char *name, size_t len);
+
+/**
+ * Create a new open file description for file `f` with `mode` and optional
+ * name, without associating it with a file descriptor.
+ *
+ * The caller is responsible for filling in the .name field of returned open
+ * file descriptions before use.
+ * The returned open file description must be released with `uk_fdtab_ret` when
+ * caller is finished with it.
+ * Open file descriptions created in this way may be used as-is, or later
+ * associated with an fd with `uk_fdtab_open_desc`.
+ *
+ * @param f
+ *   File to open
+ * @param mode
+ *   Mode flags to apply on the new open file description
+ * @param len
+ *   If > 0, allocate space for a file name of length `len` (excluding NUL)
+ * @return
+ *   The new open file description, or NULL if no memory is available
+ */
+struct uk_ofile *uk_fdtab_new_desc(const struct uk_file *f, unsigned int mode,
+				   size_t len);
+
+/**
+ * Associate a file descriptor to an existing open file description.
+ *
+ * This call consumes the `of` reference. The caller MUST NOT use or release
+ * `of` after this call returns successfully.
+ * In case of error, the reference is left untouched.
+ * The open file description must have been opened by this fdtab, through either
+ * `uk_fdtab_new_desc` or `uk_fdtab_open*`.
+ *
+ * @param of
+ *   Open file description to associate fd with
+ * @param mode
+ *   If contains O_CLOEXEC, the opened fd will be close-on-exec
+ * @return
+ *   >= 0: The newly allocated file descriptor
+ *   <  0: Negative errno
+ */
+int uk_fdtab_open_desc(struct uk_ofile *of, unsigned int mode);
+
+/**
  * Gets the open file description associated with descriptor `fd`.
  *
  * Users should call uk_fdtab_ret when done with the open file reference.

--- a/lib/posix-pipe/pipe.c
+++ b/lib/posix-pipe/pipe.c
@@ -38,6 +38,12 @@
 
 static const char PIPE_VOLID[] = "pipe_vol";
 
+#define PIPE_R_FNAME "pipe:read"
+#define PIPE_R_FNAME_LEN (sizeof(PIPE_R_FNAME) - 1)
+
+#define PIPE_W_FNAME "pipe:write"
+#define PIPE_W_FNAME_LEN (sizeof(PIPE_W_FNAME) - 1)
+
 typedef __u32 pipeidx;
 
 struct pipe_msg {
@@ -428,13 +434,15 @@ int uk_sys_pipe(int pipefd[2], int flags)
 		return r;
 
 	oflags = (flags & _OPEN_FLAGS) | UKFD_O_NOSEEK;
-	r = uk_fdtab_open(pipes[0], O_RDONLY|oflags);
+	r = uk_fdtab_open_named(pipes[0], O_RDONLY | oflags,
+				PIPE_R_FNAME, PIPE_R_FNAME_LEN);
 	if (unlikely(r < 0))
 		goto err_free;
 
 	rpipe = r;
 
-	r = uk_fdtab_open(pipes[1], O_WRONLY|oflags);
+	r = uk_fdtab_open_named(pipes[1], O_WRONLY | oflags,
+				PIPE_W_FNAME, PIPE_W_FNAME_LEN);
 	if (unlikely(r < 0))
 		goto err_close;
 

--- a/lib/posix-poll/epoll.c
+++ b/lib/posix-poll/epoll.c
@@ -29,6 +29,9 @@
 
 static const char EPOLL_VOLID[] = "epoll_vol";
 
+#define EPOLL_FNAME "epollfd"
+#define EPOLL_FNAME_LEN (sizeof(EPOLL_FNAME) - 1)
+
 #define EPOLL_EVENTS \
 	(UKFD_POLLIN|UKFD_POLLOUT|EPOLLRDHUP|EPOLLPRI|UKFD_POLL_ALWAYS)
 #define EPOLL_OPTS (EPOLLET|EPOLLONESHOT|EPOLLWAKEUP|EPOLLEXCLUSIVE)
@@ -457,7 +460,7 @@ int uk_sys_epoll_create(int flags)
 	if (flags & EPOLL_CLOEXEC)
 		mode |= O_CLOEXEC;
 
-	ret = uk_fdtab_open(f, mode);
+	ret = uk_fdtab_open_named(f, mode, EPOLL_FNAME, EPOLL_FNAME_LEN);
 	uk_file_release(f);
 	return ret;
 }

--- a/lib/posix-timerfd/timerfd.c
+++ b/lib/posix-timerfd/timerfd.c
@@ -26,6 +26,8 @@
 
 static const char TIMERFD_VOLID[] = "timerfd_vol";
 
+#define TIMERFD_FNAME "timerfd"
+#define TIMERFD_FNAME_LEN (sizeof(TIMERFD_FNAME) - 1)
 
 struct timerfd_node {
 	struct itimerspec set;
@@ -299,7 +301,8 @@ int uk_sys_timerfd_create(clockid_t id, int flags)
 		mode |= O_NONBLOCK;
 	if (flags & TFD_CLOEXEC)
 		mode |= O_CLOEXEC;
-	ret = uk_fdtab_open(timerf, mode);
+	ret = uk_fdtab_open_named(timerf, mode, TIMERFD_FNAME,
+				  TIMERFD_FNAME_LEN);
 	uk_file_release(timerf);
 	return ret;
 }

--- a/lib/posix-tty/tty.c
+++ b/lib/posix-tty/tty.c
@@ -11,37 +11,68 @@
 #include <uk/posix-pseudofile.h>
 #include <uk/posix-serialfile.h>
 
+#define STDIN_FNAME_NULL "stdin:null"
+#define STDIN_FNAME_LEN_NULL (sizeof(STDIN_FNAME_NULL) - 1)
+
+#define STDIN_FNAME_VOID "stdin:void"
+#define STDIN_FNAME_LEN_VOID (sizeof(STDIN_FNAME_VOID) - 1)
+
+#define STDIN_FNAME_SERIAL "stdin:serial"
+#define STDIN_FNAME_LEN_SERIAL (sizeof(STDIN_FNAME_SERIAL) - 1)
+
+#define STDOUT_FNAME_NULL "stdout:null"
+#define STDOUT_FNAME_LEN_NULL (sizeof(STDOUT_FNAME_NULL) - 1)
+
+#define STDOUT_FNAME_SERIAL "stdout:serial"
+#define STDOUT_FNAME_LEN_SERIAL (sizeof(STDOUT_FNAME_SERIAL) - 1)
+
 static int init_posix_tty(struct uk_init_ctx *ictx __unused)
 {
 	const struct uk_file *in;
 	const struct uk_file *out;
+	const char *in_fname;
+	const char *out_fname;
+	size_t in_fnamelen;
+	size_t out_fnamelen;
 	int r;
 
 #if CONFIG_LIBPOSIX_TTY_STDIN_NULL
 	in = uk_nullfile_create();
+	in_fname = STDIN_FNAME_NULL;
+	in_fnamelen = STDIN_FNAME_LEN_NULL;
 #elif CONFIG_LIBPOSIX_TTY_STDIN_VOID
 	in = uk_voidfile_create();
+	in_fname = STDIN_FNAME_VOID;
+	in_fnamelen = STDIN_FNAME_LEN_VOID;
 #elif CONFIG_LIBPOSIX_TTY_STDIN_SERIAL
 	in = uk_serialfile_create();
+	in_fname = STDIN_FNAME_SERIAL;
+	in_fnamelen = STDIN_FNAME_LEN_SERIAL;
 #else /* !CONFIG_LIBPOSIX_TTY_STDIN_* */
-	#error Nonexistent stdin file
-#endif
+#error Nonexistent stdin file
+#endif /* !CONFIG_LIBPOSIX_TTY_STDIN_* */
 
 #if CONFIG_LIBPOSIX_TTY_STDOUT_NULL
 	out = uk_nullfile_create();
+	out_fname = STDOUT_FNAME_NULL;
+	out_fnamelen = STDOUT_FNAME_LEN_NULL;
 #elif CONFIG_LIBPOSIX_TTY_STDOUT_SERIAL
 	out = uk_serialfile_create();
+	out_fname = STDOUT_FNAME_SERIAL;
+	out_fnamelen = STDOUT_FNAME_LEN_SERIAL;
 #else /* !CONFIG_LIBPOSIX_TTY_STDOUT_* */
-	#error Nonexistent stdout file
-#endif
+#error Nonexistent stdout file
+#endif /* !CONFIG_LIBPOSIX_TTY_STDOUT_* */
 
-	r = uk_fdtab_open(in, O_RDONLY|UKFD_O_NOSEEK);
+	r = uk_fdtab_open_named(in, O_RDONLY | UKFD_O_NOSEEK,
+				in_fname, in_fnamelen);
 	if (unlikely(r != 0)) {
 		uk_pr_err("Failed to allocate fd for stdin: %d\n", r);
 		return (r < 0) ? r : -EBADF;
 	}
 
-	r = uk_fdtab_open(out, O_WRONLY|UKFD_O_NOSEEK);
+	r = uk_fdtab_open_named(out, O_WRONLY | UKFD_O_NOSEEK,
+				out_fname, out_fnamelen);
 	if (unlikely(r != 1)) {
 		uk_pr_err("Failed to allocate fd for stdout: %d\n", r);
 		return (r < 0) ? r : -EBADF;


### PR DESCRIPTION
### Description of changes

This PR adds an optional, backwards-compatible `name` field to open file descriptions, allowing for descriptive strings to be associated with files on open.
The `posix-fdtab` interface is expanded to better facilitate opening named files, and all `ukfile` drivers in the core kernel now open descriptively named files.

This work depends on PR #1278 and has it included in a first squash commit pending its merge; please disregard during review.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A