### PR TITLE
lib/ramfs: Switch ramfs_fallocate to vfscore_vop_null()

### DIFF
--- a/lib/ramfs/ramfs_vnops.c
+++ b/lib/ramfs/ramfs_vnops.c
@@ -706,7 +706,7 @@ static int ramfs_ioctl(struct vnode *dvp __unused,
 #define ramfs_seek      ((vnop_seek_t)vfscore_vop_nullop)
 #define ramfs_fsync     ((vnop_fsync_t)vfscore_vop_nullop)
 #define ramfs_link      ((vnop_link_t)vfscore_vop_eperm)
-#define ramfs_fallocate ((vnop_fallocate_t)vfscore_vop_nullop)
+#define ramfs_fallocate ((vnop_fallocate_t)vfscore_vop_einval)
 #define ramfs_poll      ((vnop_poll_t)vfscore_vop_einval)
 
 /*


### PR DESCRIPTION
Switch ramfs_fallocate() from vfscore_vop_null() to vfscore_vop_einval(). This makes ramfs_fallocate() return a meaningful value that allows applications to progress via alternative means.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
