### PR TITLE
lib/posix-unixsocket: Fix NULL crash on accept4

### DIFF
--- a/lib/posix-unixsocket/unixsock.c
+++ b/lib/posix-unixsocket/unixsock.c
@@ -394,7 +394,8 @@ void *unix_socket_accept4(posix_sock *file,
 	acc->remote = data->listen.q[i].remote;
 	acc->flags |= UNIXSOCK_CONN;
 
-	unix_sock_remotename(acc->remote, addr, addr_len);
+	if (addr)
+		unix_sock_remotename(acc->remote, addr, addr_len);
 	return acc;
 }
 


### PR DESCRIPTION
### Description of changes

This change fixes a `NULL` deref when `accept4()` is handed a legal `NULL` argument for `addr`, in which case it should not attempt to output.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

Unixsockets enabled.