### PR TITLE
plat: Have PHDRs in their own PT_LOAD as an experimental config

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -154,6 +154,12 @@ config DEBUG_SYMBOLS_LVL3
 		support macro expansion.
 endchoice
 
+config ELF_PHDRS_IN_PT_LOAD
+	bool "ELF Program Headers in loadable segment (EXPERIMENTAL)"
+	help
+		Enables the final ELF image to have its Program Headers as part
+		of a loadable segment (Program Header with PT_LOAD).
+
 comment "Hint: Keep frame pointers to ease debugging"
 	depends on !OPTIMIZE_NOOMITFP && !DEBUG_SYMBOLS_LVL0
 

--- a/plat/kvm/arm/link64.lds.S
+++ b/plat/kvm/arm/link64.lds.S
@@ -39,7 +39,9 @@ OUTPUT_ARCH(aarch64)
 
 PHDRS
 {
+#if CONFIG_ELF_PHDRS_IN_PT_LOAD
 	phdrs PT_LOAD FILEHDR PHDRS FLAGS(PHDRS_PF_R);
+#endif /* CONFIG_ELF_PHDRS_IN_PT_LOAD */
 	text PT_LOAD FLAGS(PHDRS_PF_RX);
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
@@ -65,9 +67,11 @@ SECTIONS {
 
 	_base_addr = .;		/* Symbol to represent the load base address */
 
+#if CONFIG_ELF_PHDRS_IN_PT_LOAD
 	PROVIDE(__executable_start = _base_addr);
 	. = _base_addr + SIZEOF_HEADERS;
 	PROVIDE(__phdr = .);
+#endif /* CONFIG_ELF_PHDRS_IN_PT_LOAD */
 
 	/* Code */
 	_text = .;

--- a/plat/kvm/x86/link64.lds.S
+++ b/plat/kvm/x86/link64.lds.S
@@ -30,8 +30,10 @@
 
 PHDRS
 {
+#if CONFIG_ELF_PHDRS_IN_PT_LOAD
 	phdrs PT_PHDR PHDRS;
 	headers PT_LOAD PHDRS FILEHDR FLAGS(PHDRS_PF_R);
+#endif /* CONFIG_ELF_PHDRS_IN_PT_LOAD */
 	text PT_LOAD FLAGS(PHDRS_PF_RX);
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
@@ -42,23 +44,33 @@ PHDRS
 
 SECTIONS
 {
+#if CONFIG_ELF_PHDRS_IN_PT_LOAD
 	PROVIDE(__executable_start = BASE_ADDR);
 	. = BASE_ADDR + SIZEOF_HEADERS;
 	PROVIDE(__phdr = .);
+#endif /* CONFIG_ELF_PHDRS_IN_PT_LOAD */
 
+	. = BASE_ADDR;
 	_base_addr = BASE_ADDR;	/* Symbol to represent the load base address */
 
+#if CONFIG_ELF_PHDRS_IN_PT_LOAD
 	.headers :
 	{
 		/* prevent linker gc from removing multiboot header */
 		KEEP (*(.data.boot))
 		KEEP (*(.data.boot.*))
 	} :headers
+#endif /* CONFIG_ELF_PHDRS_IN_PT_LOAD */
 
 	/* Code */
 	_text = .;
 	.text :
 	{
+#if !CONFIG_ELF_PHDRS_IN_PT_LOAD
+		/* prevent linker gc from removing multiboot header */
+		KEEP (*(.data.boot))
+		KEEP (*(.data.boot.*))
+#endif /* !CONFIG_ELF_PHDRS_IN_PT_LOAD */
 		*(.text.boot)
 		*(.text.boot.*)
 

--- a/plat/xen/arm/link64.lds.S
+++ b/plat/xen/arm/link64.lds.S
@@ -32,7 +32,9 @@ ENTRY(_libxenplat_zimageboot)
 
 PHDRS
 {
+#if CONFIG_ELF_PHDRS_IN_PT_LOAD
 	phdrs PT_LOAD FILEHDR PHDRS FLAGS(PHDRS_PF_R);
+#endif /* CONFIG_ELF_PHDRS_IN_PT_LOAD */
 	text PT_LOAD FLAGS(PHDRS_PF_RX);
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
@@ -47,9 +49,11 @@ SECTIONS
 
   _base_addr = .;		/* Symbol to represent the load base address */
 
+#if CONFIG_ELF_PHDRS_IN_PT_LOAD
   PROVIDE(__executable_start = _base_addr);
   . = _base_addr + SIZEOF_HEADERS;
   PROVIDE(__phdr = .);
+#endif /* CONFIG_ELF_PHDRS_IN_PT_LOAD */
 
   _text = .;			/* Text and read-only data */
   .text : {

--- a/plat/xen/x86/link64.lds.S
+++ b/plat/xen/x86/link64.lds.S
@@ -31,7 +31,9 @@ OUTPUT_ARCH(i386:x86-64)
 
 PHDRS
 {
+#if CONFIG_ELF_PHDRS_IN_PT_LOAD
 	phdrs PT_LOAD FILEHDR PHDRS FLAGS(PHDRS_PF_R);
+#endif /* CONFIG_ELF_PHDRS_IN_PT_LOAD */
 	text PT_LOAD FLAGS(PHDRS_PF_RX);
 	rodata PT_LOAD FLAGS(PHDRS_PF_R);
 	data PT_LOAD;
@@ -47,9 +49,11 @@ SECTIONS
 
 	_base_addr = .;		/* Symbol to represent the load base address */
 
+#if CONFIG_ELF_PHDRS_IN_PT_LOAD
 	PROVIDE(__executable_start = _base_addr);
 	. = _base_addr + SIZEOF_HEADERS;
 	PROVIDE(__phdr = .);
+#endif /* CONFIG_ELF_PHDRS_IN_PT_LOAD */
 
 	_text = .;			/* Text and read-only data */
 	.text : {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

For now, do not define PT_LOAD segment for PHDRs by default and instead guard the feature with a configuration option that is disabled by default.

This should only be enabled if you know what you are doing.