### PR TITLE
lib/ukboot: Skip graceful shutdown on last child release

### DIFF
--- a/lib/ukboot/init.c
+++ b/lib/ukboot/init.c
@@ -204,7 +204,7 @@ int do_init(int argc, char *argv[])
 		bytes = read(sigfd, &info, sizeof(info));
 		if (bytes != sizeof(info)) {
 			uk_pr_err("Read from signalfd failed\n");
-			goto err_close_signalfd;
+			goto out;
 		}
 
 		if (info.ssi_signo == SIGCHLD) {
@@ -219,7 +219,7 @@ int do_init(int argc, char *argv[])
 
 			if (ret == -1 && errno == ECHILD) {
 				uk_pr_info("All children terminated. Initiating shutdown...\n");
-				break;
+				goto out;
 			}
 		} else if (info.ssi_signo == SIGTERM) {
 			uk_pr_info("Received SIGTERM. Initiating shutdown...\n");
@@ -231,7 +231,7 @@ int do_init(int argc, char *argv[])
 	graceful_shutdown(sigfd);
 #endif /* CONFIG_LIBUKBOOT_GRACEFUL_SHUTDOWN */
 
-err_close_signalfd:
+out:
 	/* If the application is still running, set the error code to SIGKILL
 	 * to signify it was (actually, will be) force-killed. Return back to
 	 * Unikraft to terminate all remaining processes and shut down the


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Update the execution flow to skip graceful shutdown when the last process is terminated. This fixes a system hang when entering the graceful shutdown logic blocks infinitely on epoll() for a child termination signal via signalfd.
