### PR TITLE
lib/posix-process: Fix clone() return value on thread create

### DIFF
--- a/lib/posix-process/clone.c
+++ b/lib/posix-process/clone.c
@@ -559,8 +559,13 @@ int uk_clone(struct clone_args *cl_args, size_t cl_args_len,
 
 	uk_thread_set_runnable(child);
 
-	/* We will return the child's pid to the parent */
-	ret = ukthread2pid(child);
+	/* Set the return value depending on whether
+	 * a thread or a process is created.
+	 */
+	if (cl_args->flags & CLONE_THREAD)
+		ret = ukthread2tid(child);
+	else
+		ret = ukthread2pid(child);
 
 	/* Assign the child to the scheduler */
 	uk_sched_thread_add(s, child);


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Commit 08c6ac9b0ffd ("lib/posix-process: Update semantics of vfork()'s return type") introduced a regression on the return value of clone() when new threads are created. clone() should return the tid on the creation of a new thread, and the pid when a new process is created. Although in the current implementation the pid of a new process matches the underlying tid, fix this by using the corresponding macro for each case, to keep semantics clear.
