### PR TITLE
Added 3 instances of macros instead of direct string/value

### DIFF
--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -68,6 +68,9 @@
 #define LIBVFSCORE_EXTRACT_DRV					"extract"
 #define LIBVFSCORE_EXTRACT_DEV_INITRD0				"initrd0"
 #define LIBVFSCORE_EXTRACT_DEV_EMBEDDED				"embedded"
+#define LIBVFSCORE_INITRD_OPT_MKMP				"mkmp"
+#define LIBVFSCORE_INITRD_OPT_IFINITRD0				"ifinitrd0"
+#define LIBVFSCORE_INITRD_OPT_IFNOINITRD0			"ifnoinitrd0"
 
 #define LIBVFSCORE_UKOPT_MKMP					(0x1 << 0)
 #define LIBVFSCORE_UKOPT_IFINITRD0				(0x1 << 1)
@@ -734,15 +737,15 @@ static unsigned int vfscore_volume_parse_ukopts(char *ukopts)
 			continue; /* empty option */
 		}
 
-		if (!strcmp(opt, "mkmp")) {
+		if (!strcmp(opt, LIBVFSCORE_INITRD_OPT_MKMP)) {
 			ret |= LIBVFSCORE_UKOPT_MKMP;
 			continue;
 		}
-		if (!strcmp(opt, "ifinitrd0")) {
+		if (!strcmp(opt, LIBVFSCORE_INITRD_OPT_IFINITRD0)) {
 			ret |= LIBVFSCORE_UKOPT_IFINITRD0;
 			continue;
 		}
-		if (!strcmp(opt, "ifnoinitrd0")) {
+		if (!strcmp(opt, LIBVFSCORE_INITRD_OPT_IFNOINITRD0)) {
 			ret |= LIBVFSCORE_UKOPT_IFNOINITRD0;
 			continue;
 		}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

I have verified that I have: 

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration
- N/A

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes
- Added three macros namely, ```LIBVFSCORE_INITRD_OPT_MKMP``` ``` LIBVFSCORE_INITRD_OPT_MKMP ``` ```LIBVFSCORE_INITRD_OPT_IFNOINITRD0``` that replaces ```"mkmp"``` ```"ifinitrd0"``` ```"ifnoinitrd0"```  respectively 

- This PR, aims to make things more configurable and maintain code consistency. This issue was partly solved in PR number #1409 

- Keeping in mind inputs from @StefanJum 's comment, in the PR. I have changed all three instances of the mount option.


<!--

-->


GitHub-Fixes: #1229 