### PR TITLE
lib/ukcpio: Ensure we request enough memory for allocregion metadata

### DIFF
--- a/lib/ukcpio/cpio.c
+++ b/lib/ukcpio/cpio.c
@@ -38,6 +38,7 @@
 #include <limits.h>
 #include <errno.h>
 
+#include <uk/arch/paging.h>
 #include <uk/assert.h>
 #include <uk/compat_list.h>
 #include <uk/print.h>
@@ -483,9 +484,18 @@ ukcpio_extract(const char *dest, const void *buf, size_t buflen)
 	 * a CPIO archive, just initialize the region allocator based on the
 	 * minimum between the biggest possible contiguous allocation of the
 	 * current default allocator and the maximum possible count of CPIO
-	 * entries that could fit in the given buffer.
+	 * entries that could fit in the given buffer. In the case of the
+	 * latter, if the CPIO archive is very small, the division might
+	 * actually result in a number that is not even enough for the
+	 * allocator's metadata, so add PAGE_SIZE as a safety measure,
+	 * just in case.
+	 *
+	 * TODO: Find a better estimate than PAGE_SIZE, possibly a way for
+	 * allocators to give information about minimum required usable
+	 * memory for initialization.
 	 */
 	max_alloc = MIN((size_t)uk_alloc_maxalloc(a),
+			PAGE_SIZE +
 			buflen / sizeof(struct uk_cpio_header) *
 			sizeof(struct cpio_ilist_elm));
 	region_base = uk_malloc(a, max_alloc);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

For the case where we use the estimate of highest possible count of CPIO entries to decide how much memory to request to initialize the region allocator used for multi-hardlink inodes tracking, if the CPIO archive is very small, the division might actually result in a number that is not even enough for the allocator's metadata, so add __PAGE_SIZE as a safety measure, just in case.