### PR TITLE
include/uk/event: Make handler and raise return values type-safe

### DIFF
--- a/drivers/ukps2/kbd/dumbkbd.c
+++ b/drivers/ukps2/kbd/dumbkbd.c
@@ -40,6 +40,7 @@ UK_EVENT(UKPLAT_SHUTDOWN_EVENT);
 
 static int kbd_ps2_irq_handler(void *arg __unused)
 {
+	int event_error __unused;
 	/* Read received scan code (ACPI scan code set) */
 	__u16 sc;
 
@@ -63,7 +64,8 @@ static int kbd_ps2_irq_handler(void *arg __unused)
 		if (!(lctrl_pressed && lalt_pressed))
 			break;
 
-		uk_raise_event(UKPLAT_SHUTDOWN_EVENT, (void *)UKPLAT_HALT);
+		uk_raise_event(UKPLAT_SHUTDOWN_EVENT, (void *)UKPLAT_HALT,
+			       &event_error);
 
 		break;
 	}

--- a/include/uk/event.h
+++ b/include/uk/event.h
@@ -74,13 +74,14 @@
  * void some_function(void)
  * {
  *       struct myevent_data = { .dummy = 42 };
+ *       int error;
  *       int rc;
  *
- *       rc = uk_raise_event(myevent, &myevent_data);
- *       if (rc < 0)
- *               uk_pr_crit("an event handler returned an error!\n");
- *       else if (!rc)
- *               uk_pr_err("myevent not handled!\n");
+ *       rc = uk_raise_event(myevent, &myevent_data, &error);
+ *       if (unlikely(rc < UK_EVENT_ERROR))
+ *               uk_pr_crit("an event handler returned an error (%d)\n", error);
+ *       else if (rc == UK_EVENT_NOT_HANDLED)
+ *               uk_pr_err("myevent not handled\n");
  * }
  * ```
  * **libB/myhandler.c:**
@@ -88,19 +89,19 @@
  * #include <uk/event.h>
  * #include <uk/myevent.h>
  *
- * int handler1(void *arg)
+ * enum uk_event_status handler1(void *arg, int *error)
  * {
  *       struct myevent_data *data = (struct myevent_data *)arg;
  *       ...
  *       return UK_EVENT_HANDLED_CONT;
  * }
  *
- * int handler2(void *arg)
+ * enum uk_event_status handler2(void *arg, int *error)
  * {
  *       return UK_EVENT_HANDLED_CONT;
  * }
  *
- * int handler3(void *arg)
+ * enum uk_event_status handler3(void *arg, int *error)
  * {
  *       return UK_EVENT_HANDLED;
  * }
@@ -136,14 +137,22 @@ extern "C" {
  *
  * @param data
  *   Optional data parameter. The data is supplied when raising the event
+ * @param error
+ *   Pointer to error code. Set by the handler when returning UK_EVENT_ERROR.
  * @return
  *   One of the UK_EVENT_* macros on success, errno on < 0
  */
-typedef int (*uk_event_handler_t)(void *data);
+typedef enum uk_event_status (*uk_event_handler_t)(void *data, int *error);
 
-#define UK_EVENT_NOT_HANDLED	0  /* Event not handled. Try next handler. */
-#define UK_EVENT_HANDLED	1  /* Event handled. Stop calling handlers. */
-#define UK_EVENT_HANDLED_CONT	2  /* Event handled. Call next handler. */
+enum uk_event_status {
+	UK_EVENT_NOT_HANDLED,	/* Event not handled. Try next handler. */
+	UK_EVENT_HANDLED,	/* Event handled. Stop calling handlers. */
+	UK_EVENT_HANDLED_CONT,	/* Event handled. Call next handler. */
+	UK_EVENT_ERROR		/* Error while processing the event. The
+				 * handler must return an error code via
+				 * *error.
+				 */
+};
 
 struct uk_event {
 	const uk_event_handler_t *hlist_end;
@@ -259,32 +268,35 @@ struct uk_event {
  *   Pointer to the event to raise.
  * @param data
  *   Optional data supplied to the event handlers
+ * @param error
+ *   Error code set by the handler in case of an error.
  * @returns
- *   A negative error value if a handler returns one. Event processing
- *   immediately stops in this case. Otherwise:
  *   - UK_EVENT_HANDLED if a handler indicated that it successfully handled
  *     the event and event processing should stop with this handler.
  *   - UK_EVENT_HANDLED_CONT if at least one handler indicated that it
  *     successfully handled the event but event handling can continue, and no
  *     other handler returned UK_EVENT_HANDLED.
  *   - UK_EVENT_NOT_HANDLED if no handler handled the event.
+ *   - UK_EVENT_ERROR if a handler encountered an error while handling the
+ *     event. Event processing stops immediately in this case, and an errror
+ *     code is saved in *error.
  */
-static inline int uk_raise_event_ptr(struct uk_event *e, void *data)
+static inline enum uk_event_status
+uk_raise_event_ptr(struct uk_event *e, void *data, int *error)
 {
 	const uk_event_handler_t *itr;
-	int rc;
 	int ret = UK_EVENT_NOT_HANDLED;
 
 	uk_event_handler_foreach(itr, e) {
 		__uk_event_assert(*itr);
-		rc = ((*itr)(data));
-		if (unlikely(rc < 0))
-			return rc;
+		ret = ((*itr)(data, error));
+		if (unlikely(ret == UK_EVENT_ERROR))
+			return UK_EVENT_ERROR;
 
-		if (rc == UK_EVENT_HANDLED)
+		if (ret == UK_EVENT_HANDLED)
 			return UK_EVENT_HANDLED;
 
-		if (rc == UK_EVENT_HANDLED_CONT)
+		if (ret == UK_EVENT_HANDLED_CONT)
 			ret = UK_EVENT_HANDLED_CONT;
 	}
 
@@ -302,9 +314,9 @@ static inline int uk_raise_event_ptr(struct uk_event *e, void *data)
  * @return
  *   One of the UK_EVENT_* macros on success, errno on < 0
  */
-#define uk_raise_event(event, data)					\
+#define uk_raise_event(event, data, error)				\
 	({	_UK_EVT_IMPORT_EVENT(event);				\
-		uk_raise_event_ptr(UK_EVENT_PTR(event), data);	})
+		uk_raise_event_ptr(UK_EVENT_PTR(event), data, error);	})
 
 #ifdef __cplusplus
 }

--- a/lib/posix-fdtab/fdtab.c
+++ b/lib/posix-fdtab/fdtab.c
@@ -367,7 +367,7 @@ void uk_fdtab_cloexec(void)
 
 #if CONFIG_LIBPOSIX_PROCESS_EXECVE
 #if CONFIG_LIBPOSIX_FDTAB_MULTITAB
-static int fdtab_handle_execve(void *data)
+static enum uk_event_status fdtab_handle_execve(void *data)
 {
 	struct posix_process_execve_event_data *edat = data;
 	struct uk_fdtab *tab = uk_thread_uktls_var(edat->thread, active_fdtab);
@@ -376,7 +376,7 @@ static int fdtab_handle_execve(void *data)
 	return UK_EVENT_HANDLED_CONT;
 }
 #else /* !CONFIG_LIBPOSIX_FDTAB_MULTITAB */
-static int fdtab_handle_execve(void *data)
+static uk_event_status fdtab_handle_execve(void *data)
 {
 	uk_fdtab_cloexec();
 	return UK_EVENT_HANDLED_CONT;

--- a/lib/posix-process/execve.c
+++ b/lib/posix-process/execve.c
@@ -83,9 +83,12 @@ static int pprocess_cleanup(struct posix_process *pprocess)
 	return 0;
 }
 
-int pprocess_raise_execve_event(struct posix_process_execve_event_data *data)
+enum uk_event_status
+pprocess_raise_execve_event(struct posix_process_execve_event_data *event_data,
+			    int event_error)
 {
-	return uk_raise_event(POSIX_PROCESS_EXECVE_EVENT, data);
+	return uk_raise_event(POSIX_PROCESS_EXECVE_EVENT, event_data,
+			      event_error);
 }
 
 UK_SYSCALL_R_E_DEFINE(int, execve, const char *, pathname,
@@ -95,10 +98,12 @@ UK_SYSCALL_R_E_DEFINE(int, execve, const char *, pathname,
 	struct posix_process_execve_event_data event_data;
 	struct uk_binfmt_loader_args loader_args;
 	struct ukarch_execenv *execenv_new;
+	enum uk_event_status event_status;
 	struct uk_thread *this_thread;
 	struct ukarch_ctx ctx_old;
 	void *stack_old;
 	void *stack_new;
+	int event_error;
 	int rc = 0;
 
 	/* Linux deviates from POSIX by treating NULL pointers to
@@ -175,9 +180,10 @@ UK_SYSCALL_R_E_DEFINE(int, execve, const char *, pathname,
 	 * internal cleanup.
 	 */
 	event_data.thread = this_thread;
-	rc = pprocess_raise_execve_event(&event_data);
-	if (unlikely(rc < 0)) {
-		uk_pr_err("execve event error (%d)\n", rc);
+	event_status = pprocess_raise_execve_event(&event_data, &event_error);
+	if (unlikely(event_status == UK_EVENT_ERR)) {
+		uk_pr_err("execve event error (%d)\n", event_error);
+		rc = event_error;
 		goto err_free_stack_new;
 	}
 	pprocess_cleanup(uk_pprocess_current());

--- a/lib/posix-process/exit.c
+++ b/lib/posix-process/exit.c
@@ -92,10 +92,11 @@ void pprocess_exit_pthread(struct posix_thread *pthread,
 			   int exit_status __unused)
 {
 	struct posix_process_exit_event_data event_data;
-	struct posix_process *pprocess;
 	struct posix_thread *parent_pthread;
+	enum uk_event_status event_status;
+	struct posix_process *pprocess;
 	struct uk_thread *thread;
-	int ret;
+	int event_error;
 
 	UK_ASSERT(state == POSIX_THREAD_EXITED ||
 		  state == POSIX_THREAD_KILLED);
@@ -120,9 +121,11 @@ void pprocess_exit_pthread(struct posix_thread *pthread,
 	event_data.thread = pthread->thread;
 	event_data.tid = pthread->tid;
 	event_data.pid = pprocess->pid;
-	ret = uk_raise_event(POSIX_PROCESS_EXIT_EVENT, &event_data);
-	if (unlikely(ret < 0))
-		UK_CRASH("POSIX_PROCESS_EXIT_EVENT failed with %d\n", ret);
+	event_status = uk_raise_event(POSIX_PROCESS_EXIT_EVENT, &event_data,
+				      &event_error);
+	if (unlikely(event_status == UK_EVENT_ERROR))
+		UK_CRASH("POSIX_PROCESS_EXIT_EVENT failed with %d\n",
+			 event_error);
 
 	/* Wake up parent if it was blocking on vfork */
 	if (parent_pthread &&
@@ -150,9 +153,10 @@ void pprocess_exit(struct posix_process *pprocess,
 {
 	struct posix_process_exit_event_data event_data;
 	struct posix_process *parent_process;
+	enum uk_event_status event_status;
 	struct posix_thread *pt, *ptn;
 	__bool nowait = false;
-	int ret;
+	int event_error;
 
 	UK_ASSERT(state == POSIX_PROCESS_EXITED ||
 		  state == POSIX_PROCESS_KILLED);
@@ -212,9 +216,11 @@ void pprocess_exit(struct posix_process *pprocess,
 	/* Notify handlers */
 	event_data.thread = NULL;
 	event_data.pid = pprocess->pid;
-	ret = uk_raise_event(POSIX_PROCESS_EXIT_EVENT, &event_data);
-	if (unlikely(ret < 0))
-		UK_CRASH("POSIX_PROCESS_EXIT_EVENT handler returned error\n");
+	event_status = uk_raise_event(POSIX_PROCESS_EXIT_EVENT, &event_data,
+				      &event_error);
+	if (unlikely(event_status == UK_EVENT_ERROR))
+		UK_CRASH("Exit event handler returned error (%d)\n",
+			 event_error);
 
 	uk_semaphore_up(&pprocess->exit_semaphore);
 

--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -352,10 +352,12 @@ pid_t uk_posix_process_run(uk_posix_process_mainlike_func fn,
 {
 	struct posix_process_execve_event_data event_data;
 	struct uk_sched *s = uk_sched_current();
+	enum uk_event_status event_status;
 	struct clone_args cl_args;
 	struct uk_thread *thread;
 	struct uk_thread *parent;
 	pid_t parent_tid;
+	int event_error;
 	pid_t tid;
 	int ret;
 
@@ -403,9 +405,10 @@ pid_t uk_posix_process_run(uk_posix_process_mainlike_func fn,
 
 	/* Raise the execve event */
 	event_data.thread = thread;
-	ret = pprocess_raise_execve_event(&event_data);
-	if (unlikely(ret < 0)) {
-		uk_pr_err("exeve event error (%d)\n", ret);
+	event_status = pprocess_raise_execve_event(&event_data, &event_error);
+	if (unlikely(event_status == UK_EVENT_ERROR)) {
+		uk_pr_err("exeve event error (%d)\n", event_error);
+		ret = event_error;
 		goto err_term_clonetab;
 	}
 

--- a/lib/posix-process/process.h
+++ b/lib/posix-process/process.h
@@ -203,7 +203,9 @@ int pprocess_clonetab_init(const struct clone_args *cl_args, size_t cl_args_len,
 void pprocess_clonetab_term(struct uk_thread *child);
 
 #if CONFIG_LIBPOSIX_PROCESS_EXECVE
-int pprocess_raise_execve_event(struct posix_process_execve_event_data *data);
+enum uk_event_status
+pprocess_raise_execve_event(struct posix_process_execve_event_data *event_data,
+			    int *event_error);
 #endif /* CONFIG_LIBPOSIX_PROCESS_EXECVE */
 
 #endif /* CONFIG_LIBPOSIX_PROCESS_MULTITHREADING */

--- a/lib/posix-socket/events.h
+++ b/lib/posix-socket/events.h
@@ -148,9 +148,10 @@ static inline void socket_event_raise(struct uk_socket_event_data *evd,
 		.raddr     = (evd->raddr_len == 0) ?
 				NULL : (const struct sockaddr *)&evd->raddr,
 	};
+	int err __unused;
 
 	evd->raise_cnt++;
-	uk_raise_event_ptr(evt, &emsg);
+	uk_raise_event_ptr(evt, &emsg, &err);
 
 	/* Update the state to reflect the change */
 	evd->state = new_state;

--- a/lib/posix-socket/include/uk/socket_event.h
+++ b/lib/posix-socket/include/uk/socket_event.h
@@ -6,9 +6,11 @@
 #ifndef __UK_POSIX_SOCKET_EVENT_H__
 #define __UK_POSIX_SOCKET_EVENT_H__
 
-#include <uk/config.h>
 #include <stdint.h>
 #include <sys/socket.h>
+
+#include <uk/config.h>
+#include <uk/compiler.h>
 #include <uk/event.h>
 
 /*
@@ -65,20 +67,21 @@ struct uk_socket_event {
  *   Event receiver function, must have the following singature:
  *   `void recvfn(const struct uk_socket_event *)`
  */
-#define __UK_SOCKET_EVENT_RECEIVER(afamily, event, arecvfn)		\
-	static int __uk_event ## event ## arecvfn(void *data)		\
-	{								\
-		const struct uk_socket_event *e =			\
-			(const struct uk_socket_event *) data;		\
-									\
-		if (afamily && (afamily != e->family))			\
-			return UK_EVENT_HANDLED_CONT;			\
-									\
-		arecvfn(e);						\
-		return UK_EVENT_HANDLED_CONT;				\
-	}								\
-									\
-	UK_EVENT_HANDLER(UK_POSIX_SOCKET_EVENT_ ## event,		\
+#define __UK_SOCKET_EVENT_RECEIVER(afamily, event, arecvfn)		       \
+	static enum uk_event_status					       \
+	__uk_event ## event ## arecvfn(void *data, int *error __unused)	       \
+	{								       \
+		const struct uk_socket_event *e =			       \
+			(const struct uk_socket_event *)data;		       \
+									       \
+		if (afamily && (afamily != e->family))			       \
+			return UK_EVENT_HANDLED_CONT;			       \
+									       \
+		arecvfn(e);						       \
+		return UK_EVENT_HANDLED_CONT;				       \
+	}								       \
+									       \
+	UK_EVENT_HANDLER(UK_POSIX_SOCKET_EVENT_ ## event,		       \
 			 __uk_event ## event ## arecvfn)
 
 #define _UK_SOCKET_EVENT_RECEIVER(family, event, recvfn) \

--- a/lib/syscall_shim/execve.c
+++ b/lib/syscall_shim/execve.c
@@ -4,13 +4,15 @@
  * You may not use this file except in compliance with the License.
  */
 
+#include <uk/compiler.h>
 #include <uk/event.h>
 #include <uk/prio.h>
 #include <uk/process.h>
 #include <uk/syscall.h>
 #include <uk/thread.h>
 
-static int syscall_nested_depth_reset(void *data)
+static
+enum uk_event_status syscall_nested_depth_reset(void *data, int *error __unused)
 {
 	struct posix_process_execve_event_data *event_data;
 

--- a/lib/ukboot/shutdown_req.c
+++ b/lib/ukboot/shutdown_req.c
@@ -6,6 +6,7 @@
 #include <uk/atomic.h>
 #if !__INTERRUPTSAFE__
 #include <uk/boot.h>
+#include <uk/compiler.h>
 #else /* __INTERRUPTSAFE__ */
 #include <uk/isr/boot.h>
 #include <uk/isr/semaphore.h>
@@ -57,7 +58,8 @@ int uk_boot_shutdown_req_isr(enum ukplat_gstate target)
 }
 
 #if __INTERRUPTSAFE__ && CONFIG_LIBUKBOOT_SHUTDOWNREQ_HANDLER
-static int shutdown_req_handler(void *data)
+static
+enum uk_event_status shutdown_req_handler(void *data, int *error __unused)
 {
 	enum ukplat_gstate request = (enum ukplat_gstate)data;
 	int rc;

--- a/lib/ukdebug/arch/arm64/gdbsup.c
+++ b/lib/ukdebug/arch/arm64/gdbsup.c
@@ -79,14 +79,16 @@ static int gdb_arch_check_brk(unsigned long pc)
 	return ((opcode & BRK_OPCODE_MASK) != BRK_OPCODE);
 }
 
-static int gdb_arch_debug_handler(void *data)
+static enum uk_event_status gdb_arch_debug_handler(void *data, int *error)
 {
 	int have_brk, r;
 	struct ukarch_trap_ctx *ctx = (struct ukarch_trap_ctx *)data;
 
 	r = gdb_arch_dbg_trap(5 /* SIGTRAP */, ctx->regs);
-	if (unlikely(r < 0))
-		return r;
+	if (unlikely(r < 0)) {
+		*error = r;
+		return UK_EVENT_ERROR;
+	}
 
 	/* If we return from an brk trap, we have to explicitly skip the
 	 * corresponding brk instruction. Otherwise, we will not make
@@ -98,8 +100,10 @@ static int gdb_arch_debug_handler(void *data)
 	 * must be skipped. Otherwise, just continue at the current PC.
 	 */
 	have_brk = gdb_arch_check_brk(ctx->regs->elr_el1);
-	if (unlikely(have_brk < 0))
-		return have_brk;
+	if (unlikely(have_brk < 0)) {
+		*error = have_brk;
+		return UK_EVENT_ERROR;
+	}
 
 	if ((ESR_EC_FROM(ctx->esr) == ESR_EL1_EC_BRK64) && (have_brk == 0)) {
 		ctx->regs->elr_el1 += 4; /* instructions are all 4 bytes wide */

--- a/lib/ukdebug/arch/x86_64/gdbsup.c
+++ b/lib/ukdebug/arch/x86_64/gdbsup.c
@@ -37,15 +37,17 @@ static int gdb_arch_dbg_trap(int errnr, struct __regs *regs)
 	return 0;
 }
 
-static int gdb_arch_debug_handler(void *data)
+static enum uk_event_status gdb_arch_debug_handler(void *data, int *error)
 {
 	int r;
 	struct ukarch_trap_ctx *ctx = (struct ukarch_trap_ctx *)data;
 
-	if ((r = gdb_arch_dbg_trap(5 /* SIGTRAP */, ctx->regs)) < 0)
-		return r;
-	else
-		return UK_EVENT_HANDLED;
+	r = gdb_arch_dbg_trap(5 /* SIGTRAP */, ctx->regs);
+	if (unlikely(r < 0)) {
+		*error = r;
+		return UK_EVENT_ERROR;
+	}
+	return UK_EVENT_HANDLED;
 }
 
 UK_EVENT_HANDLER(UKARCH_TRAP_DEBUG, gdb_arch_debug_handler);

--- a/lib/ukintctlr/ukintctlr.c
+++ b/lib/ukintctlr/ukintctlr.c
@@ -158,8 +158,9 @@ void uk_intctlr_irq_handle(struct __regs *regs, unsigned int irq)
 {
 	struct irq_handler *h;
 	int i;
-	int rc;
 	struct uk_intctlr_event_irq_data ctx;
+	enum uk_event_status event_status;
+	int event_error;
 #if CONFIG_LIBUKINTCTLR_ISR_ECTX_ASSERTIONS
 	__sz ectx_align = ukarch_ectx_align();
 	__u8 ectxbuf[ukarch_ectx_size() + ectx_align];
@@ -173,10 +174,10 @@ void uk_intctlr_irq_handle(struct __regs *regs, unsigned int irq)
 
 	ctx.regs = regs;
 	ctx.irq = irq;
-	rc = uk_raise_event(UK_INTCTLR_EVENT_IRQ, &ctx);
-	if (unlikely(rc < 0))
-		UK_CRASH("IRQ event handler returned error: %d\n", rc);
-	if (rc == UK_EVENT_HANDLED) {
+	event_status = uk_raise_event(UK_INTCTLR_EVENT_IRQ, &ctx, &event_error);
+	if (unlikely(event_status == UK_EVENT_ERROR))
+		UK_CRASH("IRQ event handler returned error: %d\n", event_error);
+	if (event_status == UK_EVENT_HANDLED) {
 		/* Skip all normal handlers if an event handler handled the
 		 * event
 		 */

--- a/lib/uknofault/excpttab.h
+++ b/lib/uknofault/excpttab.h
@@ -28,8 +28,8 @@ struct nf_excpttab_entry {
 	__s32 handler;
 } __packed;
 
-typedef int (*nf_excpt_handler)(const struct nf_excpttab_entry *e,
-				struct ukarch_trap_ctx *ctx);
+typedef enum uk_event_status (*nf_excpt_handler)(const struct nf_excpttab_entry *e,
+			      struct ukarch_trap_ctx *ctx, int *error);
 
 #define _NF_DECLARE_EXCPTTAB_ENTRY_GETTER(field, type)			\
 static inline type							\
@@ -78,7 +78,9 @@ extern const struct nf_excpttab_entry uk_excpttab_end[];
 #define nf_excpttab_foreach(itr, excpttab_start, excpttab_end)		\
 	for ((itr) = (excpttab_start); (itr) < (excpttab_end); (itr)++)
 
-static inline int nf_handle_trap(__vaddr_t ip, struct ukarch_trap_ctx *ctx)
+static inline
+enum uk_event_status nf_handle_trap(__vaddr_t ip, struct ukarch_trap_ctx *ctx,
+				    int *error)
 {
 	const struct nf_excpttab_entry *itr;
 	nf_excpt_handler handler;
@@ -90,7 +92,7 @@ static inline int nf_handle_trap(__vaddr_t ip, struct ukarch_trap_ctx *ctx)
 			handler = nf_excpttab_get_handler(itr);
 			UK_ASSERT(handler);
 
-			return handler(itr, ctx);
+			return handler(itr, ctx, error);
 		}
 	}
 

--- a/lib/uknofault/maccess.c
+++ b/lib/uknofault/maccess.c
@@ -5,12 +5,13 @@
  */
 
 #include <uk/arch/limits.h>
-#include <uk/nofault.h>
+#include <uk/arch/paging.h>
 #include <uk/arch/types.h>
 #include <uk/arch/traps.h>
-#include <uk/arch/paging.h>
-#include <uk/event.h>
+#include <uk/compiler.h>
 #include <uk/config.h>
+#include <uk/event.h>
+#include <uk/nofault.h>
 
 #include "arch/maccess.h"
 
@@ -44,8 +45,9 @@ typedef int nf_paging_state_t;
 #endif /* !CONFIG_LIBUKVMEM */
 
 /* Must be a library global symbol so that the linker can resolve it */
-int __used nf_mf_handler(const struct nf_excpttab_entry *e,
-			 struct ukarch_trap_ctx *ctx)
+enum uk_event_status __used nf_mf_handler(const struct nf_excpttab_entry *e,
+					  struct ukarch_trap_ctx *ctx,
+					  int *error __unused)
 {
 	/* Just continue execution at the fault label */
 	nf_regs_ip(ctx->regs) = nf_excpttab_get_cont_ip(e);
@@ -53,11 +55,11 @@ int __used nf_mf_handler(const struct nf_excpttab_entry *e,
 	return UK_EVENT_HANDLED;
 }
 
-static int nf_mem_fault_handler(void *data)
+static enum uk_enum_status nf_mem_fault_handler(void *data, int *error)
 {
 	struct ukarch_trap_ctx *ctx = (struct ukarch_trap_ctx *)data;
 
-	return nf_handle_trap(nf_regs_ip(ctx->regs), ctx);
+	return nf_handle_trap(nf_regs_ip(ctx->regs), ctx, error);
 }
 
 UK_EVENT_HANDLER_PRIO(UKARCH_TRAP_PAGE_FAULT, nf_mem_fault_handler,

--- a/lib/ukstore/README.md
+++ b/lib/ukstore/README.md
@@ -79,7 +79,7 @@ int uk_mydevice_init_metrics(struct uk_mydevice *dev)
 
 ```c
 /* This is the handler for UK_STORE_EVENT_CREATE_OBJECT */
