### PR TITLE
include/uk: Make `UK_EVENT` symbol visible to the linker

### DIFF
--- a/include/uk/event.h
+++ b/include/uk/event.h
@@ -164,6 +164,7 @@ struct uk_event {
 #define __UK_EVT_SECTION_LABEL(section, label)				\
 	__asm__ (							\
 		".pushsection \".uk_event_" section "\", \"a\"\n"	\
+		".global " #label "\n"					\
 		#label ":\n"						\
 		".popsection\n"						\
 	)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Ensure that `UK_EVENT` generated symbol is visible to the linker. This also help discourage having it optimized out during LTO or having the assembler merge it with other adjacent symbols.