### PR TITLE
arch: Check each `XSAVE` state component depending on the bitmap and add the check on ARM as well

### DIFF
--- a/arch/arm/ectx.c
+++ b/arch/arm/ectx.c
@@ -41,6 +41,7 @@
 #include <uk/essentials.h>
 #include <uk/assert.h>
 #include <uk/print.h>
+#include <uk/hexdump.h>
 #include <uk/isr/string.h> /* memset_isr */
 #include <arm/cpu.h>
 
@@ -92,4 +93,30 @@ void ukarch_ectx_load(struct ukarch_ectx *state)
 	UK_ASSERT(IS_ALIGNED((__uptr) state, ECTX_ALIGN));
 
 	restore_extregs(state);
+}
+
+void ukarch_ectx_assert_equal(struct ukarch_ectx *state)
+{
+	const __sz ectx_size = sizeof(struct fpsimd_state);
+	__u8 ectxbuf[ectx_size + ECTX_ALIGN];
+	struct ukarch_ectx *current;
+
+	/* Store the current state */
+	current = (struct ukarch_ectx *)ALIGN_UP((__uptr)ectxbuf, ECTX_ALIGN);
+	ukarch_ectx_init(current);
+
+	if (memcmp_isr(current, state, ectx_size) != 0) {
+		uk_pr_crit("Modified ECTX detected!\n");
+		uk_pr_crit("Current:\n");
+		uk_hexdumpk(KLVL_CRIT, current, ectx_size,
+			    UK_HXDF_ADDR | UK_HXDF_GRPQWORD | UK_HXDF_COMPRESS,
+			    2);
+
+		uk_pr_crit("Expected:\n");
+		uk_hexdumpk(KLVL_CRIT, state, ectx_size,
+			    UK_HXDF_ADDR | UK_HXDF_GRPQWORD | UK_HXDF_COMPRESS,
+			    2);
+
+		UK_CRASH("Modified ECTX\n");
+	}
 }

--- a/arch/x86/ectx.c
+++ b/arch/x86/ectx.c
@@ -168,11 +168,11 @@ void ukarch_ectx_store(struct ukarch_ectx *state)
 		asm volatile("fxsave (%0)" :: "r"(state) : "memory");
 		break;
 	case X86_SAVE_XSAVE:
-		asm volatile("xsave (%0)" :: "r"(state),
+		asm volatile("xsave64 (%0)" :: "r"(state),
 			     "a"(0xffffffff), "d"(0xffffffff) : "memory");
 		break;
 	case X86_SAVE_XSAVEOPT:
-		asm volatile("xsaveopt (%0)" :: "r"(state),
+		asm volatile("xsaveopt64 (%0)" :: "r"(state),
 			     "a"(0xffffffff), "d"(0xffffffff) : "memory");
 		break;
 	}

--- a/arch/x86/ectx.c
+++ b/arch/x86/ectx.c
@@ -33,6 +33,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdbool.h>
 #include <uk/arch/ctx.h>
 #include <uk/arch/lcpu.h>
 #include <uk/arch/types.h>
@@ -50,6 +51,46 @@ enum x86_save_method {
 	X86_SAVE_XSAVE,
 	X86_SAVE_XSAVEOPT
 };
+
+struct x86_fsave_ctx {
+	__u8 state[108];
+} __packed;
+
+struct x86_fxsave_ctx {
+	__u8 state[416];
+	__u8 avail[96];
+} __packed __align(16);
+
+struct x86_xsave_hdr {
+#define X86_XSAVE_HDR_XSTATE_BV_X87F			(1UL <<  0)
+#define X86_XSAVE_HDR_XSTATE_BV_SSEF			(1UL <<  1)
+#define X86_XSAVE_HDR_XSTATE_BV_AVXF			(1UL <<  2)
+	__u64 xstate_bv;
+#define X86_XSAVE_HDR_XCOMP_BV_COMPF			(1UL << 63)
+	__u64 xcomp_bv;
+	/* Bytes 63:16 of the XSAVE header are reserved */
+	__u8 rsvd[48];
+} __packed;
+
+struct x86_xsave_ctx {
+	/* x87 state comprises bytes 23:0 and bytes 159:32 */
+	__u8 x87_state1[24];
+	__u32 mxcsr;
+	__u32 mxcsr_mask;
+	__u8 x87_state2[128];
+	/* SSE state comprises bytes 31:24 and bytes 415:160 */
+	__u8 sse_state[256];
+	__u8 avail[96];
+	struct x86_xsave_hdr xsave_hdr;
+	/*
+	 * AVX state comprises bytes 831:576, after the XSAVE header,
+	 * at the beginning of the extended xsave area.
+	 *
+	 * AVX state has 256 bytes: 127:0 for YMM0_H–YMM7_H and 255:128
+	 * for YMM8_H–YMM15_H.
+	 */
+	__u8 avx_state[256];
+} __packed __align(64);
 
 static enum x86_save_method ectx_method;
 static __sz ectx_size;
@@ -77,16 +118,20 @@ static void _init_ectx_store(void)
 		}
 		ukarch_x86_cpuid(0xd, 0, &eax, &ebx, &ecx, &edx);
 		ectx_size = ebx;
