### PR TITLE
lib/*: Misc trivial fixes & warning silencing

### DIFF
--- a/include/uk/compiler.h
+++ b/include/uk/compiler.h
@@ -54,6 +54,9 @@ extern "C" {
 #ifndef __nonnull
 #define __nonnull              __attribute__((nonnull))
 #endif
+#ifndef __nonstring
+#define __nonstring            __attribute__((nonstring))
+#endif
 #ifndef __printf
 #define __printf(fmt, args)    __attribute__((format(printf, (fmt), (args))))
 #endif

--- a/lib/nolibc/musl-imported/src/unistd/getcwd.c
+++ b/lib/nolibc/musl-imported/src/unistd/getcwd.c
@@ -8,19 +8,20 @@ long uk_syscall_r_getcwd(char *buf, size_t sz);
 char *getcwd(char *buf, size_t size)
 {
 	char tmp[buf ? 1 : PATH_MAX];
+	char *p = buf;
 	if (!buf) {
-		buf = tmp;
+		p = tmp;
 		size = sizeof tmp;
 	} else if (!size) {
 		errno = EINVAL;
 		return 0;
 	}
-	long ret = uk_syscall_r_getcwd(buf, size);
+	long ret = uk_syscall_r_getcwd(p, size);
 	if (ret < 0)
 		return 0;
-	if (ret == 0 || buf[0] != '/') {
+	if (ret == 0 || p[0] != '/') {
 		errno = ENOENT;
 		return 0;
 	}
-	return buf == tmp ? strdup(buf) : buf;
+	return buf ? buf : strdup(tmp);
 }

--- a/lib/posix-fdio/sendfile-shim.c
+++ b/lib/posix-fdio/sendfile-shim.c
@@ -73,10 +73,10 @@ enum shim_combo {
 #endif /* CONFIG_LIBVFSCORE */
 };
 
