### PR TITLE
lib/devfs: Make device node name configurable and export `device_destroy`

### DIFF
--- a/lib/devfs/Config.uk
+++ b/lib/devfs/Config.uk
@@ -26,4 +26,8 @@ config LIBDEVFS_DEV_STDOUT
 	default y if LIBDEVFS_AUTOMOUNT
 	select LIBUKCONSOLE
 
+config LIBDEVFS_MAXDEVNAME
+	int "Maximum devfs entry name length"
+	default 256
+
 endif

--- a/lib/devfs/Config.uk
+++ b/lib/devfs/Config.uk
@@ -4,30 +4,26 @@ menuconfig LIBDEVFS
 	depends on LIBVFSCORE
 
 if LIBDEVFS
-	config LIBDEVFS_AUTOMOUNT
+config LIBDEVFS_AUTOMOUNT
 	bool "Mount /dev during boot"
-	default n
 
-	# hidden
-	config LIBDEVFS_DEV_NULL_ZERO
-		bool
-		default n
+# hidden
+config LIBDEVFS_DEV_NULL_ZERO
+	bool
 
-	config LIBDEVFS_DEV_NULL
-		bool "Register null device"
-		default y if LIBDEVFS_AUTOMOUNT
-		select LIBDEVFS_DEV_NULL_ZERO
-		default n
+config LIBDEVFS_DEV_NULL
+	bool "Register null device"
+	default y if LIBDEVFS_AUTOMOUNT
+	select LIBDEVFS_DEV_NULL_ZERO
 
-	config LIBDEVFS_DEV_ZERO
-		bool "Register zero device"
-		default y if LIBDEVFS_AUTOMOUNT
-		select LIBDEVFS_DEV_NULL_ZERO
-		default n
+config LIBDEVFS_DEV_ZERO
+	bool "Register zero device"
+	default y if LIBDEVFS_AUTOMOUNT
+	select LIBDEVFS_DEV_NULL_ZERO
 
-	config LIBDEVFS_DEV_STDOUT
-		bool "Register stdout device"
-		default y if LIBDEVFS_AUTOMOUNT
-		select LIBUKCONSOLE
-		default n
+config LIBDEVFS_DEV_STDOUT
+	bool "Register stdout device"
+	default y if LIBDEVFS_AUTOMOUNT
+	select LIBUKCONSOLE
+
 endif

--- a/lib/devfs/exportsyms.uk
+++ b/lib/devfs/exportsyms.uk
@@ -1,4 +1,5 @@
 device_create
+device_destroy
 device_open
 device_close
 device_read

--- a/lib/devfs/include/devfs/device.h
+++ b/lib/devfs/include/devfs/device.h
@@ -37,7 +37,7 @@
 #include <uk/init.h>
 #include <uk/posix-fdtab.h>
 
-#define MAXDEVNAME	12
+#define MAXDEVNAME	CONFIG_LIBDEVFS_MAXDEVNAME
 #define DO_RWMASK	0x3
 
 struct uio;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Make device node name configurable and export `device_destroy`. While at it, fix the KConfig styling.