### PR TITLE
lib/ukfile: Improve & expand iovec utils

### DIFF
--- a/lib/posix-pipe/pipe.c
+++ b/lib/posix-pipe/pipe.c
@@ -12,6 +12,7 @@
 #include <uk/alloc.h>
 #include <uk/essentials.h>
 #include <uk/file/nops.h>
+#include <uk/file/iovutil.h>
 #include <uk/posix-fd.h>
 #include <uk/posix-pipe.h>
 
@@ -33,7 +34,8 @@
 #define PIPE_IDX(x) ((x) & _PIPE_SZMASK)
 
 #define PIPE_SPACE(start, lim) \
-	(((start) <= (lim)) ? ((lim) - (start)) : (PIPE_SIZE - (start) + (lim)))
+	(((start) <= (lim)) ? (size_t)((lim) - (start)) : \
+			      (size_t)(PIPE_SIZE - (start) + (lim)))
 #define PIPE_USED(start, lim) \
 	(((start) == (lim)) ? PIPE_SIZE : PIPE_SPACE(start, lim))
 
@@ -75,97 +77,60 @@ struct pipe_alloc {
 	struct pipe_node node;
 };
 
-
-static void _pipebuf_read(const char *buf, pipeidx head, char *out, size_t n)
+static void pipebuf_iovread(const char *buf, pipeidx head, size_t toread,
+			    const struct iovec *iov, size_t iovcnt)
 {
-	if (head + n > PIPE_SIZE) {
-		/* pipebuf not contiguous, need 2 copies */
-		size_t l = PIPE_SIZE - head;
+	size_t iovi = 0;
+	size_t cur = 0;
+	size_t canread = MIN(toread, (size_t)(PIPE_SIZE - head));
+	size_t read;
 
-		memcpy(out, &buf[head], l);
-		memcpy(&out[l], buf, n - l);
-	} else {
-		memcpy(out, &buf[head], n);
+	read = uk_iov_scatter(iov, iovcnt, &buf[head], canread, &iovi, &cur);
+	toread -= read;
+	if (toread) {
+		head = PIPE_IDX(head + read);
+		(void)uk_iov_scatter(iov, iovcnt, &buf[head], toread,
+				     &iovi, &cur);
 	}
 }
 
-static void _pipebuf_write(char *buf, pipeidx head, const char *in, size_t n)
+static void pipebuf_iovwrite(char *buf, pipeidx head, size_t towrite,
+			     const struct iovec *iov, size_t iovcnt)
 {
-	if (head + n > PIPE_SIZE) {
-		/* pipebuf not contiguous, need 2 copies */
-		size_t l = PIPE_SIZE - head;
+	size_t iovi = 0;
+	size_t cur = 0;
+	size_t canwrite = MIN(towrite, (size_t)(PIPE_SIZE - head));
+	size_t written;
 
-		memcpy(&buf[head], in, l);
-		memcpy(buf, &in[l], n - l);
-	} else {
-		memcpy(&buf[head], in, n);
+	written = uk_iov_gather(&buf[head], iov, iovcnt, canwrite, &iovi, &cur);
+	towrite -= written;
+	if (towrite) {
+		head = PIPE_IDX(head + written);
+		(void)uk_iov_gather(&buf[head], iov, iovcnt, towrite,
+				    &iovi, &cur);
 	}
-}
-
-static void pipebuf_iovread(const char *buf, pipeidx head,
-			    const struct iovec *iov, size_t n)
-{
-	int i;
-
-	for (i = 0; iov[i].iov_len <= n; i++) {
-		size_t len = iov[i].iov_len;
-
-		_pipebuf_read(buf, head, (char *)iov[i].iov_base, len);
-		n -= len;
-		head = PIPE_IDX(head + len);
-	}
-	if (n)
-		_pipebuf_read(buf, head, (char *)iov[i].iov_base, n);
-}
-
-static void pipebuf_iovwrite(char *buf, pipeidx head,
-			     const struct iovec *iov, size_t n)
-{
-	int i;
-
-	for (i = 0; iov[i].iov_len <= n; i++) {
-		size_t len = iov[i].iov_len;
-
-		_pipebuf_write(buf, head, (const char *)iov[i].iov_base, len);
-		n -= len;
-		head = PIPE_IDX(head + len);
-	}
-	if (n)
-		_pipebuf_write(buf, head, (const char *)iov[i].iov_base, n);
-}
-
-static ssize_t _iovsz(const struct iovec *iov, size_t iovcnt)
-{
-	size_t ret = 0;
-
-	for (size_t i = 0; i < iovcnt; i++)
-		if (iov[i].iov_len) {
-			if (likely(iov[i].iov_base))
-				ret += iov[i].iov_len;
-			else
-				return -EFAULT;
-		}
-	return ret;
 }
 
 static ssize_t pipe_read(const struct uk_file *f,
 			 const struct iovec *iov, size_t iovcnt,
 			 size_t off, long flags __unused)
 {
-	ssize_t toread;
+	size_t toread;
 	struct pipe_node *d;
 	struct pipe_msg *m;
 	struct pipe_msg *prev;
-	ssize_t canread;
+	size_t canread;
 	pipeidx start;
 
 	UK_ASSERT(f->vol == PIPE_VOLID);
 	if (unlikely(off))
 		return -ESPIPE;
+	if (unlikely(!iov))
+		return -EFAULT;
 
-	toread = _iovsz(iov, iovcnt);
-	if (unlikely(toread <= 0))
-		return toread;
+	toread = uk_iov_len(iov, iovcnt);
+	if (unlikely(!toread))
+		return 0;
 
 	d = (struct pipe_node *)f->node;
 	m = d->head;
@@ -192,7 +157,7 @@ static ssize_t pipe_read(const struct uk_file *f,
 			prev = uk_exchange_n(&d->free, m);
 			m->next = prev;
 		} else { /* Stream msg; always last in queue */
-			ssize_t avail;
+			size_t avail;
 
 			start = m->start;
 			if (start == PIPE_SIZE) {
@@ -230,7 +195,7 @@ static ssize_t pipe_read(const struct uk_file *f,
 		break;
 	}
 	UK_ASSERT(canread);
-	pipebuf_iovread(d->buf, start, iov, canread);
+	pipebuf_iovread(d->buf, start, canread, iov, iovcnt);
 	uk_file_event_set(f, UKFD_POLLOUT);
 
 	return canread;
@@ -242,9 +207,9 @@ static ssize_t pipe_write(const struct uk_file *f,
 {
 	struct pipe_node *d;
 	struct pipe_msg *tail;
-	ssize_t towrite;
-	ssize_t canwrite;
-	ssize_t capacity;
+	size_t towrite;
+	size_t canwrite;
+	size_t capacity;
 	pipeidx whead;
 	pipeidx wend;
 	int empty = 0;
@@ -252,14 +217,16 @@ static ssize_t pipe_write(const struct uk_file *f,
 	UK_ASSERT(f->vol == PIPE_VOLID);
 	if (unlikely(off))
 		return -ESPIPE;
+	if (unlikely(!iov))
+		return -EFAULT;
 
 	d = (struct pipe_node *)f->node;
 	if (unlikely(d->flags & PIPE_HUP))
 		return -EPIPE;
 
-	towrite = _iovsz(iov, iovcnt);
-	if (unlikely(towrite <= 0))
-		return towrite;
+	towrite = uk_iov_len(iov, iovcnt);
+	if (unlikely(!towrite))
+		return 0;
 
 	tail = d->tail;
 	if (!tail || tail->next != tail) { /* Empty or last msg is packet */
@@ -307,7 +274,7 @@ static ssize_t pipe_write(const struct uk_file *f,
 		tail->end = PIPE_IDX(whead + canwrite);
 	}
 	UK_ASSERT(canwrite);
-	pipebuf_iovwrite(d->buf, whead, iov, canwrite);
+	pipebuf_iovwrite(d->buf, whead, canwrite, iov, iovcnt);
 	if (canwrite == capacity)
 		uk_file_event_clear(f, UKFD_POLLOUT);
 	if (empty)

--- a/lib/posix-tty/pseudo.c
+++ b/lib/posix-tty/pseudo.c
@@ -6,12 +6,13 @@
 
 /* Pseudo-files: files with constant input and discarding output */
 
-#include <string.h>
+#include <limits.h>
 #include <sys/stat.h>
 
 #include <uk/assert.h>
 #include <uk/file.h>
 #include <uk/file/nops.h>
+#include <uk/file/iovutil.h>
 #include <uk/posix-fd.h>
 
 /* Null file: input is always at EOF */
@@ -43,31 +44,26 @@ static ssize_t zero_read(const struct uk_file *f __maybe_unused,
 			 const struct iovec *iov, size_t iovcnt,
 			 size_t off __unused, long flags __unused)
 {
-	ssize_t total = 0;
+	size_t iovi = 0;
+	size_t cur = 0;
 
 	UK_ASSERT(f->vol == ZERO_VOLID);
+	if (unlikely(!iov))
+		return -EFAULT;
 
-	for (size_t i = 0; i < iovcnt; i++) {
-		if (unlikely(!iov[i].iov_base && iov[i].iov_len))
-			return -EFAULT;
-		memset(iov[i].iov_base, 0, iov[i].iov_len);
-		total += iov[i].iov_len;
-	}
-	return total;
+	return uk_iov_zero(iov, iovcnt, SSIZE_MAX, &iovi, &cur);
 }
 
 static ssize_t null_write(const struct uk_file *f __maybe_unused,
 			  const struct iovec *iov, size_t iovcnt,
 			  size_t off __unused, long flags __unused)
 {
-	ssize_t total = 0;
-
 	UK_ASSERT(f->vol == NULL_VOLID || f->vol == ZERO_VOLID ||
 		  f->vol == VOID_VOLID);
+	if (unlikely(!iov))
+		return -EFAULT;
 
-	for (size_t i = 0; i < iovcnt; i++)
-		total += iov[i].iov_len;
-	return total;
+	return uk_iov_len(iov, iovcnt);
 }
 
 #define PSEUDO_STATX_MASK \

--- a/lib/ukfile/include/uk/file/iovutil.h
+++ b/lib/ukfile/include/uk/file/iovutil.h
@@ -15,8 +15,77 @@
 #include <uk/essentials.h>
 
 /**
+ * Count the number of bytes described by `iov[iovcnt]`.
+ *
+ * @return Total number of bytes described by `iov[iovcnt]`
+ */
+static inline
+size_t uk_iov_len(const struct iovec *iov, size_t iovcnt)
+{
+	size_t total = 0;
+
+	for (size_t i = 0; i < iovcnt; i++)
+		total += iov[i].iov_len;
+	return total;
+}
+
+/**
+ * Count the number of bytes remaining in `iov[iovcnt]` starting at
+ * `iov[iovi][cur]`.
+ *
+ * If `iovi` is in bounds (< `iovcnt`), `cur` must also be in bounds
+ * (<= `iov[iovi].iov_len`).
+ *
+ * @return Total number of bytes remaining
+ */
+static inline
+size_t uk_iov_remaining(const struct iovec *iov, size_t iovcnt,
+			size_t iovi, size_t cur)
+{
+	if (iovi < iovcnt)
+		return uk_iov_len(iov + iovi, iovcnt - iovi) - cur;
+	return 0;
+}
+
+/**
+ * Fast-forward the iovec cursors `iovip` and `curp` by at most `len` bytes.
+ *
+ * If `*iovip` is in bounds (< `iovcnt`), `*curp` must also be in bounds
+ * (<= `iov[*iovip].iov_len`).
+ *
+ * @return Number of bytes actually fast-forwarded by
+ */
+static inline
+size_t uk_iov_ff(const struct iovec *iov, size_t iovcnt, size_t len,
+		 size_t *iovip, size_t *curp)
+{
+	size_t ret = 0;
+	size_t i = *iovip;
+	size_t cur = *curp;
+
+	while (i < iovcnt && len) {
+		const size_t sz = MIN(len, iov[i].iov_len - cur);
+
+		UK_ASSERT(cur <= iov[i].iov_len);
+		len -= sz;
+		cur += sz;
+		ret += sz;
+		if (cur == iov[i].iov_len) {
+			i++;
+			cur = 0;
+		}
+	}
+	*iovip = i;
+	*curp = cur;
+	return ret;
+}
+
+/**
  * Zero out at most `len` bytes in memory regions described by `iov[iovcnt]`,
  * starting at `*curp` offset from the buffer at `iov[*iovip]`.
+ *
+ * If `*iovip` is in bounds (< `iovcnt`), `*curp` must also be in bounds
+ * (<= `iov[*iovip].iov_len`).
  *
  * If the total remaining space in `iov` is less than `len`, exit early.
  * After the call, `*iovip` and `*curp` are updated with the new positions.
@@ -31,34 +100,23 @@ size_t uk_iov_zero(const struct iovec *iov, size_t iovcnt, size_t len,
 	size_t i = *iovip;
 	size_t cur = *curp;
 
-	UK_ASSERT(i < iovcnt);
-	UK_ASSERT(cur < iov[i].iov_len);
-	if (cur) {
-		const size_t l = MIN(len, iov[i].iov_len - cur);
+	while (i < iovcnt && len) {
+		const size_t sz = MIN(len, iov[i].iov_len - cur);
 
-		memset((char *)iov[i].iov_base + cur, 0, l);
-		ret += l;
-		len -= l;
-		cur += l;
+		UK_ASSERT(cur <= iov[i].iov_len); /* cur must be in bounds */
+		UK_ASSERT(sz || cur == iov[i].iov_len); /* must make progress */
+		if (sz) {
+			memset((char *)iov[i].iov_base + cur, 0, sz);
+			ret += sz;
+			len -= sz;
+			cur += sz;
+		}
 		if (cur == iov[i].iov_len) {
 			i++;
 			cur = 0;
 		}
 	}
-	if (len) {
-		UK_ASSERT(!cur);
-		while (i < iovcnt && len) {
-			const size_t l = MIN(iov[i].iov_len, len);
 
-			memset(iov[i].iov_base, 0, l);
-			ret += l;
-			len -= l;
-			if (len)
-				i++;
-			else
-				cur = l;
-		}
-	}
 	*iovip = i;
 	*curp = cur;
 	return ret;
@@ -67,6 +125,9 @@ size_t uk_iov_zero(const struct iovec *iov, size_t iovcnt, size_t len,
 /**
  * Copy at most `len` bytes from `buf` into memory regions described by
  * `iov[iovcnt]`, starting at `*curp` offset from the buffer at `iov[*iovip]`.
+ *
+ * If `*iovip` is in bounds (< `iovcnt`), `*curp` must also be in bounds
+ * (<= `iov[*iovip].iov_len`).
  *
  * If the total remaining space in `iov` is less than `len`, exit early.
  * After the call, `*iovip` and `*curp` are updated with the new positions.
@@ -81,36 +142,24 @@ size_t uk_iov_scatter(const struct iovec *iov, size_t iovcnt, const char *buf,
 	size_t i = *iovip;
 	size_t cur = *curp;
 
-	UK_ASSERT(i < iovcnt);
-	UK_ASSERT(cur < iov[i].iov_len);
-	if (cur) {
-		const size_t l = MIN(len, iov[i].iov_len - cur);
+	while (i < iovcnt && len) {
+		const size_t sz = MIN(len, iov[i].iov_len - cur);
 
-		memcpy((char *)iov[i].iov_base + cur, buf, l);
-		ret += l;
-		buf += l;
-		len -= l;
-		cur += l;
+		UK_ASSERT(cur <= iov[i].iov_len); /* cur must be in bounds */
+		UK_ASSERT(sz || cur == iov[i].iov_len); /* must make progress */
+		if (sz) {
+			memcpy((char *)iov[i].iov_base + cur, buf, sz);
+			ret += sz;
+			buf += sz;
+			len -= sz;
+			cur += sz;
+		}
 		if (cur == iov[i].iov_len) {
 			i++;
 			cur = 0;
 		}
 	}
-	if (len) {
-		UK_ASSERT(!cur);
-		while (i < iovcnt && len) {
-			const size_t l = MIN(iov[i].iov_len, len);
 
-			memcpy(iov[i].iov_base, buf, l);
-			ret += l;
-			buf += l;
-			len -= l;
-			if (len)
-				i++;
-			else
-				cur = l;
-		}
-	}
 	*iovip = i;
 	*curp = cur;
 	return ret;
@@ -119,6 +168,9 @@ size_t uk_iov_scatter(const struct iovec *iov, size_t iovcnt, const char *buf,
 /**
  * Copy at most `len` bytes from the memory regions described by `iov[iovcnt]`,
  * starting at `*curp` offset from the buffer at `iov[*iovip]`, into `buf`.
+ *
+ * If `*iovip` is in bounds (< `iovcnt`), `*curp` must also be in bounds
+ * (<= `iov[*iovip].iov_len`).
  *
  * If the total remaining bytes in `iov` are less than `len`, exit early.
  * After the call, `*iovip` and `*curp` are updated with the new positions.
@@ -133,67 +185,27 @@ size_t uk_iov_gather(char *buf, const struct iovec *iov, size_t iovcnt,
 	size_t i = *iovip;
 	size_t cur = *curp;
 
-	UK_ASSERT(i < iovcnt);
-	UK_ASSERT(cur < iov[i].iov_len);
-	if (cur) {
-		const size_t l = MIN(len, iov[i].iov_len - cur);
+	while (i < iovcnt && len) {
+		const size_t sz = MIN(len, iov[i].iov_len - cur);
 
-		memcpy(buf, (char *)iov[i].iov_base + cur, l);
-		ret += l;
-		buf += l;
-		len -= l;
-		cur += l;
+		UK_ASSERT(cur <= iov[i].iov_len); /* cur must be in bounds */
+		UK_ASSERT(sz || cur == iov[i].iov_len); /* must make progress */
+		if (sz) {
+			memcpy(buf, (char *)iov[i].iov_base + cur, sz);
+			ret += sz;
+			buf += sz;
+			len -= sz;
+			cur += sz;
+		}
 		if (cur == iov[i].iov_len) {
 			i++;
 			cur = 0;
 		}
 	}
-	if (len) {
-		UK_ASSERT(!cur);
-		while (i < iovcnt && len) {
-			const size_t l = MIN(iov[i].iov_len, len);
 
-			memcpy(buf, iov[i].iov_base, l);
-			ret += l;
-			buf += l;
-			len -= l;
-			if (len)
-				i++;
-			else
-				cur = l;
-		}
-	}
 	*iovip = i;
 	*curp = cur;
 	return ret;
-}
-
-/**
- * Check how many bytes the memory regions described by `iov[iovcnt]`,
- * starting at `cur` offset from the buffer at `iov[iovi]` can fit.
- *
- * @return total bytes the iov can fit
- */
-static inline
-size_t uk_iov_remaining(const struct iovec *iov, size_t iovcnt,
-			size_t iovi, size_t cur)
-{
-	size_t len = 0, i = iovi;
-
-	UK_ASSERT(i < iovcnt);
-	UK_ASSERT(cur < iov[i].iov_len);
-
-	if (cur) {
-		len += iov[i].iov_len - cur;
-		i++;
-	}
-
-	while (i < iovcnt) {
-		len += iov[i].iov_len;
-		i++;
-	}
-
-	return len;
 }
 
 #endif /* __UKFILE_IOVUTIL_H__ */


### PR DESCRIPTION
### Description of changes

This change corrects the logic of the existing zero, scatter and gather iovec utils, eliminating a number of buggy cornercases; the function documentation has been updated to more explicitly state preconditions.

In addition, 2 new util inlines are added: uk_iov_len and uk_iov_ff.
Implementations of pipes and pseudofiles have been updated to use the new utils.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A