### PR TITLE
lib/uksched: Rework waitqueues to use thread data

### DIFF
--- a/drivers/xen/xenbus/xs_comms.c
+++ b/drivers/xen/xenbus/xs_comms.c
@@ -75,7 +75,7 @@ struct xs_handler {
 };
 
 static struct xs_handler xsh = {
-	.waitq = __WAIT_QUEUE_INITIALIZER(xsh.waitq),
+	.waitq = UK_WAIT_QUEUE_INITIALIZER(xsh.waitq),
 };
 
 /*

--- a/lib/uklock/include/uk/mutex.h
+++ b/lib/uklock/include/uk/mutex.h
@@ -99,11 +99,11 @@ extern __spinlock              _uk_mutex_metrics_lock;
 #endif /* CONFIG_LIBUKLOCK_MUTEX_METRICS */
 
 #define	UK_MUTEX_INITIALIZER(name)				\
-	{ 0, 0, NULL, __WAIT_QUEUE_INITIALIZER((name).wait) }
+	{ 0, 0, NULL, UK_WAIT_QUEUE_INITIALIZER((name).wait) }
 
 #define	UK_MUTEX_INITIALIZER_RECURSIVE(name)			\
 	{ 0, UK_MUTEX_CONFIG_RECURSE, 0,			\
-	__WAIT_QUEUE_INITIALIZER((name).wait) }
+	UK_WAIT_QUEUE_INITIALIZER((name).wait) }
 
 void uk_mutex_init_config(struct uk_mutex *m, unsigned int flags);
 void uk_mutex_get_metrics(struct uk_mutex_metrics *dst);

--- a/lib/uksched/include/uk/isr/wait.h
+++ b/lib/uksched/include/uk/isr/wait.h
@@ -12,13 +12,13 @@
 /* ISR variant of `uk_waitq_wake_up()` */
 static inline void uk_waitq_wake_up_isr(struct uk_waitq *wq)
 {
-	struct uk_waitq_entry *curr, *tmp;
+	struct uk_waitq_ticket *t;
 	unsigned long flags;
 
-	ukplat_spin_lock_irqsave(&wq->sl, flags);
-	UK_STAILQ_FOREACH_SAFE(curr, &wq->wait_list, thread_list, tmp)
-		uk_thread_wake_isr(curr->thread);
-	ukplat_spin_unlock_irqrestore(&wq->sl, flags);
+	_uk_waitq_lock(wq, flags);
+	uk_list_for_each_entry(t, &wq->waiters, link)
+		uk_thread_wake_isr(uk_thread_of_wait_ticket(t));
+	_uk_waitq_unlock(wq, flags);
 }
 
 #endif /* __UK_SCHED_WAIT_ISR_H__ */

