### PR TITLE
lib/ukfile: Rework pollq implementation to use waitq

### DIFF
--- a/lib/posix-poll/epoll.c
+++ b/lib/posix-poll/epoll.c
@@ -115,8 +115,7 @@ static void epoll_event_callback(uk_pollevent set,
 		struct uk_pollq *upq = (struct uk_pollq *)tick->arg;
 
 		(void)uk_or(&ent->revents, set);
-		uk_pollq_set_n(upq, UKFD_POLLIN,
-			       IS_EDGEPOLL(ent) ? 1 : UK_POLLQ_NOTIFY_ALL);
+		uk_pollq_set_n(upq, UKFD_POLLIN, IS_EDGEPOLL(ent));
 		if (IS_ONESHOT(ent))
 			tick->mask = 0;
 	}
@@ -259,8 +258,7 @@ static void epoll_register(const struct uk_file *epf, struct epoll_entry *ent,
 	if (ev) {
 		/* Need atomic OR since we're registered for updates */
 		(void)uk_or(&ent->revents, ev);
-		uk_pollq_set_n(&epf->state->pollq, UKFD_POLLIN,
-			       edge ? 1 : UK_POLLQ_NOTIFY_ALL);
+		uk_pollq_set_n(&epf->state->pollq, UKFD_POLLIN, edge);
 	}
 }
 

