### PR TITLE
lib/ukvmem: Do not populate entire stack VMA if premapped_len >= len

### DIFF
--- a/lib/ukvmem/include/uk/vmem/vma_types.h
+++ b/lib/ukvmem/include/uk/vmem/vma_types.h
@@ -140,11 +140,7 @@ static inline int uk_vma_map_stack(struct uk_vas *vas, __vaddr_t *vaddr,
 
 	flags |= UK_VMA_MAP_SIZE(PAGE_SHIFT);
 
-	/* Just populate the whole stack */
-	if (premapped_len >= len) {
-		premapped_len = len;
-		flags |= UK_VMA_MAP_POPULATE;
-	}
+	premapped_len = MIN(premapped_len, len);
 
 	rc = uk_vma_map(vas, vaddr, len + UK_VMA_STACK_GUARDS_SIZE,
 			PAGE_ATTR_PROT_RW, flags, name,


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Populating the entire stack VMA leads to the population of the guarded regions as well which will not trigger stack guard exceptions if an application did indeed cross the stack guard page.

Fix this by never setting the populate flag.
