### PR TITLE
lib/posix-vfs-fstab: Run fstab init 2nd to last

### DIFF
--- a/lib/posix-vfs-fstab/fstab.c
+++ b/lib/posix-vfs-fstab/fstab.c
@@ -412,5 +412,5 @@ int init_vfs_fstab(struct uk_init_ctx *ictx __unused)
 	return 0;
 }
 
-/* The fstab runs latest in the rootfs init cycle */
-uk_rootfs_initcall(init_vfs_fstab, 0);
+/* The fstab runs second-to-last in the rootfs init cycle */
+uk_rootfs_initcall_prio(init_vfs_fstab, 0, UK_PRIO_BEFORE(UK_PRIO_LATEST));


### PR DESCRIPTION
### Description of changes

This change moves the fstab init one step of priority earlier, allowing other libraries a prio slot to finish setting up the rootfs post-fstab.



### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A