### PR TITLE
lib/vfscore: Fix write const path in automount

### DIFF
--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -568,18 +568,19 @@ static int vfscore_extract_volume(const struct vfscore_volume *vv)
 #endif /* CONFIG_LIBUKCPIO */
 
 /* Handle `mkmp` Unikraft Mount Option */
-static int vfscore_ukopt_mkmp(char *path)
+static int vfscore_ukopt_mkmp(const char *path_arg)
 {
+	char path[strlen(path_arg) + 1];
 	char *pos, *prev_pos;
 	int rc;
 
-	UK_ASSERT(path);
-	UK_ASSERT(path[0] == '/');
+	UK_ASSERT(path_arg[0] == '/');
 
-	if (path[1] == '\0') {
+	if (path_arg[1] == '\0') {
 		uk_pr_debug(" mkmp: Called on '/', nothing to pre-create\n");
 		return 0;
 	}
+	strcpy(path, path_arg);
 
 	uk_pr_debug(" mkmp: Ensure mount path \"%s\" exists\n", path);
 	pos = path;


### PR DESCRIPTION
### Description of changes

Previously vfscore_mount_volume would pass a const path to vfscore_ukopt_mkmp, which expects a mutable path, and indeed does modify it in-place during execution. This is wrong and rightfully triggers a compiler warning.
This change fixes the issue, by passing a temporary copy to mkmp.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A