### PR TITLE
libposix-process: Create PID1 from thread passed via init

### DIFF
--- a/include/uk/init.h
+++ b/include/uk/init.h
@@ -39,6 +39,10 @@
 #include <uk/essentials.h>
 #include <uk/prio.h>
 
+#if CONFIG_LIBUKSCHED
+#include <uk/thread.h>
+#endif /* CONFIG_LIBUKSCHED */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -48,6 +52,12 @@ struct uk_init_ctx {
 		int    argc;
 		char **argv;
 	} cmdline;
+#if CONFIG_LIBUKSCHED
+	/* Set if main() executes on a separate thread,
+	 * otherwise NULL.
+	 */
+	struct uk_thread *tmain;
+#endif /* CONFIG_LIBUKSCHED */
 
 	/* reserved for future additions */
 };

--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -41,6 +41,8 @@
 #include <uk/config.h>
 #include <uk/syscall.h>
 
+struct uk_thread *pprocess_thread_main;
+
 #if CONFIG_LIBPOSIX_PROCESS_PIDS
 #include <uk/bitmap.h>
 #include <uk/list.h>
@@ -406,11 +408,26 @@ void uk_posix_process_kill(struct uk_thread *thread)
 }
 
 #if CONFIG_LIBPOSIX_PROCESS_INIT_PIDS
-static int posix_process_init(struct uk_init_ctx *ictx __unused)
+static int posix_process_init(struct uk_init_ctx *ictx)
 {
+	struct uk_thread *t;
+
+	UK_ASSERT(ictx);
+
+	/* If ictx->tmain in set, main() executes on a
+	 * separate uk_thread. Instantiate PID_INIT from
+	 * that thread, and set pprocess_thread_main, as
+	 * we will need that information later.
+	 */
+	if (ictx->tmain) {
+		t = ictx->tmain;
+		pprocess_thread_main = ictx->tmain;
+	} else {
+		t = uk_thread_current();
+	}
+
 	/* Create a POSIX process without parent ("init" process) */
-	return uk_posix_process_create(uk_alloc_get_default(),
-				       uk_thread_current(), NULL);
+	return uk_posix_process_create(uk_alloc_get_default(), t, NULL);
 }
 
 uk_late_initcall(posix_process_init, 0x0);

--- a/lib/posix-process/process.h
+++ b/lib/posix-process/process.h
@@ -49,6 +49,8 @@
 
 #define TIDMAP_SIZE (CONFIG_LIBPOSIX_PROCESS_MAX_PID + 1)
 
+extern struct uk_thread *pprocess_thread_main;
+
 /* Notice: The RUNNING state is not necessarily in sync with the state
  * of the underlying uk_thread (may be blocked by the scheduler).
  * On the other hand, the BLOCKED state implies that the underlying

--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -114,8 +114,9 @@ int main(int argc, char *argv[]) __weak;
 static inline int do_main(int argc, char *argv[]);
 
 #if CONFIG_LIBUKBOOT_MAINTHREAD
-static __noreturn void main_thread(void *, void *);
+static __noreturn void main_thread(void *);
 static void main_thread_dtor(struct uk_thread *m);
+struct uk_semaphore main_sema;
 #endif /* CONFIG_LIBUKBOOT_MAINTHREAD */
 
 #if defined(CONFIG_LIBUKBOOT_HEAP_BASE) && defined(CONFIG_LIBUKVMEM)
@@ -269,6 +270,8 @@ void uk_boot_entry(void)
 	UK_ASSERT(boot_argc);
 
 #if CONFIG_LIBUKBOOT_MAINTHREAD
+	/* Initialize main thread semaphore */
+	uk_semaphore_init(&main_sema, 0);
 	/* Initialize shutdown control structure */
 	uk_boot_shutdown_ctl_init();
 #endif /* CONFIG_LIBUKBOOT_MAINTHREAD */
@@ -364,6 +367,21 @@ void uk_boot_entry(void)
 	ictx.cmdline.argc = boot_argc;
 	ictx.cmdline.argv = boot_argv;
 
+#if CONFIG_LIBUKBOOT_MAINTHREAD
+	/* Start main thread (will block on semaphore) */
+	m = uk_sched_thread_create_fn1(s, main_thread,
+				       &ictx,
+				       0x0 /* default stack size */,
+				       0x0 /* default auxiliary stack size */,
+				       false, false,
+				       "main", NULL,
+				       main_thread_dtor);
+	if (unlikely(!m || PTRISERR(m)))
+		UK_CRASH("Failed to launch application's main()\n");
+
+	ictx.tmain = m;
+#endif /* CONFIG_LIBUKBOOT_MAINTHREAD */
+
 	/* Enable interrupts before starting the application */
 	ukplat_lcpu_enable_irq();
 
@@ -400,18 +418,8 @@ void uk_boot_entry(void)
 	tctx.target = UKPLAT_HALT;
 
 #else /* CONFIG_LIBUKBOOT_MAINTHREAD */
-	m = uk_sched_thread_create_fn2(s, main_thread,
-				       (void *)((long)ictx.cmdline.argc),
-				       (void *)ictx.cmdline.argv,
-				       0x0 /* default stack size */,
-				       0x0 /* default auxiliary stack size */,
-				       false, false,
-				       "main", NULL,
-				       main_thread_dtor);
-	if (unlikely(!m || PTRISERR(m))) {
-		uk_pr_err("Failed to launch application's main()\n");
-		goto exit;
-	}
+	/* Unblock main thread (will execute main()) */
+	uk_semaphore_up(&main_sema);
 
 	/* Block execution of "init" until we receive the first request */
 	tctx.target = uk_boot_shutdown_barrier();
@@ -505,12 +513,17 @@ static inline int do_main(int argc, char *argv[])
 }
 
 #if CONFIG_LIBUKBOOT_MAINTHREAD
-static __noreturn void main_thread(void *a_argc, void *a_argv)
+/* Pass ictx so that inittab handlers can update args */
+static __noreturn void main_thread(void *ictx)
 {
-	int argc = (int)((__uptr)a_argc);
-	char **argv = (char **)a_argv;
+	UK_ASSERT(ictx);
 
-	do_main(argc, argv);
+	/* block until we are allowed to execute main() */
+	uk_semaphore_down(&main_sema);
+
+	do_main(((struct uk_init_ctx *)ictx)->cmdline.argc,
+		((struct uk_init_ctx *)ictx)->cmdline.argv);
+
 #if !CONFIG_LIBUKBOOT_MAINTHREAD_NOHALT
 	/* NOTE: The scheduler's garbage collector would also initiate a
 	 *       shutdown request via `main_thread_dtor()`.


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Add an new element to `struct uk_init_ctx` for the thread that calls `main()`, and update `libposix-process` to use that thread when instantiating PID1. When selecting `LIBUKBOOT_MAINTHREAD` this allows excluding Unikraft's init thread from the init process. Update `libukboot` to start the main thread before running through inittab. Update the parameters of `main_thread()` to pass a pointer to `struct uk_init_ctx` to allow `argc` and `argv` to be updated by inittab.