### PR TITLE
plat: Add in-exception lcpu getters and `__isr` macro

### DIFF
--- a/arch/arm/arm64/include/uk/asm/compiler.h
+++ b/arch/arm/arm64/include/uk/asm/compiler.h
@@ -58,3 +58,7 @@
 #define __no_branch_protection
 #endif /* CONFIG_ARM64_FEAT_PAUTH || CONFIG_ARM64_FEAT_BTI */
 
+#define __isr						\
+	__attribute__((__target__(			\
+		"general-regs-only"			\
+	)))

--- a/arch/x86/x86_64/include/uk/asm/compiler.h
+++ b/arch/x86/x86_64/include/uk/asm/compiler.h
@@ -32,4 +32,10 @@
 #endif
 
 /* Architecture-specific compiler definitions */
-
+#define __isr						\
+	__attribute__((__target__(			\
+		"no-mmx,"				\
+		"no-sse,"				\
+		"no-avx,"				\
+		"general-regs-only"			\
+	)))

--- a/include/uk/plat/lcpu.h
+++ b/include/uk/plat/lcpu.h
@@ -112,6 +112,7 @@ typedef __u64 __lcpuid;		/* Physical ID of logical CPU */
  * Returns the auxiliary stack pointer of the current logical CPU
  */
 __uptr ukplat_lcpu_get_auxsp(void);
+__isr __uptr ukplat_lcpu_get_auxsp_in_except(void);
 
 /**
  * Sets the auxiliary stack pointer of the current logical cpu

--- a/plat/common/arm/lcpu.c
+++ b/plat/common/arm/lcpu.c
@@ -75,6 +75,11 @@ static __align(UKARCH_SP_ALIGN)
 UKPLAT_PER_LCPU_ARRAY_DEFINE(__u8, lcpu_except_stack,
 			     CPU_EXCEPT_STACK_SIZE * 3);
 
+__isr __uptr traps_lcpu_get_except_stack_base(void)
+{
+	return (__uptr)&lcpu_except_stack;
+}
+
 __lcpuid lcpu_arch_id(void)
 {
 	__u64 mpidr_reg;

--- a/plat/common/include/uk/plat/common/lcpu.h
+++ b/plat/common/include/uk/plat/common/lcpu.h
@@ -278,6 +278,16 @@ static inline int lcpu_current_is_bsp(void)
 }
 
 /**
+ * Assuming we are in an exception handler on an exception stack, fetch the
+ * current LCPU pointer in such a manner that we do not assume any register
+ * state.
+ *
+ * WARNING: Again, only use in exception context (e.g. trap (non-syscall),
+ *          IRQ)!
+ */
+__isr struct lcpu *lcpu_get_current_in_except(void);
+
+/**
  * Initialize a logical CPU. The function must be executed on the CPU
  * represented by the LCPU as early as possible after startup.
  *

--- a/plat/common/lcpu.c
+++ b/plat/common/lcpu.c
@@ -123,6 +123,14 @@ struct lcpu *lcpu_get_current(void)
 	return lcpu_get(ukplat_lcpu_idx());
 }
 
+__isr __uptr traps_lcpu_get_except_stack_base(void);
+__isr struct lcpu *lcpu_get_current_in_except(void)
+{
+	return lcpu_get((ukarch_read_sp() -
+			 traps_lcpu_get_except_stack_base()) /
+			(CPU_EXCEPT_STACK_SIZE * 3));
+}
+
 int lcpu_init(struct lcpu *this_lcpu)
 {
 	int rc;

--- a/plat/kvm/arm/lcpu.c
+++ b/plat/kvm/arm/lcpu.c
@@ -89,3 +89,8 @@ __uptr ukplat_lcpu_get_auxsp(void)
 {
 	return lcpu_get_current()->auxsp;
 }
+
+__isr __uptr ukplat_lcpu_get_auxsp_in_except(void)
+{
+	return lcpu_get_current_in_except()->auxsp;
+}

--- a/plat/kvm/x86/lcpu.c
+++ b/plat/kvm/x86/lcpu.c
@@ -106,3 +106,8 @@ __uptr ukplat_lcpu_get_auxsp(void)
 	UK_ASSERT(IS_LCPU_PTR(lcpu_get_current()));
 	return lcpu_get_current()->auxsp;
 }
+
+__isr __uptr ukplat_lcpu_get_auxsp_in_except(void)
+{
+	return lcpu_get_current_in_except()->auxsp;
+}

--- a/plat/kvm/x86/traps.c
+++ b/plat/kvm/x86/traps.c
@@ -467,3 +467,8 @@ void traps_lcpu_init(struct lcpu *this_lcpu)
 	tss_init(this_lcpu->idx);
 	idt_init();
 }
+
+__isr __uptr traps_lcpu_get_except_stack_base(void)
+{
+	return (__uptr)&lcpu_except_stack;
+}

--- a/plat/xen/arm/traps.c
+++ b/plat/xen/arm/traps.c
@@ -132,4 +132,10 @@ void trap_init(void)
 void trap_fini(void)
 {
 }
+
+__uptr traps_lcpu_get_except_stack_base(void)
+{
+	UK_WARN_STUBBED();
+	return 0;
+}
 #endif /* __aarch64__ */

--- a/plat/xen/lcpu.c
+++ b/plat/xen/lcpu.c
@@ -91,3 +91,8 @@ __uptr ukplat_lcpu_get_auxsp(void)
 {
 	return lcpu_get_current()->auxsp;
 }
+
+__isr __uptr ukplat_lcpu_get_auxsp_in_except(void)
+{
+	return lcpu_get_current_in_except()->auxsp;
+}

--- a/plat/xen/x86/traps.c
+++ b/plat/xen/x86/traps.c
@@ -75,4 +75,9 @@ void traps_lcpu_init(struct lcpu *current __unused)
 				 (unsigned long) asm_failsafe_callback, 0);
 }
 
+__uptr traps_lcpu_get_except_stack_base(void)
+{
+	UK_WARN_STUBBED();
+	return 0;
+}
 #endif


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

In the case of some functions, we may want to be able to compile them
and be sure they do not use any extended registers (e.g., FPU, SIMD)
so that we can use them in an exception context or anywhere we do not
want to taint the said extended context.

To make it easy, add the `__isr` macro one can add to its function
to ensure it complies with the above.

Using said macro, introduce two lcpu getters:
- `lcpu_get_current_in_except`:
Assuming we are in an exception handler on an exception stack,
fetch  the current LCPU pointer in such a manner that we do not
assume any register state. This is done by dividng current stack
pointer relative to the LCPU stack base to find out the current
LCPU id.

- `ukplat_lcpu_get_auxsp_in_except`:
Implement `ukplat_lcpu_get_auxsp_in_except`, an Interrupt-safe variant
of `ukplat_lcpu_get_auxsp` that relies on the caller being in an CPU
exception handler routine. We can use this function in case we need
to get current LCPU's `auxsp` without having to do any costly
system register read/write.

