### PR TITLE
lib/vfscore: Fix uninitialized mutex in dentry

### DIFF
--- a/lib/vfscore/dentry.c
+++ b/lib/vfscore/dentry.c
@@ -86,6 +86,7 @@ dentry_alloc(struct dentry *parent_dp, struct vnode *vp, const char *path)
 	dp->d_refcnt = 1;
 	dp->d_vnode = vp;
 	dp->d_mount = mp;
+	uk_mutex_init(&dp->d_lock);
 	UK_INIT_LIST_HEAD(&dp->d_child_list);
 
 	if (parent_dp) {


### PR DESCRIPTION
### Description of changes

This change adds a missing mutex initialization to vfscore dentry code. Uninitialized mutexes would contain invalid fields and cause crashes.

Fixes #1674 .

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A