-		ectx_align = 64;
+		ectx_align = __alignof(struct x86_xsave_ctx);
+
+		UK_ASSERT(ectx_size == sizeof(struct x86_xsave_ctx) ||
+			  ectx_size == __offsetof(struct x86_xsave_ctx,
+						  avx_state));
 	} else if (edx & X86_CPUID1_EDX_FXSR) {
 		ectx_method = X86_SAVE_FXSAVE;
-		ectx_size = 512;
-		ectx_align = 16;
+		ectx_size = sizeof(struct x86_fxsave_ctx);
+		ectx_align = __alignof(struct x86_fxsave_ctx);
 		uk_pr_debug("Load/store of extended CPU state: FXSAVE\n");
 	} else {
 		ectx_method = X86_SAVE_FSAVE;
-		ectx_size = 108;
-		ectx_align = 1;
+		ectx_size = sizeof(struct x86_fsave_ctx);
+		ectx_align = __alignof(struct x86_fsave_ctx);
 		uk_pr_debug("Load/store of extended CPU state: FSAVE\n");
 	}
 
@@ -202,7 +247,117 @@ void ukarch_ectx_load(struct ukarch_ectx *state)
 	}
 }
 
-#ifdef CONFIG_ARCH_X86_64
+static inline int x86_xsave_substate_memcmp(const struct x86_xsave_ctx *ctx1,
+					    const struct x86_xsave_ctx *ctx2,
+					    __u64 substate)
+{
+	int rc;
+
+	switch (substate) {
+	case X86_XSAVE_HDR_XSTATE_BV_X87F:
+		if ((rc = memcmp_isr(ctx1->x87_state1, ctx2->x87_state1,
+				     sizeof(ctx1->x87_state1))) ||
+		    (rc = memcmp_isr(ctx1->x87_state2, ctx2->x87_state2,
+				     sizeof(ctx1->x87_state2)))) {
+			uk_pr_debug("x87 state differs!\n");
+			return rc;
+		}
+		break;
+	case X86_XSAVE_HDR_XSTATE_BV_SSEF:
+		if ((rc = memcmp_isr(ctx1->sse_state, ctx2->sse_state,
+				     sizeof(ctx1->sse_state)))) {
+			uk_pr_debug("SSE state differs!\n");
+			return rc;
+		}
+		break;
+	case X86_XSAVE_HDR_XSTATE_BV_AVXF:
+		if ((rc = memcmp_isr(ctx1->avx_state, ctx2->avx_state,
+				     sizeof(ctx1->avx_state)))) {
+			uk_pr_debug("AVX state differs!\n");
+			return rc;
+		}
+		break;
+	default:
+		UK_CRASH("Unknown XSAVE substate: %lu\n", substate);
+	}
+
+	return 0;
+}
+
+static inline bool mem_iszero(const void *mem, __sz len)
+{
+	for (__sz i = 0; i < len; i++)
+		if (((const __u8 *)mem)[i] != 0)
+			return false;
+
+	return true;
+}
+
+/*
+ * Check if a state component has the initial values defined by the
+ * architecture (all zeroes).
+ */
+static inline bool x86_xsave_substate_isinit(const struct x86_xsave_ctx *ctx,
+					     __u64 substate)
+{
+	switch (substate) {
+	case X86_XSAVE_HDR_XSTATE_BV_X87F:
+		return mem_iszero(ctx->x87_state1, sizeof(ctx->x87_state1)) &&
+		       mem_iszero(ctx->x87_state2, sizeof(ctx->x87_state2));
+	case X86_XSAVE_HDR_XSTATE_BV_SSEF:
+		return mem_iszero(ctx->sse_state, sizeof(ctx->sse_state));
+	case X86_XSAVE_HDR_XSTATE_BV_AVXF:
+		return mem_iszero(ctx->avx_state, sizeof(ctx->avx_state));
+	default:
+		UK_CRASH("Unknown XSAVE substate: %lu\n", substate);
+	}
+}
+
+static inline bool x86_xsave_mxcsr_iseq(const struct x86_xsave_ctx *ctx1,
+					const struct x86_xsave_ctx *ctx2)
+{
+	/*
+	 * Bytes 27:24 of XSAVE area are for the MXCSR register which is
+	 * loaded regardless of XSTATE_BV bitmap, so check unconditionally.
+	 */
+	return ctx1->mxcsr == ctx2->mxcsr;
+}
+
+static bool x86_xsave_substate_iseq(const struct x86_xsave_ctx *ctx1,
+				    const struct x86_xsave_ctx *ctx2,
+				    __u64 substate)
+{
+	__u64 ctx1_bitf, ctx2_bitf;
+
+	ctx1_bitf = ctx1->xsave_hdr.xstate_bv & substate;
+	ctx2_bitf = ctx2->xsave_hdr.xstate_bv & substate;
+
+	if (!ctx1_bitf && !ctx2_bitf)
+		return true;
+
+	if (ctx1_bitf != ctx2_bitf)
+		return x86_xsave_substate_isinit(ctx1_bitf ? ctx1 : ctx2,
+						 substate);
+
+	return x86_xsave_substate_memcmp(ctx1, ctx2, substate) == 0;
+}
+
+static inline bool x86_xsave_hdr_isvalid(const struct x86_xsave_ctx *ctx)
+{
+	const __u64 xhdr_supp_mask = X86_XSAVE_HDR_XSTATE_BV_X87F |
+				     X86_XSAVE_HDR_XSTATE_BV_SSEF |
+				     X86_XSAVE_HDR_XSTATE_BV_AVXF;
+	const struct x86_xsave_hdr *xhdr = &ctx->xsave_hdr;
+
+	/*
+	 * It is impossible for XCOMP_BV[63] to be set since we do not
+	 * use XSAVEC.
+	 */
+	return xhdr->xcomp_bv == 0 &&
+	       (xhdr->xstate_bv & ~xhdr_supp_mask) == 0 &&
+	       mem_iszero(xhdr->rsvd, sizeof(xhdr->rsvd));
+}
+
 void ukarch_ectx_assert_equal(struct ukarch_ectx *state)
 {
 	__u8 ectxbuf[ectx_size + ectx_align];
@@ -212,19 +367,76 @@ void ukarch_ectx_assert_equal(struct ukarch_ectx *state)
 	current = (struct ukarch_ectx *)ALIGN_UP((__uptr)ectxbuf, ectx_align);
 	ukarch_ectx_init(current);
 
-	if (memcmp_isr(current, state, ectx_size) != 0) {
-		uk_pr_crit("Modified ECTX detected!\n");
-		uk_pr_crit("Current:\n");
-		uk_hexdumpk(KLVL_CRIT, current, ectx_size,
-			    UK_HXDF_ADDR | UK_HXDF_GRPQWORD | UK_HXDF_COMPRESS,
-			    2);
+	/*
+	 * When using XSAVE(OPT) two ectx memory areas may differ
+	 * but be equivalent on XRSTOR, thus we cannot simply do memcmp.
+	 *
+	 * According to the Intel SDM, XSTATE_BV is a bitmap that, depending
+	 * on which extended register context subcomponent is used, it may
+	 * have its corresponding bit marked as dirty through the CPU-internal
+	 * state tracking structure XINUSE. If a subcomponent is enabled
+	 * (RFBM[i] = 1) then it is stated that: if the state component is in
+	 * its initial configuration, XINUSE[i] may be either 0 or 1, and
+	 * XSTATE_BV[i] may be written with either 0 or 1. In other words,
+	 * if the component happens to be zeroed out entirely, its
+	 * XSTATE_BV[i] can be either 0 or 1, both being valid.
+	 * Therefore, in some cases, following XSAVE(OPT), you can have two
+	 * ectx that differ in memory but are equivalent when loaded in.
+	 * Our comparison must take into account the state of the bitmaps
+	 * for proper checking.
+	 */
+	switch (ectx_method) {
+	case X86_SAVE_FSAVE:
+		if (unlikely(memcmp_isr(current, state,
+					sizeof(struct x86_fsave_ctx))))
+			goto ectx_corrupted;
+		break;
+	case X86_SAVE_FXSAVE:
+		/* According to Intel SDM, XSAVE does not use bytes 511:416 */
+		struct x86_fxsave_ctx *fxsave1 = (struct x86_fxsave_ctx *)state;
+		struct x86_fxsave_ctx *fxsave2 =
+			(struct x86_fxsave_ctx *)current;
 
-		uk_pr_crit("Expected:\n");
-		uk_hexdumpk(KLVL_CRIT, state, ectx_size,
-			    UK_HXDF_ADDR | UK_HXDF_GRPQWORD | UK_HXDF_COMPRESS,
-			    2);
+		if (unlikely(memcmp_isr(fxsave1->state, fxsave2->state,
+					sizeof(fxsave1->state))))
+			goto ectx_corrupted;
+		break;
+	case X86_SAVE_XSAVE:
+	case X86_SAVE_XSAVEOPT:
+		struct x86_xsave_ctx *xsave1 = (struct x86_xsave_ctx *)state;
+		struct x86_xsave_ctx *xsave2 = (struct x86_xsave_ctx *)current;
 
-		UK_CRASH("Modified ECTX\n");
+		if (unlikely(!x86_xsave_hdr_isvalid(xsave2)))
+			UK_CRASH("Error in saving current ectx\n");
+
+		if (unlikely(!x86_xsave_hdr_isvalid(xsave1) ||
+			     !x86_xsave_mxcsr_iseq(xsave1, xsave2) ||
+			     !x86_xsave_substate_iseq(xsave1, xsave2,
+					     X86_XSAVE_HDR_XSTATE_BV_X87F) ||
+			     !x86_xsave_substate_iseq(xsave1, xsave2,
+					     X86_XSAVE_HDR_XSTATE_BV_SSEF) ||
+			     !x86_xsave_substate_iseq(xsave1, xsave2,
+					     X86_XSAVE_HDR_XSTATE_BV_AVXF)))
+			goto ectx_corrupted;
+		break;
+	default:
+		UK_CRASH("Unknown ectx method: %d\n", ectx_method);
+		return;
 	}
+
+	return;
+
+ectx_corrupted:
+	uk_pr_crit("Modified ECTX detected!\n");
+	uk_pr_crit("Current:\n");
+	uk_hexdumpk(KLVL_CRIT, current, ectx_size,
+		    UK_HXDF_ADDR | UK_HXDF_GRPQWORD | UK_HXDF_COMPRESS,
+		    2);
+
+	uk_pr_crit("Expected:\n");
+	uk_hexdumpk(KLVL_CRIT, state, ectx_size,
+		    UK_HXDF_ADDR | UK_HXDF_GRPQWORD | UK_HXDF_COMPRESS,
+		    2);
+
+	UK_CRASH("Modified ECTX\n");
 }
-#endif

--- a/include/uk/arch/ctx.h
+++ b/include/uk/arch/ctx.h
@@ -526,7 +526,6 @@ void ukarch_ectx_load(struct ukarch_ectx *state);
  */
 void ukarch_execenv_load(long state) __noreturn;
 
-#ifdef CONFIG_ARCH_X86_64
 /**
  * Compare the given extended context with the state of the currently executing
  * CPU. If the state is different, crash the kernel.
@@ -535,7 +534,6 @@ void ukarch_execenv_load(long state) __noreturn;
  *   Reference to extended context to compare to
  */
 void ukarch_ectx_assert_equal(struct ukarch_ectx *state);
-#endif
 
 #endif /* !__ASSEMBLY__ */
 #endif /* __UKARCH_CTX_H__ */

--- a/lib/ukintctlr/Config.uk
+++ b/lib/ukintctlr/Config.uk
@@ -15,6 +15,5 @@ config LIBUKINTCTLR_MAX_HANDLERS_PER_IRQ
 
 config LIBUKINTCTLR_ISR_ECTX_ASSERTIONS
 	bool "Check for unmodified ECTX in interrupt handlers"
-	depends on ARCH_X86_64
 
 endif


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

According to the Intel SDM, XSTATE_BV is a bitmap that, depending on
which extended register context subcomponent is used, it may have its
corresponding bit marked as dirty through the CPU-internal state
tracking structure XINUSE. If a subcomponent is enabled (RFBM[i] = 1)
then it is stated that: If the state component is in its initial
configuration, XINUSE[i] may be either 0 or 1, and XSTATE_BV[i] may be
written with either 0 or 1. In other words, if the component happens to
be zeroed out entirely, its XSTATE_BV[i] can be either 0 or 1, both
being valid. Some microarchitectures asynchrounously track this state
and may unset the component's bit if its state is noticed to be clean.

This could lead to rare cases where even sequential XSAVEOPT
instructions, executed one after another, may save a different XSTATE_BV
value in the XSAVE header which is valid.

Therefore, we must split the memory comparing in case of XSAVE(OPT). We
have 3 individual subcomponents to check: x87, SSE and AVX states. If
a subcomponent's bit in the bitmap is 0 in both states to compare, it
means that subcomponent was not touched. Otherwise, if the bits differ
then we must check that the subcomponent of the XSAVE's image whose bit
is 1, is entirely zeroed out. If both bits are 1 then we must compare
the subcomponent of each XSAVE image against each other and they must
coincide.

Below are some interesting experiments and their results. Consider the
starting extended register state as clean and the following steps:
1. dirty an AVX register (e.g. VMOVDQU with non-zero values)
2. loop for a while
3. undirty AVX register
4. do xgetbv with RCX as 1 to get XINUSE bitmap until the XINUSE[2]
(2 being the bit corresponding to AVX) is undirtied

If you do VZEROALL/VZEROUPPER or a self-VPXOR of said register at
step 3, the loop at step 4 end instantly, as the bit is syncrhounously
cleared.
If you do VMOVDQU with zeroed out memory for step 3, the loop at step 4
will run for a while, indicating that the CPU does not syncrhounously set
the bit but rather after some arbitrary cycles it clears the bit after
noticing the state being clean again.

While at it, implement this check on ARM as well.