### PR TITLE
lib/ukallocregion: Fix stats with alignment

### DIFF
--- a/lib/ukallocregion/region.c
+++ b/lib/ukallocregion/region.c
@@ -84,9 +84,11 @@ static void *uk_allocregion_malloc(struct uk_alloc *a, size_t size)
 	if (newbase <= (uintptr_t) b->heap_base)
 		goto enomem;
 
+	uk_alloc_stats_count_alloc(a, (void *) intptr,
+				   newbase - (uintptr_t) b->heap_base);
+
 	b->heap_base = (void *)(newbase);
 
-	uk_alloc_stats_count_alloc(a, (void *) intptr, size);
 	return (void *) intptr;
 
 enomem:
@@ -128,9 +130,12 @@ static int uk_allocregion_posix_memalign(struct uk_alloc *a, void **memptr,
 		goto enomem;
 
 	*memptr = (void *)intptr;
+
+	uk_alloc_stats_count_alloc(a, (void *) intptr,
+				   newbase - (uintptr_t)b->heap_base);
+
 	b->heap_base = (void *)(newbase);
 
-	uk_alloc_stats_count_alloc(a, (void *) intptr, size);
 	return 0;
 
 enomem:


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The region allocator failes to incorporate wasted space due to alignment constrains when calculating the used memory space for the stats. This commit fixes this.