### PR TITLE
lib/posix-process: Make rt_sigtimedwait stub block

### DIFF
--- a/lib/posix-process/signal/rt_sigtimedwait.c
+++ b/lib/posix-process/signal/rt_sigtimedwait.c
@@ -46,11 +46,15 @@ UK_LLSYSCALL_R_DEFINE(int, rt_sigtimedwait,
 	if ((sig = pprocess_signal_next_pending_t(pthread)))
 		goto out;
 
-	if (timeout)
+	if (timeout) {
+		if (unlikely(!(uk_time_spec_canonical(timeout) &&
+			       uk_time_spec_positive(timeout))))
+			return -EINVAL;
 		uk_semaphore_down_to(&pthread->signal->pending_semaphore,
 				     uk_time_spec_to_nsec(timeout));
-	else
+	} else {
 		uk_semaphore_down(&pthread->signal->pending_semaphore);
+	}
 
 	if ((sig = pprocess_signal_next_pending_t(pthread)))
 		goto out;

--- a/lib/posix-process/signal/rt_sigtimedwait.c
+++ b/lib/posix-process/signal/rt_sigtimedwait.c
@@ -12,6 +12,11 @@
 #include <uk/syscall.h>
 #include <uk/timeutil.h>
 
+#if !CONFIG_LIBPOSIX_PROCESS_SIGNAL
+#include <uk/plat/time.h>
+#include <uk/sched.h>
+#endif /* !CONFIG_LIBPOSIX_PROCESS_SIGNAL */
+
 #include "process.h"
 #include "signal.h"
 
@@ -64,9 +69,31 @@ UK_LLSYSCALL_R_DEFINE(int, rt_sigtimedwait,
 		      const struct timespec *, timeout,
 		      size_t, sigsetsize)
 {
-	UK_WARN_STUBBED();
+	struct uk_thread *current = uk_thread_current();
+	__nsec timeout_ns;
+	int rc;
+
+	if (timeout) {
+		if (unlikely(!(uk_time_spec_canonical(timeout) &&
+			       uk_time_spec_positive(timeout))))
+			return -EINVAL;
+		timeout_ns = ukplat_monotonic_clock() +
+			ukarch_time_sec_to_nsec(timeout->tv_sec) +
+			timeout->tv_nsec;
+		uk_thread_block_until(current, (__snsec)timeout_ns);
+		uk_sched_yield();
+		rc = -EAGAIN;
+	} else {
+		uk_thread_block(current);
+		uk_sched_yield();
+		/* If this ever returns then just return an EINTR to not
+		 * confuse the application
+		 */
+		rc = -EINTR;
+	}
+
+	/* We currently never return a signal */
 	*info = (siginfo_t){0};
-	info->si_signo = SIGINT;
-	return 0;
+	return rc;
 }
 #endif /* !CONFIG_LIBPOSIX_PROCESS_SIGNAL */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

According to rt_sigtimedwait(2) the syscall should return a signal number on success (> 0) or -1 on failure, so the zero 
value currently returned by the stubbed implementation can be misinterpreted by applications that check against failure. Update the stub to return implementation to block and never return a signal.
