### PR TITLE
lib/ukvmem: Return ENOMEM for invalid addresses

### DIFF
--- a/lib/ukvmem/vmem.c
+++ b/lib/ukvmem/vmem.c
@@ -665,7 +665,15 @@ int uk_vma_map(struct uk_vas *vas, __vaddr_t *vaddr, __sz len,
 
 	UK_ASSERT(PAGE_Lx_ALIGNED(va, algn_lvl));
 	UK_ASSERT(va <= __VADDR_MAX - len);
-	UK_ASSERT(ukarch_vaddr_range_isvalid(va, len));
+
+	/* Applications can request invalid memory ranges in mmap. In case the
+	 * address is not valid, then ENOMEM is the specfied error code.
+	 * This should only happen rarely in practice, for example when JS
+	 * engines (mozjs) do weird stuff to figure out the available address
+	 * bits.
+	 */
+	if (unlikely(!ukarch_vaddr_range_isvalid(va, len)))
+		return -ENOMEM;
 
 	/* Create a new VMA for the requested range. */
 	if (ops->new) {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): `mozjs`


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

`mmap` which calls this function can be called with non-canonical addresses. In this case, it should indicate an ENOMEM error. mozjs uses this to detect the amount of address bits.