--- a/lib/uksched/include/uk/thread.h
+++ b/lib/uksched/include/uk/thread.h
@@ -46,6 +46,7 @@ extern "C" {
 #endif
 
 struct uk_sched;
+struct uk_thread;
 
 typedef void (*uk_thread_dtor_t)(struct uk_thread *);
 typedef void (*uk_thread_gc_t)(struct uk_thread *, void *);
@@ -65,6 +66,7 @@ struct uk_thread {
 	uint32_t flags;
 	__snsec wakeup_time;
 	struct uk_sched *sched;
+	struct uk_waitq_ticket wait_ticket;
 
 	struct {
 		struct uk_alloc *t_a;
@@ -100,6 +102,24 @@ static inline
 struct uk_thread *uk_thread_current(void)
 {
 	return ukplat_per_lcpu_current(__uk_sched_thread_current);
+}
+
+/**
+ * Return thread containing the waitqueue ticket `ticket`.
+ */
+static inline
+struct uk_thread *uk_thread_of_wait_ticket(struct uk_waitq_ticket *ticket)
+{
+	return __containerof(ticket, struct uk_thread, wait_ticket);
+}
+
+/**
+ * True if `thread` is linked in a wait queue.
+ */
+static inline
+bool uk_thread_in_waitq(struct uk_thread *thread)
+{
+	return !!thread->wait_ticket.wq;
 }
 
 /*
@@ -652,6 +672,19 @@ void uk_thread_block_until(struct uk_thread *thread, __snsec until);
 void uk_thread_block_timeout(struct uk_thread *thread, __nsec nsec);
 void uk_thread_block(struct uk_thread *thread);
 void uk_thread_wake(struct uk_thread *thread);
+
+/**
+ * Set the wakeup timer state for thread `t`.
+ *
+ * If `deadline`:
+ *  != 0: arm a wakeup timer for time `deadline`
+ *  == 0: disarm wakeup timer
+ */
+static inline
+void uk_thread_set_wakeup(struct uk_thread *t, __snsec deadline)
+{
+	t->wakeup_time = deadline;
+}
 
 /**
  * Macro to access a Unikraft thread-local (UKTLS) variable of a

--- a/lib/uksched/include/uk/wait.h
+++ b/lib/uksched/include/uk/wait.h
@@ -102,7 +102,7 @@ do { \
 	unsigned long flags; \
 	int timedout = 0; \
 	DEFINE_WAIT(__wait); \
-	if (!(condition)) { \
+	if (unlikely(!(condition))) { \
 		__current = uk_thread_current(); \
 		for (;;) { \
 			/* protect the list */ \

--- a/lib/uksched/include/uk/wait.h
+++ b/lib/uksched/include/uk/wait.h
@@ -1,27 +1,14 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
-/*
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2025, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
  */
-/* Ported from Mini-OS */
+
+/* Unikraft wait queues */
+
+/* This is a reimplementation of the API of waitqueues from Xen MiniOS, whose
+ * BSD-2 licensed implementation served as the first waitqueues in Unikraft.
+ */
 
 #ifndef __UK_SCHED_WAIT_H__
 #define __UK_SCHED_WAIT_H__
@@ -30,6 +17,7 @@
 #include <uk/plat/lcpu.h>
 #include <uk/plat/time.h>
 #include <uk/sched.h>
+#include <uk/thread.h>
 #include <uk/wait_types.h>
 
 #ifdef __cplusplus
@@ -39,183 +27,230 @@ extern "C" {
 static inline
 void uk_waitq_init(struct uk_waitq *wq)
 {
-	ukarch_spin_init(&(wq->sl));
-	UK_STAILQ_INIT(&(wq->wait_list));
-}
-
-static inline
-void uk_waitq_entry_init(struct uk_waitq_entry *entry,
-		struct uk_thread *thread)
-{
-	entry->thread = thread;
-	entry->waiting = 0;
+	UK_INIT_LIST_HEAD(&wq->waiters);
+	ukarch_spin_init(&wq->lock);
 }
 
 static inline
 int uk_waitq_empty(struct uk_waitq *wq)
 {
-	return UK_STAILQ_EMPTY(&(wq->wait_list));
+	return uk_list_empty(&wq->waiters);
 }
 
+/**
+ * INTERNAL. Add the thread `thread` to waitqueue `wq`.
+ *
+ * `thread` must not be in a waitqueue and the lock of `wq` must be acquired.
+ */
 static inline
-void uk_waitq_add(struct uk_waitq *wq,
-		struct uk_waitq_entry *entry)
+void _uk_waitq_add(struct uk_waitq *wq, struct uk_thread *thread)
 {
-	if (!entry->waiting) {
-		UK_STAILQ_INSERT_TAIL(&(wq->wait_list), entry, thread_list);
-		entry->waiting = 1;
-	}
+	struct uk_waitq_ticket *t = &thread->wait_ticket;
+
+	UK_ASSERT(!t->wq);
+	t->wq = wq;
+	uk_list_add_tail(&t->link, &wq->waiters);
 }
 
+/**
+ * INTERNAL. Remove `thread` from the waitqueue it's in.
+ *
+ * `thread` must be linked in a waitqueue and that queue's lock must be held.
+ */
 static inline
-void uk_waitq_remove(struct uk_waitq *wq,
-		struct uk_waitq_entry *entry)
+void _uk_waitq_remove(struct uk_thread *thread)
 {
-	if (entry->waiting) {
-		UK_STAILQ_REMOVE(&(wq->wait_list), entry,
-				 struct uk_waitq_entry, thread_list);
-		entry->waiting = 0;
-	}
+	struct uk_waitq_ticket *t = &thread->wait_ticket;
+
+	UK_ASSERT(t->wq);
+	uk_list_del(&t->link);
+	t->wq = __NULL;
 }
 
-#define uk_waitq_add_waiter(wq, w) \
-do { \
-	unsigned long flags; \
-	ukplat_spin_lock_irqsave(&((wq)->sl), flags); \
-	uk_waitq_add(wq, w); \
-	ukplat_spin_unlock_irqrestore(&((wq)->sl), flags); \
-	uk_thread_block(uk_thread_current()); \
-} while (0)
+/**
+ * INTERNAL. Block thread until deadline without safeguards.
+ *
+ * We know what we're doing.
+ */
+static inline
+void _uk_waitq_block_until(struct uk_thread *thread, __snsec deadline)
+{
+	uk_thread_set_wakeup(thread, deadline);
+	uk_thread_set_blocked(thread);
+	uk_sched_thread_blocked(thread);
+}
 
-#define uk_waitq_remove_waiter(wq, w) \
-do { \
-	unsigned long flags; \
-	ukplat_spin_lock_irqsave(&((wq)->sl), flags); \
-	uk_waitq_remove(wq, w); \
-	ukplat_spin_unlock_irqrestore(&((wq)->sl), flags); \
-} while (0)
+/**
+ * INTERNAL. Acquire lock on `wq`, using `flags` to store irqflags.
+ */
+#define _uk_waitq_lock(wq, flags) \
+	ukplat_spin_lock_irqsave(&((wq)->lock), (flags))
 
-#define __wq_wait_event_deadline(wq, condition, deadline, deadline_condition, \
-				 lock_fn, unlock_fn, lock) \
-({ \
-	struct uk_thread *__current; \
-	unsigned long flags; \
-	int timedout = 0; \
-	DEFINE_WAIT(__wait); \
-	if (unlikely(!(condition))) { \
-		__current = uk_thread_current(); \
-		for (;;) { \
-			/* protect the list */ \
-			ukplat_spin_lock_irqsave(&((wq)->sl), flags); \
-			if (condition) { \
-				ukplat_spin_unlock_irqrestore(&((wq)->sl), \
-							      flags); \
-				break; \
-			} \
-			uk_waitq_add(wq, &__wait); \
-			__current->wakeup_time = deadline; \
-			uk_thread_set_blocked(__current); \
-			uk_sched_thread_blocked(__current); \
-			ukplat_spin_unlock_irqrestore(&((wq)->sl), flags); \
-			if (lock) \
-				unlock_fn(lock); \
-			uk_sched_yield(); \
-			if (lock) \
-				lock_fn(lock); \
-			if (condition) \
-				break; \
-			if (deadline_condition) { \
-				timedout = 1; \
-				break; \
-			} \
-		} \
-		ukplat_spin_lock_irqsave(&((wq)->sl), flags); \
-		/* need to wake up */ \
-		uk_thread_wake(__current); \
-		uk_waitq_remove(wq, &__wait); \
-		ukplat_spin_unlock_irqrestore(&((wq)->sl), flags); \
-	} \
-	timedout; \
+/**
+ * INTERNAL. Release lock on `wq`, restoring irqflags from `flags`.
+ */
+#define _uk_waitq_unlock(wq, flags) \
+	ukplat_spin_unlock_irqrestore(&((wq)->lock), (flags))
+
+/**
+ * INTERNAL. Wait using `wq` until `condition` is met or until a deadline.
+ *
+ * Expression returns non-zero if timed out.
+ *
+ * Depending on `condition` may wait 0 or multiple times in the queue.
+ *
+ * If `deadline` is non-zero, wait at most until that point in time;
+ * after wakeup, if `condition` is still unmet, compare `deadline` with the
+ * value supplied by `clock_expr` to determine whether a timeout has occurred.
+ *
+ * If `lock` evaluates true, it will be released before sleeping with
+ * `unlock_fn` and re-acquired after wakeup with `lock_fn`.
+ */
+#define _uk_waitq_wait_until(wq, condition, deadline, clock_expr,	\
+			     lock_fn, unlock_fn, lock)			\
+({									\
+	int _uk_waitq_timedout = 0;					\
+									\
+	while (unlikely(!(condition))) {				\
+		struct uk_thread *_uk_waitq_current = uk_thread_current();\
+		unsigned long _uk_waitq_flags;				\
+									\
+		_uk_waitq_lock((wq), _uk_waitq_flags);			\
+		if ((condition)) {					\
+			/* Condition changed in the meantime */		\
+			_uk_waitq_unlock((wq), _uk_waitq_flags);	\
+			break;						\
+		}							\
+		/* Need to wait; add self to waitqueue & block */	\
+		_uk_waitq_add((wq), _uk_waitq_current);			\
+		for (;;) {						\
+			_uk_waitq_block_until(_uk_waitq_current, (deadline));\
+			_uk_waitq_unlock((wq), _uk_waitq_flags);	\
+			if ((lock))					\
+				unlock_fn((lock));			\
+			uk_sched_yield();				\
+			/* Awoken */					\
+			if ((lock))					\
+				lock_fn((lock));			\
+			_uk_waitq_lock((wq), _uk_waitq_flags);		\
+			if ((condition))				\
+				break;					\
+			if ((deadline) && ((clock_expr) >= (deadline))) {\
+				_uk_waitq_timedout = 1;			\
+				break;					\
+			}						\
+			/* Still need to wait; back to sleep */		\
+		}							\
+		/* No more waiting, remove from queue & exit */		\
+		_uk_waitq_remove(_uk_waitq_current);			\
+		_uk_waitq_unlock((wq), _uk_waitq_flags);		\
+		break;							\
+	}								\
+	_uk_waitq_timedout;						\
 })
 
-#define uk_waitq_wait_deadline(wq, lock_fn, unlock_fn, lock, deadline, \
-			       deadline_condition) \
-({ \
-	struct uk_thread *__current; \
-	unsigned long flags; \
-	int timedout = 0; \
-	DEFINE_WAIT(__wait); \
-	__current = uk_thread_current(); \
-	ukplat_spin_lock_irqsave(&((wq)->sl), flags); \
-	uk_waitq_add(wq, &__wait); \
-	__current->wakeup_time = deadline; \
-	uk_thread_set_blocked(__current); \
-	uk_sched_thread_blocked(__current); \
-	ukplat_spin_unlock_irqrestore(&((wq)->sl), flags); \
-	if (lock) \
-		unlock_fn(lock); \
-	uk_sched_yield(); \
-	if (lock) \
-		lock_fn(lock); \
-	if (deadline_condition) \
-		timedout = 1; \
-	ukplat_spin_lock_irqsave(&((wq)->sl), flags); \
-	/* need to wake up */ \
-	uk_thread_wake(__current); \
-	uk_waitq_remove(wq, &__wait); \
-	ukplat_spin_unlock_irqrestore(&((wq)->sl), flags); \
-	timedout; \
+/**
+ * INTERNAL. Wait exactly once using `wq` until awoken or a deadline.
+ *
+ * Expression returns non-zero if timed out.
+ *
+ * If `deadline` is non-zero, wait at most until that point in time;
+ * after wakeup compare `deadline` with the value supplied by `clock_expr` to
+ * determine whether a timeout has occurred.
+ *
+ * If `lock` evaluates true, it will be released before sleeping with
+ * `unlock_fn` and re-acquired after wakeup with `lock_fn`.
+ */
+#define _uk_waitq_wait(wq, deadline, clock_expr, lock_fn, unlock_fn, lock)\
+({									\
+	struct uk_thread *_uk_waitq_current = uk_thread_current();	\
+	int _uk_waitq_timedout = 0;					\
+	unsigned long _uk_waitq_flags;					\
+									\
+	_uk_waitq_lock((wq), _uk_waitq_flags);				\
+	_uk_waitq_add((wq), _uk_waitq_current);				\
+	_uk_waitq_block_until(_uk_waitq_current, (deadline));		\
+	_uk_waitq_unlock((wq), _uk_waitq_flags);			\
+	if ((lock))							\
+		unlock_fn((lock));					\
+	uk_sched_yield();						\
+	/* Awoken */							\
+	if ((lock))							\
+		lock_fn((lock));					\
+	_uk_waitq_lock((wq), _uk_waitq_flags);				\
+	if ((deadline) && ((clock_expr) >= (deadline)))			\
+		_uk_waitq_timedout = 1;					\
+	_uk_waitq_remove(_uk_waitq_current);				\
+	_uk_waitq_unlock((wq), _uk_waitq_flags);			\
+									\
+	_uk_waitq_timedout;						\
 })
 
 #define uk_waitq_wait_locked(wq, lock_fn, unlock_fn, lock) \
-	uk_waitq_wait_deadline(wq, lock_fn, unlock_fn, lock, 0, 0)
+	_uk_waitq_wait((wq), 0, 0, lock_fn, unlock_fn, (lock))
 
-static inline void __lock_dummy(void *lock __unused) {}
+static inline void _uk_waitq_noplock(int lock __unused) {}
 
-#define uk_waitq_wait_event(wq, condition) \
-	__wq_wait_event_deadline(wq, (condition), 0, 0, \
-				 __lock_dummy, __lock_dummy, NULL)
+#define uk_waitq_wait_event(wq, condition)				\
+	_uk_waitq_wait_until((wq), (condition), 0, 0,			\
+			     _uk_waitq_noplock, _uk_waitq_noplock, 0)
 
 #define uk_waitq_wait_event_locked(wq, condition, lock_fn, unlock_fn, lock) \
-	__wq_wait_event_deadline(wq, (condition), 0, 0, \
-				 lock_fn, unlock_fn, lock)
+	_uk_waitq_wait_until((wq), (condition), 0, 0,			\
+			     lock_fn, unlock_fn, (lock))
 
-#define uk_waitq_wait_event_deadline(wq, condition, deadline) \
-	__wq_wait_event_deadline(wq, (condition), \
-		(deadline), \
-		(deadline) && ukplat_monotonic_clock() >= (deadline), \
-		__lock_dummy, __lock_dummy, NULL)
+#define uk_waitq_wait_event_deadline(wq, condition, deadline)		\
+	_uk_waitq_wait_until((wq), (condition), (deadline),		\
+			     ukplat_monotonic_clock(),			\
+			     _uk_waitq_noplock, _uk_waitq_noplock, 0)
 
-#define uk_waitq_wait_event_deadline_locked(wq, condition, deadline, \
-					    lock_fn, unlock_fn, lock) \
-	__wq_wait_event_deadline(wq, (condition), \
-		(deadline), \
-		(deadline) && ukplat_monotonic_clock() >= (deadline), \
-		lock_fn, unlock_fn, lock)
+#define uk_waitq_wait_event_deadline_locked(wq, condition, deadline,	\
+					    lock_fn, unlock_fn, lock)	\
+	_uk_waitq_wait_until((wq), (condition), (deadline),		\
+			     ukplat_monotonic_clock(),			\
+			     lock_fn, unlock_fn, (lock))
 
+/**
+ * INTERNAL. Wake thread of ticket `t` from `wq`.
+ */
+static inline
+void _uk_waitq_wake(struct uk_waitq *wq __maybe_unused,
+		    struct uk_waitq_ticket *t)
+{
+	UK_ASSERT(t->wq == wq);
+	uk_thread_wake(uk_thread_of_wait_ticket(t));
+}
+
+/**
+ * Wake all threads waiting on `wq`
+ */
 static inline
 void uk_waitq_wake_up(struct uk_waitq *wq)
 {
-	struct uk_waitq_entry *curr, *tmp;
+	struct uk_waitq_ticket *t;
 	unsigned long flags;
 
-	ukplat_spin_lock_irqsave(&(wq->sl), flags);
-	UK_STAILQ_FOREACH_SAFE(curr, &(wq->wait_list), thread_list, tmp)
-		uk_thread_wake(curr->thread);
-	ukplat_spin_unlock_irqrestore(&(wq->sl), flags);
+	_uk_waitq_lock(wq, flags);
+	uk_list_for_each_entry(t, &wq->waiters, link)
+		_uk_waitq_wake(wq, t);
+	_uk_waitq_unlock(wq, flags);
 }
 
+/**
+ * Wake at most one thread waiting on `wq`.
+ */
 static inline
 void uk_waitq_wake_up_one(struct uk_waitq *wq)
 {
-	struct uk_waitq_entry *head;
+	struct uk_waitq_ticket *t;
 	unsigned long flags;
 
-	ukplat_spin_lock_irqsave(&(wq->sl), flags);
-	head = UK_STAILQ_FIRST(&wq->wait_list);
-	if (head)
-		uk_thread_wake(head->thread);
-	ukplat_spin_unlock_irqrestore(&(wq->sl), flags);
+	_uk_waitq_lock(wq, flags);
+	t = uk_list_first_entry_or_null(&wq->waiters,
+					struct uk_waitq_ticket, link);
+	if (t)
+		_uk_waitq_wake(wq, t);
+	_uk_waitq_unlock(wq, flags);
 }
 
 #ifdef __cplusplus

--- a/lib/uksched/include/uk/wait_types.h
+++ b/lib/uksched/include/uk/wait_types.h
@@ -1,27 +1,10 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
-/*
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2025, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
  */
-/* Ported from Mini-OS */
+
+/* Types used for wait queues in Unikraft */
 
 #ifndef __UK_SCHED_WAIT_TYPES_H__
 #define __UK_SCHED_WAIT_TYPES_H__
@@ -33,34 +16,33 @@
 extern "C" {
 #endif
 
-struct uk_waitq_entry {
-	int waiting;
-	struct uk_thread *thread;
-	UK_STAILQ_ENTRY(struct uk_waitq_entry) thread_list;
+struct uk_waitq;
+
+struct uk_waitq_ticket {
+	/* Entry to link into wait queue */
+	struct uk_list_head link;
+	/* Queue we're waiting on, if waiting; must be NULL if not waiting */
+	struct uk_waitq *wq;
 };
+
+#define UK_WAITQ_TICKET_INITIALIZER { .wq = __NULL }
+
+#define UK_WAITQ_TICKET_INIT_VALUE \
+	((struct uk_waitq_ticket)UK_WAITQ_TICKET_INITIALIZER)
 
 struct uk_waitq {
-	__spinlock sl;
-	UK_STAILQ_HEAD(wait_list, struct uk_waitq_entry) wait_list;
+	struct uk_list_head waiters;
+	__spinlock lock;
 };
 
-#define __WAIT_QUEUE_INITIALIZER(name) \
-{ \
-	UKARCH_SPINLOCK_INITIALIZER(), \
-	UK_STAILQ_HEAD_INITIALIZER(name.wait_list) \
+#define UK_WAIT_QUEUE_INITIALIZER(name)				\
+{								\
+	.waiters = UK_LIST_HEAD_INIT((name).waiters),		\
+	.lock = UKARCH_SPINLOCK_INITIALIZER()			\
 }
-
-#define UK_WAIT_QUEUE_INITIALIZER(name) __WAIT_QUEUE_INITIALIZER(name)
 
 #define DEFINE_WAIT_QUEUE(name) \
-	struct uk_waitq name = __WAIT_QUEUE_INITIALIZER(name)
-
-#define DEFINE_WAIT(name) \
-struct uk_waitq_entry name = { \
-	.waiting      = 0, \
-	.thread       = uk_thread_current(), \
-	.thread_list  = { NULL } \
-}
+	struct uk_waitq name = UK_WAIT_QUEUE_INITIALIZER(name)
 
 #ifdef __cplusplus
 }

--- a/lib/uksched/sched.c
+++ b/lib/uksched/sched.c
@@ -302,6 +302,10 @@ void uk_sched_thread_terminate(struct uk_thread *thread)
 	uk_pr_debug("%p: thread %p (%s) terminated\n",
 		    sched, thread, thread->name ? thread->name : "<unnamed>");
 
+	if (uk_thread_in_waitq(thread))
+		uk_pr_warn("%p: thread %p (%s) terminated while waiting\n",
+			   sched, thread,
+			   thread->name ? thread->name : "<unnamed>");
 	/* remove from scheduling queue */
 	uk_sched_thread_remove(thread);
 	/* causes calling termination table */

--- a/lib/uksched/thread.c
+++ b/lib/uksched/thread.c
@@ -250,6 +250,7 @@ static void _uk_thread_struct_init(struct uk_thread *t,
 	t->priv = priv;
 	t->dtor = dtor;
 	t->exec_time = 0;
+	t->wait_ticket = UK_WAITQ_TICKET_INIT_VALUE;
 
 	if (auxsp) {
 		t->flags |= UK_THREADF_AUXSP;


### PR DESCRIPTION
### Description of changes

This changeset reworks the implementation of wait queues to use wakeup entries (tickets) embedded within the thread data structure instead of allocated on the execution stack of a thread.
This ensures a thread is waiting on at most one queue at a time, and enables detection when terminating a waiting thread.

The public wait queue API remains unchanged.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A
