### PR TITLE
lib/: Misc build and compiler warning fixes

### DIFF
--- a/arch/x86/ectx.c
+++ b/arch/x86/ectx.c
@@ -392,6 +392,7 @@ void ukarch_ectx_assert_equal(struct ukarch_ectx *state)
 			goto ectx_corrupted;
 		break;
 	case X86_SAVE_FXSAVE:
+	{
 		/* According to Intel SDM, XSAVE does not use bytes 511:416 */
 		struct x86_fxsave_ctx *fxsave1 = (struct x86_fxsave_ctx *)state;
 		struct x86_fxsave_ctx *fxsave2 =
@@ -401,8 +402,10 @@ void ukarch_ectx_assert_equal(struct ukarch_ectx *state)
 					sizeof(fxsave1->state))))
 			goto ectx_corrupted;
 		break;
+	}
 	case X86_SAVE_XSAVE:
 	case X86_SAVE_XSAVEOPT:
+	{
 		struct x86_xsave_ctx *xsave1 = (struct x86_xsave_ctx *)state;
 		struct x86_xsave_ctx *xsave2 = (struct x86_xsave_ctx *)current;
 
@@ -419,6 +422,7 @@ void ukarch_ectx_assert_equal(struct ukarch_ectx *state)
 					     X86_XSAVE_HDR_XSTATE_BV_AVXF)))
 			goto ectx_corrupted;
 		break;
+	}
 	default:
 		UK_CRASH("Unknown ectx method: %d\n", ectx_method);
 		return;

--- a/lib/nolibc/musl-imported/src/dirent/readdir.c
+++ b/lib/nolibc/musl-imported/src/dirent/readdir.c
@@ -1,9 +1,9 @@
+#define _GNU_SOURCE
+
 #include <dirent.h>
 #include <errno.h>
 #include <stddef.h>
 #include "__dirent.h"
-
-int uk_syscall_r_getdents64(int fd, void *buf, size_t len);
 
 typedef char dirstream_buf_alignment_check[1-2*(int)(
 	offsetof(struct __dirstream, buf) % sizeof(off_t))];
