### PR TITLE
lib/posix-tty: Fix TTY devfs initcall priority typo

### DIFF
--- a/lib/posix-tty/tty.c
+++ b/lib/posix-tty/tty.c
@@ -134,7 +134,7 @@ static int init_posix_tty(struct uk_init_ctx *ictx __unused)
 }
 
 #if CONFIG_LIBPOSIX_TTY_DEVFS
-uk_rootfs_initcall_prio(init_posix_tty, 0x0, UK_PRIO_FSAVAIL);
+uk_rootfs_initcall_prio(init_posix_tty, 0x0, UK_FS_PRIO_FSAVAIL);
 #else /* !CONFIG_LIBPOSIX_TTY_DEVFS */
 uk_rootfs_initcall(init_posix_tty, 0x0);
 #endif /* !CONFIG_LIBPOSIX_TTY_DEVFS */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The correct macro is `UK_FS_PRIO_FSAVAIL` not `UK_PRIO_FSAVAIL`.