### PR TITLE
lib/ukallocregion: Fix variable name in allocregion_posix_memalign

### DIFF
--- a/lib/ukallocregion/region.c
+++ b/lib/ukallocregion/region.c
@@ -129,7 +129,7 @@ static int allocregion_posix_memalign(struct uk_alloc *a, void **memptr,
 	allocregion_do_bump(ar, size, align);
 	*memptr = ar->heap_pos;
 
-	uk_alloc_stats_count_alloc(&ar->a, b->heap_pos, size);
+	uk_alloc_stats_count_alloc(&ar->a, ar->heap_pos, size);
 	return 0;
 }
 


### PR DESCRIPTION
…ats call

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes
In the `allocregion_posix_memalign` function in `lib/ukallocregion/region.c`, there was a bug on line `132` where the code referenced an undefined variable `b` instead of the `ar` variable defined at the beginning of the function.

I produced this bug by enabling the following configurations in the `make menuconfig` menu:

1. `Library Configuration`:
    1. `ukalloc: Abstraction for memory allocators`:
        1. `[*] Allocator statistics interface`
        2. `[*] Global statistics`
    2. `[*] ukallocregion: Region-based allocator`


