### PR TITLE
lib/uksched: Remove terminated thread from waitq

### DIFF
--- a/lib/uksched/include/uk/wait.h
+++ b/lib/uksched/include/uk/wait.h
@@ -211,6 +211,24 @@ static inline void _uk_waitq_noplock(int lock __unused) {}
 			     lock_fn, unlock_fn, (lock))
 
 /**
+ * Forcefully cancel the wait ticket of `thread` and remove it from the queue.
+ *
+ * `thread` must be waiting on a queue and will not be awoken; continuing its
+ * execution after forceful cancellation is undefined.
+ */
+static inline
+void uk_waitq_cancel(struct uk_thread *thread)
+{
+	struct uk_waitq *wq = thread->wait_ticket.wq;
+	unsigned long flags;
+
+	UK_ASSERT(wq);
+	_uk_waitq_lock(wq, flags);
+	_uk_waitq_remove(thread);
+	_uk_waitq_unlock(wq, flags);
+}
+
+/**
  * INTERNAL. Wake thread of ticket `t` from `wq`.
  */
 static inline

--- a/lib/uksched/sched.c
+++ b/lib/uksched/sched.c
@@ -42,6 +42,7 @@
 #include <uk/plat/lcpu.h>
 #include <uk/sched.h>
 #include <uk/syscall.h>
+#include <uk/wait.h>
 
 struct uk_sched *uk_sched_head;
 
@@ -303,9 +304,7 @@ void uk_sched_thread_terminate(struct uk_thread *thread)
 		    sched, thread, thread->name ? thread->name : "<unnamed>");
 
 	if (uk_thread_in_waitq(thread))
-		uk_pr_warn("%p: thread %p (%s) terminated while waiting\n",
-			   sched, thread,
-			   thread->name ? thread->name : "<unnamed>");
+		uk_waitq_cancel(thread);
 	/* remove from scheduling queue */
 	uk_sched_thread_remove(thread);
 	/* causes calling termination table */


### PR DESCRIPTION
### Description of changes

This change adds logic that removes waiting threads from their waitqueues on termination, preventing the leakage of freed memory (dead thread struct) through the still active waitq.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A
