### PR TITLE
lib/posix-socket: Don't block if `MSG_DONTWAIT` is set in `flags`

### DIFF
--- a/lib/posix-socket/socket.c
+++ b/lib/posix-socket/socket.c
@@ -773,7 +773,9 @@ UK_SYSCALL_R_DEFINE(ssize_t, recvfrom, int, sock, void *, buf, size_t, len,
 		ret = posix_socket_recvfrom(of->file, buf, len, flags,
 					    from, fromlen);
 		uk_file_runlock(of->file);
-		if (!_SHOULD_BLOCK(mode) || !_ERR_BLOCK(ret))
+		if (!_SHOULD_BLOCK(mode) ||
+		    (flags & MSG_DONTWAIT) ||
+		    !_ERR_BLOCK(ret))
 			break;
 		(void)uk_file_poll(of->file, UKFD_POLLIN);
 	}
@@ -822,7 +824,9 @@ UK_SYSCALL_R_DEFINE(ssize_t, recvmsg, int, sock, struct msghdr *, msg,
 		uk_file_rlock(of->file);
 		ret = posix_socket_recvmsg(of->file, msg, flags);
 		uk_file_runlock(of->file);
-		if (!_SHOULD_BLOCK(mode) || !_ERR_BLOCK(ret))
+		if (!_SHOULD_BLOCK(mode) ||
+		    (flags & MSG_DONTWAIT) ||
+		    !_ERR_BLOCK(ret))
 			break;
 		(void)uk_file_poll(of->file, UKFD_POLLIN);
 	}
@@ -864,7 +868,9 @@ UK_SYSCALL_R_DEFINE(ssize_t, sendmsg, int, sock, const struct msghdr *, msg,
 		uk_file_rlock(of->file);
 		ret = posix_socket_sendmsg(of->file, msg, flags);
 		uk_file_runlock(of->file);
-		if (!_SHOULD_BLOCK(mode) || !_ERR_BLOCK(ret))
+		if (!_SHOULD_BLOCK(mode) ||
+		    (flags & MSG_DONTWAIT) ||
+		    !_ERR_BLOCK(ret))
 			break;
 		(void)uk_file_poll(of->file, UKFD_POLLOUT);
 	}
@@ -909,7 +915,9 @@ UK_SYSCALL_R_DEFINE(ssize_t, sendto, int, sock, const void *, buf, size_t, len,
 		ret = posix_socket_sendto(of->file, buf, len, flags,
 					  dest_addr, addrlen);
 		uk_file_runlock(of->file);
-		if (!_SHOULD_BLOCK(mode) || !_ERR_BLOCK(ret))
+		if (!_SHOULD_BLOCK(mode) ||
+		    (flags & MSG_DONTWAIT) ||
+		    !_ERR_BLOCK(ret))
 			break;
 		(void)uk_file_poll(of->file, UKFD_POLLOUT);
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

If the caller specified `MSG_DONTWAIT` then don't block. This applies to `recvfrom`/`recvmsg` and their sending counterparts, `sendto`/`sendmsg`.