--- a/lib/posix-unixsocket/unixsock.c
+++ b/lib/posix-unixsocket/unixsock.c
@@ -237,7 +237,7 @@ void unix_socket_poll_setup(posix_sock *file)
 
 	if (data->rpipe) {
 		UK_ASSERT(!(data->flags & UNIXSOCK_RDEV));
-		data->rio = UK_POLL_CHAIN_UPDATE(UKFD_POLLIN, sockq, 0);
+		data->rio = UK_POLL_CHAIN_UPDATE(UKFD_POLLIN, sockq);
 		data->rerr = UK_POLL_CHAIN_CALLBACK(EPOLLHUP,
 			unix_sock_rdown, sockq);
 		posix_sock_event_set(
@@ -251,8 +251,7 @@ void unix_socket_poll_setup(posix_sock *file)
 	if (_SOCK_CONNECTION(data->type)) {
 		if (data->wpipe) {
 			UK_ASSERT(!(data->flags & UNIXSOCK_WREV));
-			data->wio = UK_POLL_CHAIN_UPDATE(UKFD_POLLOUT,
-				sockq, 0);
+			data->wio = UK_POLL_CHAIN_UPDATE(UKFD_POLLOUT, sockq);
 			data->werr = UK_POLL_CHAIN_CALLBACK(EPOLLERR,
 				unix_sock_wdown, sockq);
 			posix_sock_event_set(

--- a/lib/ukfile/Config.uk
+++ b/lib/ukfile/Config.uk
@@ -9,6 +9,7 @@ config LIBUKFILE
 # Hidden, selected by core components when required
 config LIBUKFILE_CHAINUPDATE
 	bool
+	select LIBUKLOCK_MUTEX
 
 config LIBUKFILE_FINALIZERS
 	bool

--- a/lib/ukfile/include/uk/file.h
+++ b/lib/ukfile/include/uk/file.h
@@ -148,7 +148,7 @@ static inline void uk_file_state_wunlock(struct uk_file_state *st)
 #if CONFIG_LIBUKFILE_POLLED
 #define UK_FILE_POLLED_STATE_INITIALIZER(name, pollfunc) { \
 	.iolock = UK_RWLOCK_INITIALIZER((name).iolock, 0), \
-	.pollq = UK_POLLQ_EDGE_INITIALIZER((name).pollq, (pollfunc)) \
+	.pollq = UK_POLLQ_POLLED_INITIALIZER((name).pollq, (pollfunc)) \
 }
 #define UK_FILE_POLLED_STATE_INIT_VALUE(name, pollfunc) \
 	((struct uk_file_state)UK_FILE_POLLED_STATE_INITIALIZER( \
@@ -157,7 +157,7 @@ static inline void uk_file_state_wunlock(struct uk_file_state *st)
 
 #define UK_FILE_STATE_EVENTS_INITIALIZER(name, ev) { \
 	.iolock = UK_RWLOCK_INITIALIZER((name).iolock, 0), \
-	.pollq = UK_POLLQ_LEVEL_EVENTS_INITIALIZER((name).pollq, (ev)) \
+	.pollq = UK_POLLQ_MANAGED_EVENTS_INITIALIZER((name).pollq, (ev)) \
 }
 #define UK_FILE_STATE_EVENTS_INIT_VALUE(name, ev) \
 	((struct uk_file_state)UK_FILE_STATE_EVENTS_INITIALIZER((name), (ev)))

--- a/lib/ukfile/include/uk/file/pollqueue.h
+++ b/lib/ukfile/include/uk/file/pollqueue.h
@@ -569,14 +569,12 @@ out:
  *
  * @param q Target queue.
  * @param set Events to set.
- * @param n Maximum number of threads to wake up. If < 0 wake up all threads.
- *   Chained updates have their own defined notification semantics and may
- *   notify more threads than specified in `n`.
+ * @param one If zero, notify all waiting threads, if non-zero notify at most 1.
  *
  * @return
  *   The previous event set.
  */
-uk_pollevent uk_pollq_set_n(struct uk_pollq *q, uk_pollevent set, int n);
+uk_pollevent uk_pollq_set_n(struct uk_pollq *q, uk_pollevent set, int one);
 
 /**
  * Update events, clearing those in `clr`.
@@ -598,39 +596,15 @@ uk_pollevent uk_pollq_clear(struct uk_pollq *q, uk_pollevent clr);
  *
  * @param q Target queue.
  * @param val New event set.
- * @param n Maximum number of threads to wake up. If < 0 wake up all threads.
- *   Chained updates have their own defined notification semantics and may
- *   notify more threads than specified in `n`
+ * @param one If zero, notify all waiting threads, if non-zero notify at most 1.
  *
  * @return
  *   The previous event set.
  */
-uk_pollevent uk_pollq_assign_n(struct uk_pollq *q, uk_pollevent val, int n);
+uk_pollevent uk_pollq_assign_n(struct uk_pollq *q, uk_pollevent val, int one);
 
-#define UK_POLLQ_NOTIFY_ALL -1
+#define uk_pollq_set(q, s) uk_pollq_set_n(q, s, 0)
 
-/**
- * Update events, setting those in `set` and handling notifications.
- *
- * @param q Target queue.
- * @param set Events to set.
- *
- * @return
- *   The previous event set.
- */
-#define uk_pollq_set(q, s) uk_pollq_set_n(q, s, UK_POLLQ_NOTIFY_ALL)
-
-/**
- * Replace the events in `q` with `val` and handle notifications.
- *
- * Only available on level-triggered queues.
- *
- * @param q Target queue.
- * @param val New event set.
- *
- * @return
- *   The previous event set.
- */
-#define uk_pollq_assign(q, s) uk_pollq_assign_n(q, s, UK_POLLQ_NOTIFY_ALL)
+#define uk_pollq_assign(q, s) uk_pollq_assign_n(q, s, 0)
 
 #endif /* __UKFILE_POLLQUEUE_H__ */

--- a/lib/ukfile/include/uk/file/pollqueue.h
+++ b/lib/ukfile/include/uk/file/pollqueue.h
@@ -171,23 +171,23 @@ struct uk_pollq {
 };
 
 /*
- * Pollqueues come in two varieties: edge- and level-notified.
- * Edge-notified queues require drivers to only notify rising edges of events,
- * while providing a callback for fetching instantaneous levels.
- * Level-notified queues require drivers to notify both rising and falling edges
+ * Pollqueues come in two varieties: managed and polled.
+ * Polled queues require drivers to only notify rising edges of events, while
+ * providing a callback for fetching instantaneous levels (.poll).
+ * Managed queues require drivers to notify both rising and falling edges
  * of events, with the queue itself maintaining event levels.
  * See description of `uk_poll_func` for more details.
  *
- * Edge-notified queues require setting LIBUKFILE_POLLED during configuration.
+ * Polled queues require setting LIBUKFILE_POLLED during configuration.
  */
 /*
- * We define initializers separate from an initial values.
+ * We define initializers separate from initial values.
  * The former can only be used in (static) variable initializations, while the
  * latter is meant for assigning to variables or as anonymous data structures.
  */
 #if CONFIG_LIBUKFILE_CHAINUPDATE
 #if CONFIG_LIBUKFILE_POLLED
-#define _POLLQ_INIT(q, pollfunc, ev) { \
+#define __UK_POLLQ_INIT(q, pollfunc, ev) { \
 	.wait = NULL, \
 	.waitend = &(q).wait, \
 	.prop = NULL, \
@@ -200,7 +200,7 @@ struct uk_pollq {
 	.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0), \
 }
 #else /* !CONFIG_LIBUKFILE_POLLED */
-#define _POLLQ_INIT(q, pollfunc, ev) { \
+#define __UK_POLLQ_INIT(q, pollfunc, ev) { \
 	.wait = NULL, \
 	.waitend = &(q).wait, \
 	.prop = NULL, \
@@ -214,7 +214,7 @@ struct uk_pollq {
 #endif /* !CONFIG_LIBUKFILE_POLLED */
 #else /* !CONFIG_LIBUKFILE_CHAINUPDATE */
 #if CONFIG_LIBUKFILE_POLLED
-#define _POLLQ_INIT(q, pollfunc, ev) { \
+#define __UK_POLLQ_INIT(q, pollfunc, ev) { \
 	.wait = NULL, \
 	.waitend = &(q).wait, \
 	.poll = (pollfunc), \
@@ -223,7 +223,7 @@ struct uk_pollq {
 	.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0), \
 }
 #else /* !CONFIG_LIBUKFILE_POLLED */
-#define _POLLQ_INIT(q, pollfunc, ev) { \
+#define __UK_POLLQ_INIT(q, pollfunc, ev) { \
 	.wait = NULL, \
 	.waitend = &(q).wait, \
 	.events = (ev), \
@@ -234,19 +234,20 @@ struct uk_pollq {
 #endif /* !CONFIG_LIBUKFILE_CHAINUPDATE */
 
 #if CONFIG_LIBUKFILE_POLLED
-#define UK_POLLQ_EDGE_INITIALIZER(q, pollfunc) _POLLQ_INIT(q, pollfunc, 0)
+#define UK_POLLQ_POLLED_INITIALIZER(q, pollfunc) __UK_POLLQ_INIT(q, pollfunc, 0)
 
-#define UK_POLLQ_EDGE_INIT_VALUE(q, pollfunc) \
-	((struct uk_pollq)UK_POLLQ_EDGE_INITIALIZER(q, pollfunc))
+#define UK_POLLQ_POLLED_INIT_VALUE(q, pollfunc) \
+	((struct uk_pollq)UK_POLLQ_POLLED_INITIALIZER(q, pollfunc))
 #endif /* CONFIG_LIBUKFILE_POLLED */
 
-#define UK_POLLQ_LEVEL_EVENTS_INITIALIZER(q, ev) _POLLQ_INIT(q, NULL, ev)
-#define UK_POLLQ_LEVEL_INITIALIZER(q) UK_POLLQ_LEVEL_EVENTS_INITIALIZER(q, 0)
+#define UK_POLLQ_MANAGED_EVENTS_INITIALIZER(q, ev) __UK_POLLQ_INIT(q, NULL, ev)
+#define UK_POLLQ_MANAGED_INITIALIZER(q) \
+	UK_POLLQ_MANAGED_EVENTS_INITIALIZER(q, 0)
 
-#define UK_POLLQ_LEVEL_EVENTS_INIT_VALUE(q, ev) \
-	((struct uk_pollq)UK_POLLQ_LEVEL_EVENTS_INITIALIZER(q, ev))
-#define UK_POLLQ_LEVEL_INIT_VALUE(q) \
-	((struct uk_pollq)UK_POLLQ_LEVEL_INITIALIZER(q))
+#define UK_POLLQ_MANAGED_EVENTS_INIT_VALUE(q, ev) \
+	((struct uk_pollq)UK_POLLQ_MANAGED_EVENTS_INITIALIZER(q, ev))
+#define UK_POLLQ_MANAGED_INIT_VALUE(q) \
+	((struct uk_pollq)UK_POLLQ_MANAGED_INITIALIZER(q))
 
 /* Polling cancellation */
 

--- a/lib/ukfile/include/uk/file/pollqueue.h
+++ b/lib/ukfile/include/uk/file/pollqueue.h
@@ -15,7 +15,12 @@
 #include <uk/atomic.h>
 #include <uk/rwlock.h>
 #include <uk/plat/time.h>
-#include <uk/thread.h>
+#include <uk/wait.h>
+
+#if CONFIG_LIBUKFILE_CHAINUPDATE
+#include <uk/list.h>
+#include <uk/mutex.h>
+#endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
 
 /*
  * Bitmask of event flags.
@@ -34,6 +39,7 @@ struct uk_file;
  *
  * This function cannot (meaningfully) fail, must not block indefinitely, and
  * should avoid taking locks or yielding execution when possible.
+ * This function may be called arbitrarily concurrent.
  *
  * Drivers may choose to not provide this callback, in which case they are
  * responsible for updating the current event levels with `uk_pollq_set`,
@@ -52,18 +58,6 @@ struct uk_file;
 typedef uk_pollevent (*uk_poll_func)(const struct uk_file *f,
 				     uk_pollevent mask);
 #endif /* CONFIG_LIBUKFILE_POLLED */
-
-/**
- * Ticket for registering on the poll waiting list.
- *
- * If the newly set events overlap with those in `mask`, wake up `thread`.
- * Tickets are atomically released from the wait queue when waking.
- */
-struct uk_poll_ticket {
-	struct uk_poll_ticket *next;
-	struct uk_thread *thread; /* Thread to wake up */
-	uk_pollevent mask; /* Events to register for */
-};
 
 #if CONFIG_LIBUKFILE_CHAINUPDATE
 
@@ -101,13 +95,11 @@ typedef void (*uk_poll_chain_callback_fn)(uk_pollevent ev,
  *   - UK_POLL_CHAINTYPE_CALLBACK: call `callback`
  */
 struct uk_poll_chain {
-	struct uk_poll_chain *next;
+	UK_STAILQ_ENTRY(struct uk_poll_chain) list_entry;
 	uk_pollevent mask; /* Events to register for */
 	enum uk_poll_chain_type type;
 	union {
-		struct {
-			struct uk_pollq *queue; /* Where to propagate updates */
-		};
+		struct uk_pollq *queue; /* Where to propagate updates */
 		struct {
 			uk_poll_chain_callback_fn callback;
 			void *arg;
@@ -119,7 +111,6 @@ struct uk_poll_chain {
 
 /* Initializer for a chain ticket that propagates events to another queue */
 #define UK_POLL_CHAIN_UPDATE_INITIALZER(msk, to) { \
-	.next = NULL, \
 	.mask = (msk), \
 	.type = UK_POLL_CHAINTYPE_UPDATE, \
 	.queue = (to), \
@@ -130,7 +121,6 @@ struct uk_poll_chain {
 
 /* Initializer for a chain ticket that calls a custom callback */
 #define UK_POLL_CHAIN_CALLBACK_INITIALIZER(msk, cb, dat) { \
-	.next = NULL, \
 	.mask = (msk), \
 	.type = UK_POLL_CHAINTYPE_CALLBACK, \
 	.callback = (cb), \
@@ -144,35 +134,25 @@ struct uk_poll_chain {
 
 /* Main queue */
 struct uk_pollq {
-	/* Notification lists */
-	struct uk_poll_ticket *wait; /* Polling threads */
-	struct uk_poll_ticket **waitend;
-#if CONFIG_LIBUKFILE_CHAINUPDATE
-	struct uk_poll_chain *prop; /* Registrations for chained updates */
-	struct uk_poll_chain **propend;
-#endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
-
-	/* Events */
 #if CONFIG_LIBUKFILE_POLLED
-	uk_poll_func poll; /* If provided, used instead of reading .events */
+	uk_poll_func poll_fn;
 #endif /* CONFIG_LIBUKFILE_POLLED */
-	volatile uk_pollevent events; /* Instantaneous event levels */
-	uk_pollevent waitmask; /* Events waited on by threads */
-#if CONFIG_LIBUKFILE_CHAINUPDATE
-	uk_pollevent propmask; /* Events registered for chaining */
-#endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
-	/* Locks & sundry */
+	uk_pollevent events;
+	uk_pollevent waitmask;
+	struct uk_waitq waitq; /* Polling threads */
+	struct uk_rwlock waitlock;
 #if CONFIG_LIBUKFILE_CHAINUPDATE
 	void *_tag; /* Internal use */
-	struct uk_rwlock proplock; /* Chained updates list lock */
+	UK_STAILQ_HEAD(uk_pollq_chain_head, struct uk_poll_chain) prop;
+	struct uk_mutex proplock;
+	uk_pollevent propmask;
 #endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
-	struct uk_rwlock waitlock; /* Wait list lock */
 };
 
 /*
  * Pollqueues come in two varieties: managed and polled.
  * Polled queues require drivers to only notify rising edges of events, while
- * providing a callback for fetching instantaneous levels (.poll).
+ * providing a callback for fetching instantaneous levels (.poll_fn).
  * Managed queues require drivers to notify both rising and falling edges
  * of events, with the queue itself maintaining event levels.
  * See description of `uk_poll_func` for more details.
@@ -187,47 +167,41 @@ struct uk_pollq {
 #if CONFIG_LIBUKFILE_CHAINUPDATE
 #if CONFIG_LIBUKFILE_POLLED
 #define __UK_POLLQ_INIT(q, pollfunc, ev) { \
-	.wait = NULL, \
-	.waitend = &(q).wait, \
-	.prop = NULL, \
-	.propend = &(q).prop, \
-	.poll = (pollfunc), \
-	.events = (ev), \
-	.waitmask = 0, \
-	.propmask = 0, \
-	.proplock = UK_RWLOCK_INITIALIZER((q).proplock, 0), \
-	.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0), \
+	.poll_fn = (pollfunc),					\
+	.events = (ev),						\
+	.waitmask = 0,						\
+	.waitq = UK_WAIT_QUEUE_INITIALIZER((q).waitq),		\
+	.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0),	\
+	.prop = UK_STAILQ_HEAD_INITIALIZER((q).prop),		\
+	.proplock = UK_MUTEX_INITIALIZER((q).proplock),		\
+	.propmask = 0,						\
 }
 #else /* !CONFIG_LIBUKFILE_POLLED */
 #define __UK_POLLQ_INIT(q, pollfunc, ev) { \
-	.wait = NULL, \
-	.waitend = &(q).wait, \
-	.prop = NULL, \
-	.propend = &(q).prop, \
-	.events = (ev), \
-	.waitmask = 0, \
-	.propmask = 0, \
-	.proplock = UK_RWLOCK_INITIALIZER((q).proplock, 0), \
-	.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0), \
+	.events = (ev),						\
+	.waitmask = 0,						\
+	.waitq = UK_WAIT_QUEUE_INITIALIZER((q).waitq),		\
+	.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0),	\
+	.prop = UK_STAILQ_HEAD_INITIALIZER((q).prop),		\
+	.proplock = UK_MUTEX_INITIALIZER((q).proplock),		\
+	.propmask = 0,						\
 }
 #endif /* !CONFIG_LIBUKFILE_POLLED */
 #else /* !CONFIG_LIBUKFILE_CHAINUPDATE */
 #if CONFIG_LIBUKFILE_POLLED
 #define __UK_POLLQ_INIT(q, pollfunc, ev) { \
-	.wait = NULL, \
-	.waitend = &(q).wait, \
-	.poll = (pollfunc), \
-	.events = (ev), \
-	.waitmask = 0, \
-	.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0), \
+	.poll_fn = (pollfunc),					\
+	.events = (ev),						\
+	.waitmask = 0,						\
+	.waitq = UK_WAIT_QUEUE_INITIALIZER((q).waitq),		\
+	.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0),	\
 }
 #else /* !CONFIG_LIBUKFILE_POLLED */
 #define __UK_POLLQ_INIT(q, pollfunc, ev) { \
-	.wait = NULL, \
-	.waitend = &(q).wait, \
-	.events = (ev), \
-	.waitmask = 0, \
-	.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0), \
+	.events = (ev),						\
+	.waitmask = 0,						\
+	.waitq = UK_WAIT_QUEUE_INITIALIZER((q).waitq),		\
+	.waitlock = UK_RWLOCK_INITIALIZER((q).waitlock, 0),	\
 }
 #endif /* !CONFIG_LIBUKFILE_POLLED */
 #endif /* !CONFIG_LIBUKFILE_CHAINUPDATE */
@@ -248,73 +222,30 @@ struct uk_pollq {
 #define UK_POLLQ_MANAGED_INIT_VALUE(q) \
 	((struct uk_pollq)UK_POLLQ_MANAGED_INITIALIZER(q))
 
-/* Polling cancellation */
-
-/**
- * Remove a specific `ticket` from the wait list.
- */
-static inline
-void uk_pollq_cancel_ticket(struct uk_pollq *q, struct uk_poll_ticket *ticket)
-{
-	uk_rwlock_wlock(&q->waitlock);
-	for (struct uk_poll_ticket **p = &q->wait; *p; p = &(*p)->next)
-		if (*p == ticket) {
-			*p = ticket->next;
-			ticket->next = NULL;
-			if (!*p)
-				q->waitend = p;
-			break;
-		}
-	uk_rwlock_wunlock(&q->waitlock);
-}
-
-/**
- * Remove the ticket of a specific `thread` from the wait list.
- */
-static inline
-void uk_pollq_cancel_thread(struct uk_pollq *q, struct uk_thread *thread)
-{
-	uk_rwlock_wlock(&q->waitlock);
-	for (struct uk_poll_ticket **p = &q->wait; *p; p = &(*p)->next) {
-		struct uk_poll_ticket *t = *p;
-
-		if (t->thread == thread) {
-			*p = t->next;
-			t->next = NULL;
-			if (!*p)
-				q->waitend = p;
-			break;
-		}
-	}
-	uk_rwlock_wunlock(&q->waitlock);
-}
-
-/**
- * Remove the ticket of the current thread from the wait list.
- */
-#define uk_pollq_cancel(q) uk_pollq_cancel_thread((q), uk_thread_current())
-
 /* Polling */
 
 #if CONFIG_LIBUKFILE_POLLED
+
+#define UK_POLLQ_IS_POLLED(q) (!!((q)->poll_fn))
+
 /**
  * INTERNAL. Poll for the events in `req`; never block or take locks,
  * always return immediately.
  */
 static inline
-uk_pollevent _pollq_poll_immediate(struct uk_pollq *q, uk_pollevent req)
+uk_pollevent _uk_pollq_poll_immediate(struct uk_pollq *q, uk_pollevent req)
 {
-	return q->poll ? 0 : q->events & req;
+	return UK_POLLQ_IS_POLLED(q) ? 0 : (q->events & req);
 }
 
 /**
  * INTERNAL. Poll for the events in `req` with the waitlock held; may block.
  */
 static inline
-uk_pollevent _pollq_poll_locked(struct uk_pollq *q, uk_pollevent req,
-				const struct uk_file *f)
+uk_pollevent _uk_pollq_poll_locked(struct uk_pollq *q, uk_pollevent req,
+				   const struct uk_file *f)
 {
-	return q->poll ? q->poll(f, req) : q->events & req;
+	return UK_POLLQ_IS_POLLED(q) ? q->poll_fn(f, req) : (q->events & req);
 }
 #else /* !CONFIG_LIBUKFILE_POLLED */
 /**
@@ -322,7 +253,7 @@ uk_pollevent _pollq_poll_locked(struct uk_pollq *q, uk_pollevent req,
  * always return immediately.
  */
 static inline
-uk_pollevent _pollq_poll_immediate(struct uk_pollq *q, uk_pollevent req)
+uk_pollevent _uk_pollq_poll_immediate(struct uk_pollq *q, uk_pollevent req)
 {
 	return q->events & req;
 }
@@ -331,10 +262,10 @@ uk_pollevent _pollq_poll_immediate(struct uk_pollq *q, uk_pollevent req)
  * INTERNAL. Poll for the events in `req` with the waitlock held; may block.
  */
 static inline
-uk_pollevent _pollq_poll_locked(struct uk_pollq *q, uk_pollevent req,
-				const struct uk_file *f __unused)
+uk_pollevent _uk_pollq_poll_locked(struct uk_pollq *q, uk_pollevent req,
+				   const struct uk_file *f __unused)
 {
-	return _pollq_poll_immediate(q, req);
+	return _uk_pollq_poll_immediate(q, req);
 }
 #endif
 
@@ -350,22 +281,23 @@ uk_pollevent _pollq_poll_locked(struct uk_pollq *q, uk_pollevent req,
  *   0 with lock held otherwise.
  */
 static inline
-uk_pollevent _pollq_lock(struct uk_pollq *q, uk_pollevent req,
-			 uk_pollevent exp, const struct uk_file *f)
+uk_pollevent _uk_pollq_lock(struct uk_pollq *q, uk_pollevent req,
+			    const struct uk_file *f)
 {
 	uk_pollevent ev;
 
 	uk_rwlock_rlock(&q->waitlock);
 	/* Check if events were set while acquiring the lock */
-	if ((ev = _pollq_poll_locked(q, req, f) & ~exp))
+	if ((ev = _uk_pollq_poll_locked(q, req, f)))
 		uk_rwlock_runlock(&q->waitlock);
 	return ev;
 }
 
 /**
- * INTERNAL. Wait for events until a timeout.
+ * INTERNAL. Wait for events or until a timeout.
  *
- * Must be called only after `_pollq_lock` returns 0.
+ * Must be called only after `_pollq_lock` returns 0 (read waitlock held).
+ * Returns with read waitlock held.
  *
  * @param q Target queue.
  * @param req Events to poll for.
@@ -376,43 +308,22 @@ uk_pollevent _pollq_lock(struct uk_pollq *q, uk_pollevent req,
  *   non-zero if awoken
  */
 static inline
-int _pollq_wait(struct uk_pollq *q, uk_pollevent req, __nsec deadline)
+int _uk_pollq_wait(struct uk_pollq *q, uk_pollevent req, __nsec deadline)
 {
-	struct uk_poll_ticket **tail;
-	struct uk_thread *__current;
-	struct uk_poll_ticket tick;
-	int timeout;
-
 	/* Mark request in waitmask */
 	(void)uk_or(&q->waitmask, req);
-	/* Compete to register */
-
-	__current = uk_thread_current();
-	tick = (struct uk_poll_ticket){
-		.next = NULL,
-		.thread = __current,
-		.mask = req,
-	};
-	tail = uk_exchange_n(&q->waitend, &tick.next);
-	/* tail is ours alone, safe to link in */
-	UK_ASSERT(!*tail); /* Should be a genuine list tail */
-	*tail = &tick;
-
-	/* Block until awoken */
-	uk_thread_block_until(__current, deadline);
-	uk_rwlock_runlock(&q->waitlock);
-	uk_sched_yield();
-	/* Back, wake up, check if timed out & try again */
-	timeout = deadline && ukplat_monotonic_clock() >= deadline;
-	if (timeout)
-		uk_pollq_cancel_ticket(q, &tick);
-	return !timeout;
+	/* Set events as cookie & wait */
+	uk_waitq_set_cookie(req);
+	return !uk_waitq_wait_deadline_locked(&q->waitq, deadline,
+					      uk_rwlock_rlock,
+					      uk_rwlock_runlock,
+					      &q->waitlock);
 }
 
 /**
  * Poll for the events in `req`, returning the present levels of events.
  *
- * May yield execution or acquire locks, but will never block indefinitely.
+ * May yield execution or acquire locks, but will never wait on events.
  *
  * @param q Target queue.
  * @param req Events to poll for.
@@ -427,11 +338,14 @@ uk_pollevent uk_pollq_poll_level(struct uk_pollq *q, uk_pollevent req,
 {
 	uk_pollevent ev;
 
-	if ((ev = _pollq_poll_immediate(q, req)))
+	if ((ev = _uk_pollq_poll_immediate(q, req)))
 		return ev;
 #if CONFIG_LIBUKFILE_POLLED
-	if (q->poll && !(ev = _pollq_lock(q, req, 0, f)))
-		uk_rwlock_runlock(&q->waitlock);
+	if (UK_POLLQ_IS_POLLED(q)) {
+		ev = _uk_pollq_lock(q, req, f);
+		if (!ev)
+			uk_rwlock_runlock(&q->waitlock);
+	}
 #endif /* CONFIG_LIBUKFILE_POLLED */
 	return ev;
 }
@@ -452,12 +366,15 @@ uk_pollevent uk_pollq_poll_until(struct uk_pollq *q, uk_pollevent req,
 {
 	uk_pollevent ev;
 
-	do {
-		if ((ev = _pollq_poll_immediate(q, req)))
-			return ev;
-		if ((ev = _pollq_lock(q, req, 0, f)))
-			return ev;
-	} while (_pollq_wait(q, req, deadline));
+	if ((ev = _uk_pollq_poll_immediate(q, req)))
+		return ev;
+	if ((ev = _uk_pollq_lock(q, req, f)))
+		return ev;
+	while (_uk_pollq_wait(q, req, deadline)) {
+		if ((ev = _uk_pollq_poll_locked(q, req, f)))
+			break;
+	}
+	uk_rwlock_runlock(&q->waitlock);
 	return ev;
 }
 
@@ -478,20 +395,16 @@ uk_pollevent uk_pollq_poll_until(struct uk_pollq *q, uk_pollevent req,
 /**
  * INTERNAL. Register update chaining ticket.
  *
- * Must be called with appropriate locks held
+ * Must be called with prop lock held.
  *
  * @param q Target queue.
  * @param tick Update chaining ticket to register.
  */
 static inline
-void _pollq_register(struct uk_pollq *q, struct uk_poll_chain *tick)
+void _uk_pollq_register(struct uk_pollq *q, struct uk_poll_chain *tick)
 {
-	struct uk_poll_chain **tail;
-
-	(void)uk_or(&q->propmask, tick->mask);
-	tail = uk_exchange_n(&q->propend, &tick->next);
-	UK_ASSERT(!*tail); /* Should be genuine list tail */
-	*tail = tick;
+	q->propmask |= tick->mask;
+	UK_STAILQ_INSERT_TAIL(&q->prop, tick, list_entry);
 }
 
 /**
@@ -503,9 +416,9 @@ void _pollq_register(struct uk_pollq *q, struct uk_poll_chain *tick)
 static inline
 void uk_pollq_register(struct uk_pollq *q, struct uk_poll_chain *tick)
 {
-	uk_rwlock_rlock(&q->proplock);
-	_pollq_register(q, tick);
-	uk_rwlock_runlock(&q->proplock);
+	uk_mutex_lock(&q->proplock);
+	_uk_pollq_register(q, tick);
+	uk_mutex_unlock(&q->proplock);
 }
 
 /**
@@ -517,16 +430,9 @@ void uk_pollq_register(struct uk_pollq *q, struct uk_poll_chain *tick)
 static inline
 void uk_pollq_unregister(struct uk_pollq *q, struct uk_poll_chain *tick)
 {
-	uk_rwlock_wlock(&q->proplock);
-	for (struct uk_poll_chain **p = &q->prop; *p; p = &(*p)->next)
-		if (*p == tick) {
-			*p = tick->next;
-			tick->next = NULL;
-			if (!*p) /* We unlinked last node */
-				q->propend = p;
-			break;
-		}
-	uk_rwlock_wunlock(&q->proplock);
+	uk_mutex_lock(&q->proplock);
+	UK_STAILQ_REMOVE(&q->prop, tick, struct uk_poll_chain, list_entry);
+	uk_mutex_unlock(&q->proplock);
 }
 
 /**
@@ -534,29 +440,30 @@ void uk_pollq_unregister(struct uk_pollq *q, struct uk_poll_chain *tick)
  *
  * @param q Target queue.
  * @param tick Update chaining ticket to register, if needed.
- * @param force If 0, will immediately return without registering if any of the
- *   requested events are set. If non-zero, always register.
+ * @param always_register If 0, will immediately return without registering if
+ *   any of the requested events are set. If non-zero, always register.
  *
  * @return
  *   Requested events that are currently active.
  */
 static inline
 uk_pollevent uk_pollq_poll_register(struct uk_pollq *q,
-				    struct uk_poll_chain *tick, int force,
+				    struct uk_poll_chain *tick,
+				    int always_register,
 				    const struct uk_file *f)
 {
 	uk_pollevent ev;
 	uk_pollevent req = tick->mask;
 
-	if (!force && (ev = _pollq_poll_immediate(q, req)))
+	if (!always_register && (ev = _uk_pollq_poll_immediate(q, req)))
 		return ev;
 	/* Might need to register */
-	uk_rwlock_rlock(&q->proplock);
-	if ((ev = _pollq_poll_locked(q, req, f)) && !force)
+	uk_mutex_lock(&q->proplock);
+	if ((ev = _uk_pollq_poll_locked(q, req, f)) && !always_register)
 		goto out;
-	_pollq_register(q, tick);
+	_uk_pollq_register(q, tick);
 out:
-	uk_rwlock_runlock(&q->proplock);
+	uk_mutex_unlock(&q->proplock);
 	return ev;
 }
 #endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
@@ -578,7 +485,7 @@ uk_pollevent uk_pollq_set_n(struct uk_pollq *q, uk_pollevent set, int one);
 /**
  * Update events, clearing those in `clr`.
  *
- * Only available on level-triggered queues.
+ * Only meaningful on managed queues, no-op on polled queues.
  *
  * @param q Target queue.
  * @param clr Events to clear.
@@ -591,7 +498,7 @@ uk_pollevent uk_pollq_clear(struct uk_pollq *q, uk_pollevent clr);
 /**
  * Replace the events in `q` with `val` and handle notifications.
  *
- * Only available on level-triggered queues.
+ * Only meaningful on managed queues, identical to set on polled queues.
  *
  * @param q Target queue.
  * @param val New event set.

--- a/lib/ukfile/include/uk/file/pollqueue.h
+++ b/lib/ukfile/include/uk/file/pollqueue.h
@@ -98,7 +98,6 @@ typedef void (*uk_poll_chain_callback_fn)(uk_pollevent ev,
  * If newly modified events overlap with those in `mask`, perform a chain update
  * of these overlapping bits according to `type`:
  *   - UK_POLL_CHAINTYPE_UPDATE: propagate events to `queue`.
- *     If `set` != 0 set/clear events in `set`, instead of original
  *   - UK_POLL_CHAINTYPE_CALLBACK: call `callback`
  */
 struct uk_poll_chain {
@@ -108,7 +107,6 @@ struct uk_poll_chain {
 	union {
 		struct {
 			struct uk_pollq *queue; /* Where to propagate updates */
-			uk_pollevent set; /* Events to set */
 		};
 		struct {
 			uk_poll_chain_callback_fn callback;
@@ -120,15 +118,15 @@ struct uk_poll_chain {
 /* See comment for main queue below on initializers vs initial values */
 
 /* Initializer for a chain ticket that propagates events to another queue */
-#define UK_POLL_CHAIN_UPDATE_INITIALZER(msk, to, ev) { \
+#define UK_POLL_CHAIN_UPDATE_INITIALZER(msk, to) { \
 	.next = NULL, \
 	.mask = (msk), \
 	.type = UK_POLL_CHAINTYPE_UPDATE, \
 	.queue = (to), \
-	.set = (ev) \
 }
-#define UK_POLL_CHAIN_UPDATE(msk, to, ev) ((struct uk_poll_chain) \
-	UK_POLL_CHAIN_UPDATE_INITIALZER((msk), (to), (ev)))
+
+#define UK_POLL_CHAIN_UPDATE(msk, to) \
+	((struct uk_poll_chain)UK_POLL_CHAIN_UPDATE_INITIALZER((msk), (to)))
 
 /* Initializer for a chain ticket that calls a custom callback */
 #define UK_POLL_CHAIN_CALLBACK_INITIALIZER(msk, cb, dat) { \
@@ -138,6 +136,7 @@ struct uk_poll_chain {
 	.callback = (cb), \
 	.arg = (dat) \
 }
+
 #define UK_POLL_CHAIN_CALLBACK(msk, cb, dat) ((struct uk_poll_chain) \
 	UK_POLL_CHAIN_CALLBACK_INITIALIZER((msk), (cb), (dat)))
 

--- a/lib/ukfile/pollqueue.c
+++ b/lib/ukfile/pollqueue.c
@@ -8,7 +8,7 @@
 
 #include <uk/assert.h>
 
-static void pollq_notify_n(struct uk_pollq *q, uk_pollevent set, int n)
+static void pollq_notify_n(struct uk_pollq *q, uk_pollevent set, int one)
 {
 	uk_rwlock_wlock(&q->waitlock);
 	if (q->waitmask & set) {
@@ -18,13 +18,11 @@ static void pollq_notify_n(struct uk_pollq *q, uk_pollevent set, int n)
 		for (struct uk_poll_ticket **p = &q->wait; *p; p = &(*p)->next) {
 			struct uk_poll_ticket *t = *p;
 
-			if (!n)
-				goto done;
 			if (t->mask & set) {
 				*p = t->next;
 				t->next = NULL;
 				uk_thread_wake(t->thread);
-				n--;
+				one--;
 			} else {
 				seen |= t->mask;
 			}
@@ -33,6 +31,8 @@ static void pollq_notify_n(struct uk_pollq *q, uk_pollevent set, int n)
 				q->waitend = p;
 				break;
 			}
+			if (!one)
+				goto done;
 		}
 		/* Reached end of list, can prune waitmask */
 		q->waitmask = seen;
@@ -103,7 +103,7 @@ uk_pollevent uk_pollq_clear(struct uk_pollq *q, uk_pollevent clr)
 	return prev;
 }
 
-uk_pollevent uk_pollq_set_n(struct uk_pollq *q, uk_pollevent set, int n)
+uk_pollevent uk_pollq_set_n(struct uk_pollq *q, uk_pollevent set, int one)
 {
 	uk_pollevent prev;
 
@@ -122,14 +122,14 @@ uk_pollevent uk_pollq_set_n(struct uk_pollq *q, uk_pollevent set, int n)
 #endif /* CONFIG_LIBUKFILE_POLLED */
 		prev = uk_or(&q->events, set);
 
-	pollq_notify_n(q, set, n);
+	pollq_notify_n(q, set, !!one);
 #if CONFIG_LIBUKFILE_CHAINUPDATE
 	pollq_propagate(q, UK_POLL_CHAINOP_SET, set);
 #endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
 	return prev;
 }
 
-uk_pollevent uk_pollq_assign_n(struct uk_pollq *q, uk_pollevent val, int n)
+uk_pollevent uk_pollq_assign_n(struct uk_pollq *q, uk_pollevent val, int one)
 {
 	uk_pollevent prev;
 	uk_pollevent set;
@@ -141,7 +141,7 @@ uk_pollevent uk_pollq_assign_n(struct uk_pollq *q, uk_pollevent val, int n)
 	prev = uk_exchange_n(&q->events, val);
 	set = val & ~prev;
 	if (set) {
-		pollq_notify_n(q, set, n);
+		pollq_notify_n(q, set, !!one);
 #if CONFIG_LIBUKFILE_CHAINUPDATE
 		pollq_propagate(q, UK_POLL_CHAINOP_SET, set);
 #endif /* CONFIG_LIBUKFILE_CHAINUPDATE */

--- a/lib/ukfile/pollqueue.c
+++ b/lib/ukfile/pollqueue.c
@@ -61,18 +61,14 @@ static void pollq_propagate(struct uk_pollq *q,
 			if (req) {
 				switch (t->type) {
 				case UK_POLL_CHAINTYPE_UPDATE:
-				{
-					uk_pollevent ev = t->set ? t->set : req;
-
 					switch (op) {
 					case UK_POLL_CHAINOP_CLEAR:
-						uk_pollq_clear(t->queue, ev);
+						uk_pollq_clear(t->queue, req);
 						break;
 					case UK_POLL_CHAINOP_SET:
-						uk_pollq_set(t->queue, ev);
+						uk_pollq_set(t->queue, req);
 						break;
 					}
-				}
 					break;
 				case UK_POLL_CHAINTYPE_CALLBACK:
 					t->callback(req, op, t);
@@ -95,6 +91,11 @@ uk_pollevent uk_pollq_clear(struct uk_pollq *q, uk_pollevent clr)
 #if CONFIG_LIBUKFILE_POLLED
 	UK_ASSERT(!q->poll);
 #endif /* CONFIG_LIBUKFILE_POLLED */
+
+#if CONFIG_LIBUKFILE_CHAINUPDATE
+	if (q->_tag == uk_thread_current()) /* Chaining update loop, return */
+		return 0;
+#endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
 
 	prev = uk_and(&q->events, ~clr);
 #if CONFIG_LIBUKFILE_CHAINUPDATE
@@ -133,18 +134,29 @@ uk_pollevent uk_pollq_assign_n(struct uk_pollq *q, uk_pollevent val, int one)
 {
 	uk_pollevent prev;
 	uk_pollevent set;
+#if CONFIG_LIBUKFILE_CHAINUPDATE
+	uk_pollevent clr;
+#endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
 
 #if CONFIG_LIBUKFILE_POLLED
 	UK_ASSERT(!q->poll);
 #endif /* CONFIG_LIBUKFILE_POLLED */
 
+#if CONFIG_LIBUKFILE_CHAINUPDATE
+	if (q->_tag == uk_thread_current()) /* Chaining update loop, return */
+		return 0;
+#endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
+
 	prev = uk_exchange_n(&q->events, val);
 	set = val & ~prev;
-	if (set) {
+	if (set)
 		pollq_notify_n(q, set, !!one);
 #if CONFIG_LIBUKFILE_CHAINUPDATE
+	clr = prev & ~val;
+	if (clr)
+		pollq_propagate(q, UK_POLL_CHAINOP_CLEAR, clr);
+	if (set)
 		pollq_propagate(q, UK_POLL_CHAINOP_SET, set);
 #endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
-	}
 	return prev;
 }

--- a/lib/ukfile/pollqueue.c
+++ b/lib/ukfile/pollqueue.c
@@ -4,40 +4,28 @@
  * You may not use this file except in compliance with the License.
  */
 
-#include <uk/file/pollqueue.h>
-
 #include <uk/assert.h>
+#include <uk/file/pollqueue.h>
 
 static void pollq_notify_n(struct uk_pollq *q, uk_pollevent set, int one)
 {
 	uk_rwlock_wlock(&q->waitlock);
 	if (q->waitmask & set) {
-		/* Walk wait list, wake up & collect */
+		struct uk_waitq_ticket *t;
 		uk_pollevent seen = 0;
+		int broke_early = 0;
 
-		for (struct uk_poll_ticket **p = &q->wait; *p; p = &(*p)->next) {
-			struct uk_poll_ticket *t = *p;
-
-			if (t->mask & set) {
-				*p = t->next;
-				t->next = NULL;
-				uk_thread_wake(t->thread);
-				one--;
-			} else {
-				seen |= t->mask;
-			}
-			if (!*p) {
-				/* We just unlinked last node */
-				q->waitend = p;
-				break;
-			}
-			if (!one)
-				goto done;
-		}
-		/* Reached end of list, can prune waitmask */
-		q->waitmask = seen;
+		if (one)
+			uk_waitq_wake_up_one_if(&q->waitq, t,
+				(seen |= t->cookie,
+				 broke_early = !!(t->cookie & set)));
+		else
+			uk_waitq_wake_up_if(&q->waitq, t,
+				(seen |= t->cookie, !!(t->cookie & set)));
+		/* Prune waitmask if we've seen all tickets */
+		if (!broke_early)
+			q->waitmask = seen;
 	}
-done:
 	uk_rwlock_wunlock(&q->waitlock);
 }
 
@@ -45,19 +33,19 @@ done:
 static void pollq_propagate(struct uk_pollq *q,
 			    enum uk_poll_chain_op op, uk_pollevent set)
 {
-	uk_rwlock_wlock(&q->proplock);
+	uk_mutex_lock(&q->proplock);
 	if (q->propmask & set) {
-		uk_pollevent seen;
+		struct uk_poll_chain *t;
+		uk_pollevent seen = 0;
 
 		/* Tag this queue in case of chaining loops */
 		UK_ASSERT(!q->_tag);
 		q->_tag = uk_thread_current();
 		/* Walk chain list & propagate updates */
-		seen = 0;
-		for (struct uk_poll_chain **p = &q->prop; *p; p = &(*p)->next) {
-			struct uk_poll_chain *t = *p;
+		UK_STAILQ_FOREACH(t, &q->prop, list_entry) {
 			uk_pollevent req = set & t->mask;
 
+			seen |= t->mask;
 			if (req) {
 				switch (t->type) {
 				case UK_POLL_CHAINTYPE_UPDATE:
@@ -75,12 +63,11 @@ static void pollq_propagate(struct uk_pollq *q,
 					break;
 				}
 			}
-			seen |= t->mask;
 		}
 		q->propmask = seen; /* Prune propmask */
 		q->_tag = NULL; /* Clear tag */
 	}
-	uk_rwlock_wunlock(&q->proplock);
+	uk_mutex_unlock(&q->proplock);
 }
 #endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
 
@@ -89,7 +76,8 @@ uk_pollevent uk_pollq_clear(struct uk_pollq *q, uk_pollevent clr)
 	uk_pollevent prev;
 
 #if CONFIG_LIBUKFILE_POLLED
-	UK_ASSERT(!q->poll);
+	if (UK_POLLQ_IS_POLLED(q))
+		return 0;
 #endif /* CONFIG_LIBUKFILE_POLLED */
 
 #if CONFIG_LIBUKFILE_CHAINUPDATE
@@ -117,13 +105,13 @@ uk_pollevent uk_pollq_set_n(struct uk_pollq *q, uk_pollevent set, int one)
 #endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
 
 #if CONFIG_LIBUKFILE_POLLED
-	if (q->poll)
+	if (UK_POLLQ_IS_POLLED(q))
 		prev = 0;
 	else
 #endif /* CONFIG_LIBUKFILE_POLLED */
 		prev = uk_or(&q->events, set);
 
-	pollq_notify_n(q, set, !!one);
+	pollq_notify_n(q, set, one);
 #if CONFIG_LIBUKFILE_CHAINUPDATE
 	pollq_propagate(q, UK_POLL_CHAINOP_SET, set);
 #endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
@@ -139,7 +127,8 @@ uk_pollevent uk_pollq_assign_n(struct uk_pollq *q, uk_pollevent val, int one)
 #endif /* CONFIG_LIBUKFILE_CHAINUPDATE */
 
 #if CONFIG_LIBUKFILE_POLLED
-	UK_ASSERT(!q->poll);
+	if (UK_POLLQ_IS_POLLED(q))
+		return uk_pollq_set_n(q, val, one);
 #endif /* CONFIG_LIBUKFILE_POLLED */
 
 #if CONFIG_LIBUKFILE_CHAINUPDATE
@@ -150,7 +139,7 @@ uk_pollevent uk_pollq_assign_n(struct uk_pollq *q, uk_pollevent val, int one)
 	prev = uk_exchange_n(&q->events, val);
 	set = val & ~prev;
 	if (set)
-		pollq_notify_n(q, set, !!one);
+		pollq_notify_n(q, set, one);
 #if CONFIG_LIBUKFILE_CHAINUPDATE
 	clr = prev & ~val;
 	if (clr)

--- a/lib/uksched/include/uk/wait.h
+++ b/lib/uksched/include/uk/wait.h
@@ -211,6 +211,18 @@ static inline void _uk_waitq_noplock(int lock __unused) {}
 			     lock_fn, unlock_fn, (lock))
 
 /**
+ * Set the wait cookie of the current thread to `cookie`.
+ *
+ * Waitq code does not interpret this field, it is up to consumers of waitq to
+ * use it as e.g., a condition in `uk_waitq_wake_up_if`.
+ */
+static inline
+void uk_waitq_set_cookie(__uptr cookie)
+{
+	uk_thread_current()->wait_ticket.cookie = cookie;
+}
+
+/**
  * Forcefully cancel the wait ticket of `thread` and remove it from the queue.
  *
  * `thread` must be waiting on a queue and will not be awoken; continuing its
@@ -270,6 +282,25 @@ void uk_waitq_wake_up_one(struct uk_waitq *wq)
 		_uk_waitq_wake(wq, t);
 	_uk_waitq_unlock(wq, flags);
 }
+
+#define _uk_waitq_wake_up_if_then(wq, ticket, condition, aftermath)	\
+do {									\
+	unsigned long _uk_waitq_flags;					\
+									\
+	_uk_waitq_lock((wq), _uk_waitq_flags);				\
+	uk_list_for_each_entry((ticket), &(wq)->waiters, link)		\
+		if ((condition)) {					\
+			_uk_waitq_wake((wq), (ticket));			\
+			aftermath;					\
+		}							\
+	_uk_waitq_unlock((wq), _uk_waitq_flags);			\
+} while (0)
+
+#define uk_waitq_wake_up_if(wq, ticket, condition) \
+	_uk_waitq_wake_up_if_then((wq), (ticket), (condition), (void)0)
+
+#define uk_waitq_wake_up_one_if(wq, ticket, condition) \
+	_uk_waitq_wake_up_if_then((wq), (ticket), (condition), break)
 
 #ifdef __cplusplus
 }

--- a/lib/uksched/include/uk/wait.h
+++ b/lib/uksched/include/uk/wait.h
@@ -189,6 +189,10 @@ void _uk_waitq_block_until(struct uk_thread *thread, __snsec deadline)
 #define uk_waitq_wait_locked(wq, lock_fn, unlock_fn, lock) \
 	_uk_waitq_wait((wq), 0, 0, lock_fn, unlock_fn, (lock))
 
+#define uk_waitq_wait_deadline_locked(wq, deadline, lock_fn, unlock_fn, lock) \
+	_uk_waitq_wait((wq), deadline, ukplat_monotonic_clock(),	\
+		       lock_fn, unlock_fn, (lock))
+
 static inline void _uk_waitq_noplock(int lock __unused) {}
 
 #define uk_waitq_wait_event(wq, condition)				\

--- a/lib/uksched/include/uk/wait_types.h
+++ b/lib/uksched/include/uk/wait_types.h
@@ -23,6 +23,8 @@ struct uk_waitq_ticket {
 	struct uk_list_head link;
 	/* Queue we're waiting on, if waiting; must be NULL if not waiting */
 	struct uk_waitq *wq;
+	/* Value & interpretation up to consumers of waitq */
+	__uptr cookie;
 };
 
 #define UK_WAITQ_TICKET_INITIALIZER { .wq = __NULL }


### PR DESCRIPTION
### Description of changes

This changeset reworks the ukfile pollqueue implementation to use standard waitqueues instead of bespoke waiting code.
During this pass, unused parts of the pollqueue API were trimmed off and/or brought more in-line with other standard synchronization primitives.
The waitqueue interface has been expanded with a `cookie` field freely available to callers, in order to accomodate pollq's more complex use-case.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A