### PR TITLE
lib/ukrandom: Add CSPRNG reseed

### DIFF
--- a/lib/ukrandom/Config.uk
+++ b/lib/ukrandom/Config.uk
@@ -34,6 +34,21 @@ config LIBUKRANDOM_DTB_SEED
 		32-bit words. In that case any hardware RNG driver enabled
 		will be ignored.
 
+config LIBUKRANDOM_RESEED
+	bool "Periodic reseed"
+	depends on !LIBUKRANDOM_CMDLINE_SEED && !LIBUKRANDOM_DTB_SEED
+	default y
+	help
+		Periodically reseed the CSPRNG for forward secrecy.
+                Without reseeding, an attacker who obtains the internal
+		state of the RNG can derive past and future outputs.
+
+if LIBUKRANDOM_RESEED
+config LIBUKRANDOM_RESEED_INTERVAL
+	int "Reseed interval (sec)"
+	default 300
+endif
+
 config LIBUKRANDOM_GETRANDOM
 	bool "getrandom() system call"
 	depends on LIBSYSCALL_SHIM

--- a/lib/ukrandom/chacha.h
+++ b/lib/ukrandom/chacha.h
@@ -12,10 +12,17 @@
 #define CHACHA20_SEED_WORDS	8 /* 256-bit */
 #define CHACHA20_IV_WORDS	2 /* 16-bit */
 
+#define CHACHA_COUNTER_MAX  __U64_MAX
+
 struct chacha_ctx {
 	int k;
 	__u32 input[16], output[16];
 };
+
+static inline __u64 chacha_counter(struct chacha_ctx *ctx)
+{
+	return ((((__u64)ctx->input[13]) << 32) | ctx->input[12]);
+}
 
 /**
  * INTERNAL Initialize ChaCha

--- a/lib/ukrandom/exportsyms.uk
+++ b/lib/ukrandom/exportsyms.uk
@@ -1,3 +1,4 @@
 getrandom
 uk_random_fill_buffer
 uk_random_init
+uk_random_reseed

--- a/lib/ukrandom/include/uk/random.h
+++ b/lib/ukrandom/include/uk/random.h
@@ -49,6 +49,15 @@ extern "C" {
  */
 int __check_result uk_random_fill_buffer(void *buf, __sz buflen);
 
+/**
+ * Reseed the CSPRNG
+ *
+ * Request libukrandom to reseed the CSPRNG
+ *
+ * @return zero on success, negative value on error.
+ */
+int __check_result uk_random_reseed(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/ukrandom/random.c
+++ b/lib/ukrandom/random.c
@@ -130,5 +130,10 @@ int uk_random_early_init(struct ukplat_bootinfo __maybe_unused *bi)
 	return 0;
 }
 
+int __check_result uk_random_reseed(void)
+{
+	return uk_swrand_reseed();
+}
+
 UK_BOOT_EARLYTAB_ENTRY(uk_random_early_init, UK_PRIO_AFTER(2));
 #endif /* CONFIG_LIBUKRANDOM_DTB_SEED */

--- a/lib/ukrandom/random.c
+++ b/lib/ukrandom/random.c
@@ -43,9 +43,21 @@
 #include <uk/prio.h>
 #endif /* CONFIG_LIBUKRANDOM_DTB_SEED || CONFIG_LIBUKRANDOM_CMDLINE_SEED */
 
+#if CONFIG_LIBUKRANDOM_RESEED
+#include <uk/arch/time.h>
+#include <uk/errptr.h>
+#include <uk/prio.h>
+#include <uk/sched.h>
+#endif /* CONFIG_LIBUKRANDOM_RESEED */
+
 #include "swrand.h"
 
 struct uk_random_driver *driver;
+
+#if CONFIG_LIBUKRANDOM_RESEED
+static const
+__nsec reseed_interval = CONFIG_LIBUKRANDOM_RESEED_INTERVAL * UKARCH_NSEC_PER_SEC;
+#endif /* CONFIG_LIBUKRANDOM_RESEED */
 
 int __check_result uk_random_fill_buffer(void *buf, size_t buflen)
 {
@@ -98,13 +110,18 @@ int uk_random_init(struct uk_random_driver *drv)
 	return rc;
 }
 
+int __check_result uk_random_reseed(void)
+{
+	return uk_swrand_reseed();
+}
+
 #if CONFIG_LIBUKRANDOM_DTB_SEED || CONFIG_LIBUKRANDOM_CMDLINE_SEED
 /* Do not print a warning if the user did not pass a seed.
  * It may be the case that the application does not require
  * randomness, or that a hardware RNG will be initialized later
  * via init.
  *
- * For the same reasons, do not return an arror as that would cause
+ * For the same reasons, do not return an error as that would cause
  * init to trigger a fatal error. At the worst case the application
  * (or the kernel) will fail later, upon request for entropy.
  */