+#if CONFIG_LIBVFSCORE
 static inline
 enum shim_combo shim_combo_of(int in_type, int out_type, void *op)
 {
-#if CONFIG_LIBVFSCORE
 	switch (in_type) {
 	case UK_SHIM_OFILE:
 		switch (out_type) {
@@ -99,10 +99,15 @@ enum shim_combo shim_combo_of(int in_type, int out_type, void *op)
 	default:
 		UK_BUG(); /* Do validation before */
 	}
-#else /* !CONFIG_LIBVFSCORE */
-	return op ? SHIM_OFILE_OFILE_OFF : SHIM_OFILE_OFILE;
-#endif /* !CONFIG_LIBVFSCORE */
 }
+#else /* !CONFIG_LIBVFSCORE */
+static inline
+enum shim_combo shim_combo_of(int in_type __unused, int out_type __unused,
+			      void *op)
+{
+	return op ? SHIM_OFILE_OFILE_OFF : SHIM_OFILE_OFILE;
+}
+#endif /* !CONFIG_LIBVFSCORE */
 
 #if CONFIG_LIBVFSCORE
 

--- a/lib/posix-vfs-fstab/fstab.c
+++ b/lib/posix-vfs-fstab/fstab.c
@@ -308,7 +308,7 @@ int fstab_process_internal(const struct vfs_fstab_entry fstab[],
 #endif /* CONFIG_LIBPOSIX_VFS_FSTAB_BUILTIN || CONFIG_LIBPOSIX_VFS_FSTAB_FALLBACK */
 
 /* Assumes path is directly under `/` or an existing dir */
-static
+static __maybe_unused
 int fstab_mount_special(const char *path, const char *fstype,
 			const char *source, unsigned long flags, void *data)
 {

--- a/lib/ukallocstack/stack.c
+++ b/lib/ukallocstack/stack.c
@@ -134,8 +134,9 @@ static void *stack_memalign(struct uk_alloc *a, __sz align, __sz size)
 	__vaddr_t vaddr;
 
 	UK_ASSERT(a);
-	UK_ASSERT(align >= UKARCH_SP_ALIGN);
-	UK_ASSERT(IS_ALIGNED(align,  UKARCH_SP_ALIGN));
+
+	if (unlikely(!IS_ALIGNED(align, UKARCH_SP_ALIGN)))
+		return NULL;
 #if CONFIG_LIBUKALLOCSTACK_PAGE_GUARDS
 	/* If using page guards then we allocate stack VMA's instead. So,
 	 * the return address will always be page-aligned and the maximum
@@ -159,7 +160,8 @@ static void *stack_memalign(struct uk_alloc *a, __sz align, __sz size)
 	 * Therefore, make this constraint clear when using page guards
 	 * configuration: alignment must not be bigger than PAGE_SIZE.
 	 */
-	UK_ASSERT(align <= PAGE_SIZE);
+	if (unlikely(align > PAGE_SIZE))
+		return NULL;
 #endif /* CONFIG_LIBUKALLOCSTACK_PAGE_GUARDS */
 
 	if (unlikely(!size))

--- a/lib/ukfs-ramfs/ramfs.c
+++ b/lib/ukfs-ramfs/ramfs.c
@@ -1144,7 +1144,8 @@ union ramfs_link {
 
 static
 int ramfs_linkin(struct ramfs_node *n, const char *name, size_t namelen,
-		 unsigned char dtype, union ramfs_link target, int flags)
+		 unsigned char dtype, union ramfs_link target,
+		 unsigned int mode, int flags)
 {
 	/* Lookup name dentry */
 	struct ramfs_dentry *dp = ramfs_dir_find(n, name, namelen);
@@ -1174,7 +1175,12 @@ int ramfs_linkin(struct ramfs_node *n, const char *name, size_t namelen,
 		uk_file_acquire(target.file);
 		break;
 	case RAMFS_DENT_SPEC:
-		dp->target.special = *target.special;
+		dp->target.special = (struct uk_fs_specfile){
+			.major = target.special->major,
+			.minor = target.special->minor,
+			.mode = mode,
+			/* TODO: use euid/egid */
+		};
 		break;
 	default:
 		UK_BUG();
@@ -1225,7 +1231,8 @@ struct ramfs_node *ramfs_live_fs_create(struct ramfs_node *n,
 
 	/* Link in if not tmpfile */
 	if (!(flags & O_TMPFILE)) {
-		err = ramfs_linkin(n, name, namelen, dtype, newlink, flags);
+		err = ramfs_linkin(n, name, namelen, dtype,
+				   newlink, mode, flags);
 		if (unlikely(err)) {
 			if (dtype == RAMFS_DENT_NODE)
 				ramfs_live_release(newlink.node);

--- a/lib/ukrandom/chacha.c
+++ b/lib/ukrandom/chacha.c
@@ -82,7 +82,7 @@ UK_LIBPARAM_PARAM_ARR_ALIAS(seed, seedv_cmdl, __u32, CHACHA_SEED_LENGTH,
 static __bool initialized = __false;
 
 /* This value isn't important, as long as it's sufficiently asymmetric */
-static const char sigma[16] = "expand 32-byte k";
+static const char sigma[16] __nonstring = "expand 32-byte k";
 
 static inline __u32 uk_rotl32(__u32 v, int c)
 {

--- a/lib/uksparsebuf/include/uk/sparsebuf/util.h
+++ b/lib/uksparsebuf/include/uk/sparsebuf/util.h
@@ -28,7 +28,7 @@ void uk_sparsebuf_memclear(struct uk_sparsebuf_cur *cur, __sz off, __sz len)
 
 	if (blen && buf) {
 		UK_ASSERT(blen >= len);
-		while (blen--)
+		while (len--)
 			*(buf++) = 0;
 	}
 }


### PR DESCRIPTION
### Description of changes

This changeset contains miscellaneous small fixes found by following compiler warnings. First two commits are fixes for genuine issues caught, while the rest fix unlikely cornercases in some configurations.

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A
