### PR TITLE
lib/*: Update VFS stack documentation

### DIFF
--- a/lib/posix-fd/README.md
+++ b/lib/posix-fd/README.md
@@ -1,0 +1,27 @@
+# `posix-fd`: POSIX Open File Descriptions for Unikraft
+
+This core library provides the Unikraft abstraction for POSIX open file descriptions -- references to a file that is "in use", along with any state required to correctly implement POSIX file operations.
+
+Not to be confused with POSIX file descrip**tor**s, which are handled by `posix-fdtab`.
+
+Consult the main `uk/posix-fd.h` header for API & implementation details.
+
+## What is an Open File Description?
+
+An open file description consists of:
+- A counted reference to the open file
+- An optional name for the open file
+- Mutable state:
+  - Reference count, allowing multiple independent shared references
+  - Open file "mode", a bitmask of options the file is opened with, that affects the behavior of POSIX file operations
+  - Current position for I/O (i.e. what one sets with `lseek()`)
+  - Lock for synchronizing changes to the above
+
+Open files are represented in Unikraft by `struct uk_ofile`, with fields storing the above.
+A single `ukfile` may be referenced by an arbitrary number of open file descriptions, each of which acts independently.
+
+Open file descriptions do not expose any operations themselves beyond lifetime management, with the following libraries responsible for typical POSIX file operations:
+- `posix-fdio`: I/O, metadata, control
+- `posix-vfs`: VFS operations
+- `posix-mmap`: memory mapping
+- `posix-socket`: socket operations

--- a/lib/posix-fdio/README.md
+++ b/lib/posix-fdio/README.md
@@ -1,0 +1,11 @@
+# `posix-fdio`: POSIX File I/O, Metadata & Control for Unikraft
+
+This library implements core POSIX file operations on top of open file descriptions.
+These are:
+- I/O: `read` & `write` family, `lseek`, `sendfile`
+- Metadata: `fstat`, `fchmod`, `futime(n)s`, etc.
+- Control: `fcntl`, `ioctl`, `ftruncate`, etc.
+- Driver-agnostic behavior of file memory mappings
+
+These operations are exported under the Unikraft-internal `uk_sys_*` API in `uk/posix-fdio.h`.
+If `posix-fdtab` is enabled, the equivalent file-descriptor-based Linux-compatible syscalls / libc functions are also provided.

--- a/lib/posix-fdtab/README.md
+++ b/lib/posix-fdtab/README.md
@@ -1,0 +1,18 @@
+# `posix-fdtab`: POSIX File Descriptors & their Tables for Unikraft
+
+This library implements POSIX file descriptor tables (fdtabs), providing management of file descriptors.
+
+A file descriptor (fd) is a non-negative integer that is used to reference an open file description from userspace.
+This contextual mapping of integer-to-file-description is managed by an fdtab, which provides:
+- Kernel API:
+  - `open*`: associate an open file description with a free fd
+  - `get`: retrieve open file description associated with an fd
+  - `[get|set]flags`: manipulate file descriptor flags (`O_CLOEXEC`)
+- Userspace API:
+  - `close()`: close an fd, releasing its open file description
+  - `dup*()`: associate a free fd with a duplicate reference to the same open file description as another fd
+
+Both kernel and userspace APIs are exported under the Unikraft-internal `uk_sys_*` namespace.
+The userspace API is additionally exported as Linux-compatible syscalls / libc functions, depending on configuration.
+
+Consult the main `uk/posix-fdtab.h` header for API details.

--- a/lib/posix-vfs/README.md
+++ b/lib/posix-vfs/README.md
@@ -1,3 +1,10 @@
-# `posix-vfs`: POSIX-compatible filesystem interface
+# `posix-vfs`: POSIX Virtual Filesystem for Unikraft
 
-This library implements a POSIX-compatible filesystem interface, exposed under both an internal API (`uk_sys_*`), as well as Linux-compatible syscalls.
+This library implements a POSIX-compatible virtual filesystem in Unikraft on top of the ukfs API.
+This includes all operations working with paths, as well as with VFS state more generally.
+
+Filesystem operations are exported under the Unikraft-internal `uk_sys_*` API.
+If filesystem syscalls are enabled, Linux-compatible syscall / libc equivalents are also exported.
+This will have `posix-vfs` take over filesystem duties from `vfscore` entirely, requiring the latter to be disabled.
+
+Consult the `uk/posix-vfs.h` header for more details.

--- a/lib/posix-vfs/posix-vfsroot/README.md
+++ b/lib/posix-vfs/posix-vfsroot/README.md
@@ -1,7 +1,7 @@
-# `posix-vfs-fsroot`: Static filesystem root file
+# `posix-vfs-fsroot`: POSIX VFS Static Root File
 
-This library implements a static singleton file intended to serve as the root of the virtual filesystem.
+This sub-library implements a static singleton file intended to serve as the root of the POSIX virtual filesystem.
 It is responsible for exactly three things:
-- behave as a read-only empty dir when nothing is mounted
+- behave as a read-only empty root dir when nothing is mounted
 - be a mount point for any real root
-- ensure, via lookup, that '/' is always its own parent
+- ensure, via lookup, that `/` is always its own parent

--- a/lib/ukfile/README.md
+++ b/lib/ukfile/README.md
@@ -1,43 +1,61 @@
-# `ukfile`: files for Unikraft
+# `ukfile`: Files for Unikraft
 
-This core library contains the unikraft abstractions of a "file" as well as an "open file" (a.k.a. "open file descriptions").
-These are low-level internal abstractions that do not have direct correspondents in any userspace-facing API.
-Not to be confused with "file descriptors" or other similar POSIX-y concepts; please see `posix-fd*` for those.
+This core library provides the Unikraft abstraction of a "file".
+`ukfile` is a low-level kernel API that decouples file _drivers_ -- implementers of the API -- from file _consumers_ -- callers of the API.
 
-This README discusses higher-level design considerations for (open) files.
-Consult the headers `uk/file.h` and `uk/ofile.h` for specifics on implementation.
+This README provides a high-level overview, consult the public header files for more details:
+- `uk/file.h` -- main file API
+- `uk/file/iovutil.h` -- utilities for working with buffers in `struct iovec`s
+- `uk/file/nops.h` -- no-op file operations, provided as convenience for drivers
 
-## What is a _file_?
+## What is a File?
 
-To overuse a classical *NIX idiom, "everything is a file".
-More concretely however, a file is an abstraction for any resource that offers a combination of input, output, and/or control operations.
-A file in Unikraft is a combination of an _immutable identity_ coupled with _mutable state_.
+To overuse a classic *NIX idiom, "everything is a file".
+More concretely however, a file is an abstraction for any resource that offers a combination of I/O, and/or control operations.
 
-Files are represented in Unikraft by the `struct uk_file` type, referenced in APIs as `const struct uk_file *` to enforce immutability.
-Identity consists of:
-- A volume identifier: driver-specific field, used to identify the file type as well as its originating driver instance
-- A file node: reference to driver-specific data associated with the file
-- Table of file operations: implementations of well-defined file operations (see below)
+### What a File is not
 
-File state is used for bookkeeping purposes and includes:
+Although tightly related to files, the following fall outside the scope of `ukfile` and are handled by their own core libraries:
+- `posix-fd`: open file descriptions -- state linked to open instances of files
+- `posix-fdtab`: file descriptors (`int fd`) & their management
+- `posix-fdio`: POSIX file operations -- `read`, `write`, `fcntl`, etc.
+- `ukfs`: filesystem API -- additional operations for filesystem-backed files
+- `posix-vfs`: POSIX virtual filesystem (VFS) layer
+
+### File Identity & State
+
+Files are represented in Unikraft by `struct uk_file`, whose fields, once initialized, form the file's identity and must never be changed over the lifetime of the file.
+
+**`ukfile` drivers and consumers should always return and accept `const struct uk_file *` to enforce immutability.**
+
+File identity consists of:
+- Driver-private fields for volume and node identifier
+- File operation table(s): implementations of well-defined operations (see below)
+- References to mutable public file state
+
+Public file state is used for bookkeeping purposes and includes:
 - Reference counting (strong & weak references)
 - Locks for synchronization
-- Event set & queue for polling operations
+- Polling mechanism & queue
 
 ### File Operations
 
 Files allow for a defined set of operations, some of which are driver-implemented, while others are common across all files.
+
 Driver-specific operations have a well-defined interface and are implemented by file drivers.
 These are:
-- I/O: manipulating an array of unstructured bytes
+- Traditional I/O: manipulating file contents as an array of unstructured bytes
   - `read`: retrieve a specific contiguous block of bytes from this array
   - `write`: ensure a specific contiguous block in this array has specific bytes
+- Direct Memory I/O: unmediated access to a file's backing memory
+  - `mem`: reserve, retrieve, and manage the memory backing a file's contents
 - Metadata: manipulating a defined structure of metadata related to the file
-  - `getstat`: get file metadata fields
-  - `setstat`: set file metadata fields
+  - `getstat`
+  - `setstat`
 - Control: requests for special operations to be performed by the file
   - `ctl`
 - (internal) cleanup/destructor: what happens, if anything, when we no longer need the file
+- (optional) Filesystem Operations: see `ukfs` for details
 
 Common operations are implemented centrally for all file objects:
 - Reference counting: acquire/release of regular (strong) or weak references
@@ -45,7 +63,8 @@ Common operations are implemented centrally for all file objects:
   - Weak references allow only common operations (polling, locking)
 - Event polling & notification:
   - Driver API:
-    - Set & clear what event flags are active on the file
+    - Managed Events: Drivers set & clear what events are active on the file in-band with I/O
+    - Polled Events: Drivers only notify rising edges of events and provide a callback for polling
   - User API:
     - Check whether specific events are set on a file
     - Wait and be awoken when an event becomes set on a file
@@ -54,18 +73,45 @@ Common operations are implemented centrally for all file objects:
   - Drivers are free to implement these operations as efficiently as their internal data model allows
   - Higher-level APIs that want to provide atomicity guarantees (e.g. POSIX read vs. write serialization) can and should use these mechanisms to achieve their goal
 
+Note that there are no "open" or "close" operations; a ukfile is not "open" or "closed", it simply _is_.
+A ukfile is a "live" object -- an existing reference gives full access to all of its capabilities.
+All resource management is done at creation or in-band with operations, and released during destruction.
 
-## What is an _open file_?
+## File Lifetime
 
-Open files are stateful and mutable references to a file that is "in use".
-The precise definition of "in use" is intentionally left vague and up to client code.
-Open file state consists of:
-- Reference count, allowing multiple independent shared references
-- Open "mode", a client-defined bitmask of open file options
-- Current position for I/O (i.e. what one sets with `lseek()`)
-- Lock for synchronizing changes to the above
+While every file's journey is different, there are some common points defining its lifetime.
 
-Open files are represented in Unikraft by the `struct uk_ofile` type.
-A single `struct uk_file` may be referenced by an arbitrary number of ofiles, each of which acts independently from the others.
+### Creation
 
-Open files do not expose any operations themselves, instead providing only a base data structure for higher-level abstractions, such as file descriptor tables and POSIX I/O syscalls.
+The `ukfile` API does not specify any way of "looking up" file drivers, nor any common interface for creating files.
+This is a deliberate choice, as these "file sources"[^1] are extremely varied and a one-size-fits-all API could not work.
+Instead, file sources are free to use bespoke APIs, provided they output files as a strongly refcounted `const struct uk_file *` reference.
+
+**NOTE**: Although refcounted, ukfiles need not be heap-allocated or even runtime-initialized, as long as the static allocation is included in the reference count.
+
+[^1]: _sources_ are different from and orthogonal to _drivers_: drivers implement file functionality, sources create and publish file objects.
+
+### Use
+
+With a ukfile reference in hand, there are really only a few things one can do:
+1. Perform file operations
+2. Store the reference for later
+3. Acquire a new (weak) reference
+4. Release a (weak) reference
+
+Unless explicitly (and very loudly) documented otherwise, all functions operating on ukfiles "borrow" the reference for the duration of the call.
+It is undefined to call any such function without a refcount of appropriate strength held.
+
+### Destruction
+
+When all references to a file have been released, it is cleaned up in two stages:
+1. Release driver resources
+   - done on releasing last strong reference
+   - driver can release all private resources related to the file
+   - (optional) run external file destruction hooks ("finalizers")
+   - most file operations are undefined past this point (see "File Operations" above)
+   - file struct & public state is still available
+2. Release file object
+   - done on releasing last reference of any kind
+   - driver releases all resources, including the memory of file's struct
+   - file is completely destroyed, reference is now freed memory and any further access is undefined

--- a/lib/ukfile/include/uk/file.h
+++ b/lib/ukfile/include/uk/file.h
@@ -344,10 +344,17 @@ typedef struct uk_swrefcount uk_file_refcnt;
 struct uk_fs_ops;
 #endif /* CONFIG_LIBUKFS */
 
