### PR TITLE
lib/posix-process/arch/arm64: Save/restore lr/fp on clone asm stub

### DIFF
--- a/lib/posix-process/arch/arm64/clone.S
+++ b/lib/posix-process/arch/arm64/clone.S
@@ -20,10 +20,16 @@
 #if UK_LIBC_SYSCALLS
 .global clone
 clone:
+	/* We must also save the link/frame register because no one else will
+	 * do it for us since we are invoking a function call not a system call
+	 */
+	stp	x29, x30, [sp, #-32]!
+	mov	x29, sp
+
 	/* Save fn and arg in callee-saved registers, but first make sure
 	 * we can also restore them before returning in the parent.
 	 */
-	stp	x20, x21, [sp, #-16]
+	stp	x20, x21, [sp, #16]
 	mov	x20, x0
 	mov	x21, x3
 
@@ -65,6 +71,8 @@ clone:
 
 1:
 	/* Restore the registers saved in the beginning */
-	ldp	x20, x21, [sp, #-16]
+	ldp	x20, x21, [sp, #16]
+	ldp	x29, x30, [sp], #32
+
 	ret
 #endif /* UK_LIBC_SYSCALLS */

--- a/lib/syscall_shim/arch/arm64/include/arch/syscall_prologue.h
+++ b/lib/syscall_shim/arch/arm64/include/arch/syscall_prologue.h
@@ -142,7 +142,7 @@
 		"msr	daifclr, #2\n\t"				\
 		"bl	" STRINGIFY(fname) "\n\t"			\
 		"/* Only restore callee preserved regs (ABI) */\n\t"	\
-		"ldr	x30, [sp, #16 * 15]\n\t"			\
+		"ldr	x30, [sp, #16 * 15 + 8]\n\t"			\
 		"ldp	x28, x29, [sp, #16 * 14]\t\n"			\
 		"ldp	x26, x27, [sp, #16 * 13]\t\n"			\
 		"ldp	x24, x25, [sp, #16 * 12]\t\n"			\


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Commit 87fa095ae8bf ("lib/syscall_shim/arch/arm64: Store caller's link register")
updated the way we save the link register to properly emulate a                  
system call trap, so that the actual link register substitued our                
supposed ELR_EL1 and the link register from before substitutes the               
actual link register of the function that trapped. In order to achieve           
the latter it does a level 1 stack unwinding to extract the link                 
register saved at offset 8 from the frame pointer.                               
                                                                                 
However, the commit forgot to also update the way we restore the link            
register as now it wrongly restores the link register saved from the             
unwinding instead of the one from where the syscall was called.                  
                                                                                 
Fix this by properly restoring the link register from where we                   
actually save it now after said commit.                                          

Additionally, since we are invoking `clone` as a regular function call instead
of a system call, there is nobody to remember the asm stub entry
link register for us once we branch into the syscall. Therefore 
save and restore it.                                            
