### PR TITLE
lib/uknetdev: Reset the semaphore to zero in the dispatcher threads 

### DIFF
--- a/lib/uklock/include/uk/semaphore.h
+++ b/lib/uklock/include/uk/semaphore.h
@@ -73,6 +73,30 @@ static inline void uk_semaphore_down(struct uk_semaphore *s)
 	uk_spin_unlock_irqrestore(&(s->sl), irqf);
 }
 
+static inline long uk_semaphore_down_all(struct uk_semaphore *s)
+{
+	unsigned long irqf;
+	long count;
+
+	UK_ASSERT(s);
+
+	for (;;) {
+		uk_waitq_wait_event(&s->wait, s->count > 0);
+		irqf = ukplat_lcpu_save_irqf();
+		if (s->count > 0)
+			break;
+		ukplat_lcpu_restore_irqf(irqf);
+	}
+	count = s->count;
+	s->count = 0;
+#ifdef UK_SEMAPHORE_DEBUG
+	uk_pr_debug("Decreased semaphore %p to %ld\n", s, s->count);
+#endif
+	ukplat_lcpu_restore_irqf(irqf);
+
+	return count;
+}
+
 static inline int uk_semaphore_down_try(struct uk_semaphore *s)
 {
 	unsigned long irqf;

--- a/lib/uknetdev/netdev.c
+++ b/lib/uknetdev/netdev.c
@@ -433,7 +433,7 @@ static __noreturn void _dispatcher(void *arg)
 	UK_ASSERT(handler->callback);
 
 	for (;;) {
-		uk_semaphore_down(&handler->events);
+		uk_semaphore_down_all(&handler->events);
 		handler->callback(handler->dev,
 				  handler->queue_id,
 				  handler->cookie);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
