### PR TITLE
lib/posix-process/signal: Rework syserror handling

### DIFF
--- a/lib/posix-process/signal/deliver.c
+++ b/lib/posix-process/signal/deliver.c
@@ -76,19 +76,6 @@ static void uk_sigact_cont(int __unused sig)
 	uk_pr_warn("SIG_CONT not supported\n");
 }
 
-bool pprocess_signal_is_deliverable(struct posix_thread *pthread, int signum)
-{
-	struct posix_process *proc;
-
-	UK_ASSERT(pthread);
-	UK_ASSERT(signum);
-
-	proc = tid2pprocess(pthread->tid);
-	UK_ASSERT(proc);
-
-	return (!IS_MASKED(pthread, signum) && !IS_IGNORED(proc, signum));
-}
-
 static void handle_self(struct uk_signal *sig, const struct kern_sigaction *ks,
 			struct ukarch_execenv *execenv)
 {
@@ -403,17 +390,6 @@ void sys_error_handler(struct ukarch_execenv *ee __unused, long arg)
 		UK_BUG(); /* noreturn */
 	}
 
-	/* If the application masks or ignores this signal, panic.
-	 * A general-purpose OS would terminate the application.
-	 * Being a unikernel, we treat this as a non-recoverable
-	 * error instead.
-	 */
-	if (!pprocess_signal_is_deliverable(pthread, error->signum))
-		goto err_panic;
-
-	if (KERN_SIGACTION(pproc, error->signum)->ks_handler == SIG_DFL)
-		goto err_panic;
-
 	/* Prepare siginfo */
 	set_siginfo_kill(error->signum, &sig.siginfo);
 
@@ -421,8 +397,4 @@ void sys_error_handler(struct ukarch_execenv *ee __unused, long arg)
 	do_deliver(pthread, &sig, ee);
 
 	return;
-
-err_panic:
-	/* FIXME: Cascading faulting */
-	UK_CRASH("Cannot deliver SIGSEGV for pf at 0x%lx\n", error->vaddr);
 }

--- a/lib/posix-process/signal/signal.h
+++ b/lib/posix-process/signal/signal.h
@@ -312,13 +312,6 @@ void pprocess_signal_arch_set_ucontext(struct ukarch_execenv *execenv,
 void pprocess_signal_arch_get_ucontext(ucontext_t *ucontext,
 				       struct ukarch_execenv *execenv);
 
-/* Checks whether a signal can be delivered to a given thread, depending
- * on the thread's mask, whether the process chooses to ingores this signal,
- * or whether the process uses a default disposition of ignore.
- *
- * Does NOT check permissions.
- */
-bool pprocess_signal_is_deliverable(struct posix_thread *pthread, int signum);
 
 #if CONFIG_LIBPOSIX_PROCESS_SIGNALFD
 /* Add a signal file to a process in order to track it */
@@ -359,12 +352,32 @@ void pthread_signal_files_notify(struct posix_process *pproc,
 }
 #endif /* CONFIG_LIBPOSIX_PROCESS_SIGNALFD */
 
+#if CONFIG_LIBPOSIX_PROCESS_SIGNAL
+/* Checks whether a signal can be delivered to a given thread, depending
+ * on the thread's mask, whether the process chooses to ingores this signal,
+ * or whether the process uses a default disposition of ignore.
+ *
+ * Does NOT check permissions.
+ */
+static inline
+bool pprocess_signal_is_deliverable(struct posix_thread *pthread, int signum)
+{
+	struct posix_process *proc;
+
+	UK_ASSERT(pthread);
+	UK_ASSERT(signum);
+
+	proc = tid2pprocess(pthread->tid);
+	UK_ASSERT(proc);
+
+	return (!IS_MASKED(pthread, signum) && !IS_IGNORED(proc, signum));
+}
+
+#if CONFIG_LIBPOSIX_PROCESS_SIGNALFD
 /*
  * Check if a signal should be dropped: it is ignored by the process and
  * there are no signal files that are monitoring for this signal.
  */
-#if CONFIG_LIBPOSIX_PROCESS_SIGNAL
-#if CONFIG_LIBPOSIX_PROCESS_SIGNALFD
 static inline
 bool pprocess_signal_should_drop(struct posix_process *pproc, int signum)
 {

--- a/lib/posix-process/signal/system_error.c
+++ b/lib/posix-process/signal/system_error.c
@@ -22,26 +22,36 @@ void sys_error_handler(struct ukarch_execenv *ee __unused, long arg);
 static
 int sys_error_handler_except(int signum, struct ukarch_trap_ctx *trap_ctx)
 {
-	__uptr auxsp, handler_sp, curr_sp;
+	__uptr auxsp, handler_sp;
 	struct sys_error_desc *handler_desc;
 	struct ukarch_auxspcb *auxspcb;
+	struct posix_thread *pthread;
+	struct posix_process *pproc;
 	struct ukarch_ctx ctx;
 
 	UK_ASSERT(trap_ctx);
 
-	auxsp = ukplat_lcpu_get_auxsp_in_except();
-	curr_sp = ukarch_regs_get_sp(trap_ctx->regs);
+	pthread = uk_pthread_current();
 
-	/* If there is no auxsp, the fault happened during boot before
-	 * an aux stack is set up. If, however, we are executing in auxsp
-	 * then we know fore sure we are in uk context (not application).
-	 */
-	if (!auxsp || SP_IN_AUXSP(curr_sp, auxsp))
+	/* If not in pprocess context, fall through */
+	if (!pthread)
+		return UK_EVENT_NOT_HANDLED;
+
+	pproc = uk_pprocess_current();
+	UK_ASSERT(pproc);
+
+	/* If the appliation does not trap the signal, fall through */
+	if (KERN_SIGACTION(pproc, signum)->ks_handler == SIG_DFL)
+		return UK_EVENT_NOT_HANDLED;
+
+	/* If the appliation ignores the signal, fall through */
+	if (!pprocess_signal_is_deliverable(pthread, signum))
 		return UK_EVENT_NOT_HANDLED;
 
 	/* Prepare execution stack. Use the aux stack, as it's
 	 * the stack handle_self() expects to be opreating on.
 	 */
+	auxsp = ukplat_lcpu_get_auxsp_in_except();
 	auxspcb = ukarch_auxsp_get_cb(auxsp);
 	handler_sp = ukarch_auxspcb_get_curr_fp(auxspcb);
 	handler_sp = ALIGN_DOWN(handler_sp - sizeof(*handler_desc),


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Rework handling of system errors so that the decision on whether to signal the application is taken before jumping to the interrupt safe context. This allows falling-through to the UNHANDLED_EXEPTION event handler, if the signal is not deliverable.

Notice that although the current implementation could be updated to call UK_CRASH_EX() with the application's context, falling-through to the default handler is the right approach as it allows applying a unified policy to unhandled system failures.