### PR TITLE
lib/posix-vfs-fstab: Fix wrong ukopts separator

### DIFF
--- a/lib/posix-vfs-fstab/Config.uk
+++ b/lib/posix-vfs-fstab/Config.uk
@@ -25,8 +25,8 @@ config LIBPOSIX_VFS_FSTAB_USER
 	help
 	  These volumes are parsed from a command-line argument:
 	  vfs.fstab=[
-	    "<dev>:<mntpoint>:<fsdriver>[:<flags>[:<opts>[:<ukopt>]]]"
-	    "<dev>:<mntpoint>:<fsdriver>[:<flags>[:<opts>[:<ukopt>]]]"
+	    "<dev>:<mntpoint>:<fsdriver>[:<flags>[:<opts>[:<ukopt>[,<ukopt>]]]]"
+	    "<dev>:<mntpoint>:<fsdriver>[:<flags>[:<opts>[:<ukopt>[,<ukopt>]]]]"
 	    ...
 	  ]
 	  The list elements are to be separated by whitespace.

--- a/lib/posix-vfs-fstab/fstab.c
+++ b/lib/posix-vfs-fstab/fstab.c
@@ -18,7 +18,7 @@
 #include "fstab.h"
 
 #define FSTAB_VOL_ARGS_SEP ':'
-#define FSTAB_UKOPTS_ARGS_SEP FSTAB_VOL_ARGS_SEP
+#define FSTAB_UKOPTS_ARGS_SEP ','
 
 #define FSTAB_FSTYPE_EXTRACT "extract"
 


### PR DESCRIPTION
### Description of changes

This change fixes a bug where ':' was wrongly used as the separator between ukopts, instead of ',' as the cmdline interface demands. Since this confusion was caused by a lack of clear documentation, the Kconfig help line is also updated to show the correct separator.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A
