### PR TITLE
kconfig: Increase shell command output buffer size

### DIFF
--- a/support/kconfig/preprocess.c
+++ b/support/kconfig/preprocess.c
@@ -140,7 +140,7 @@ static char *do_lineno(int argc, char *argv[])
 static char *do_shell(int argc, char *argv[])
 {
 	FILE *p;
-	char buf[256];
+	char buf[4096];
 	char *cmd;
 	size_t nread;
 	int i;


### PR DESCRIPTION
### Description of changes
Backport upstream Linux kernel fix (commit 8a4c5b2) to increase the buffer size in do_shell from 256 to 4096 bytes. This fixes an issue where paths longer than 256 characters would be truncated.

The shell built-in is used to return paths in various Kconfig operations, and the previous buffer size was insufficient for deep directory structures, particularly in environments like Yocto builds.

Fixes: #1588

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ x] Tested your changes against relevant architectures and platforms;
 - [ x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->



<!--
Please provide a detailed description of the changes made in this new PR.
-->
