### PR TITLE
lib/posix-process: Fix stack corruption in signal delivery

### DIFF
--- a/lib/posix-process/arch/arm64/signal.S
+++ b/lib/posix-process/arch/arm64/signal.S
@@ -5,22 +5,91 @@
  */
 
 #include <uk/asm.h>
+#include <uk/arch/lcpu.h>
+#include <uk/arch/ctx.h>
+#include <uk/plat/common/lcpu.h>
 
-/* Switch to application stack and call signal handler.
- * Switch back to UK stack before return.
+#include "../../signal/signal.h"
+
+/* Switch to application's context and call signal handler.
  *
- * void pprocess_signal_call_handler_with_stack(int signum, siginfo_t *si,
- *                                              ucontext_t *ctx, void *handler,
- *                                              void *sp);
+ * Before executing the handler, align the auxsp and update
+ * auxspcb->current_frame so that any kernel entry that happens
+ * while the signal handler executes, starts off a clean state.
  *
- * Notice: Parameters to handler already saved to registers
- *         via this function's first four parameters.
+ * @param handler_ctx    ptr to struct pprocess_signal_handler_ctx (x0)
+ * @param execenv        ptr to application's execenv (x1)
  */
-ENTRY(pprocess_signal_call_handler_with_stack)
-	str	x19, [sp], #16	/* save x19 before we corrupt */
-	mov	x19, sp		/* save uk sp */
-	mov	sp, x4		/* switch to handler sp */
-	blr	x3		/* call handler */
-	mov	sp, x19		/* switch back to uk sp */
-	ldr	x19, [sp], #16	/* restore x19 */
+ENTRY(pprocess_signal_jmp_handler)
+	stp	x29, x30, [sp, #-16]!
+
+	stp	x19, x20, [sp, #-16]!
+	stp	x21, x22, [sp, #-16]!
+	stp	x23, x24, [sp, #-16]!
+	mov	x29, sp /* save pre-aligned sp */
+
+	mov	x19, x0 /* handler_ctx */
+	mov	x20, x1 /* execenv */
+
+	/*───────────────────────────────────────────────────────────────────*
+	 * Save uk sysctx                                                    *
+	 *───────────────────────────────────────────────────────────────────*/
+	sub sp, sp, #UKARCH_SYSCTX_SIZE     /* reserve space for ukarch sysctx */
+	and sp, sp, #~0xf                         /* mare sure we're aligned */
+	mov x0, sp                                /* prepare args */
+	bl	ukarch_sysctx_store		/* save uk sysctx */
+
+	/*───────────────────────────────────────────────────────────────────*
+	 * Align auxspcb->curr_fp.
+	 *───────────────────────────────────────────────────────────────────*/
+	mrs	x10, tpidr_el1			/* get auxspcb */
+	add	x10, x10, #(LCPU_AUXSP_OFFSET - (UKARCH_AUXSPCB_SIZE - UKARCH_AUXSPCB_OFFSETOF_CURR_FP))
+	ldr	x11, [x10]			/* save curr_fp and its addr */
+	stp	x11, x10, [sp, #-16]!
+
+	/* Save uk sp *before* we align auxsp for nested calls.
+	 * We will be restoring the saved value upon handler return.
+	 */
+	mov	x21, sp
+
+	/* Align auxsp */
+	and	x11, sp, #~(UKARCH_AUXSP_ALIGN - 1)
+	str	x11, [x10]
+
+	/*───────────────────────────────────────────────────────────────────*
+	 * Switch to the application's sysctx                                *
+	 *───────────────────────────────────────────────────────────────────*/
+	add	x0, x20, #UKARCH_EXECENV_OFFSETOF_SYSCTX
+	bl	ukarch_sysctx_load			/* load app sysctx */
+
+	/*───────────────────────────────────────────────────────────────────*
+	 * Call signal handler                                               *
+	 *───────────────────────────────────────────────────────────────────*/
+	ldr	x22, [x19, #PPROCESS_SIGHNDL_CTX_FN_OFFS]	/* handler_fn */
+	ldr	x23, [x19, #PPROCESS_SIGHNDL_CTX_SP_OFFS]	/* handler_sp */
+	ldr	w0, [x19, #PPROCESS_SIGHNDL_CTX_SN_OFFS]	/* signum */
+	ldr	x1, [x19, #PPROCESS_SIGHNDL_CTX_SI_OFFS]	/* siginfo_t */
+	ldr	x2, [x19, #PPROCESS_SIGHNDL_CTX_UC_OFFS]	/* ucontext_t */
+
+	mov	sp, x23			/* switch to handler stack */
+	blr	x22			/* call handler */
+	mov	sp, x21			/* switch back to uk sp */
+
+	/*───────────────────────────────────────────────────────────────────*
+	 * Restore auxspcb->curr_fp                                          *
+	 *───────────────────────────────────────────────────────────────────*/
+	ldp	x11, x10, [sp], #16	/* pop auxpcb->curr_fp and &auxpcb->curr_fp */
+	str	x11, [x10]		/* restore old value */
+
+	/*───────────────────────────────────────────────────────────────────*
+	 * Restore uk sysctx                                                 *
+	 *───────────────────────────────────────────────────────────────────*/
+	mov	x0, sp				/* prepare args */
+	bl	ukarch_sysctx_load		/* restore saved sysctx */
+
+	mov	sp, x29				/* restore pre-aligned sp */
+	ldp	x23, x24, [sp], #16
+	ldp	x21, x22, [sp], #16
+	ldp	x19, x20, [sp], #16
+	ldp	x29, x30, [sp], #16
 	ret

--- a/lib/posix-process/arch/x86_64/signal.S
+++ b/lib/posix-process/arch/x86_64/signal.S
@@ -5,22 +5,90 @@
  */
 
 #include <uk/asm.h>
+#include <uk/arch/lcpu.h>
+#include <uk/arch/ctx.h>
+#include <uk/plat/common/lcpu.h>
 
-/* Switch to application stack and call signal handler.
- * Switch back to UK stack before return.
+#include "../../signal/signal.h"
+
+/* Switch to application's context and call signal handler.
  *
- * void pprocess_signal_call_handler_with_stack(int signum, siginfo_t *si,
- *                                              ucontext_t *ctx, void *handler,
- *                                              void *sp);
+ * Before executing the handler, align the auxsp and update
+ * auxspcb->current_frame so that any kernel entry that happens
+ * while the signal handler executes, starts off a clean state.
  *
- * Notice: Parameters to handler already saved to registers
- *         via this function's first four parameters.
+ * @param handler_ctx    ptr to struct pprocess_signal_handler_ctx (rdi)
+ * @param execenv        ptr to application's execenv (rsi)
  */
-ENTRY(pprocess_signal_call_handler_with_stack)
-	push	%rbp		/* save rbp before we corrupt */
-	movq    %rsp, %rbp	/* save uk sp */
-	movq    %r8, %rsp	/* switch to handler sp */
-	call    *%rcx		/* call handler */
-	movq    %rbp, %rsp	/* switch back to uk sp */
-	pop	%rbp		/* restore rbp */
+ENTRY(pprocess_signal_jmp_handler)
+	pushq	%rbp
+	pushq	%rbx
+	pushq	%r12
+	pushq	%r13
+	movq	%rsp, %rbp /* save pre-aligned rsp */
+
+	movq	%rdi, %r12 /* handler_ctx */
+	movq	%rsi, %r13 /* execenv */
+
+	/*───────────────────────────────────────────────────────────────────*
+	 * Save uk sysctx                                                    *
+	 *───────────────────────────────────────────────────────────────────*/
+	subq	$(UKARCH_SYSCTX_SIZE), %rsp /* allocate space for struct */
+	andq	$~0xf, %rsp		    /* align rsp */
+	movq	%rsp, %rdi		    /* prepare args */
+	call	ukarch_sysctx_store	    /* save uk sysctx */
+
+	/*───────────────────────────────────────────────────────────────────*
+	 * Align auxspcb->curr_fp.
+	 *───────────────────────────────────────────────────────────────────*/
+	movq	%gs:LCPU_AUXSP_OFFSET, %r10	/* get auxpcb */
+	subq	$(UKARCH_AUXSPCB_SIZE - UKARCH_AUXSPCB_OFFSETOF_CURR_FP), %r10
+	pushq	(%r10)				/* save curr_fp */
+	pushq	%r10				/* also save its addr */
+
+	/* Save uk rsp *before* we align auxsp for nested calls.
+	 * We will be restoring the saved value upon handler return.
+	 */
+	movq	%rsp, %rbx
+
+	movq	%rsp, %r11		/* now proceed to align auxsp */
+	andq	$~(UKARCH_AUXSP_ALIGN - 1), %r11
+	movq	%r11, (%r10)		/* write aligned address */
+
+	/*───────────────────────────────────────────────────────────────────*
+	 * Switch to the application's sysctx                                *
+	 *───────────────────────────────────────────────────────────────────*/
+	leaq	UKARCH_EXECENV_OFFSETOF_SYSCTX(%r13), %rdi  /* &ee->sysctx in rdi */
+	call	ukarch_sysctx_load			    /* load app sysctx */
+
+	/*───────────────────────────────────────────────────────────────────*
+	 * Call signal handler                                               *
+	 *───────────────────────────────────────────────────────────────────*/
+	movq	PPROCESS_SIGHNDL_CTX_FN_OFFS(%r12), %r10	/* handler_fn */
+	movq	PPROCESS_SIGHNDL_CTX_SP_OFFS(%r12), %r11	/* handler_sp */
+	movl	PPROCESS_SIGHNDL_CTX_SN_OFFS(%r12), %edi	/* signum */
+	movq	PPROCESS_SIGHNDL_CTX_SI_OFFS(%r12), %rsi	/* siginfo_t */
+	movq	PPROCESS_SIGHNDL_CTX_UC_OFFS(%r12), %rdx	/* ucontext_t */
+
+	movq	%r11, %rsp	/* switch to handler stack */
+	call	*%r10		/* call handler */
+	movq	%rbx, %rsp	/* switch back to uk sp */
+
+	/*───────────────────────────────────────────────────────────────────*
+	 * Restore auxspcb->curr_fp                                          *
+	 *───────────────────────────────────────────────────────────────────*/
+	popq	%r10		/* pop &auxpcb->curr_fp */
+	popq	(%r10)		/* pop &auxpcb->curr_fp */
+
+	/*───────────────────────────────────────────────────────────────────*
+	 * Restore uk sysctx                                                 *
+	 *───────────────────────────────────────────────────────────────────*/
+	movq	%rsp, %rdi		    /* prepare args */
+	call	ukarch_sysctx_load	    /* restore saved sysctx */
+
+	movq	%rbp, %rsp  /* restore pre-aligned rsp */
+	popq	%r13
+	popq	%r12
+	popq	%rbx
+	popq	%rbp
 	ret

--- a/lib/posix-process/signal/deliver.c
+++ b/lib/posix-process/signal/deliver.c
@@ -4,7 +4,9 @@
  * You may not use this file except in compliance with the License.
  */
 
+#include <uk/arch/ctx.h>
 #include <uk/essentials.h>
+#include <uk/plat/config.h>
 #include <uk/prio.h>
 #include <uk/process.h>
 #include <uk/syscall.h>
@@ -14,10 +16,30 @@
 #include "signal.h"
 #include "siginfo.h"
 
-/* asm */
-void pprocess_signal_call_handler_with_stack(int signum, siginfo_t *si,
-					     ucontext_t *ctx, void *handler,
-					     void *sp);
+struct pprocess_signal_handler_ctx {
+	void *handler_fn;
+	void *handler_sp;
+	siginfo_t *siginfo;
+	ucontext_t *ucontext;
+	int signo;
+} __packed;
+
+UK_CTASSERT(__offsetof(struct pprocess_signal_handler_ctx, handler_fn) ==
+	    PPROCESS_SIGHNDL_CTX_FN_OFFS);
+UK_CTASSERT(__offsetof(struct pprocess_signal_handler_ctx, handler_sp) ==
+	    PPROCESS_SIGHNDL_CTX_SP_OFFS);
+UK_CTASSERT(__offsetof(struct pprocess_signal_handler_ctx, signo) ==
+	    PPROCESS_SIGHNDL_CTX_SN_OFFS);
+UK_CTASSERT(__offsetof(struct pprocess_signal_handler_ctx, siginfo) ==
+	    PPROCESS_SIGHNDL_CTX_SI_OFFS);
+UK_CTASSERT(__offsetof(struct pprocess_signal_handler_ctx, ucontext) ==
+	    PPROCESS_SIGHNDL_CTX_UC_OFFS);
+
+/* Notice: We implement this in pure asm, as there is a number of issues
+ *         with correctly preserving context in inline asm.
+ */
+void pprocess_signal_jmp_handler(struct pprocess_signal_handler_ctx *h,
+				 struct ukarch_execenv *execenv);
 
 static void uk_sigact_term(int __unused sig)
 {
@@ -67,40 +89,21 @@ bool pprocess_signal_is_deliverable(struct posix_thread *pthread, int signum)
 	return (!IS_MASKED(pthread, signum) && !IS_IGNORED(proc, signum));
 }
 
-/* Switches to application context and jumps to handler.
- * Restores uk context on return.
- */
-static
-void jmp_handler(struct ukarch_execenv *execenv, int signum, siginfo_t *si,
-		 ucontext_t *ctx, void *handler, void *sp)
-{
-	struct ukarch_sysctx uk_sysctx;
-
-	ukarch_sysctx_store(&uk_sysctx);
-	ukarch_sysctx_load(&execenv->sysctx);
-
-	/* Notice: We implement this trampoline in asm as there is a ton of
-	 *         challenges involved with correctly preserving context
-	 *         with inline asm.
-	 */
-	pprocess_signal_call_handler_with_stack(signum, si, ctx, handler, sp);
-
-	ukarch_sysctx_load(&uk_sysctx);
-}
-
 static void handle_self(struct uk_signal *sig, const struct kern_sigaction *ks,
 			struct ukarch_execenv *execenv)
 {
-	ucontext_t ucontext __maybe_unused;
+	struct pprocess_signal_handler_ctx handler_ctx;
+	ucontext_t ucontext;
 	struct posix_process *this_process;
-	struct ukarch_auxspcb *auxspcb;
-	__uptr fp, saved_fp;
 	stack_t *altstack;
 	__uptr ulsp;
 
 	UK_ASSERT(sig);
 	UK_ASSERT(ks);
 	UK_ASSERT(execenv);
+
+	/* We expect to be operating on the aux stack */
+	UK_ASSERT(SP_IN_AUXSP(ukarch_read_sp(), ukplat_lcpu_get_auxsp()));
 
 	this_process = uk_pprocess_current();
 	UK_ASSERT(this_process);
@@ -116,7 +119,6 @@ static void handle_self(struct uk_signal *sig, const struct kern_sigaction *ks,
 	 * while we are executing on it, neither sigaction() modifies
 	 * sa_flags->SA_ONSTACK.
 	 */
-
 	if ((ks->ks_flags & SA_ONSTACK) && !(altstack->ss_flags & SS_DISABLE)) {
 		UK_ASSERT(altstack->ss_sp);
 		UK_ASSERT(!(altstack->ss_flags & SS_ONSTACK));
@@ -133,43 +135,23 @@ static void handle_self(struct uk_signal *sig, const struct kern_sigaction *ks,
 		uk_pr_debug("Using the application stack @ 0x%lx\n", ulsp);
 	}
 
-	/* Signal handlers can make syscalls, that can invoke signal handlers,
-	 * that can make syscalls, and so on. We need to support nesting.
-	 * Since on syscall entry we switch to the auxsp, nested syscalls will
-	 * corrupt the previous syscall's stack. To avoid that from happening,
-	 * save the base auxsp of this syscall. Once the handler returns we will
-	 * restore the original value. Moreover, prepare a new base auxsp for
-	 * the nested syscall based on the current (aligned) value of the auxsp.
-	 */
-
-	/* Assuming that we are operating on the auxsp and that
-	 * the sp has moved down since entry, align down to
-	 * UKARCH_AUXSP_ALIGN so that a nested syscall finds the
-	 * auxsp aligned. Make sure we reserve enough space for
-	 * pprocess_signal_arch_jmp_handler() to save our general
-	 * purpose registers before we jump to the application
-	 * handler.
-	 */
-	auxspcb = ukarch_auxsp_get_cb(uk_thread_current()->auxsp);
-	saved_fp = ukarch_auxspcb_get_curr_fp(auxspcb);
-
-	fp = ALIGN_DOWN(ukarch_read_sp(), UKARCH_AUXSP_ALIGN);
-	ukarch_auxspcb_set_curr_fp(auxspcb, fp);
+	handler_ctx.handler_fn = ks->ks_handler;
+	handler_ctx.handler_sp = (void *)ulsp;
+	handler_ctx.signo = sig->siginfo.si_signo;
 
 	if (ks->ks_flags & SA_SIGINFO) {
+		handler_ctx.siginfo = &sig->siginfo;
+		handler_ctx.ucontext = &ucontext;
+
 		pprocess_signal_arch_set_ucontext(execenv, &ucontext);
-		jmp_handler(execenv, sig->siginfo.si_signo,
-			    &sig->siginfo, &ucontext,
-			    ks->ks_handler, (void *)ulsp);
+		pprocess_signal_jmp_handler(&handler_ctx, execenv);
 		pprocess_signal_arch_get_ucontext(&ucontext, execenv);
 	} else {
-		jmp_handler(execenv, sig->siginfo.si_signo,
-			    NULL, NULL, ks->ks_handler,
-			    (void *)ulsp);
-	}
+		handler_ctx.siginfo = __NULL;
+		handler_ctx.ucontext = __NULL;
 
-	/* Restore the aux stack's fp */
-	ukarch_auxspcb_set_curr_fp(auxspcb, saved_fp);
+		pprocess_signal_jmp_handler(&handler_ctx, execenv);
+	}
 
 	if (ks->ks_flags & SA_ONSTACK) {
 		UK_ASSERT(altstack->ss_flags & SS_ONSTACK);
@@ -284,7 +266,7 @@ static int deliver_pending_proc(struct posix_process *proc,
 			if (IS_MASKED(thread, signum))
 				continue;
 
-			while ((sig = pprocess_signal_dequeue(proc, NULL,
+			while ((sig = pprocess_signal_dequeue(proc, __NULL,
 							      signum))) {
 				do_deliver(thread, sig, execenv);
 				uk_signal_free(proc->_a, sig);
@@ -299,7 +281,7 @@ static int deliver_pending_proc(struct posix_process *proc,
 			if (IS_MASKED(this_thread, signum))
 				continue;
 
-			while ((sig = pprocess_signal_dequeue(proc, NULL,
+			while ((sig = pprocess_signal_dequeue(proc, __NULL,
 							      signum))) {
 				do_deliver(this_thread, sig, execenv);
 				uk_signal_free(proc->_a, sig);

--- a/lib/posix-process/signal/signal.h
+++ b/lib/posix-process/signal/signal.h
@@ -7,6 +7,7 @@
 #ifndef __UK_PROCESS_SIGNAL_H__
 #define __UK_PROCESS_SIGNAL_H__
 
+#if !__ASSEMBLY__
 #include <limits.h>
 #include <signal.h>
 #include <stdbool.h>
@@ -24,9 +25,18 @@
 #if CONFIG_LIBPOSIX_PROCESS_SIGNALFD
 #include "signal_file.h"
 #endif /* CONFIG_LIBPOSIX_PROCESS_SIGNALFD */
+#endif /* __ASSEMBLY__ */
 
 #define SIG_ARRAY_COUNT		_NSIG /* SIGRTMAX + 1 */
 
+/* struct pprocess_signal_handler_ctx */
+#define	PPROCESS_SIGHNDL_CTX_FN_OFFS	 0/* handler_fn */
+#define	PPROCESS_SIGHNDL_CTX_SP_OFFS	 8/* handler_sp */
+#define	PPROCESS_SIGHNDL_CTX_SI_OFFS	16/* siginfo_t */
+#define	PPROCESS_SIGHNDL_CTX_UC_OFFS	24/* ucontext_t */
+#define	PPROCESS_SIGHNDL_CTX_SN_OFFS	32/* signum */
+
+#if !__ASSEMBLY__
 /* Check if signal number is valid */
 #define IS_VALID(_signum)						\
 	((_signum) > 0 && (_signum) <= SIGRTMAX)
@@ -91,7 +101,7 @@
  * passed to the sigaction() glibc wrapper.
  */
 struct kern_sigaction {
-	void (*ks_handler)(int signo);
+	void *ks_handler;
 	unsigned long ks_flags;
 	void (*ks_restorer)(void);
 	uk_sigset_t ks_mask;
@@ -366,4 +376,5 @@ bool pprocess_signal_should_drop(struct posix_process *pproc, int signum)
 
 #endif /* CONFIG_LIBPOSIX_PROCESS_MULTITHREADING */
 
+#endif /* !__ASSEMBLY__ */
 #endif /* __UK_PROCESS_SIGNAL_H__ */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Rework signal delivery to fix a corruption bug on the auxstack triggered when the exception handling trampoline is entered while handling a signal.