+/* Main file struct.
+ *
+ * Drivers should always use designated initializers or zero the memory when
+ * populating the struct. Optional fields may be added in the future, but always
+ * with the guarantee that a NULL / all-zero value remains backwards-compatible.
+ */
+
 struct uk_file {
 	/* Identity */
-	const void *vol; /* Driver-specific volume state */
-	void *node; /* Driver-specific inode data */
+	const void *vol; /* Driver-private volume state */
+	void *node; /* Driver-private file data */
 	/* Ops table */
 	const struct uk_file_ops *ops;
 #if CONFIG_LIBUKFS

--- a/lib/ukfile/include/uk/file/pollqueue.h
+++ b/lib/ukfile/include/uk/file/pollqueue.h
@@ -274,7 +274,7 @@ uk_pollevent _uk_pollq_poll_locked(struct uk_pollq *q, uk_pollevent req,
  *
  * @param q Target queue.
  * @param req Events to poll for.
- * @param exp Events expected to be already set.
+ * @param f File whose events to poll.
  *
  * @return
  *   non-zero evmask with lock released if events appeared

--- a/lib/ukfs-devfs/README.md
+++ b/lib/ukfs-devfs/README.md
@@ -1,1 +1,5 @@
-# `ukfs-devfs`: A filesystem for pseudofiles under `/dev/`
+# `ukfs-devfs`: A filesystem for pseudofiles under `/dev`
+
+This library provides a pseudo-filesystem registered as "devfs" under `ukfs` where libraries can publish special files intended to appear under `/dev`.
+
+Consult the `uk/devfs.h` header for the bespoke API of devfs, and `ukfs` and above layers for the general filesystem API.

--- a/lib/ukfs/README.md
+++ b/lib/ukfs/README.md
@@ -1,1 +1,131 @@
-# ukfs: Unikraft filesystem interface
+# `ukfs`: Unikraft Filesystem Interface
+
+This core library provides the Unikraft abstraction of filesystem-backed files.
+Also known as "filesystem nodes", these are ukfiles that provide an extra set of filesystem operations in addition to the base `ukfile` API.
+
+Note that while all filesystem nodes are ukfiles, not all ukfiles are filesystem nodes, with pipes, network sockets, and pseudo-files (epollfd, timerfd, etc.) being perfect examples of the latter.
+It is undefined to pass a non-filesystem file to the `ukfs` API.
+
+Not to be confused with _the_ filesystem -- aka VFS, the single filesystem namespace anchored at `/` common to any *nix OS.
+The VFS is a higher-level concept and implemented by `posix-vfs`.
+
+This README provides a high-level overview, consult the public header files for more details.
+
+Consumer API:
+- `uk/fs.h`: filesystem API
+- `uk/fs/driver.h`: driver registration & lookup
+
+Driver utils:
+- `uk/fs/pathutil.h`: utilities for manipulating paths
+- `uk/fs/dirent.h`: utilities for outputting `struct dirent64`
+- `uk/fs/prio.h`: priority conventions for initializing filesystems
+- `uk/fs/common-ops.h`: common boilerplate filesystem operations
+
+Driver templates:
+- `uk/fs/template/live.h`: live reference driver template
+- `uk/fs/template/pseudo.h`: pseudo-fs driver template
+
+## Filesystem Operations
+
+In brief, the ukfs API provides operations for:
+- volume-wide stats & sync
+- lookup on all nodes
+- readlink of symbolic links
+- directory ops: listing, creation, deletion, renaming
+- runtime state management: `mount`, `graft`, `rebind`
+
+Detailed description of each operation can be found in `uk/fs.h`.
+
+## Peculiarities
+
+To someone familiar with userspace VFS APIs or legacy vfscore, some design choices of ukfs may seem peculiar.
+This is mainly because ukfs focuses on defining _mechanism_, leaving higher abstraction layers to build upon it to implement _policy_.
+Here we aim to clarify and argue some of these design choices.
+
+#### Locality
+
+All ukfs operations are _relative_ to their target node, and any changes they enact are _local_ to that node.
+This has several notable implications:
+1. each node provides an authoritative reference to the ops it can perform
+2. all paths are relative, there's no concept of "absolute path"
+3. all lookups are relative and must make progress with local information only
+4. changes to filesystem state are local
+5. there is no global view of in-use filesystems whatsoever
+
+Point (1) differs from the legacy vfscore stack as there is no single public "driver ops table" to speak of, giving drivers the freedom to tailor ops tables to different file types.
+
+Point (2) highlights ukfs's focus on mechanism, as "`/` -- the VFS root" along with absolute paths are a higher-level concept and fall outside its scope.
+
+Continuing from this, point (3) informs the interface of `lookup` and the separation of responsibilities it enforces between the caller and driver.
+Most notably this affects what happens when lookup encounters something other than a regular filesystem node, such as a symlink, mount point, etc., where the driver notifies the caller about the event, but makes no decision on what action to take.
+Indeed, concepts like traversing symlinks or mount points are alien to a ukfs driver and belong in a higher-level library that calls into ukfs.
+
+Point (4) removes the need for complex or global synchronization of filesystem ops in calling code, improving parallelism.
+Drivers are of course free to synchronize internally as needed.
+
+Finally point (5) means that concepts like "mount table" also fall outside the scope of ukfs.
+However, this in conjunction with point (3) means that ukfs drivers must be made locally aware of larger-scale structures like mounts, at least to a very minimal extent.
+This leads nicely into the next section.
+
+#### Mount, Graft & Rebind
+
+Known collectively as "ops managing runtime-volatile state", `mount`, `graft`, and `rebind` are probably the most peculiar of ukfs operations.
+When broken down however, their logic is very simple and boils down to 3 things:
+1. `mount` manages what happens on lookup of self (or `.`)
+   - every file implicitly looks up itself on any lookup, which is a no-op by default
+   - `mount` allows callers to hook this step in order to return a special case at lookup -- the mounted node
+   - the driver remains oblivious to what "mounting" means in context; it just knows to return this one special case on lookup
+   - caller logic can decide whether to traverse this mount point or handle it some other way
+2. `graft` manages what happens on lookup of parent (`..`)
+   - making traversal of a mount point work in reverse requires `..` in the mounted directory to reference the parent of its mount point
+   - `graft` allows for this to happen, causing a lookup of `..` to report a mount point with the appropriate target
+   - drivers are as oblivious to the larger context as for `mount`; to them it is merely a lookup artifice
+   - this is separate from and orthogonal to `mount` -- callers may use a combination of either to "weave" together any structure they wish, not just a single VFS tree
+3. `rebind` creates a new instance of an open volume
+   - similar to a "clone" but for filesystem nodes, creating an independent instance that shares state with the original
+   - intended to facilitate bind mounts, where a sub-tree of an existing filesystem is re-instanced and mounted somewhere else
+   - different to opening the same volume twice (although depending on driver implementation these might behave the same)
+
+#### Lifetime
+
+The ukfs API provides exactly three ways to obtain new filesystem node references: `lookup`, `create`, and `rebind`.
+This poses somewhat of a chicken-and-egg problem, as all of these are relative, and thus require an existing node to operate on.
+In practice this means that at any point in time all live filesystem nodes can be traced, through a combination of these three operations, back to a set of seed nodes.
+
+Producing these seed nodes is the responsibility of `vopen`, the single part of a ukfs driver that can be called from a global context.
+`vopen` takes a (driver-specific) volume, along with flags and options, and returns the root node of a new filesystem instance.
+
+There is no corresponding `vclose` operation.
+Drivers are responsible for cleaning up volume instances when the last node referencing it has been released, or, at the very latest, at system shutdown.
+
+## Filesystem Driver Templates
+
+The ukfs/ukfile interface gives drivers complete control over all aspects of their files:
+- volume-wide state
+- volume lifetime management
+- driver-internal node representation
+- public ukfile mutable state
+- lifetime management (refcounting semantics)
+- ukfs runtime volatile state (mounts, rebinds, etc.)
+
+Oftentimes however, a particular driver may not need this level of control, nor want to be burdened with the corresponding responsibility.
+For these cases, ukfs provides so-called driver "templates" -- header files specialized in generating ukfs-compatible operations from driver code that natively operates at a lower abstraction layer.
+
+### Live Reference
+
+The "live reference" driver template is tailored for drivers that can naturally handle all lifetime management and public file state, but want a boilerplate implementation of ukfs runtime state.
+The name "live reference" refers to the node objects of these drivers which, just like ukfiles, are "live" -- references are counted, there are no explicit open/close operations, and a reference simply existing implies it being "open".
+
+Consult the `uk/fs/template/live.h` header for more details.
+
+### Pseudo-FS
+
+In addition to "true" filesystems (ones whose purpose is the organization of data) there are many use-cases for so-called pseudo-filesystems -- hierarchies of special filesystem nodes that provide a file-like interface to various kernel functionalities.
+Their implementation usually follows a simple pattern:
+1. Initialize at boot time a backend root piggy-backing on top of another (usually volatile) filesystem
+2. Populate said root with desired contents
+3. Export a rebind of the backend root under a custom filesystem name
+
+The pseudo-fs driver template generates boilerplate code handling steps (1) and (3) above, leaving drivers to focus on implementing their bespoke functionality.
+
+Consult the `uk/fs/template/pseudo.h` header for more details.


### PR DESCRIPTION
### Description of changes

This changeset updates the documentation across the file/vfs stack, expanding and changing to better reflect recent developments.

~~Depends on the following PRs and has them included as squashed commits that will be removed on rebase, please ignore during review:~~
- ~~https://github.com/unikraft/unikraft/pull/1654~~
- ~~https://github.com/unikraft/unikraft/pull/1681~~

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A