### PR TITLE
lib/posix-mmap: Add workaround for writable MAP_SHARED

### DIFF
--- a/lib/vfscore/Config.uk
+++ b/lib/vfscore/Config.uk
@@ -16,6 +16,14 @@ menuconfig LIBVFSCORE
 	select HAVE_VFS
 
 if LIBVFSCORE
+config LIBVFSCORE_MMAP_SHARED_PRIVATE_FALLBACK
+	bool "Enable private-mapping fallback for writable MAP_SHARED"
+	help
+		When enabled, writable MAP_SHARED mappings will not require
+		UK_VMA_FILE_SHARED and will effectively fallback to private
+		mappings. This is a temporary workaround for workloads that do
+		not rely on in-kernel writeback or cross-mapping visibility.
+
 config LIBVFSCORE_NONLARGEFILE
 	bool "Non-largefile system calls"
 	default y if LIBSYSCALL_SHIM_HANDLER

--- a/lib/vfscore/vma_file.c
+++ b/lib/vfscore/vma_file.c
@@ -60,8 +60,10 @@ int vma_op_file_new(struct uk_vas *vas, __vaddr_t vaddr __unused,
 	 * to the underlying file while the mapping is established will not be
 	 * reflected in memory.
 	 */
+#if !CONFIG_LIBVFSCORE_MMAP_SHARED_PRIVATE_FALLBACK
 	if ((*flags & UK_VMA_FILE_SHARED) && (attr & PAGE_ATTR_PROT_WRITE))
 		return -ENOTSUP;
+#endif
 
 	/* Since we cannot do ISR-safe file accesses in the fault handler,
 	 * we enforce full load at mapping time for now.
@@ -230,8 +232,10 @@ static int vma_op_file_merge(struct uk_vma *vma, struct uk_vma *next)
 static int vma_op_file_set_attr(struct uk_vma *vma, unsigned long attr)
 {
 	/* Writable shared mappings are not supported. */
+#if !CONFIG_LIBVFSCORE_MMAP_SHARED_PRIVATE_FALLBACK
 	if ((vma->flags & UK_VMA_FILE_SHARED) && (attr & PAGE_ATTR_PROT_WRITE))
 		return -EPERM;
+#endif
 
 	/* Default handler */
 	return uk_vma_op_set_attr(vma, attr);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->
### Description of Changes

This draft PR adds a workaround for file-backed `MAP_SHARED` in Unikraft, useful for certain loads.

* Use of a new configuration `CONFIG_LIBPOSIX_MMAP_FILE_WRITEBACK`.
* When the `CONFIG_LIBPOSIX_MMAP_FILE_WRITEBACK` configuration is used, `UK_VMA_FILE_SHARED` isn't added to flags. `MAP_SHARED` is downgraded to `MAP_PRIVATE`


### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->
N/A