@@ -13,8 +13,8 @@ struct dirent *readdir(DIR *dir)
 	struct dirent *de;
 
 	if (dir->buf_pos >= dir->buf_end) {
-		int len = uk_syscall_r_getdents64(dir->fd, (void *)dir->buf,
-						  sizeof(dir->buf));
+		int len = getdents64(dir->fd, (void *)dir->buf,
+				     sizeof(dir->buf));
 		if (len <= 0) {
 			if (len < 0 && len != -ENOENT) errno = -len;
 			return 0;

--- a/lib/nolibc/musl-imported/src/unistd/getcwd.c
+++ b/lib/nolibc/musl-imported/src/unistd/getcwd.c
@@ -3,7 +3,12 @@
 #include <limits.h>
 #include <string.h>
 
-long uk_syscall_r_getcwd(char *buf, size_t sz);
+/* Includes for the internal `getcwd` syscall */
+#if CONFIG_LIBPOSIX_VFS
+#include <uk/posix-vfs.h>
+#else /* !CONFIG_LIBPOSIX_VFS */
+#error No suitable VFS stack enabled in config
+#endif /* !CONFIG_LIBPOSIX_VFS */
 
 char *getcwd(char *buf, size_t size)
 {
@@ -16,7 +21,7 @@ char *getcwd(char *buf, size_t size)
 		errno = EINVAL;
 		return 0;
 	}
-	long ret = uk_syscall_r_getcwd(p, size);
+	long ret = uk_sys_getcwd(p, size);
 	if (ret < 0)
 		return 0;
 	if (ret == 0 || p[0] != '/') {

--- a/lib/posix-netlink/Config.uk
+++ b/lib/posix-netlink/Config.uk
@@ -3,6 +3,7 @@ config LIBPOSIX_NETLINK
 	select LIBPOSIX_SOCKET
 	select LIBUKMPI
 	select LIBUKMPI_MBOX
+	select LIBUKSTREAMBUF
 	help
 		This microlibrary allows other microlibraries to register a
 		netlink protocol family, such as NETLINK_ROUTE, for their netlink

--- a/lib/posix-process/clone.c
+++ b/lib/posix-process/clone.c
@@ -124,7 +124,7 @@ int uk_clone(struct clone_args *cl_args, size_t cl_args_len,
 	     struct ukarch_execenv *execenv)
 {
 	struct posix_process_clone_event_data clone_event;
-	struct posix_process *child_process;
+	struct posix_process *child_process __maybe_unused;
 	struct posix_process *pprocess;
 	struct posix_thread *pthread;
 	struct uk_thread *child = NULL;

--- a/lib/posix-process/exit.c
+++ b/lib/posix-process/exit.c
@@ -271,7 +271,7 @@ UK_LLSYSCALL_R_DEFINE(int, exit_group, int, status)
 	uk_sched_thread_exit();
 }
 #else /* !CONFIG_LIBPOSIX_PROCESS_MULTITHREADING */
-void pprocess_exit_stub(int status)
+__noreturn void pprocess_exit_stub(int status)
 {
 	if (pprocess_thread_main) {
 		pprocess_exit_status = status;

--- a/lib/posix-process/include/uk/process.h
+++ b/lib/posix-process/include/uk/process.h
@@ -84,7 +84,15 @@ int uk_posix_process_create_pthread(struct uk_thread *thread);
 
 #if CONFIG_LIBPOSIX_PROCESS_MULTIPROCESS
 
-typedef int (*uk_posix_process_mainlike_func)(int argc, char *argv[]);
+/**
+ * Main-like function that calls exit() when done instead of returning.
+ *
+ * Parameters are passed as void *, and are to be cast by the implementation to:
+ * - argc: int
+ * - argv: char * []
+ */
+typedef __noreturn void (*uk_posix_process_mainlike_func)(void *argc,
+							  void *argv);
 
 /**
  * Spawn a process that jumps into function.

--- a/lib/posix-process/process.c
+++ b/lib/posix-process/process.c
@@ -406,14 +406,12 @@ pid_t uk_posix_process_run(uk_posix_process_mainlike_func fn,
 	struct uk_sched *s = uk_sched_current();
 	struct uk_thread *parent;
 	struct uk_thread *child;
-	pid_t parent_tid;
 	int ret;
 
 	UK_ASSERT(s);
 
 	parent = uk_thread_current();
-	parent_tid = ukthread2tid(parent);
-	UK_ASSERT(parent_tid > 0);
+	UK_ASSERT(ukthread2tid(parent) > 0);
 
 	/* Create container thread */
 	child = uk_thread_create_container(uk_alloc_get_default(),

--- a/lib/ukboot/init.c
+++ b/lib/ukboot/init.c
@@ -171,6 +171,17 @@ err_close_epollfd:
 }
 #endif /* CONFIG_LIBUKBOOT_GRACEFUL_SHUTDOWN */
 
+static __noreturn void init_mainlike(void *argc_arg, void *argv_arg)
+{
+	const int argc = (int)(intptr_t)argc_arg;
+	char **const argv = (char **)argv_arg;
+	int r;
+
+	r = do_main(argc, argv);
+	/* INIT main should never return; it should call exit() when done */
+	UK_CRASH("INIT main returned %d\n", r);
+}
+
 int do_init(int argc, char *argv[])
 {
 	struct signalfd_siginfo info;
@@ -196,7 +207,7 @@ int do_init(int argc, char *argv[])
 	}
 
 	/* Spawn application process */
-	application_pid = uk_posix_process_run(do_main, argc,
+	application_pid = uk_posix_process_run(init_mainlike, argc,
 					       (const char **)argv);
 
 	/* Wait for application to exit and reap reparented children */

--- a/lib/ukdebug/crash.c
+++ b/lib/ukdebug/crash.c
@@ -82,7 +82,7 @@ __noreturn static void crash_shutdown(void)
 
 UK_EVENT(UK_CRASH_EVENT);
 
-void _uk_crash(struct __regs *regs, struct uk_crash_descr *descr)
+__noreturn void _uk_crash(struct __regs *regs, struct uk_crash_descr *descr)
 {
 	struct uk_crash_event_param param;
 #if HAVE_SMP

--- a/lib/ukdebug/include/uk/assert.h
+++ b/lib/ukdebug/include/uk/assert.h
@@ -76,12 +76,6 @@ extern "C" {
 	} while (0)
 #endif
 
-#define UK_BUGON(x)							\
-	UK_ASSERT(!(x))
-
-#define UK_BUG()							\
-	UK_BUGON(1)
-
 #ifdef __cplusplus
 }
 #endif

--- a/lib/ukdebug/include/uk/crash.h
+++ b/lib/ukdebug/include/uk/crash.h
@@ -22,6 +22,16 @@ extern "C" {
 		uk_crash_trigger();					\
 	} while (0)
 
+/* Stops execution when reaching an impossible path, likely sign of a bug */
+#define UK_BUG() UK_CRASH("Impossible execution path\n")
+
+/* Conditional version of UK_BUG() */
+#define UK_BUGON(x)							\
+	do {								\
+		if (unlikely(x))					\
+			UK_BUG();					\
+	} while (0)
+
 /**
  * Triggers a system crash with the given register context and description.
  *

--- a/lib/ukfs-ramfs/ramfs.c
+++ b/lib/ukfs-ramfs/ramfs.c
@@ -276,7 +276,9 @@ unsigned char ramfs_dentry_type(const struct ramfs_dentry *dp)
 	case RAMFS_DENT_FILE:
 		return DT_UNKNOWN;
 	default:
-		UK_BUG();
+		uk_pr_err("Invalid dentry type %d; likely bug or corruption\n",
+			  dp->type);
+		return DT_UNKNOWN;
 	}
 }
 
@@ -291,7 +293,9 @@ ino_t ramfs_dentry_inode(const struct ramfs_dentry *dp)
 	case RAMFS_DENT_SPEC:
 		return (ino_t)(uintptr_t)dp;
 	default:
-		UK_BUG();
+		uk_pr_err("Invalid dentry type %d; likely bug or corruption\n",
+			  dp->type);
+		return 0;
 	}
 }
 
@@ -649,8 +653,6 @@ ssize_t ramfs_live_mem(struct ramfs_node *n, enum uk_file_mem_op op,
 		if (unlikely(total != len))
 			return -EINVAL;
 		break;
-	default:
-		return -EINVAL;
 	}
 
 	if (unlikely(!len))
@@ -675,7 +677,7 @@ ssize_t ramfs_live_mem(struct ramfs_node *n, enum uk_file_mem_op op,
 			n->statx.stx_size = off + len;
 		return r;
 	default:
-		UK_BUG(); /* Validate op beforehand */
+		return -EINVAL;
 	}
 }
 
@@ -989,7 +991,9 @@ int ramfs_dir_lookup(struct ramfs_node *n, const char *name, size_t len,
 		out_ukfs->special = dp->target.special;
 		return UKFS_STOP_SPEC;
 	default:
-		UK_BUG();
+		uk_pr_err("Invalid dentry type %d; likely bug or corruption\n",
+			  dp->type);
+		return -EIO;
 	}
 }
 
@@ -1242,15 +1246,7 @@ struct ramfs_node *ramfs_live_fs_create(struct ramfs_node *n,
 		ramfs_node_touch(n, RAMFS_TOUCH_MODIFY, mntflags);
 	}
 	/* Success */
-	switch (dtype) {
-	case RAMFS_DENT_SPEC:
-	case RAMFS_DENT_FILE:
-		return NULL;
-	case RAMFS_DENT_NODE:
-		return newlink.node;
-	default:
-		UK_BUG();
-	}
+	return dtype == RAMFS_DENT_NODE ? newlink.node : NULL;
 }
 
 static

--- a/lib/uksparsebuf/sparsebuf-rbtree.c
+++ b/lib/uksparsebuf/sparsebuf-rbtree.c
@@ -144,7 +144,10 @@ int sparsebuf_separate(struct uk_sparsebuf_blk **headp,
 		uk_sparsebuf_advance(cur);
 	}
 	r = uk_sparsebuf_lookup(headp, epgoff, &ecur);
-	UK_ASSERT(r); /* Buffer cannot have been empty */
+	if (unlikely(!r)) {
+		uk_pr_err("Separate called on empty buffer; likely bug\n");
+		return -EIO;
+	}
 	if (uk_sparsebuf_pg_intersects(epgoff, uk_sparsebuf_slice_at(&ecur))) {
 		r = sparsebuf_cut(headp, &ecur, epgoff, alloc);
 		if (unlikely(r))


### PR DESCRIPTION
### Description of changes

This changeset fixes a number of minor build errors and compiler warnings; more details in the commit descriptions, in brief:
- nolibc: switch away from syscalls for `getcwd` and `getdents64` to enable native builds
- posix-netlink: add missing select of `ukstreambuf`
- ukdebug, posix-process, ukfs-ramfs, uksparsebuf: silence compiler warnings

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

N/A