### PR TITLE
lib/posix-process/signals: Fix conditional for sigsetops

### DIFF
--- a/lib/posix-process/signal/sigset.c
+++ b/lib/posix-process/signal/sigset.c
@@ -11,7 +11,7 @@
 
 #include "sigset.h"
 
-#if !HAVE_LIBC
+#if !CONFIG_HAVE_LIBC
 int sigaddset(sigset_t *set, int signo)
 {
 	if (unlikely(signo <= 0 || signo >= NSIG)) {
@@ -53,4 +53,4 @@ int sigismember(const sigset_t *set, int signo)
 
 	return uk_sigismember(set, signo);
 }
-#endif /* !HAVE_LIBC */
+#endif /* !CONFIG_HAVE_LIBC */


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The implementation of sigsetops was conditional to HAVE_LIBC instead of CONFIG_HAVE_LIBC, causing a build error when musl is used, due to the definiton of sigset_t to different types. Update the conditional to fix. Notice that this works as each flavor of libc controls both the type and the implementation of the functions that operate on it.
