### PR TITLE
plat/kvm/x86: Provide access to ELF/PHDR structures

### DIFF
--- a/plat/kvm/arm/link64.lds.S
+++ b/plat/kvm/arm/link64.lds.S
@@ -39,6 +39,7 @@ OUTPUT_ARCH(aarch64)
 
 PHDRS
 {
+	phdrs PT_LOAD FILEHDR PHDRS FLAGS(PHDRS_PF_R);
 	text PT_LOAD FLAGS(PHDRS_PF_RX);
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
@@ -63,6 +64,10 @@ SECTIONS {
 	. = . + DTB_RESERVED_SIZE;
 
 	_base_addr = .;		/* Symbol to represent the load base address */
+
+	PROVIDE(__executable_start = _base_addr);
+	. = _base_addr + SIZEOF_HEADERS;
+	PROVIDE(__phdr = .);
 
 	/* Code */
 	_text = .;

--- a/plat/kvm/x86/link64.lds.S
+++ b/plat/kvm/x86/link64.lds.S
@@ -26,8 +26,12 @@
 #include <uk/arch/limits.h> /* for __PAGE_SIZE */
 #include <uk/plat/common/common.lds.h>
 
+#define BASE_ADDR 0x100000
+
 PHDRS
 {
+	phdrs PT_PHDR PHDRS;
+	headers PT_LOAD PHDRS FILEHDR FLAGS(PHDRS_PF_R);
 	text PT_LOAD FLAGS(PHDRS_PF_RX);
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
@@ -38,17 +42,23 @@ PHDRS
 
 SECTIONS
 {
-	. = 0x100000;
+	PROVIDE(__executable_start = BASE_ADDR);
+	. = BASE_ADDR + SIZEOF_HEADERS;
+	PROVIDE(__phdr = .);
 
-	_base_addr = .;		/* Symbol to represent the load base address */
+	_base_addr = BASE_ADDR;	/* Symbol to represent the load base address */
+
+	.headers :
+	{
+		/* prevent linker gc from removing multiboot header */
+		KEEP (*(.data.boot))
+		KEEP (*(.data.boot.*))
+	} :headers
 
 	/* Code */
 	_text = .;
 	.text :
 	{
-		/* prevent linker gc from removing multiboot header */
-		KEEP (*(.data.boot))
-		KEEP (*(.data.boot.*))
 		*(.text.boot)
 		*(.text.boot.*)
 

--- a/plat/xen/arm/link64.lds.S
+++ b/plat/xen/arm/link64.lds.S
@@ -32,6 +32,7 @@ ENTRY(_libxenplat_zimageboot)
 
 PHDRS
 {
+	phdrs PT_LOAD FILEHDR PHDRS FLAGS(PHDRS_PF_R);
 	text PT_LOAD FLAGS(PHDRS_PF_RX);
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
@@ -45,6 +46,10 @@ SECTIONS
   . = 0xffffffc000000000;
 
   _base_addr = .;		/* Symbol to represent the load base address */
+
+  PROVIDE(__executable_start = _base_addr);
+  . = _base_addr + SIZEOF_HEADERS;
+  PROVIDE(__phdr = .);
 
   _text = .;			/* Text and read-only data */
   .text : {

--- a/plat/xen/x86/link64.lds.S
+++ b/plat/xen/x86/link64.lds.S
@@ -31,6 +31,7 @@ OUTPUT_ARCH(i386:x86-64)
 
 PHDRS
 {
+	phdrs PT_LOAD FILEHDR PHDRS FLAGS(PHDRS_PF_R);
 	text PT_LOAD FLAGS(PHDRS_PF_RX);
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
@@ -45,6 +46,10 @@ SECTIONS
 	. = 0x0;
 
 	_base_addr = .;		/* Symbol to represent the load base address */
+
+	PROVIDE(__executable_start = _base_addr);
+	. = _base_addr + SIZEOF_HEADERS;
+	PROVIDE(__phdr = .);
 
 	_text = .;			/* Text and read-only data */
 	.text : {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Programs and libc implementation can use these symbols to figure out the layout of the program in-memory. Usually, programs access this information using the `dl_iterate_phdr` function.