### PR TITLE
lib/vfscore: Dot not drop file on read/write

### DIFF
--- a/lib/posix-fdio/fd-shim.c
+++ b/lib/posix-fdio/fd-shim.c
@@ -36,6 +36,7 @@ UK_SYSCALL_R_DEFINE(ssize_t, preadv2, int, fd, const struct iovec *, iov,
 			r = -EINVAL;
 		else
 			r = vfscore_preadv(sf.vfile, iov, iovcnt, offset);
+		fdrop(sf.vfile);
 		break;
 #endif /* CONFIG_LIBVFSCORE */
 	default:
@@ -58,6 +59,7 @@ UK_SYSCALL_R_DEFINE(ssize_t, preadv, int, fd, const struct iovec *, iov,
 #if CONFIG_LIBVFSCORE
 	case UK_SHIM_LEGACY:
 		r = vfscore_preadv(sf.vfile, iov, iovcnt, offset);
+		fdrop(sf.vfile);
 		break;
 #endif /* CONFIG_LIBVFSCORE */
 	default:
@@ -90,6 +92,7 @@ UK_SYSCALL_R_DEFINE(ssize_t, pread64, int, fd,
 #if CONFIG_LIBVFSCORE
 	case UK_SHIM_LEGACY:
 		r = vfscore_pread64(sf.vfile, buf, count, offset);
+		fdrop(sf.vfile);
 		break;
 #endif /* CONFIG_LIBVFSCORE */
 	default:
@@ -116,6 +119,7 @@ UK_SYSCALL_R_DEFINE(ssize_t, readv, int, fd,
 #if CONFIG_LIBVFSCORE
 	case UK_SHIM_LEGACY:
 		r = vfscore_readv(sf.vfile, iov, iovcnt);
+		fdrop(sf.vfile);
 		break;
 #endif /* CONFIG_LIBVFSCORE */
 	default:
@@ -138,6 +142,7 @@ UK_SYSCALL_R_DEFINE(ssize_t, read, int, fd,
 #if CONFIG_LIBVFSCORE
 	case UK_SHIM_LEGACY:
 		r = vfscore_read(sf.vfile, buf, count);
+		fdrop(sf.vfile);
 		break;
 #endif /* CONFIG_LIBVFSCORE */
 	default:
@@ -163,6 +168,7 @@ UK_SYSCALL_R_DEFINE(ssize_t, pwritev2, int, fd, const struct iovec*, iov,
 			r = -EINVAL;
 		else
 			r = vfscore_pwritev(sf.vfile, iov, iovcnt, offset);
+		fdrop(sf.vfile);
 		break;
 #endif /* CONFIG_LIBVFSCORE */
 	default:
@@ -185,6 +191,7 @@ UK_SYSCALL_R_DEFINE(ssize_t, pwritev, int, fd, const struct iovec*, iov,
 #if CONFIG_LIBVFSCORE
 	case UK_SHIM_LEGACY:
 		r = vfscore_pwritev(sf.vfile, iov, iovcnt, offset);
+		fdrop(sf.vfile);
 		break;
 #endif /* CONFIG_LIBVFSCORE */
 	default:
@@ -212,6 +219,7 @@ UK_SYSCALL_R_DEFINE(ssize_t, pwrite64, int, fd,
 #if CONFIG_LIBVFSCORE
 	case UK_SHIM_LEGACY:
 		r = vfscore_pwrite64(sf.vfile, buf, count, offset);
+		fdrop(sf.vfile);
 		break;
 #endif /* CONFIG_LIBVFSCORE */
 	default:
@@ -238,6 +246,7 @@ UK_SYSCALL_R_DEFINE(ssize_t, writev, int, fd, const struct iovec *, iov,
 #if CONFIG_LIBVFSCORE
 	case UK_SHIM_LEGACY:
 		r = vfscore_writev(sf.vfile, iov, iovcnt);
+		fdrop(sf.vfile);
 		break;
 #endif /* CONFIG_LIBVFSCORE */
 	default:
@@ -259,6 +268,7 @@ UK_SYSCALL_R_DEFINE(ssize_t, write, int, fd, const void *, buf, size_t, count)
 #if CONFIG_LIBVFSCORE
 	case UK_SHIM_LEGACY:
 		r = vfscore_write(sf.vfile, buf, count);
+		fdrop(sf.vfile);
 		break;
 #endif /* CONFIG_LIBVFSCORE */
 	default:

--- a/lib/vfscore/main.c
+++ b/lib/vfscore/main.c
@@ -313,8 +313,6 @@ ssize_t vfscore_preadv(struct vfscore_file *fp, const struct iovec *iov,
 	error = do_preadv(fp, iov, iovcnt, offset, &bytes);
 
 out_error_fdrop:
-	fdrop(fp);
-
 	if (error < 0)
 		goto out_error;
 
@@ -389,8 +387,6 @@ ssize_t vfscore_readv(struct vfscore_file *fp,
 	error = do_preadv(fp, iov, iovcnt, -1, &bytes);
 
 out_error_fdrop:
-	fdrop(fp);
-
 	if (error < 0)
 		goto out_error;
 
@@ -481,8 +477,6 @@ ssize_t vfscore_pwritev(struct vfscore_file *fp, const struct iovec *iov,
 	error = do_pwritev(fp, iov, iovcnt, offset, &bytes);
 
 out_error_fdrop:
-	fdrop(fp);
-
 	if (error < 0)
 		goto out_error;
 
@@ -557,8 +551,6 @@ ssize_t vfscore_writev(struct vfscore_file *fp,
 	error = do_pwritev(fp, vec, vlen, -1, &bytes);
 
 out_error_fdrop:
-	fdrop(fp);
-
 	if (error < 0)
 		goto out_error;
 


### PR DESCRIPTION
### Description of changes

Previously vfscore would drop the file reference as the last step of read/write operations, uniquely among all vfscore file ops, effectively consuming the file reference passed to them.
This (frankly silly) behavior is a ticking timebomb for any code handling vfscore file references, and is corrected by this commit. Calling code in posix-fdio has been patched to release files after use.

Prerequisite to correct functioning of #1632 .

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A