### PR TITLE
lib/posix-process: Terminate underlying thread only if added to sched

### DIFF
--- a/lib/posix-process/exit.c
+++ b/lib/posix-process/exit.c
@@ -131,12 +131,16 @@ void pprocess_exit_pthread(struct posix_thread *pthread,
 		parent_pthread->state = POSIX_THREAD_RUNNING;
 	}
 
-	/* Release pthread and terminate the undelying uk_thread
-	 * unless it's the current one.
+	/* Release pthread and terminate the underlying uk_thread
+	 * unless it's the current one or if it hasn't been associated
+	 * with a scheduler yet (may happen if a thread is released
+	 * before being added to the scheduler, e.g. on some error path
+	 * that cleans up created threads that didn't get the chance to
+	 * be added).
 	 */
 	thread = pthread->thread;
 	pprocess_release_pthread(pthread);
-	if (thread != uk_thread_current())
+	if (thread != uk_thread_current() && thread->sched)
 		uk_sched_thread_terminate(thread);
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The pthread termination path may try to terminate the underlying thread if it's different from the current one. However this implies that it has been added to the scheduler at some point and this may not be true if, for example, it is simply being released on the error/cleanup path of some function that created said thread and hasn't gotten to adding it to a scheduler yet.