### PR TITLE
lib/posix-vfs-fstab: Go past `NULL` user entries and don't `break`

### DIFF
--- a/lib/posix-vfs-fstab/fstab.c
+++ b/lib/posix-vfs-fstab/fstab.c
@@ -271,7 +271,7 @@ int fstab_process_user(const struct ukplat_memregion_desc *initrd0)
 
 	for (size_t i = 0; i < ARRAY_SIZE(fstab_user); i++) {
 		if (!fstab_user[i])
-			break;
+			continue;
 
 		r = fstab_parse(fstab_user[i], &ent);
 		if (unlikely(r))


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Maintain `libvfscore` behavior and do not break upon first NULL user fstab entry but rather simply go past it.