### PR TITLE
Fix Build Warning in vfscore: Update vfscore_ukopt_mkmp Parameter Type

### DIFF
--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -568,7 +568,7 @@ static int vfscore_extract_volume(const struct vfscore_volume *vv)
 #endif /* CONFIG_LIBUKCPIO */
 
 /* Handle `mkmp` Unikraft Mount Option */
-static int vfscore_ukopt_mkmp(char *path)
+static int vfscore_ukopt_mkmp(const char *path)
 {
 	char *pos, *prev_pos;
 	int rc;


### PR DESCRIPTION
### Description of changes

This pull request resolves a build warning encountered when building applications using the `vfscore` library. The warning was related to passing a `const char*` argument to the `vfscore_ukopt_mkmp` function, which expects a `char*` parameter, thereby discarding the `const` qualifier.

#### Changes made:
- Updated the `vfscore_ukopt_mkmp` function to accept a `const char*` parameter instead of `char*`. This change ensures that the function can safely accept string literals without modifying them.
- Modified the call to `vfscore_ukopt_mkmp` in the `vfscore_mount_volume` function to pass a `const char*` argument.

#### Impact:
- This change eliminates the build warning, allowing for a cleaner build process when compiling applications that use the `vfscore` library.


