### PR TITLE
lib/syscall_shim/arch/x86: Properly fetch `curr_fp` in execenv entry

### DIFF
--- a/lib/syscall_shim/arch/x86_64/include/arch/syscall_prologue.h
+++ b/lib/syscall_shim/arch/x86_64/include/arch/syscall_prologue.h
@@ -40,6 +40,9 @@
 		" */\n\t"                                               \
 		"movq   %rsp, %r11\n\t"					\
 		"movq	%gs:(" STRINGIFY(LCPU_AUXSP_OFFSET) "), %rsp\n\t"\
+		"subq	$(" STRINGIFY(UKARCH_AUXSPCB_SIZE) "), %rsp\n\t"\
+		"movq	" STRINGIFY(UKARCH_AUXSPCB_OFFSETOF_CURR_FP)	\
+						"(%rsp), %rsp\n\t"	\
 		"/* Auxiliary stack is already ECTX aligned */\n\t"	\
 		"/* Make room for `struct UKARCH_EXECENV` */\n\t"	\
 		"subq	$(" STRINGIFY(UKARCH_EXECENV_SIZE -		\


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Somehow, when
commit c716bcca4822 ("{lib,arch,plat}: Redo syscall ctx's and `swapgs` logic") introduced the auxiliary stack pointer control block it updated fetching of current frame pointer into the auxiliary stack space for ARM64 on both binary syscall entry and execenv entries but for x86 it only did so for the binary syscall entry, completely forgeting about doing the same for the execenv entry.

Fix this by updating the execenv entry to also properly fetch the current frame pointer from the auxiliary stack pointer control block.