### PR TITLE
drivers/ukintctlr: enable PIC interrupt routing in APIC

### DIFF
--- a/arch/x86/x86_64/include/uk/asm/apic.h
+++ b/arch/x86/x86_64/include/uk/asm/apic.h
@@ -95,6 +95,7 @@
 #define APIC_ICR_DMODE_NMI		(4 << 8)
 #define APIC_ICR_DMODE_INIT		(5 << 8)
 #define APIC_ICR_DMODE_SUP		(6 << 8)
+#define APIC_ICR_DMODE_EXTINT		(7 << 8)
 
 #define APIC_ICR_DESTMODE_PHYSICAL	0
 #define APIC_ICR_DESTMODE_LOGICAL	(1 << 11)

--- a/drivers/ukintctlr/xpic/include/uk/intctlr/apic.h
+++ b/drivers/ukintctlr/xpic/include/uk/intctlr/apic.h
@@ -78,6 +78,11 @@ static inline int x2apic_enable(void)
 	return 0;
 }
 
+static inline void x2apic_enable_extint(void)
+{
+	wrmsr(APIC_MSR_LVT_LINT0, APIC_ICR_DMODE_EXTINT, 0);
+}
+
 static inline void x2apic_send_ipi(int irqno, int dest)
 {
 	__u32 eax;
@@ -150,6 +155,7 @@ static inline void x2apic_ack_interrupt(void)
 
 /* We only support x2APIC at the moment */
 #define apic_enable		x2apic_enable
+#define apic_enable_extint	x2apic_enable_extint
 #define apic_send_ipi		x2apic_send_ipi
 #define apic_send_nmi		x2apic_send_nmi
 #define apic_send_sipi		x2apic_send_sipi

--- a/drivers/ukintctlr/xpic/ukintctlr.c
+++ b/drivers/ukintctlr/xpic/ukintctlr.c
@@ -50,6 +50,8 @@ int uk_intctlr_probe(void)
 
 #if CONFIG_LIBUKINTCTLR_APIC
 	apic_enable();
+	/* Enable routing PIC interrupts. */
+	apic_enable_extint();
 	intctlr.name = "APIC";
 #else /* ! CONFIG_LIBUKINTCTLR_APIC */
 	intctlr.name = "PIC";


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`
 - Platform(s): `kvm`
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Architecturally, the APIC at reset does not route the PIC INT line to the CPU--this must be explicitly configured by setting the LVT_LINT0 register appropriately. By default, the in-kernel implementation in KVM does configure it this way, but this non-standard behavior can be disabled via a quirk flag, and some VMMs (such as OpenVMM) do this.

Support such VMMs by explicitly enabling PIC interrupt routing during startup. This is harmless on qemu/fc.

This can be removed when the PIC is no longer used (by leveraging the IOAPIC and/or MSIs for device interrupts).