@@ -130,10 +147,36 @@ int uk_random_early_init(struct ukplat_bootinfo __maybe_unused *bi)
 	return 0;
 }
 
-int __check_result uk_random_reseed(void)
-{
-	return uk_swrand_reseed();
-}
-
 UK_BOOT_EARLYTAB_ENTRY(uk_random_early_init, UK_PRIO_AFTER(2));
 #endif /* CONFIG_LIBUKRANDOM_DTB_SEED */
+
+#if CONFIG_LIBUKRANDOM_RESEED
+static void __noreturn reseed_thread(void *arg __unused)
+{
+	int ret;
+
+	while (1) {
+		uk_sched_thread_sleep(reseed_interval);
+		uk_pr_debug("CSPRNG scheduled reseed\n");
+		ret = uk_random_reseed();
+		if (unlikely(ret))
+			UK_CRASH("Could not reseed the CSPRNG (%d)\n", ret);
+	}
+}
+
+static int reseed_thread_create(struct uk_init_ctx *ctx __unused)
+{
+	struct uk_thread *t;
+
+	t = uk_sched_thread_create(uk_sched_current(), reseed_thread,
+				   __NULL, "csprng_reseed");
+	if (unlikely(PTRISERR(t))) {
+		uk_pr_err("Could not create reseed thread (%d)\n", PTR2ERR(t));
+		return PTR2ERR(t);
+	}
+
+	return 0;
+}
+
+uk_lib_initcall_prio(reseed_thread_create, 0, UK_PRIO_LATEST);
+#endif /* CONFIG_LIBUKRANDOM_RESEED */

--- a/lib/ukrandom/swrand.c
+++ b/lib/ukrandom/swrand.c
@@ -129,12 +129,51 @@ int uk_swrand_init(struct uk_random_driver **drv)
 	return 0;
 }
 
+int __check_result uk_swrand_reseed(void)
+{
+	__u32 seedv[CHACHA20_SEED_WORDS];
+	int ret;
+
+	if (unlikely(!ctx.driver))
+		return -ENODEV;
+
+	if (unlikely(ctx.driver == (void *)UK_SWRAND_DRIVER_NONE)) {
+		uk_pr_err("Could not reseed, no driver\n");
+		return -ENODEV;
+	}
+
+	ret = (ctx.driver)->ops->seed_bytes_fb((__u8 *)seedv, sizeof(seedv));
+	if (unlikely(ret)) {
+		uk_pr_err("Could not reseed: Failed to collect entropy (%d)\n",
+			  ret);
+		return ret;
+	}
+
+	chacha_init(&ctx.chacha, seedv, iv, 0);
+
+	return 0;
+}
+
 int __check_result uk_swrand_randr(__u32 *val)
 {
+	int ret;
+
 	if (unlikely(!ctx.driver))
 		return -ENODEV;
 
 	uk_spin_lock(&ctx.lock);
+
+	/* Depending on the implementation of chacha_rand32()
+	 * this may skip the last block, which we favor over
+	 * increasing implementation complexity.
+	 */
+	if (chacha_counter(&ctx.chacha) == CHACHA_COUNTER_MAX) {
+		ret = uk_swrand_reseed();
+		if (unlikely(ret)) {
+			uk_spin_unlock(&ctx.lock);
+			return ret;
+		}
+	}
 
 	*val = chacha_rand32(&ctx.chacha);
 

--- a/lib/ukrandom/swrand.h
+++ b/lib/ukrandom/swrand.h
@@ -49,4 +49,7 @@ int uk_swrand_init(struct uk_random_driver **drv);
 /* Get a 32-bit random number */
 int __check_result uk_swrand_randr(__u32 *val);
 
+/* Reseed the CSPRNG */
+int uk_swrand_reseed(void);
+
 #endif /* __UK_RANDOM_SWRAND_H__ */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->
* `CONFIG_LIBUKRANDOM_RESEED`: Enable periodic reseed.
* `CONFIG_LIBUKRANDOM_RESEED_INTERVAL`: Reseed interval, defaults to 5min.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Introduce CSPRNG reseed. This adds `uk_random_reseed()` into the API, to allow external components to trigger a reseed in events like system resume. Update `chacha_rand32()` to reseed the CSPRNG once the counter reaches its max value. Introduce  new config options for scheduled reseed for forward secrecy. Without periodic reseed an attacker obtaining the internal state of the CSPRNG can derive past and future outputs.