### PR TITLE
plat/kvm: Fix linker warning for ARM64:warning: -z relro ignored

### DIFF
--- a/plat/kvm/Linker.uk
+++ b/plat/kvm/Linker.uk
@@ -19,7 +19,7 @@ KVM_LDFLAGS-y += -Wl,-m,aarch64elf
 KVM_LDLIBS-y += -lgcc
 else
 KVM_LDFLAGS-y += -Wl,--entry=_libkvmplat_entry
-KVM_LDFLAGS-y += -Wl,-m,aarch64elf
+KVM_LDFLAGS-y += -Wl,-m,aarch64linux
 KVM_LDLIBS-y += -lgcc
 endif
 endif


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.

### Base target

 - Architecture(s): [arm64]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Building for ARM64 with gcc results in a linker warning, as the issue https://github.com/unikraft/unikraft/issues/1507#issue-2554010253 commented.

Building with clang will not produce this warning, because clang invokes ld.lld while gcc invokes ld.bfd.

The default linker emulation for an aarch64-linux ld.bfd is -maarch64linux, the default for an aarch64-elf is -maarch64elf. And the aarch64-elf emulation does not support -z relro.

In the past, the KVM_LDFLAGS adds -m,aarch64-elf to linker regardless of its type. BFD does not support RELRO relocation types, thus a warning is generated, while LLD always creates RELRO relocation types regardless of target emulation.

Due to reasons explained above, use aarch64linux for BFD and use aarch64elf for LLD instead.