### PR TITLE
lib/posix-vfs: Fix off-by-1 in return of getcwd

### DIFF
--- a/lib/posix-vfs/vfs.c
+++ b/lib/posix-vfs/vfs.c
@@ -927,7 +927,7 @@ ssize_t uk_sys_getcwd(char *buf, size_t len)
 		return -ERANGE;
 	memcpy(buf, cwdpath, cwdlen);
 	buf[cwdlen] = '\0';
-	return cwdlen;
+	return cwdlen + 1;
 }
 
 int uk_sys_chroot(const char *path)


### PR DESCRIPTION
### Description of changes

This change has getcwd return the length of the copied string including the NUL terminator.


### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A
