### PR TITLE
lib/uknofault: Add fuzzing layer

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -228,6 +228,13 @@ config LLVM_TARGET_ARCH
 #	  Number of jobs to run simultaneously.  If 0, determine
 #	  automatically according to number of CPUs on the host
 #	  system.
+
+config FUZZING_INTERFACE
+	bool "Add interface for fuzzing precision"
+	default n
+	help
+		Add additional checks and redirects to avoid false-positives
+		during fuzzing.
 endmenu
 
 config UK_NAME

--- a/lib/uknofault/include/uk/nofault.h
+++ b/lib/uknofault/include/uk/nofault.h
@@ -13,6 +13,24 @@
 extern "C" {
 #endif
 
+#ifdef CONFIG_FUZZING_INTERFACE
+#define FUZZING_MEMCHECK(buffer, size, permission) \
+	do { \
+		if (permission == 'r') { \
+			if (uk_nofault_probe_r(buffer, size, 0) != size) { \
+				return -EINVAL; \
+			} \
+		} \
+		else if (permission == 'w') { \
+			if (uk_nofault_probe_rw(buffer, size, 0) != size) { \
+				return -EINVAL; \
+			} \
+		} \
+	while ()
+#else
+#define FUZZING_MEMCHECK(buffer, size, permission)
+#endif
+
 /* Forces probing of the entire range. On a fault skips the offending page. */
 #define UK_NOFAULTF_CONTINUE	0x01
 


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64`]
 - Platform(s): [`kvm`]
 - Application(s): [N/A]


### Additional configuration

 - `CONFIG_FUZZING_INTERFACE=y`

### Description of changes

Add a macro that can avoid syzkaller false positives generated by the lack of `copy_from_user()` and `copy_to_user()` functions. The macro fails the checkpatch, but removing the error would  mean adding more additions to the syscalls code.

**Example of Usage**
Fuzzing the `rmdir()` syscall generates false positives when the fuzzer provides an invalid address as the syscall parameter. This can be solved by adding a `FUZZING_MEMCHECK` to the syscall code:

```c
UK_SYSCALL_R_DEFINE(int, rmdir, const char*, pathname)
{
	struct task *t = main_task;
	char path[PATH_MAX];
	int error;

       FUZZING_MEMCHECK(pathname, 1, 'r');
.....
```