### PR TITLE
lib/ukfs: Breaking API changes for 0.21

### DIFF
--- a/lib/posix-vfs-fstab/einitrd.h
+++ b/lib/posix-vfs-fstab/einitrd.h
@@ -17,6 +17,8 @@
 extern const char vfs_einitrd_start[];
 extern const char vfs_einitrd_end;
 
+#define VFS_EINITRD_LEN (&vfs_einitrd_end - vfs_einitrd_start)
+
 #endif /* CONFIG_LIBPOSIX_VFS_FSTAB_EINITRD */
 
 #endif /* __UK_POSIX_VFS_FSTAB_EINITRD_H__ */

--- a/lib/posix-vfs-fstab/fstab.c
+++ b/lib/posix-vfs-fstab/fstab.c
@@ -350,10 +350,9 @@ int fstab_mount_special(const char *path, const char *fstype,
 	int r;
 
 	r = fstab_mkdir(path);
-	if (unlikely(r)) {
-		uk_pr_err("Failed to create %s: %d\n", path, r);
-		return r;
-	}
+	if (unlikely(r))
+		uk_pr_warn("Failed to create %s: %d\n", path, r);
+		/* Try to mount anyway */
 	r = uk_sys_mount(source, path, fstype, flags, data);
 	if (unlikely(r)) {
 		uk_pr_err("Failed to mount special filesystem %s on %s: %d\n",

--- a/lib/posix-vfs-fstab/fstab.c
+++ b/lib/posix-vfs-fstab/fstab.c
@@ -11,6 +11,7 @@
 #include <uk/init.h>
 #include <uk/argparse.h>
 #include <uk/essentials.h>
+#include <uk/fs/driver.h>
 #include <uk/fs/pathutil.h>
 #include <uk/posix-vfs.h>
 #include <uk/plat/memory.h>
@@ -62,7 +63,7 @@ int fstab_extract(const struct vfs_fstab_entry *e,
 #if CONFIG_LIBPOSIX_VFS_FSTAB_EINITRD
 	} else if (!strcmp(e->dev, FSTAB_DEV_EINITRD)) {
 		base = (const void *)vfs_einitrd_start;
-		len = (uintptr_t)&vfs_einitrd_end - (uintptr_t)base;
+		len = VFS_EINITRD_LEN;
 #endif /* CONFIG_LIBPOSIX_VFS_FSTAB_EINITRD */
 	} else {
 		uk_pr_crit("Invalid initrd source: %s\n", e->dev);
@@ -149,6 +150,41 @@ int fstab_mkmp(const char *path)
 }
 
 static
+int fstab_mount_initrd(const struct vfs_fstab_entry *e,
+		       const void *base, size_t len)
+{
+	const struct uk_fs_drv *drv;
+	struct uk_fs_vopen_memimg img;
+	union uk_fs_vopen_vol vol;
+	union uk_fs_vopen_data data;
+	const struct uk_file *newroot;
+	int r;
+
+	drv = uk_fs_driver(e->fstype);
+	if (unlikely(!drv))
+		return -ENODEV;
+	if (unlikely(!uk_fs_vopen_supports(drv->formats, UK_FS_VOPEN_VOL_MASK,
+					   UK_FS_VOPEN_VOL_MEMIMG)))
+		return -EINVAL;
+	if (unlikely(!uk_fs_vopen_supports(drv->formats, UK_FS_VOPEN_DATA_MASK,
+					   UK_FS_VOPEN_DATA_RAW)))
+		return -EINVAL;
+	img.base = base;
+	img.len = len;
+	vol.memimg = &img;
+	data.raw = e->opts;
+
+	newroot = drv->vopen(vol, e->flags, data,
+			     UK_FS_VOPEN_VOL_MEMIMG | UK_FS_VOPEN_DATA_RAW);
+	if (unlikely(PTRISERR(newroot)))
+		return PTR2ERR(newroot);
+
+	r = uk_posix_vfs_mount(e->path, newroot);
+	uk_file_release(newroot);
+	return r;
+}
+
+static
 int fstab_mount(const struct vfs_fstab_entry *e,
 		const struct ukplat_memregion_desc *initrd0)
 {
@@ -178,12 +214,11 @@ int fstab_mount(const struct vfs_fstab_entry *e,
 			uk_pr_crit("Could not find an initrd!\n");
 			return -ENOENT;
 		}
-		r = uk_sys_mount((const void *)initrd0->vbase, e->path,
-				 e->fstype, e->flags, e->opts);
+		r = fstab_mount_initrd(e, (const void *)initrd0->vbase,
+				       initrd0->len);
 #if CONFIG_LIBPOSIX_VFS_FSTAB_EINITRD
 	} else if (!strcmp(e->dev, FSTAB_DEV_EINITRD)) {
-		r = uk_sys_mount((const void *)vfs_einitrd_start, e->path,
-				 e->fstype, e->flags, e->opts);
+		r = fstab_mount_initrd(e, vfs_einitrd_start, VFS_EINITRD_LEN);
 #endif /* CONFIG_LIBPOSIX_VFS_FSTAB_EINITRD */
 	} else {
 		r = uk_sys_mount(e->dev, e->path, e->fstype, e->flags, e->opts);

--- a/lib/posix-vfs/exportsyms.uk
+++ b/lib/posix-vfs/exportsyms.uk
@@ -1,3 +1,6 @@
+# uk_posix_vfs_* API
+uk_posix_vfs_mount
+
 # uk_sys_* API
 # FS-wide ops
 uk_sys_sync

--- a/lib/posix-vfs/include/uk/posix-vfs.h
+++ b/lib/posix-vfs/include/uk/posix-vfs.h
@@ -18,6 +18,15 @@
 #include <uk/posix-fd.h>
 
 /*
+ * Unikraft API (not directly mappable to syscalls)
+ */
+
+/**
+ * Mount `node` on `path`.
+ */
+int uk_posix_vfs_mount(const char *path, const struct uk_file *node);
+
+/*
  * Internal syscalls
  */
 

--- a/lib/posix-vfs/vfs.c
+++ b/lib/posix-vfs/vfs.c
@@ -1648,13 +1648,18 @@ int uk_sys_mount(const char *source, const char *targetpath, const char *fstype,
 		newmnt = uk_fs_rebind(src, flags, data);
 		uk_file_release(src);
 	} else {
-		uk_fs_vopen_func vopen = uk_fs_driver(fstype);
+		const struct uk_fs_drv *drv = uk_fs_driver(fstype);
+		union uk_fs_vopen_vol vvol;
+		union uk_fs_vopen_data vdata;
 
-		if (unlikely(!vopen)) {
+		if (unlikely(!drv)) {
 			ret = -ENODEV;
 			goto out_targ_p;
 		}
-		newmnt = vopen(source, flags, data);
+		vvol.raw = source;
+		vdata.raw = data;
+		newmnt = drv->vopen(vvol, flags, vdata,
+				    UK_FS_VOPEN_VOL_RAW | UK_FS_VOPEN_DATA_RAW);
 	}
 	if (unlikely(PTRISERR(newmnt))) {
 		ret = PTR2ERR(newmnt);

--- a/lib/posix-vfs/vfs.c
+++ b/lib/posix-vfs/vfs.c
@@ -1574,14 +1574,153 @@ out_src:
 }
 
 /* Mounting */
+
+int uk_posix_vfs_mount(const char *path, const struct uk_file *newroot)
+{
+	const struct uk_file *target;
+	const struct uk_file *parent = NULL;
+	const struct vfs_mtab_entry *parent_ent;
+	struct uk_fs_poslen p;
+	int ret;
+
+	/* Find mount target */
+	p = uk_fs_path_len_trail(path, 0);
+	target = vfs_lookup(NULL, path, p.len, 0);
+	if (unlikely(PTRISERR(target)))
+		return PTR2ERR(target);
+
+	if (!uk_fs_isdir(target)) {
+		/* Need to look up parent */
+		parent = vfs_lookup(NULL, path, p.pos, 0);
+		if (unlikely(PTRISERR(parent))) {
+			uk_file_release(target);
+			return PTR2ERR(parent);
+		}
+	}
+
+	/* uk_fs_mount */
+	uk_mutex_lock(&mtab.lock);
+	if (unlikely(mtab.top == CONFIG_LIBPOSIX_VFS_MAX_MOUNTS)) {
+		ret = -EMFILE;
+		goto out_unlock;
+	}
+	/* This takes a ref on newroot */
+	ret = uk_fs_mountat(target, &newroot);
+	if (unlikely(ret))
+		goto out_unlock;
+	if (uk_fs_isdir(newroot)) {
+		/* This takes a ref on target */
+		ret = uk_fs_graft(newroot, target);
+		if (unlikely(ret)) {
+			/* Undo the previous mount & drop ref */
+			const struct uk_file *prev = NULL;
+			int r __maybe_unused;
+
+			r = uk_fs_mountat(target, &prev);
+			UK_ASSERT(!r); /* This should never fail */
+			UK_ASSERT(prev == newroot);
+			uk_file_release(prev);
+			goto out_unlock;
+		}
+	}
+	/* Mount is now live in VFS, cannot fail past this point */
+	parent_ent = vfs_parent_mount(parent ? parent : target);
+	mtab.tab[mtab.top].point = target; /* Uses reference from graft */
+	mtab.tab[mtab.top].root = newroot; /* Uses reference from mount */
+	mtab.tab[mtab.top].parent_root = parent_ent ? parent_ent->root : NULL;
+	mtab.top++;
+	ret = 0;
+out_unlock:
+	uk_mutex_unlock(&mtab.lock);
+
+	if (parent)
+		uk_file_release(parent);
+	uk_file_release(target);
+	return ret;
+}
+
+static
+const struct uk_file *vfs_vopen(const char *source, const char *fstype,
+				unsigned long flags, void *data)
+{
+	const struct uk_fs_drv *drv = uk_fs_driver(fstype);
+	union uk_fs_vopen_vol vol = UK_FS_VOPEN_NULLVOL;
+	union uk_fs_vopen_data vdata = UK_FS_VOPEN_NULLDATA;
+	size_t fmt = UK_FS_VOPEN_VOL_IGNORE | UK_FS_VOPEN_DATA_IGNORE;
+	const struct uk_file *f;
+	int err = 0;
+
+	if (unlikely(!drv))
+		return ERR2PTR(-ENODEV);
+
+	/* Process source, if required */
+	if ((drv->formats & UK_FS_VOPEN_VOL_MASK) == UK_FS_VOPEN_VOL_IGNORE)
+		goto vol_done; /* Don't bother */
+	if ((drv->formats & UK_FS_VOPEN_VOL_FILE) &&
+	    source && source[0] == '/') {
+		/* source is absolute path; try to open */
+		f = vfs_lookup(NULL, source, strlen(source), 0);
+		if (!PTRISERR(f)) {
+			vol.file = f;
+			fmt |= UK_FS_VOPEN_VOL_FILE;
+			goto vol_done;
+		}
+		/* On failure remember error & try other options */
+		err = PTR2ERR(f);
+	}
+	if (drv->formats & UK_FS_VOPEN_VOL_RAW) {
+		vol.raw = source;
+		fmt |= UK_FS_VOPEN_VOL_RAW;
+		goto vol_done;
+	}
+	if (err)
+		return ERR2PTR(err);
+	else
+		return ERR2PTR(-EINVAL); /* Unsupported source expected */
+vol_done:
+	err = 0;
+
+	/* Process data, if required */
+	if ((drv->formats & UK_FS_VOPEN_DATA_MASK) == UK_FS_VOPEN_DATA_IGNORE)
+		goto data_done; /* Don't bother */
+	if ((drv->formats & UK_FS_VOPEN_DATA_FILE) &&
+	    data && ((const char *)data)[0] == '/') {
+		/* data is absolute path; try to open */
+		f = vfs_lookup(NULL, data, strlen(data), 0);
+		if (!PTRISERR(f)) {
+			vdata.file = f;
+			fmt |= UK_FS_VOPEN_DATA_FILE;
+			goto data_done;
+		}
+		/* On failure try to pass verbatim */
+		err = PTR2ERR(f);
+	}
+	if (drv->formats & UK_FS_VOPEN_DATA_RAW) {
+		vdata.raw = data;
+		fmt |= UK_FS_VOPEN_DATA_RAW;
+		goto data_done;
+	}
+	if (err) {
+		f = ERR2PTR(err);
+		goto out_vol;
+	}
+data_done:
+
+	/* Call vopen, drop refs & output */
+	f = drv->vopen(vol, flags, vdata, fmt);
+
+	if (fmt & UK_FS_VOPEN_DATA_FILE)
+		uk_file_release(vdata.file);
+out_vol:
+	if (fmt & UK_FS_VOPEN_VOL_FILE)
+		uk_file_release(vol.file);
+	return f;
+}
+
 int uk_sys_mount(const char *source, const char *targetpath, const char *fstype,
 		 unsigned long flags, void *data)
 {
-	const struct uk_file *target;
-	const struct uk_file *target_p;
-	const struct uk_file *newmnt;
-	const struct vfs_mtab_entry *parent_ent;
-	struct uk_fs_poslen p;
+	const struct uk_file *newroot;
 	int ret;
 
 	if (unlikely(flags & MS_REMOUNT)) {
@@ -1592,88 +1731,25 @@ int uk_sys_mount(const char *source, const char *targetpath, const char *fstype,
 		uk_pr_err("MS_MOVE not supported\n");
 		return -ENOSYS;
 	}
-
 	/* TODO: require privileges for (un)mounting */
-
-	/* Find mount target */
-	p = uk_fs_path_len_trail(targetpath, 0);
-	target = vfs_lookupat(vfs_atroot(NULL, targetpath, p.len),
-			      targetpath, p.len, 0);
-	if (unlikely(PTRISERR(target)))
-		return PTR2ERR(target);
-
-	/* Find mount point parent */
-	if (uk_fs_isdir(target)) {
-		uk_file_acquire(target);
-		target_p = target;
-	} else {
-		target_p = vfs_lookupat(vfs_atroot(NULL, targetpath, p.pos),
-					targetpath, p.pos, 0);
-		if (unlikely(PTRISERR(target_p))) {
-			ret = PTR2ERR(target_p);
-			goto out_targ;
-		}
-	}
 
 	if (flags & MS_BIND) {
 		const struct uk_file *src;
-		size_t srclen;
 
-		srclen = strlen(source);
-		src = vfs_lookupat(vfs_atroot(NULL, source, srclen),
-				   source, srclen, 0);
+		src = vfs_lookup(NULL, source, strlen(source), 0);
 
-		if (unlikely(PTRISERR(src))) {
-			ret = PTR2ERR(src);
-			goto out_targ_p;
-		}
-		newmnt = uk_fs_rebind(src, flags, data);
+		if (unlikely(PTRISERR(src)))
+			return PTR2ERR(src);
+		newroot = uk_fs_rebind(src, flags, data);
 		uk_file_release(src);
 	} else {
-		const struct uk_fs_drv *drv = uk_fs_driver(fstype);
-		union uk_fs_vopen_vol vvol;
-		union uk_fs_vopen_data vdata;
+		newroot = vfs_vopen(source, fstype, flags, data);
+	}
+	if (unlikely(PTRISERR(newroot)))
+		return PTR2ERR(newroot);
 
-		if (unlikely(!drv)) {
-			ret = -ENODEV;
-			goto out_targ_p;
-		}
-		vvol.raw = source;
-		vdata.raw = data;
-		newmnt = drv->vopen(vvol, flags, vdata,
-				    UK_FS_VOPEN_VOL_RAW | UK_FS_VOPEN_DATA_RAW);
-	}
-	if (unlikely(PTRISERR(newmnt))) {
-		ret = PTR2ERR(newmnt);
-		goto out_targ_p;
-	}
-	/* uk_fs_mount */
-	uk_mutex_lock(&mtab.lock);
-	if (unlikely(mtab.top == CONFIG_LIBPOSIX_VFS_MAX_MOUNTS)) {
-		ret = -EMFILE;
-		goto out_unlock;
-	}
-	if (uk_fs_isdir(newmnt)) {
-		ret = uk_fs_graft(newmnt, target);
-		if (unlikely(ret))
-			goto out_unlock;
-	}
-	ret = uk_fs_mountat(target, &newmnt);
-	if (unlikely(ret))
-		goto out_unlock;
-	/* Mount is now live in VFS, cannot fail past this point */
-	parent_ent = vfs_parent_mount(target_p);
-	mtab.tab[mtab.top].point = target;
-	mtab.tab[mtab.top].root = newmnt;
-	mtab.tab[mtab.top].parent_root = parent_ent ? parent_ent->root : NULL;
-	mtab.top++;
-out_unlock:
-	uk_mutex_unlock(&mtab.lock);
-	uk_file_release(newmnt);
-out_targ_p:
-	uk_file_release(target_p);
-out_targ:
-	uk_file_release(target);
+	ret = uk_posix_vfs_mount(targetpath, newroot);
+	uk_file_release(newroot);
 	return ret;
 }
 

--- a/lib/posix-vfs/vfs.c
+++ b/lib/posix-vfs/vfs.c
@@ -521,6 +521,8 @@ const struct uk_file *_vfs_symfollow(const struct uk_file *sym,
 		return ERR2PTR(-ELOOP);
 
 	sympath = uk_fs_readlink(sym);
+	if (unlikely(PTRISERR(sympath.s)))
+		return ERR2PTR(PTR2ERR(sympath.s));
 	return _vfs_lookupat(vfs_atroot(parent, sympath.s, sympath.len),
 			     sympath.s, sympath.len, 0, lvl);
 }
@@ -546,6 +548,8 @@ const struct uk_file *_vfs_symfollow(const struct uk_file *sym,
 		return ERR2PTR(-ELOOP);
 
 	sympath = uk_fs_readlink(sym);
+	if (unlikely(PTRISERR(sympath.s)))
+		return ERR2PTR(PTR2ERR(sympath.s));
 	return _vfs_lookupat(vfs_atroot(parent, sympath.s, sympath.len),
 			     sympath.s, sympath.len, 0, nsyms);
 }
@@ -1210,6 +1214,10 @@ ssize_t uk_sys_readlinkat(const struct uk_file *f, const char *restrict path,
 
 	/* Symlinks uniquely don't have meaningful permissions to check */
 	linkpath = uk_fs_readlink(target);
+	if (unlikely(PTRISERR(linkpath.s))) {
+		ret = PTR2ERR(linkpath.s);
+		goto out;
+	}
 	ret = MIN(bufsz, linkpath.len);
 	memcpy(buf, linkpath.s, ret);
 out:
@@ -1818,6 +1826,10 @@ int vfs_lookupat_parent(const struct uk_file *atroot,
 		if (uk_fs_issym(target)) {
 			struct uk_fs_path p = uk_fs_readlink(target);
 
+			if (unlikely(PTRISERR(p.s))) {
+				ret = PTR2ERR(p.s);
+				break;
+			}
 			f = dir;
 			path = p.s;
 			pathlen = p.len;

--- a/lib/posix-vfs/vfs.c
+++ b/lib/posix-vfs/vfs.c
@@ -725,6 +725,15 @@ const struct uk_file *vfs_lookupat(const struct uk_file *atroot,
 #endif /* CONFIG_LIBPOSIX_VFS_SYMLIMIT_DEPTH */
 }
 
+/* Convenience for the common call vfs_lookupat(vfs_atroot(...), ...) */
+static inline
+const struct uk_file *vfs_lookup(const struct uk_file *start,
+				 const char *path, size_t len,
+				 unsigned int flags)
+{
+	return vfs_lookupat(vfs_atroot(start, path, len), path, len, flags);
+}
+
 #if CONFIG_LIBPOSIX_VFS_PERMISSIONS
 
 #define VFS_MODEMASK (UK_STATX_TYPE | UK_STATX_MODE | \
@@ -856,15 +865,12 @@ void uk_sys_sync(void)
 int uk_sys_statfs(const char *path, struct statfs *buf)
 {
 	const struct uk_file *target;
-	size_t pathlen;
 	int r;
 
 	if (unlikely(!path))
 		return -EFAULT;
 
-	pathlen = strlen(path);
-	target = vfs_lookupat(vfs_atroot(NULL, path, pathlen),
-			      path, pathlen, 0);
+	target = vfs_lookup(NULL, path, strlen(path), 0);
 	if (unlikely(PTRISERR(target)))
 		return PTR2ERR(target);
 
@@ -938,15 +944,12 @@ int uk_sys_chroot(const char *path)
 {
 	const struct uk_file *newroot;
 	const struct uk_file *prev;
-	size_t pathlen;
 	int err;
 
 	if (unlikely(!path))
 		return -EFAULT;
 
-	pathlen = strlen(path);
-	newroot = vfs_lookupat(vfs_atroot(NULL, path, pathlen),
-			       path, pathlen, 0);
+	newroot = vfs_lookup(NULL, path, strlen(path), 0);
 	if (unlikely(PTRISERR(newroot)))
 		return PTR2ERR(newroot);
 
@@ -979,15 +982,12 @@ int uk_sys_faccessat(const struct uk_file *f, const char *path,
 	const int lflags = (flags & AT_SYMLINK_NOFOLLOW) ?
 			   VFS_LOOKUP_NOFOLLOW : 0;
 	const struct uk_file *target;
-	size_t pathlen;
 	int ret;
 
 	if (unlikely((ret = vfs_check_path(path, 0))))
 		return ret;
 
-	pathlen = strlen(path);
-	target = vfs_lookupat(vfs_atroot(f, path, pathlen),
-			      path, pathlen, lflags);
+	target = vfs_lookup(f, path, strlen(path), lflags);
 	if (unlikely(PTRISERR(target)))
 		return PTR2ERR(target);
 	ret = (mode == F_OK) ? 0 : vfs_check_perms(target, mode);
@@ -1002,7 +1002,6 @@ int uk_sys_statx(const struct uk_file *f, const char *restrict path, int flags,
 			   VFS_LOOKUP_NOFOLLOW : 0;
 	const struct uk_file *target;
 	struct uk_ofile of;
-	size_t pathlen;
 	int ret;
 
 	if (unlikely(!statxbuf))
@@ -1010,9 +1009,7 @@ int uk_sys_statx(const struct uk_file *f, const char *restrict path, int flags,
 	if (unlikely((ret = vfs_check_path(path, flags))))
 		return ret;
 
-	pathlen = strlen(path);
-	target = vfs_lookupat(vfs_atroot(f, path, pathlen),
-			      path, pathlen, lflags);
+	target = vfs_lookup(f, path, strlen(path), lflags);
 	if (unlikely(PTRISERR(target)))
 		return PTR2ERR(target);
 
@@ -1046,7 +1043,6 @@ int uk_sys_fchownat(const struct uk_file *f, const char *path,
 			   VFS_LOOKUP_NOFOLLOW : 0;
 	const struct uk_file *target;
 	struct uk_ofile of;
-	size_t pathlen;
 	int ret;
 
 	if (unlikely(flags & ~(AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW)))
@@ -1054,9 +1050,7 @@ int uk_sys_fchownat(const struct uk_file *f, const char *path,
 	if (unlikely((ret = vfs_check_path(path, flags))))
 		return ret;
 
-	pathlen = strlen(path);
-	target = vfs_lookupat(vfs_atroot(f, path, pathlen),
-			      path, pathlen, lflags);
+	target = vfs_lookup(f, path, strlen(path), lflags);
 	if (unlikely(PTRISERR(target)))
 		return PTR2ERR(target);
 
@@ -1074,15 +1068,12 @@ int uk_sys_fchmodat(const struct uk_file *f, const char *path,
 			   VFS_LOOKUP_NOFOLLOW : 0;
 	const struct uk_file *target;
 	struct uk_ofile of;
-	size_t pathlen;
 	int ret;
 
 	if (unlikely((ret = vfs_check_path(path, 0))))
 		return ret;
 
-	pathlen = strlen(path);
-	target = vfs_lookupat(vfs_atroot(f, path, pathlen),
-			      path, pathlen, lflags);
+	target = vfs_lookup(f, path, strlen(path), lflags);
 	if (unlikely(PTRISERR(target)))
 		return PTR2ERR(target);
 
@@ -1098,14 +1089,12 @@ int uk_sys_futimesat(const struct uk_file *f, const char *path,
 {
 	const struct uk_file *target;
 	struct uk_ofile of;
-	size_t pathlen;
 	int ret;
 
 	if (unlikely((ret = vfs_check_path(path, 0))))
 		return ret;
 
-	pathlen = strlen(path);
-	target = vfs_lookupat(vfs_atroot(f, path, pathlen), path, pathlen, 0);
+	target = vfs_lookup(f, path, strlen(path), 0);
 	if (unlikely(PTRISERR(target)))
 		return PTR2ERR(target);
 	if (!times) {
@@ -1142,15 +1131,12 @@ int uk_sys_utimensat(const struct uk_file *f, const char *path,
 			   VFS_LOOKUP_NOFOLLOW : 0;
 	const struct uk_file *target;
 	struct uk_ofile of;
-	size_t pathlen;
 	int ret;
 
 	if (unlikely((ret = vfs_check_path(path, 0))))
 		return ret;
 
-	pathlen = strlen(path);
-	target = vfs_lookupat(vfs_atroot(f, path, pathlen),
-			      path, pathlen, lflags);
+	target = vfs_lookup(f, path, strlen(path), lflags);
 	if (unlikely(PTRISERR(target)))
 		return PTR2ERR(target);
 	if (!times ||
@@ -1194,7 +1180,6 @@ ssize_t uk_sys_readlinkat(const struct uk_file *f, const char *restrict path,
 {
 	const struct uk_file *target;
 	struct uk_fs_path linkpath;
-	size_t pathlen;
 	ssize_t ret;
 
 	if (unlikely(!buf))
@@ -1202,9 +1187,7 @@ ssize_t uk_sys_readlinkat(const struct uk_file *f, const char *restrict path,
 	if (unlikely((ret = vfs_check_path(path, 0))))
 		return ret;
 
-	pathlen = strlen(path);
-	target = vfs_lookupat(vfs_atroot(f, path, pathlen),
-			      path, pathlen, VFS_LOOKUP_NOFOLLOW);
+	target = vfs_lookup(f, path, strlen(path), VFS_LOOKUP_NOFOLLOW);
 	if (unlikely(PTRISERR(target)))
 		return PTR2ERR(target);
 	if (unlikely(!uk_fs_issym(target))) {
@@ -1230,12 +1213,9 @@ int uk_sys_truncate(const char *path, off_t len)
 {
 	const struct uk_file *target;
 	struct uk_ofile of;
-	size_t pathlen;
 	int ret;
 
-	pathlen = strlen(path);
-	target = vfs_lookupat(vfs_atroot(NULL, path, pathlen),
-			      path, pathlen, 0);
+	target = vfs_lookup(NULL, path, strlen(path), 0);
 	if (unlikely(PTRISERR(target)))
 		return PTR2ERR(target);
 
@@ -1264,7 +1244,7 @@ int uk_sys_mkdirat(const struct uk_file *f, const char *path, mode_t mode)
 	/* Lookup parent of path */
 	/* ignore trailing slashes (uniquely among *dir syscalls) */
 	p = uk_fs_path_len_trail(path, 1);
-	dir = vfs_lookupat(vfs_atroot(f, path, p.len), path, p.pos, 0);
+	dir = vfs_lookup(f, path, p.pos, 0);
 	if (unlikely(PTRISERR(dir)))
 		return PTR2ERR(dir);
 
@@ -1302,7 +1282,6 @@ int uk_sys_linkat(const struct uk_file *olddir, const char *oldpath,
 	union uk_fs_create_target target;
 	const struct uk_file *dest;
 	const struct uk_file *newlink;
-	size_t oldpathlen;
 	struct uk_fs_poslen np;
 	int ret;
 
@@ -1313,17 +1292,14 @@ int uk_sys_linkat(const struct uk_file *olddir, const char *oldpath,
 	if (unlikely((ret = vfs_check_path(oldpath, flags))))
 		return ret;
 
-	oldpathlen = strlen(oldpath);
-	target.file = vfs_lookupat(vfs_atroot(olddir, oldpath, oldpathlen),
-				   oldpath, oldpathlen,
-				   (flags & AT_SYMLINK_FOLLOW) ?
-				   0 : VFS_LOOKUP_NOFOLLOW);
+	target.file = vfs_lookup(olddir, oldpath, strlen(oldpath),
+				 (flags & AT_SYMLINK_FOLLOW) ?
+				 0 : VFS_LOOKUP_NOFOLLOW);
 	if (unlikely(PTRISERR(target.file)))
 		return PTR2ERR(target.file);
 
 	np = uk_fs_path_len_trail(newpath, 0);
-	dest = vfs_lookupat(vfs_atroot(newdir, newpath, np.pos),
-			    newpath, np.pos, 0);
+	dest = vfs_lookup(newdir, newpath, np.pos, 0);
 	if (unlikely(PTRISERR(dest))) {
 		ret = PTR2ERR(dest);
 		goto out_targ;
@@ -1369,7 +1345,7 @@ int uk_sys_symlinkat(const char *targetpath, const struct uk_file *f,
 		return ret;
 
 	p = uk_fs_path_len_trail(linkpath, 0);
-	dir = vfs_lookupat(vfs_atroot(f, linkpath, p.pos), linkpath, p.pos, 0);
+	dir = vfs_lookup(f, linkpath, p.pos, 0);
 	if (unlikely(PTRISERR(dir)))
 		return PTR2ERR(dir);
 
@@ -1427,7 +1403,7 @@ int uk_sys_mknodat(const struct uk_file *f, const char *path,
 		}
 
 	p = uk_fs_path_len_trail(path, 0);
-	dir = vfs_lookupat(vfs_atroot(f, path, p.pos), path, p.pos, 0);
+	dir = vfs_lookup(f, path, p.pos, 0);
 	if (unlikely(PTRISERR(dir)))
 		return PTR2ERR(dir);
 
@@ -1483,7 +1459,7 @@ int uk_sys_unlinkat(const struct uk_file *f, const char *path, int flags)
 
 	/* Get parent of path; rmdir ignores trailing slashes in path */
 	p = uk_fs_path_len_trail(path, !!(flags & AT_REMOVEDIR));
-	dir = vfs_lookupat(vfs_atroot(f, path, p.pos), path, p.pos, 0);
+	dir = vfs_lookup(f, path, p.pos, 0);
 	if (unlikely(PTRISERR(dir)))
 		return PTR2ERR(dir);
 
@@ -1557,8 +1533,7 @@ int uk_sys_renameat(const struct uk_file *olddir, const char *oldpath,
 		return ret;
 
 	op = uk_fs_path_len_trail(oldpath, 1);
-	sdir = vfs_lookupat(vfs_atroot(olddir, oldpath, op.pos),
-			    oldpath, op.pos, 0);
+	sdir = vfs_lookup(olddir, oldpath, op.pos, 0);
 	if (unlikely(PTRISERR(sdir)))
 		return PTR2ERR(sdir);
 	if (unlikely(!uk_fs_isdir(sdir))) {
@@ -1567,8 +1542,7 @@ int uk_sys_renameat(const struct uk_file *olddir, const char *oldpath,
 	}
 
 	np = uk_fs_path_len_trail(newpath, 0);
-	ddir = vfs_lookupat(vfs_atroot(newdir, newpath, np.pos),
-			    newpath, np.pos, 0);
+	ddir = vfs_lookup(newdir, newpath, np.pos, 0);
 	if (unlikely(PTRISERR(ddir))) {
 		ret = PTR2ERR(ddir);
 		goto out_src;
@@ -1706,16 +1680,13 @@ out_targ:
 int uk_sys_umount(const char *targetpath, int flags __unused)
 {
 	const struct uk_file *target;
-	size_t pathlen;
 	size_t mntidx;
 	int ret;
 	int inval __maybe_unused = 0;
 
 	/* TODO: require privileges for (un)mounting */
 
-	pathlen = strlen(targetpath);
-	target = vfs_lookupat(vfs_atroot(NULL, targetpath, pathlen),
-			      targetpath, pathlen, 0);
+	target = vfs_lookup(NULL, targetpath, strlen(targetpath), 0);
 	if (unlikely(PTRISERR(target)))
 		return PTR2ERR(target);
 

--- a/lib/ukfs-devfs/devfs.c
+++ b/lib/ukfs-devfs/devfs.c
@@ -9,4 +9,6 @@
 
 const struct uk_file *uk_fs_devfs_root;
 
-UK_FS_TMPL_PSEUDO(devfs, "ramfs", uk_fs_devfs_root, NULL, 0, NULL);
+UK_FS_TMPL_PSEUDO(devfs, "ramfs", uk_fs_devfs_root,
+		  UK_FS_VOPEN_NULLVOL, 0, UK_FS_VOPEN_NULLDATA,
+		  UK_FS_VOPEN_VOL_IGNORE | UK_FS_VOPEN_DATA_IGNORE);

--- a/lib/ukfs-ramfs/ramfs.c
+++ b/lib/ukfs-ramfs/ramfs.c
@@ -518,9 +518,10 @@ UK_FS_TMPL_LIVE_TYPES(ramfs, struct ramfs_node *);
 UK_FS_TMPL_LIVE_OPS(ramfs, struct ramfs_node *);
 
 static
-struct ramfs_node *ramfs_live_vopen(const void *vol __unused,
+struct ramfs_node *ramfs_live_vopen(union uk_fs_vopen_vol vol __unused,
 				    unsigned long flags __unused,
-				    const void *data __unused)
+				    union uk_fs_vopen_data data __unused,
+				    size_t fmt __unused)
 {
 	struct ramfs_node *rootnode;
 	int r;
@@ -1483,4 +1484,5 @@ static int ramfs_node_cmp(struct ramfs_node *a, struct ramfs_node *b)
 UK_FS_TMPL_LIVE_GENERATE_STATIC(ramfs, struct ramfs_node *, ramfs_node_cmp,
 				ramfs_liveops, 0);
 
-UK_FS_DRIVER_REGISTER(ramfs, UK_FS_TMPL_LIVE_OP_VOPEN(ramfs));
+UK_FS_DRIVER_REGISTER(ramfs, UK_FS_TMPL_LIVE_OP_VOPEN(ramfs),
+		      UK_FS_VOPEN_VOL_IGNORE | UK_FS_VOPEN_DATA_IGNORE);

--- a/lib/ukfs/drivers.c
+++ b/lib/ukfs/drivers.c
@@ -15,7 +15,7 @@ extern const struct uk_fs_drv uk_fs_driver_list_end[];
 #define UKFS_DRIVER_COUNT \
 	(uk_fs_driver_list_end - uk_fs_driver_list_start)
 
-uk_fs_vopen_func uk_fs_driver(const char *fstype)
+const struct uk_fs_drv *uk_fs_driver(const char *fstype)
 {
 	const struct uk_fs_drv *drv = uk_fs_driver_list_start;
 	size_t len = UKFS_DRIVER_COUNT;
@@ -26,7 +26,7 @@ uk_fs_vopen_func uk_fs_driver(const char *fstype)
 		int r = strcmp(fstype, drv[mid].fstype);
 
 		if (!r)
-			return drv[mid].vopen;
+			return &drv[mid];
 		if (r < 0) {
 			len = mid;
 		} else {

--- a/lib/ukfs/include/uk/fs.h
+++ b/lib/ukfs/include/uk/fs.h
@@ -388,7 +388,7 @@ typedef int (*uk_fs_mount_func)(const struct uk_file *f,
 
 /**
  * Create a new filesystem instance for the filesystem containing `f`, using
- * mount options specified in `flags` and/or `opts`, and return a reference to
+ * mount options specified in `flags` and/or `data`, and return a reference to
  * the same file as `f` on this new binding.
  *
  * Drivers not wishing to support mounting a volume multiple times, including

--- a/lib/ukfs/include/uk/fs.h
+++ b/lib/ukfs/include/uk/fs.h
@@ -178,7 +178,9 @@ struct uk_fs_path {
  * The returned string is guaranteed a lifetime at least as long as `f`.
  * This operation should avoid any memory allocation or copying.
  * Callers must treat returned memory as immutable.
- * This operation cannot fail.
+ *
+ * This operation cannot meaningfully fail beyond critial I/O errors, signaled
+ * by an error value in the string pointer.
  *
  * @param f Symlink to read
  *

--- a/lib/ukfs/include/uk/fs/driver.h
+++ b/lib/ukfs/include/uk/fs/driver.h
@@ -11,33 +11,69 @@
 
 #include <uk/fs.h>
 
+struct uk_fs_vopen_memimg {
+	const void *base;
+	size_t len;
+};
+
+union uk_fs_vopen_vol {
+	const void *raw;
+	const struct uk_file *file;
+	const struct uk_fs_vopen_memimg *memimg;
+};
+
+#define UK_FS_VOPEN_NULLVOL ((union uk_fs_vopen_vol){ .raw = NULL })
+
+union uk_fs_vopen_data {
+	const void *raw;
+	const struct uk_file *file;
+};
+
+#define UK_FS_VOPEN_NULLDATA ((union uk_fs_vopen_data){ .raw = NULL })
+
+/* Format bitmask for vopen is 16 bits; type is larger for API fwd compat */
+
+/* Lower byte describes `vol` */
+#define UK_FS_VOPEN_VOL_MASK	0x00ff
+#define UK_FS_VOPEN_VOL_IGNORE	0x0000
+#define UK_FS_VOPEN_VOL_RAW	0x0001
+#define UK_FS_VOPEN_VOL_FILE	0x0002
+#define UK_FS_VOPEN_VOL_MEMIMG	0x0004
+
+/* Upper byte describes `data` */
+#define UK_FS_VOPEN_DATA_MASK	0xff00
+#define UK_FS_VOPEN_DATA_IGNORE	0x0000
+#define UK_FS_VOPEN_DATA_RAW	0x0100
+#define UK_FS_VOPEN_DATA_FILE	0x0200
+
+/* True iff argument is ignored or explicitly supports `feat` */
+static inline
+bool uk_fs_vopen_supports(size_t formats, size_t mask, size_t feat)
+{
+	return !(formats & mask) || (formats & feat);
+}
+
 /**
  * Open volume `vol` and return its root directory ready for use.
  *
  * This function is the entry point for a filesystem driver, and the only
  * operation that is not relative to a filesystem node.
  *
+ * At most one supported format flag for each of vol and data is set in `fmt`.
+ *
  * @param vol Driver-specific volume specifier
  * @param flags Bitmask of flags common to all filesystems
  * @param data Driver-specific additional options
+ * @param fmt Format flags
  *
  * @return
  *  !PTRISERR: Reference to the root directory of the filesystem.
  *   PTRISERR: Negative error code encoded in return
  */
-typedef const struct uk_file *(*uk_fs_vopen_func)(const void *vol,
+typedef const struct uk_file *(*uk_fs_vopen_func)(union uk_fs_vopen_vol vol,
 						  unsigned long flags,
-						  const void *data);
-
-/**
- * Retrieve the vopen function of the filesystem driver registered for the
- * filesystem named `fstype`.
- *
- * @return
- *  != NULL: vopen function of desired filesystem
- *  == NULL: Filesystem name `fstype` not recognized
- */
-uk_fs_vopen_func uk_fs_driver(const char *fstype);
+						  union uk_fs_vopen_data data,
+						  size_t fmt);
 
 /**
  * Entry for registering a filesystem driver with ukfs.
@@ -45,20 +81,32 @@ uk_fs_vopen_func uk_fs_driver(const char *fstype);
 struct uk_fs_drv {
 	const char *fstype; /* Filesystem name, used to look up driver */
 	uk_fs_vopen_func vopen; /* Vopen operation used to create fs mounts */
+	size_t formats; /* Supported formats of vopen arguments */
 };
+
+/**
+ * Retrieve the filesystem registration of the driver named `fstype`.
+ *
+ * @return
+ *  != NULL: Driver registration of desired filesystem
+ *  == NULL: Filesystem name `fstype` not recognized
+ */
+const struct uk_fs_drv *uk_fs_driver(const char *fstype);
 
 /**
  * Convenience macro to register a ukfs driver.
  *
  * @param fsname Filesystem name to register; do not enclose in quotes
  * @param drv_vopen vopen function of filesystem driver
+ * @param drv_formats Supported formats of vopen arguments
  */
-#define UK_FS_DRIVER_REGISTER(fsname, drv_vopen)		\
+#define UK_FS_DRIVER_REGISTER(fsname, drv_vopen, drv_formats)	\
 	__used __align(8)					\
 		__section("." STRINGIFY(uk_fs_driver_##fsname))	\
 	static const struct uk_fs_drv uk_fs_driver_##fsname = {	\
 		.fstype = STRINGIFY(fsname),			\
-		.vopen = (drv_vopen)				\
+		.vopen = (drv_vopen),				\
+		.formats = (drv_formats)			\
 	}
 
 #endif /* __UKFS_FS_DRIVER_H__ */

--- a/lib/ukfs/include/uk/fs/template/live.h
+++ b/lib/ukfs/include/uk/fs/template/live.h
@@ -91,8 +91,10 @@ union UK_FS_TMPL_LIVE_CREATE_TARGET(drv) {				\
  */
 #define UK_FS_TMPL_LIVE_OPS(drv, nodetype)				\
 /* Similar to ukfs vopen; return new root via nodetype */		\
-typedef nodetype (*drv##LIVEOP_VOPEN)(const void *vol, unsigned long flags,\
-				      const void *data);		\
+typedef nodetype (*drv##LIVEOP_VOPEN)(union uk_fs_vopen_vol vol,	\
+				      unsigned long flags,		\
+				      union uk_fs_vopen_data data,	\
+				      size_t fmt);			\
 \
 /* Standard ukfile operations */					\
 typedef ssize_t (*drv##LIVEOP_IO)(nodetype n, const struct iovec *iov,	\
@@ -1935,7 +1937,8 @@ attr const struct uk_fs_ops UK_FS_TMPL_LIVE_FSOPS_RODIR(drv) = {	\
  */
 #define UK_FS_TMPL_LIVE_DECL_VOPEN(drv)					\
 const struct uk_file *UK_FS_TMPL_LIVE_OP_VOPEN(drv)(			\
-	const void *vol, unsigned long flags, const void *data)
+	union uk_fs_vopen_vol vol, unsigned long flags,			\
+	union uk_fs_vopen_data data, size_t fmt)
 
 /**
  * Generate the ukfs vopen operation with regular linkage.
@@ -1986,7 +1989,7 @@ attr UK_FS_TMPL_LIVE_DECL_VOPEN(drv)					\
 	const struct uk_file *ret;					\
 	UK_FS_TMPL_LIVE_NODETYPE(drv) rootnode;				\
 									\
-	rootnode = (live_vopen)(vol, flags, data);			\
+	rootnode = (live_vopen)(vol, flags, data, fmt);			\
 	if (unlikely((err = (live_errnode)(rootnode))))			\
 		return ERR2PTR(err);					\
 									\

--- a/lib/ukfs/include/uk/fs/template/pseudo.h
+++ b/lib/ukfs/include/uk/fs/template/pseudo.h
@@ -41,17 +41,18 @@
  * @param bvol Volume argument for the initial backend
  * @param bflags Flags argument for the initial backend
  * @param bdata Data argument for the initial backend
+ * @param bfmt Format argument for the initial backend
  */
-#define UK_FS_TMPL_PSEUDO(drv, backend, rootptr, bvol, bflags, bdata)	\
+#define UK_FS_TMPL_PSEUDO(drv, backend, rootptr, bvol, bflags, bdata, bfmt)\
 static									\
 int init_##drv##_root(struct uk_init_ctx *ictx __unused)		\
 {									\
-	uk_fs_vopen_func vopen = uk_fs_driver((backend));		\
+	const struct uk_fs_drv *fsdrv = uk_fs_driver((backend));	\
 									\
-	if (unlikely(!vopen))						\
+	if (unlikely(!fsdrv))						\
 		return -ENOENT;						\
 									\
-	(rootptr) = vopen((bvol), (bflags), (bdata));			\
+	(rootptr) = fsdrv->vopen((bvol), (bflags), (bdata), (bfmt));	\
 	if (unlikely(PTRISERR((rootptr))))				\
 		return PTR2ERR((rootptr));				\
 	return 0;							\
@@ -67,13 +68,15 @@ uk_rootfs_initcall_prio(init_##drv##_root, term_##drv##_root,		\
 			UK_FS_PRIO_SECONDARY);				\
 \
 static									\
-const struct uk_file *drv##_VOPEN(const void *vol __unused,		\
+const struct uk_file *drv##_VOPEN(union uk_fs_vopen_vol vol __unused,	\
 				  unsigned long flags,			\
-				  const void *data __unused)		\
+				  union uk_fs_vopen_data data __unused,	\
+				  size_t fmt __unused)			\
 {									\
 	return uk_fs_rebind((rootptr), flags, NULL);			\
 }									\
 \
-UK_FS_DRIVER_REGISTER(drv, drv##_VOPEN)
+UK_FS_DRIVER_REGISTER(drv, drv##_VOPEN,					\
+		      UK_FS_VOPEN_VOL_IGNORE | UK_FS_VOPEN_DATA_IGNORE)
 
 #endif /* __UK_FS_TEMPLATE_PSEUDO_H__ */


### PR DESCRIPTION
### Description of changes

This changeset updates the ukfs API with two major breaking changes:
- `vopen()` signature changed, it now accepts typed arguments
- `readlink()` is allowed to fail

These changes percolate across the fs stack, and as a consequence:
- the ukfs driver API is updated with drivers needing to declare what types their `vopen()` accepts
- drivers that accept paths as arguments no longer need to "call up" into the VFS layer to open files
- drivers that accept multiple types no longer need to use heuristics to disambiguate
- `posix-vfs` is responsible for interpreting the arguments of `mount()` if the fs driver so requests
- `posix-vfs-fstab` can unambiguously pass blobs in RAM (e.g., initrds) directly to a fs driver

Two minor issues were also fixed in the pass:
- minor docstring inconsistency in `<uk/fs.h>`
- fstab now ignores mkdir failures for special mounts (the logic failed overly eagerly; if the directory _really_ isn't there, the mount will fail instead)

### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A