-static int handle_create_object(void *arg)
+static enum uk_event_status handle_create_object(void *arg, int *error __unused)
 {
     struct uk_store_event_data *data = (struct uk_store_event_data *)arg;
 
@@ -114,6 +114,7 @@ UK_EVENT_HANDLER_(UK_STORE_EVENT_CREATE_OBJECT, handle_create_object);
 int uk_mydevice_teardown_metrics(struct uk_mydevice *dev)
 {
     struct uk_store_object *obj;
+    int error;
 
     /* this is looked up via library-specific means */
     obj = get_obj_by_device(dev);
@@ -124,7 +125,7 @@ int uk_mydevice_teardown_metrics(struct uk_mydevice *dev)
         .object_id = obj->id,
         .owner = NULL
     };
-    uk_raise_event(UK_STORE_EVENT_RELEASE_OBJECT, &event_data);
+    uk_raise_event(UK_STORE_EVENT_RELEASE_OBJECT, &event_data, &error);
 
     /* Decrement the refcount. The object will be freed as soon as
      * all consumers decrement the refcount.
@@ -139,7 +140,9 @@ int uk_mydevice_teardown_metrics(struct uk_mydevice *dev)
 
 ```c
 /* This is the handler for UK_STORE_EVENT_RELEASE_OBJECT */
-static int handle_release_object(struct uk_event_data *data)
+static
+enum uk_event_status handle_release_object(struct uk_event_data *data,
+					   int *error __unused)
 {
     struct uk_store_event_data *data = (struct uk_store_event_data *)arg;
 
@@ -155,6 +158,8 @@ static int handle_release_object(struct uk_event_data *data)
      * free, along with its entries.
      */
     uk_store_obj_release(obj);
+
+    return UK_EVENT_HANDLED;
 }
 
 /* Registers handler */

--- a/lib/ukstore/store.c
+++ b/lib/ukstore/store.c
@@ -301,6 +301,8 @@ uk_store_obj_alloc(struct uk_alloc *a, __u64 id, const char *name,
 int _uk_store_obj_add(__u16 library_id, struct uk_store_object *object)
 {
 	struct uk_store_event_data event_data;
+	enum uk_event_status event_status;
+	int event_error;
 
 	UK_ASSERT(object);
 
@@ -316,7 +318,12 @@ int _uk_store_obj_add(__u16 library_id, struct uk_store_object *object)
 		.object_id = object->id
 	};
 
-	uk_raise_event(UKSTORE_EVENT_CREATE_OBJECT, &event_data);
+	event_status = uk_raise_event(UKSTORE_EVENT_CREATE_OBJECT, &event_data,
+				      &event_error);
+	if (unlikely(event_status == UK_EVENT_ERROR)) {
+		uk_pr_err("Handler returned error (%d)\n", event_error);
+		return event_error;
+	}
 
 	return 0;
 }

--- a/lib/ukvmem/arch/arm/pagefault64.c
+++ b/lib/ukvmem/arch/arm/pagefault64.c
@@ -6,14 +6,16 @@
 
 #include "../../vmem.h"
 
-#include <uk/assert.h>
-#include <uk/arch/traps.h>
-#include <uk/arch/types.h>
-#include <uk/print.h>
-#include <uk/config.h>
 #include <string.h>
 
-static int vmem_arch_pagefault(void *data)
+#include <uk/arch/traps.h>
+#include <uk/arch/types.h>
+#include <uk/assert.h>
+#include <uk/compiler.h>
+#include <uk/config.h>
+#include <uk/print.h>
+
+static enum uk_event_status vmem_arch_pagefault(void *data, int *error __unused)
 {
 	struct ukarch_trap_ctx *ctx = (struct ukarch_trap_ctx *)data;
 	__vaddr_t vaddr = (__vaddr_t)ctx->far;

--- a/lib/ukvmem/arch/x86_64/pagefault.c
+++ b/lib/ukvmem/arch/x86_64/pagefault.c
@@ -6,14 +6,16 @@
 
 #include "../../vmem.h"
 
-#include <uk/assert.h>
-#include <uk/arch/traps.h>
-#include <uk/arch/types.h>
-#include <uk/print.h>
-#include <uk/config.h>
 #include <string.h>
 
-static int vmem_arch_pagefault(void *data)
+#include <uk/arch/traps.h>
+#include <uk/arch/types.h>
+#include <uk/assert.h>
+#include <uk/print.h>
+#include <uk/compiler.h>
+#include <uk/config.h>
+
+static enum uk_event_status vmem_arch_pagefault(void *data, int *error __unused)
 {
 	struct ukarch_trap_ctx *ctx = (struct ukarch_trap_ctx *)data;
 	__vaddr_t vaddr = (__vaddr_t)ctx->fault_address;

--- a/plat/common/arm/traps_arm64.c
+++ b/plat/common/arm/traps_arm64.c
@@ -21,15 +21,16 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <uk/arch/lcpu.h>
-#include <uk/arch/types.h>
-#include <uk/arch/ctx.h>
 #include <arm/cpu.h>
 #include <arm/traps.h>
-#include <uk/print.h>
+#include <uk/arch/ctx.h>
+#include <uk/arch/lcpu.h>
+#include <uk/arch/types.h>
 #include <uk/assert.h>
+#include <uk/compiler.h>
 #include <uk/intctlr/gic.h>
 #include <uk/plat/syscall.h>
+#include <uk/print.h>
 
 #ifdef CONFIG_ARM64_FEAT_MTE
 #include <arm/arm64/mte.h>
@@ -195,15 +196,18 @@ void invalid_trap_handler(struct __regs *regs, __u32 el, __u32 reason,
 
 void trap_el1_sync(struct __regs *regs, __u64 far)
 {
-	int rc;
 	struct ukarch_trap_ctx ctx = {regs, regs->esr_el1, 1, 0, far};
 	enum aarch64_trap trap = esr_to_trap(regs->esr_el1);
+	enum uk_event_status event_status;
+	int event_error;
 
 	if (trap < AARCH64_TRAP_MAX) {
-		rc = uk_raise_event_ptr(_trap_table[trap].event, &ctx);
-		if (unlikely(rc < 0))
-			uk_pr_crit("event handler returned error: %d\n", rc);
-		else if (rc)
+		event_status = uk_raise_event_ptr(_trap_table[trap].event, &ctx,
+						  &event_error);
+		if (unlikely(event_status == UK_EVENT_ERROR))
+			uk_pr_crit("event handler returned error: %d\n",
+				   event_error);
+		else if (event_status != UK_EVENT_NOT_HANDLED)
 			return;
 	}
 
@@ -228,7 +232,8 @@ void trap_el1_irq(struct __regs *regs)
 
 extern void ukplat_syscall_handler(struct uk_syscall_ctx *usc);
 
-static int arm64_syscall_adapter(void *data)
+static
+enum uk_event_status arm64_syscall_adapter(void *data, int *error __unused)
 {
 	struct ukarch_trap_ctx *ctx = (struct ukarch_trap_ctx *)data;
 	struct ukarch_execenv *execenv = (struct ukarch_execenv *)ctx->regs;
@@ -248,7 +253,7 @@ static int arm64_syscall_adapter(void *data)
 	/* Restore extended register state */
 	ukarch_ectx_load((struct ukarch_ectx *)&execenv->ectx);
 
-	return 1; /* Success */
+	return UK_EVENT_HANDLED;
 }
 
 UK_EVENT_HANDLER(UKARCH_TRAP_SYSCALL, arm64_syscall_adapter);

--- a/plat/common/include/x86/traps.h
+++ b/plat/common/include/x86/traps.h
@@ -96,10 +96,13 @@ void do_unhandled_trap(int trapnr, char *str, struct __regs *regs,
 
 #define DECLARE_TRAP_EVENT(event)					\
 UK_EVENT(event);							\
-static inline int _raise_event_##event(int trapnr, struct __regs *regs,	\
-		unsigned long error_code) {				\
+static inline								\
+int _raise_event_##event(int trapnr, struct __regs *regs,		\
+		unsigned long error_code, int *event_error)		\
+{									\
 	struct ukarch_trap_ctx ctx = {regs, trapnr, error_code, 0};	\
-	return uk_raise_event(event, &ctx);				\
+									\
+	return uk_raise_event(event, &ctx, event_error);		\
 }
 
 #define _raise_event_NULL(...) (0)
@@ -107,24 +110,32 @@ static inline int _raise_event_##event(int trapnr, struct __regs *regs,	\
 #define DECLARE_TRAP(name, str, event)					\
 void do_##name(struct __regs *regs)					\
 {									\
-	int rc;								\
-	rc = _raise_event_##event(TRAP_##name, regs, 0);		\
-	if (unlikely(rc < 0))						\
-		uk_pr_crit("trap handler returned error: %d\n", rc);	\
+	enum uk_event_status event_status;				\
+	int event_error;						\
 									\
-	if (!rc)							\
+	event_status = _raise_event_##event(TRAP_##name, regs, 0,	\
+					    &event_error);		\
+	if (unlikely(event_status == UK_EVENT_ERROR))			\
+		uk_pr_crit("trap handler returned error: %d\n",		\
+			   event_error);				\
+									\
+	if (event_status == UK_EVENT_NOT_HANDLED)			\
 		do_unhandled_trap(TRAP_##name, str, regs, 0);		\
 }
 
 #define DECLARE_TRAP_EC(name, str, event)				\
 void do_##name(struct __regs *regs, unsigned long error_code)		\
 {									\
-	int rc;								\
-	rc = _raise_event_##event(TRAP_##name, regs, error_code);	\
-	if (unlikely(rc < 0))						\
-		uk_pr_crit("trap handler returned error: %d\n", rc);	\
+	enum uk_event_status event_status;				\
+	int event_error;						\
 									\
-	if (!rc)							\
+	event_status = _raise_event_##event(TRAP_##name, regs,		\
+					    error_code, &event_error);	\
+	if (unlikely(event_status == UK_EVENT_ERROR))			\
+		uk_pr_crit("trap handler returned error: %d\n",		\
+			   event_error);				\
+									\
+	if (event_status == UK_EVENT_NOT_HANDLED)			\
 		do_unhandled_trap(TRAP_##name, str, regs, error_code);	\
 }
 

--- a/plat/common/x86/traps.c
+++ b/plat/common/x86/traps.c
@@ -92,14 +92,17 @@ void do_unhandled_trap(int trapnr, char *str, struct __regs *regs,
 
 void do_page_fault(struct __regs *regs, unsigned long error_code)
 {
-	int rc;
 	unsigned long vaddr = read_cr2();
 	struct ukarch_trap_ctx ctx = {regs, TRAP_page_fault, error_code, vaddr};
+	enum uk_event_status event_status;
+	int event_error;
 
-	rc = uk_raise_event(UKARCH_TRAP_PAGE_FAULT, &ctx);
-	if (unlikely(rc < 0))
-		uk_pr_crit("page fault handler returned error: %d\n", rc);
-	else if (rc)
+	event_status = uk_raise_event(UKARCH_TRAP_PAGE_FAULT, &ctx,
+				      &event_error);
+	if (unlikely(event_status == UK_EVENT_ERROR))
+		uk_pr_crit("page fault handler returned error: %d\n",
+			   event_error);
+	else if (event_status != UK_EVENT_NOT_HANDLED)
 		return;
 
 	dump_regs(regs);

--- a/plat/xen/events.c
+++ b/plat/xen/events.c
@@ -92,9 +92,10 @@ void unbind_all_ports(void)
  */
 int do_event(evtchn_port_t port, struct __regs *regs)
 {
-	ev_action_t *action;
-	int rc;
+	enum uk_event_status event_status;
 	struct uk_event_irq_data ctx;
+	int event_error;
+	ev_action_t *action;
 
 	clear_evtchn(port);
 
@@ -105,10 +106,10 @@ int do_event(evtchn_port_t port, struct __regs *regs)
 
 	ctx.regs = regs;
 	ctx.irq = port;
-	rc = uk_raise_event(UKPLAT_EVENT_IRQ, &ctx);
-	if (unlikely(rc < 0))
-		UK_CRASH("IRQ event handler returned error: %d\n", rc);
-	if (rc == UK_EVENT_HANDLED)
+	event_status = uk_raise_event(UKPLAT_EVENT_IRQ, &ctx, &event_error);
+	if (unlikely(event_status == UK_EVENT_ERROR))
+		UK_CRASH("IRQ event handler returned error: %d\n", event_error);
+	if (event_status == UK_EVENT_HANDLED)
 		return 1;
 
 	action = &ev_actions[port];


### PR DESCRIPTION
`uk_event` handlers often omit using one of the designated macro values, and return an integer instead. This is particularly problematic when returning zero to signify that the event was handled, as `event.h` assigns zero to `UK_EVENT_NOT_HANDLED`.

Convert `uk_event` handler return values to enum to catch such errors at compile-time. Introduce a `UK_EVENT_ERROR` state and an additional parameter in the handler prototype that handlers must populate before returning `UK_EVENT_ERROR`.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): N/A
 - Platform(s): N/A
 - Application(s): N/A


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
