### PR TITLE
build/linker, plat/*: Move optional PDHR to last

### DIFF
--- a/plat/kvm/arm/link64.lds.S
+++ b/plat/kvm/arm/link64.lds.S
@@ -122,9 +122,9 @@ SECTIONS {
 	_ectors = .;
 	. = ALIGN(__PAGE_SIZE);
 
-	TLS_SECTIONS
-
 	DATA_SECTIONS
+
+	TLS_SECTIONS
 
 	/*
 	 * TODO

--- a/plat/kvm/x86/link64.lds.S
+++ b/plat/kvm/x86/link64.lds.S
@@ -115,9 +115,9 @@ SECTIONS
 	}
 	_ectors = .;
 
-	TLS_SECTIONS
-
 	DATA_SECTIONS
+
+	TLS_SECTIONS
 
 	_end = .;
 

--- a/plat/xen/arm/link32.lds.S
+++ b/plat/xen/arm/link32.lds.S
@@ -99,9 +99,9 @@ SECTIONS
 	. = ALIGN(__PAGE_SIZE);
 	_ectors = .;
 
-	TLS_SECTIONS
-
 	DATA_SECTIONS
+
+	TLS_SECTIONS
 
 	_end = .;
 

--- a/plat/xen/arm/link64.lds.S
+++ b/plat/xen/arm/link64.lds.S
@@ -98,9 +98,9 @@ SECTIONS
   . = ALIGN(__PAGE_SIZE);
   _ectors = .;
 
-  TLS_SECTIONS
-
   DATA_SECTIONS
+
+  TLS_SECTIONS
 
   .dtors : {
         __DTOR_LIST__ = .;

--- a/plat/xen/x86/link64.lds.S
+++ b/plat/xen/x86/link64.lds.S
@@ -100,9 +100,9 @@ SECTIONS
 	. = ALIGN(__PAGE_SIZE);
 	_ectors = .;
 
-	TLS_SECTIONS
-
 	DATA_SECTIONS
+
+	TLS_SECTIONS
 
 	_end = .;
 


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.


### Base target

 - Architecture(s): `x86_64`, `arm`
 - Platform(s): `kvm`, `xen`
 - Application(s): N/A


### Additional configuration

None


### Description of changes

The TLS program header can sometimes be a zero length LOAD segment. But GRUB will complain if two LOAD program headers map to the same virtual address, even if one is zero-length. The TLS header is the only header which is likely to be both LOAD and zero-length, so by making it the last LOAD header in the ELF file, this overlap will never occur.

This resolves Unikraft issue #1680, and was tested on kvm x86_64, and kvm arm. Though this required changing the Xen linker script, switching hypervisors between Xen and KVM will not change how an ELF file is created or loaded, therefore, Xen was not tested. Programs which use TLS, and those which do not, continue to function.