### PR TITLE
lib/ukrandom: Validate getrandom input & rm assert

### DIFF
--- a/lib/ukrandom/getrandom.c
+++ b/lib/ukrandom/getrandom.c
@@ -42,7 +42,15 @@ UK_SYSCALL_R_DEFINE(ssize_t, getrandom,
 {
 	int rc;
 
-	UK_ASSERT(buf);
+	/* Observed behavior is that for a 0-length buffer, the value in buf is
+	 * never checked and the syscall shortcuts to success.
+	 * Documentation does not specifically state this, but userspace apps
+	 * have been seen to rely on getrandom(NULL, 0, ...) returning success.
+	 */
+	if (unlikely(!buflen))
+		return 0;
+	if (unlikely(!buf))
+		return -EFAULT;
 
 	rc = uk_random_fill_buffer(buf, buflen);
 	if (unlikely(rc))


### PR DESCRIPTION
### Description of changes

This change removes the assert on the buffer argument to the getrandom syscall and replaces it with defined input validation, based on observed behavior in Linux:
- if the requested number of bytes is 0, getrandom shortcuts to success
- if buffer is NULL and > 0 bytes requested, return -EFAULT instead of crashing

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A
