### PR TITLE
lib/posix-vfs-fstab: Register with `uklibparam` with `vfs.` prefix

### DIFF
--- a/lib/posix-vfs-fstab/Makefile.uk
+++ b/lib/posix-vfs-fstab/Makefile.uk
@@ -1,5 +1,8 @@
 $(eval $(call addlib_s,libposix_vfs_fstab,$(CONFIG_LIBPOSIX_VFS_FSTAB)))
 
+# Register to uklibparam, sets "vfs" as parameter prefix (vfs.*)
+$(eval $(call addlib_paramprefix,libposix_vfs_fstab,vfs))
+
 LIBPOSIX_VFS_FSTAB_SRCS-$(CONFIG_LIBPOSIX_VFS_FSTAB_INIT) += $(LIBPOSIX_VFS_FSTAB_BASE)/fstab.c
 
 LIBPOSIX_VFS_FSTAB_SRCS-$(CONFIG_LIBPOSIX_VFS_FSTAB_EINITRD) += $(LIBPOSIX_VFS_FSTAB_BASE)/einitrd.S


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Call into the build rule that defines/registers the `vfs.` prefix with `uklibparam`. Without this, the `vfs.`-prefixed kernel arguments don't work when using `libposix-vfs-fstab` for user-provided fstab args.