### PR TITLE
plat: Add `.headers` `PROGBITS` section

### DIFF
--- a/plat/kvm/arm/link64.lds.S
+++ b/plat/kvm/arm/link64.lds.S
@@ -39,7 +39,8 @@ OUTPUT_ARCH(aarch64)
 
 PHDRS
 {
-	phdrs PT_LOAD FILEHDR PHDRS FLAGS(PHDRS_PF_R);
+	phdrs PT_PHDR PHDRS;
+	headers PT_LOAD PHDRS FILEHDR FLAGS(PHDRS_PF_R);
 	text PT_LOAD FLAGS(PHDRS_PF_RX);
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
@@ -68,6 +69,22 @@ SECTIONS {
 	PROVIDE(__executable_start = _base_addr);
 	. = _base_addr + SIZEOF_HEADERS;
 	PROVIDE(__phdr = .);
+
+	.headers :
+	{
+		/*
+		 * Add dummy PROGBITS data to have this section and its
+		 * corresponding Program Header associated
+		 * with a place relative to the other sections in
+		 * the memory layout.
+		 * Without this, the PT_LOAD segment containing the Program
+		 * headers will not have an associated section and it will
+		 * result in its base physical/virtual addresses being 0x0.
+		 */
+		LONG(0xDEADB0B0)
+		. = ALIGN(__PAGE_SIZE);
+		ASSERT((. < (_base_addr + __PAGE_SIZE)), "ELF Headers cross a page boundary");
+	} :headers
 
 	/* Code */
 	_text = .;

--- a/plat/xen/arm/link64.lds.S
+++ b/plat/xen/arm/link64.lds.S
@@ -32,7 +32,8 @@ ENTRY(_libxenplat_zimageboot)
 
 PHDRS
 {
-	phdrs PT_LOAD FILEHDR PHDRS FLAGS(PHDRS_PF_R);
+	phdrs PT_PHDR PHDRS;
+	headers PT_LOAD PHDRS FILEHDR FLAGS(PHDRS_PF_R);
 	text PT_LOAD FLAGS(PHDRS_PF_RX);
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
@@ -50,6 +51,21 @@ SECTIONS
   PROVIDE(__executable_start = _base_addr);
   . = _base_addr + SIZEOF_HEADERS;
   PROVIDE(__phdr = .);
+
+  .headers : {
+    /*
+     * Add dummy PROGBITS data to have this section and its
+     * corresponding Program Header associated
+     * with a place relative to the other sections in
+     * the memory layout.
+     * Without this, the PT_LOAD segment containing the Program
+     * headers will not have an associated section and it will
+     * result in its base physical/virtual addresses being 0x0.
+     */
+    LONG(0xDEADB0B0)
+    . = ALIGN(__PAGE_SIZE);
+    ASSERT((. < (_base_addr + __PAGE_SIZE)), "ELF Headers cross a page boundary");
+  } :headers
 
   _text = .;			/* Text and read-only data */
   .text : {

--- a/plat/xen/x86/link64.lds.S
+++ b/plat/xen/x86/link64.lds.S
@@ -31,7 +31,8 @@ OUTPUT_ARCH(i386:x86-64)
 
 PHDRS
 {
-	phdrs PT_LOAD FILEHDR PHDRS FLAGS(PHDRS_PF_R);
+	phdrs PT_PHDR PHDRS;
+	headers PT_LOAD PHDRS FILEHDR FLAGS(PHDRS_PF_R);
 	text PT_LOAD FLAGS(PHDRS_PF_RX);
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
@@ -50,6 +51,21 @@ SECTIONS
 	PROVIDE(__executable_start = _base_addr);
 	. = _base_addr + SIZEOF_HEADERS;
 	PROVIDE(__phdr = .);
+
+	.headers : {
+		/*
+		 * Add dummy PROGBITS data to have this section and its
+		 * corresponding Program Header associated
+		 * with a place relative to the other sections in
+		 * the memory layout.
+		 * Without this, the PT_LOAD segment containing the Program
+		 * headers will not have an associated section and it will
+		 * result in its base physical/virtual addresses being 0x0.
+		 */
+		LONG(0xDEADB0B0)
+		. = ALIGN(__PAGE_SIZE);
+		ASSERT((. < (_base_addr + __PAGE_SIZE)), "ELF Headers cross a page boundary");
+	} :headers
 
 	_text = .;			/* Text and read-only data */
 	.text : {

--- a/support/scripts/mklinux.py
+++ b/support/scripts/mklinux.py
@@ -5,6 +5,9 @@ import os
 import re
 import subprocess
 
+# For ELF headers reading
+from struct import unpack
+
 # Linux arm64 boot header
 # https://www.kernel.org/doc/Documentation/arm64/booting.txt
 LINUX_ARM64_HDR = {
@@ -41,6 +44,24 @@ def get_sym_val(elf, sym):
         raise Exception("Found no " + sym + " symbol.")
 
     return int(re_out[0], 16)
+
+
+def get_pt_load_headers(elf):
+    with open(elf, "rb") as f:
+        # We assume the Program Headers immediately follow the ELF64 Headers
+        # (we control the layout through the linker script)
+        f.seek(32)
+        e_phoff = unpack("<" + "Q", f.read(8))[0]
+        assert (
+            e_phoff == 64
+        ), "Program headers are not immediately after ELF64 header"
+
+        f.seek(54)
+        e_phentsize = unpack("<" + "h", f.read(2))[0]
+        e_phnum = unpack("<" + "h", f.read(2))[0]
+
+        f.seek(0)
+        return f.read(e_phoff + e_phnum * e_phentsize)
 
 
 def main():
@@ -101,6 +122,33 @@ def main():
     total_size = os.path.getsize(opt.bin) + LINUX_ARM64_HDR_SIZE
     LINUX_ARM64_HDR["IMAGE_SIZE"][0] = align_up(total_size, 2**21)
 
+    # We place the Program Headers in a PT_LOAD ELF segment with the help of
+    # a dummy PROGBITS 4-byte-sized section ".headers". However, the Linux
+    # boot protocol on ARM64 involves no ELF loading so the ELF kernel is dumped
+    # as a raw binary directly. For this to work, we use objcopy to convert
+    # from ELF to raw binary. The way objcopy does this is with the help
+    # of ELF Sections (not Program Headers). It goes through each one and
+    # tries to write them into the newly converted file as if they were loaded
+    # in memory.
+    # Our problem is that we don't have a section associated with the contents
+    # of the Program Headers themselves so objcopy will end up not copying them,
+    # despite them being part of a loadable segment (it will only load
+    # ".headers"'s dummy 4 bytes). What objcopy will do is just copy
+    # .headers to offset 0 of raw binary, followed by whatever padding there
+    # is until .text.
+    # Besides not having the Program Headers loaded in memory together with
+    # the kernel, this also results in all offsets being off by
+    # Elf64_Ehdr(.e_phoff) + Elf64_Ehdr.e_phnum * Elf64_Ehdr.e_phentsize
+    # (assuming that e_phoff == sizeof(Elf64_Ehdr), i.e. Program Headers
+    # immediately follow the ELF header).
+    #
+    # To fix this, after writing the linux boot protocol header, simply append
+    # the ELF headers that are loadable but do not have a PROGBITS section
+    # associated with them, followed by our objcopy-created binary, since the
+    # latter will contain the loadable bytes that would have come right after
+    # the ELF headers we are interested in.
+    pt_load_hdrs = get_pt_load_headers(opt.elf)
+
     # Create final image
     with open(opt.bin, "r+b") as f:
         img = f.read()
@@ -111,6 +159,17 @@ def main():
                     LINUX_ARM64_HDR[field][1], "little"
                 )
             )
+        # Add the ELF Header + Program Headers that do not have a PROGBITS
+        # section associated
+        f.write(pt_load_hdrs)
+
+        # Ensure we do not cross a page (64-byte linux header not included)
+        # including the 4-byte dummy section
+        assert f.tell() < 4096 + 64 - 4, "ELF Headers cross a page boundary"
+
+        # We should now be at the offset where .headers should begin in the
+        # original ELF's first PT_LOAD segment, right after the headers.
+        # Write the rest of the image (from .headers and on).
         f.write(img)
 
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Since the PHDRs do not have a PROGBITS section associated with
the PT_LOAD segment that contains them and thus nothing to define their
memory layout placement relative to the other segments/sections,
the linker will place said segment at virtual/physical address 0x0.

Fix this by adding a dummy, non-empty, PROGBITS ".headers" section
to be part of this PHDR and whose memory placement is right before
the .text section. To maintain proper alignment of the .text section
that follows, pad this section to the next page-aligned boundary.

Lastly, for a bit of space efficiency reasons, ensure that the ELF
headers and this dummy padding are not a bigger than a page and
associate this dummy section with a meaningful 4-byte magic value
that is easy to find in hexdumps: 0xDEADB0B0 (we often use this for
magic values).

However, there is still a problem in the case of the Linux boot protocol
on ARM64 that involves no ELF loading so the ELF kernel is dumped
as a raw binary directly. For this to work, we use objcopy to convert
from ELF to raw binary. The way objcopy does this is with the help
of ELF Sections (not Program Headers). It goes through each one and
tries to write them into the newly converted file as if they were loaded
in memory.
Our problem is that we don't have a section associated with the contents
of the Program Headers themselves so objcopy will end up not copying them,
despite them being part of a loadable segment (it will only load
".headers"'s dummy 4 bytes). What objcopy will do is just copy
.headers to offset 0 of raw binary, followed by whatever padding there
is until .text.
Besides not having the Program Headers loaded in memory together with
the kernel, this also results in all offsets being off by
Elf64_Ehdr(.e_phoff) + Elf64_Ehdr.e_phnum * Elf64_Ehdr.e_phentsize
(assuming that e_phoff == sizeof(Elf64_Ehdr), i.e. Program Headers
immediately follow the ELF header).

To fix this, after writing the linux boot protocol header, simply append
the ELF headers that are loadable but do not have a PROGBITS section
associated with them, followed by our objcopy-created binary, since the
latter will contain the loadable bytes that would have come right after
the ELF headers we are interested in.
