### PR TITLE
lib/ukvmem: Do not assert on uninitialized DMA VMA creation

### DIFF
--- a/lib/ukvmem/include/uk/vmem/vma_types.h
+++ b/lib/ukvmem/include/uk/vmem/vma_types.h
@@ -200,7 +200,6 @@ static inline int uk_vma_map_dma(struct uk_vas *vas, __vaddr_t *vaddr,
 	};
 
 	UK_ASSERT(PAGE_ALIGNED(paddr));
-	UK_ASSERT(!(flags & UK_VMA_MAP_UNINITIALIZED));
 
 	return uk_vma_map(vas, vaddr, len, attr, flags, name,
 			  &uk_vma_dma_ops, &args);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Some scenarios, where one may not want to pre-zero out an entire DMA area, could exist.

Generally, when doing DMA transfers with a device, some provided buffers may need to be zeroed-out, while some others don't (for example write buffers that are written fully).

In other scenarios, we may want to simply direct-map a region that already contains information that we do not want to be zeroed-out, or just want to direct-map a device memory region.

Thus, do not make it a hard requirement that DMA VMAs are zeroed-out for each faulted/populated page.