### PR TITLE
drivers/pci/arm64: Fix virtio-pci reset hang

### DIFF
--- a/drivers/ukbus/pci/arch/arm64/pci_bus.c
+++ b/drivers/ukbus/pci/arch/arm64/pci_bus.c
@@ -61,7 +61,7 @@
 #include "../../pci_ecam.h"
 
 #define DEVFN(dev, fn)   ((dev << PCI_FN_BIT_NBR) | fn)
-#define SIZE_PER_PCI_DEV 0x20	/* legacy pci device size, no msi */
+#define SIZE_PER_PCI_DEV 0x1000	/* legacy pci device size, no msi */
 
 static int arch_pci_driver_add_device(struct pci_driver *drv,
 					struct pci_address *addr,
@@ -176,7 +176,7 @@ int arch_pci_probe(struct uk_alloc *pha)
 			} else {
 				base = pcw.pci_device_base + (bus << 5 | dev)*SIZE_PER_PCI_DEV;
 				pci_generic_config_write(bus, DEVFN(dev, 0), PCI_COMMAND, 2, PCI_COMMAND_INTX_DISABLE);
-				pci_generic_config_write(bus, DEVFN(dev, 0), PCI_BASE_ADDRESS_0, 4, (bus << 5 | dev)*SIZE_PER_PCI_DEV);
+				pci_generic_config_write(bus, DEVFN(dev, 0), PCI_BASE_ADDRESS_0, 4, ((bus << 5 | dev)*SIZE_PER_PCI_DEV)) & ~0xF;
 				pci_generic_config_write(bus, DEVFN(dev, 0), PCI_COMMAND, 2, PCI_COMMAND_MASTER | PCI_COMMAND_IO);
 			}
 


### PR DESCRIPTION
Fixes issue #1622 https://github.com/unikraft/unikraft/issues/1622

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ X] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [X ] Tested your changes against relevant architectures and platforms;
 - [ X] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [X] Updated relevant documentation.


### Base target

 - Architecture(s): [arm64]
 - Platform(s): [qemu/kvm]
 - Application(s): [N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

Fixes a virtio-pci device initialization hang on ARM64 caused by
incorrect PCI BAR window sizing. The arm64 PCI implementation previously
allocated only a 32-byte MMIO window per device, hard coded through SIZE_PER_PCI_DEVICE = 0x20, while virtio-pci devices
require a 4KB BAR as reported via PCI configuration space.

The BAR size was confirmed using QEMU's `info pci` command, which showed
that each virtio-pci device reports a 4KB MMIO region. Because only
32 bytes were allocated, the second device was mapped into unmapped MMIO
space, causing all status reads to return 0xff and trapping the device in
an infinite reset loop during reset. The SIZE_PER_PCI_DEVICE has been updated to reflect the 4KB required and the BAR base address is now masked with `& ~0xF` for PCI-alignment

<!--
Please provide a detailed description of the changes made in this new PR.
-->
