### PR TITLE
drivers/virtio/net: Only enable LRO if mergeable RX buffers

### DIFF
--- a/drivers/virtio/net/virtio_net.c
+++ b/drivers/virtio/net/virtio_net.c
@@ -1340,16 +1340,28 @@ static void virtio_net_info_get(struct uk_netdev *dev,
 		dev_info->nb_encap_rx = VTNET_HDR_SIZE_PADDED(vndev);
 	dev_info->ioalign = VIRTIO_PKT_BUFFER_ALIGN;
 
-	dev_info->features = UK_NETDEV_F_RXQ_INTR
-		| (VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_CSUM)
-		   ? UK_NETDEV_F_PARTIAL_CSUM : 0)
-		| ((VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_HOST_TSO4)
-		    || VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_GSO))
-		   ? UK_NETDEV_F_TSO4 : 0)
-		| ((VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_GUEST_TSO4)
-		    || VIRTIO_FEATURE_HAS(host_features,
-					  VIRTIO_NET_F_GUEST_TSO6)
-		   ? UK_NETDEV_F_LRO : 0));
+	dev_info->features = UK_NETDEV_F_RXQ_INTR;
+	if (VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_CSUM))
+		dev_info->features |= UK_NETDEV_F_PARTIAL_CSUM;
+
+	if (VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_HOST_TSO4) ||
+	    VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_GSO))
+		dev_info->features |= UK_NETDEV_F_TSO4;
+
+	/**
+	 * Large Receive Offload
+	 * NOTE: This allows the host to send packets larger than MTU. The
+	 *       network stack needs to be able to handle such packets.
+	 *       We only enable this if we have also support for mergeable RX
+	 *       buffers, otherwise we would have to either allocate huge
+	 *       buffers (wasting space for smaller buffers) or use many small
+	 *       descriptors (needing indirect descriptors and putting a large
+	 *       burden on the allocator).
+	 */
+	if (VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_MRG_RXBUF) &&
+	    (VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_GUEST_TSO4) ||
+	     VIRTIO_FEATURE_HAS(host_features, VIRTIO_NET_F_GUEST_TSO6)))
+		dev_info->features |= UK_NETDEV_F_LRO;
 }
 
 static int virtio_net_start(struct uk_netdev *n)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Currently we only support LRO if the virtio net device supports mergeable RX buffers. So only set this netdev framework-visible bit if this condition is met. While at it, make the setting of the bits more readable.