### PR TITLE
lib/uknofault: Ensure LTO does not remove nf_mf_handler

### DIFF
--- a/lib/uknofault/maccess.c
+++ b/lib/uknofault/maccess.c
@@ -44,8 +44,8 @@ typedef int nf_paging_state_t;
 #endif /* !CONFIG_LIBUKVMEM */
 
 /* Must be a library global symbol so that the linker can resolve it */
-int nf_mf_handler(const struct nf_excpttab_entry *e,
-		  struct ukarch_trap_ctx *ctx)
+int __used nf_mf_handler(const struct nf_excpttab_entry *e,
+			 struct ukarch_trap_ctx *ctx)
 {
 	/* Just continue execution at the fault label */
 	nf_regs_ip(ctx->regs) = nf_excpttab_get_cont_ip(e);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The compiler does not know about the uk_excpttab section and thinks that the function is not needed.