### PR TITLE
lib/posix-fdtab: Fix exec handler & ref leak on fdtab clone

### DIFF
--- a/lib/posix-fdtab/fdtab.c
+++ b/lib/posix-fdtab/fdtab.c
@@ -485,9 +485,15 @@ static int fdtab_clone(const struct clone_args *cl_args,
 		return 0;
 	} else {
 		/* Duplicate parent's fdtab */
+		int r __maybe_unused;
+
 		newtab = fdtab_duplicate(tab);
 		if (unlikely(!newtab))
 			return -ENOMEM;
+		/* Compat stop-gap: release previous duplicate ref */
+		UK_ASSERT(uk_thread_uktls_var(child, active_fdtab) == tab);
+		r = uk_refcount_release(&tab->refcnt);
+		UK_ASSERT(!r); /* Cannot have been the last ref */
 	}
 	uk_thread_uktls_var(child, active_fdtab) = newtab;
 	return 0;

--- a/lib/posix-fdtab/fdtab.c
+++ b/lib/posix-fdtab/fdtab.c
@@ -366,11 +366,22 @@ void uk_fdtab_cloexec(void)
 }
 
 #if CONFIG_LIBPOSIX_PROCESS_EXECVE
-static int fdtab_handle_execve(void *data __unused)
+#if CONFIG_LIBPOSIX_FDTAB_MULTITAB
+static int fdtab_handle_execve(void *data)
+{
+	struct posix_process_execve_event_data *edat = data;
+	struct uk_fdtab *tab = uk_thread_uktls_var(edat->thread, active_fdtab);
+
+	fdtab_cleanup(tab, 0);
+	return UK_EVENT_HANDLED_CONT;
+}
+#else /* !CONFIG_LIBPOSIX_FDTAB_MULTITAB */
+static int fdtab_handle_execve(void *data)
 {
 	uk_fdtab_cloexec();
 	return UK_EVENT_HANDLED_CONT;
 }
+#endif /* !CONFIG_LIBPOSIX_FDTAB_MULTITAB */
 
 UK_EVENT_HANDLER_PRIO(POSIX_PROCESS_EXECVE_EVENT, fdtab_handle_execve,
 		      UK_PRIO_EARLIEST);


### PR DESCRIPTION
### Description of changes

This change adds:
- a missing ref release of the previous fdtab instance on clone, leading to a reference (and thus memory) leak with multi-fdtab
- correct selection of target fdtab in the exec handler

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

Only applicable if `CONFIG_LIBPOSIX_FDTAB_MULTITAB`.