### PR TITLE
Makefile: Fix linker warning for ARM64:warning: -z norelro ignored 

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -96,7 +96,7 @@ endif
 COMPFLAGS-$(call gcc_version_ge,7,0)	+= -fPIE
 LDFLAGS-$(call gcc_version_ge,7,0)	+= -static-pie
 LDFLAGS-$(call gcc_version_ge,7,0)	+= -Wl,--no-dynamic-linker
-LDFLAGS-$(call gcc_version_ge,7,0)	+= -z notext -z norelro
+LDFLAGS-$(call gcc_version_ge,7,0)	+= -z notext
 COMPFLAGS-$(call have_clang)	+= -fPIE
 LDFLAGS-$(call have_clang)	+= -static-pie
 LDFLAGS-$(call have_clang)	+= -Wl,--no-dynamic-linker


### PR DESCRIPTION
…th CONFIG_OPTIMIZE_PIE enabled

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [arm64]
 - Platform(s): [Makefile]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->
 - `CONFIG_OPTIMIZE_PIE=y`
 
### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
When CONFIG_OPTIMIZE_PIE=y, -z norelro is added into LDFLAGS when compile with GCC. While the ld.bfd invoked by GCC does not support this option, thus generate a warning.  This PR removes this option to eliminate the warning.
