### PR TITLE
lib/posix-process: Propagate exit code to term context

### DIFF
--- a/lib/posix-process/exit.c
+++ b/lib/posix-process/exit.c
@@ -34,7 +34,7 @@
 
 UK_EVENT(POSIX_PROCESS_EXIT_EVENT);
 
-int pprocess_exit_status;
+int pprocess_exit_status = PPROCESS_EXIT_STATUS_UNSET;
 
 #if CONFIG_LIBPOSIX_PROCESS_MULTITHREADING
 

--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -492,13 +492,19 @@ static void posix_thread_fini(struct uk_thread *thread)
 
 	pthread = uk_thread_uktls_var(thread, pthread_self);
 
+	/* No pthread was ever assigned to this uk_thread,
+	 * or the pthread was already terminated as a result
+	 * to an exit syscall or a signal.
+	 *
+	 * If the pthread exists, this is its return path.
+	 */
 	if (!pthread)
-		return; /* no posix thread was assigned */
+		return;
 
 	pprocess = pthread->process;
 	UK_ASSERT(pprocess);
 
-	/* Perform thread termination and relase the thread */
+	/* Terminate and release thread */
 	pprocess_exit_pthread(pthread_self, POSIX_THREAD_EXITED, 0);
 
 	/* If last thread, also release the process */

--- a/lib/posix-process/process.h
+++ b/lib/posix-process/process.h
@@ -23,6 +23,11 @@ extern struct uk_thread *pprocess_thread_main;
 
 extern int pprocess_exit_status;
 
+/* Defined as a value larger than the max error code
+ * to distinguish between set to zero and unset.
+ */
+#define PPROCESS_EXIT_STATUS_UNSET  (1 << 8)
+
 #if CONFIG_LIBPOSIX_PROCESS_MULTITHREADING
 
 #define UK_PID_INIT		1

--- a/lib/posix-process/shutdown.c
+++ b/lib/posix-process/shutdown.c
@@ -43,12 +43,30 @@ static void pprocess_system_shutdown(struct uk_term_ctx *ctx __unused)
 {
 	struct posix_process *pproc_init;
 	struct posix_process *pproc;
+	int rc;
 
 	pproc_init = pid2pprocess(UK_PID_INIT);
 
-	if (pproc_init && pproc_init->state == POSIX_PROCESS_RUNNING) {
-		pprocess_signal_send(pproc_init, SIGTERM, NULL);
-		uk_semaphore_down(&pproc_init->exit_semaphore);
+	/* If the init process does not exist, it must have returned.
+	 * We can't know its return status, but hopefully the caller
+	 * (libukboot) saved it to term_ctx already.
+	 *
+	 * If the init process exists and it's stil running, terminate
+	 * now with signal, and propagate its status.
+	 *
+	 * If the init process exists but is not running, it has been
+	 * terminated by an exit syscall or a signal. Propagate its exit
+	 * status.
+	 */
+	if (pproc_init) {
+		if (pproc_init->state == POSIX_PROCESS_RUNNING) {
+			rc = pprocess_signal_send(pproc_init, SIGTERM, NULL);
+			if (unlikely(rc))
+				UK_CRASH("Could not signal init process (%d)\n",
+					 rc);
+			uk_semaphore_down(&pproc_init->exit_semaphore);
+		}
+		ctx->exit_code = pproc_init->exit_status;
 	}
 
 	uk_pprocess_foreach(pproc)
@@ -67,11 +85,23 @@ static void pprocess_system_shutdown(struct uk_term_ctx *ctx)
 
 	pproc_init = pid2pprocess(UK_PID_INIT);
 
-	/* If terminated, we come from a return,
-	 * hence the exit_code is already set.
+	/* If the init process does not exist, it must have returned.
+	 * We can't know its return status, but hopefully the caller
+	 * (libukboot) saved it to term_ctx already.
+	 *
+	 * If the init process exists and it's stil running, terminate
+	 * now with an appropriate exit code and propagate its status.
+	 *
+	 * If the init process exists but is not running, it has been
+	 * terminated by an exit syscall or by signal. Propagate its
+	 * exit status.
 	 */
-	if (pproc_init && pproc_init->state == POSIX_PROCESS_RUNNING)
-		ctx->exit_code = 0x80 | SIGKILL;
+	if (pproc_init) {
+		if (pproc_init->state == POSIX_PROCESS_RUNNING)
+			ctx->exit_code = 0x80 | SIGKILL;
+		else
+			ctx->exit_code = pproc_init->exit_status;
+	}
 
 	uk_pprocess_foreach(pproc)
 		force_kill(pproc);
@@ -83,7 +113,13 @@ static void pprocess_system_shutdown(struct uk_term_ctx *ctx)
  */
 static void pprocess_system_shutdown(struct uk_term_ctx *ctx)
 {
-	ctx->exit_code = pprocess_exit_status;
+	/* If we the application called one of the emulated
+	 * exit syscalls, propagate the status. Otherwise,
+	 * main() returned already and its return status
+	 * was already set, so do not overwrite.
+	 */
+	if (pprocess_exit_status != PPROCESS_EXIT_STATUS_UNSET)
+		ctx->exit_code = pprocess_exit_status;
 }
 #endif /* !CONFIG_LIBPOSIX_PROCESS_MULTITHREADING */
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Fixes an issue where the exit code of the init process is not correctly propagated to the inittab's term_ctx.
This has been tested with all config variants of libposix-process.