### PR TITLE
lib/posix-process: Use exit_signal from clone()

### DIFF
--- a/lib/posix-process/clone.c
+++ b/lib/posix-process/clone.c
@@ -32,6 +32,7 @@
  */
 
 #include <errno.h>
+#include <signal.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -354,6 +355,11 @@ int uk_clone(struct clone_args *cl_args, size_t cl_args_len,
 			uk_pr_err("Could not create process (%d)\n", ret);
 			goto err_free_child;
 		}
+
+		if (cl_args->exit_signal)
+			child_process->exit_signal = cl_args->exit_signal;
+		else
+			child_process->exit_signal = SIGCHLD;
 #else /* CONFIG_LIBPOSIX_PROCESS_MULTIPROCESS */
 		ret = -ENOTSUP;
 		goto err_free_child;

--- a/lib/posix-process/exit.c
+++ b/lib/posix-process/exit.c
@@ -69,15 +69,21 @@ static void pprocess_reparent_children(struct posix_process *pprocess)
 static inline int signal_exit(struct posix_process *pprocess)
 {
 	struct kern_sigaction *ks;
+	__u64 exit_signal;
 
 	UK_ASSERT(pprocess);
 	UK_ASSERT(pprocess->signal);
 
-	ks = KERN_SIGACTION(pprocess, SIGCHLD);
+	if (pprocess->exit_signal)
+		exit_signal = pprocess->exit_signal;
+	else
+		exit_signal = SIGCHLD;
+
+	ks = KERN_SIGACTION(pprocess, exit_signal);
 	if (ks->ks_handler == SIG_IGN || ks->ks_flags & SA_NOCLDWAIT)
 		return 1;
 
-	return pprocess_signal_send(pprocess, SIGCHLD, NULL);
+	return pprocess_signal_send(pprocess, exit_signal, NULL);
 }
 #endif /* CONFIG_LIBPOSIX_PROCESS_SIGNAL */
 

--- a/lib/posix-process/process.h
+++ b/lib/posix-process/process.h
@@ -67,6 +67,7 @@ struct posix_process {
 	struct uk_semaphore wait_semaphore;
 	struct uk_semaphore exit_semaphore;
 	enum posix_process_state state;
+	__u64 exit_signal;
 	int exit_status;
 
 	/* TODO: Mutex */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [N/A]
 - Platform(s): [N/A]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The exit_signal parameter of clone() instructs the kernel to notify the parent with a signal other than SIGCHLD, when
the child returns. Add a new field into struct posix_process and update clone and exit as needed.

Depends-on: #1734 