### PR TITLE
lib/nolibc: Add libc function declarations to nolibc

### DIFF
--- a/lib/nolibc/include/dlfcn.h
+++ b/lib/nolibc/include/dlfcn.h
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+
+#ifndef _DLFCN_H
+#define _DLFCN_H
+
+#include <uk/config.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef CONFIG_LIBPOSIX_LIBDL
+
+#define RTLD_LAZY   1
+#define RTLD_NOW    2
+#define RTLD_NOLOAD 4
+#define RTLD_NODELETE 4096
+#define RTLD_GLOBAL 256
+#define RTLD_LOCAL  0
+
+#define RTLD_NEXT    ((void *)-1)
+#define RTLD_DEFAULT ((void *)0)
+
+#define RTLD_DI_LINKMAP 2
+
+int dlclose(void *handle);
+char *dlerror(void);
+void *dlopen(const char *filename, int flags);
+void *dlsym(void *restrict handle, const char *restrict symbol);
+
+typedef struct {
+	const char *dli_fname;
+	void *dli_fbase;
+	const char *dli_sname;
+	void *dli_saddr;
+} Dl_info;
+
+int dladdr(const void *addr, Dl_info *info);
+int dlinfo(void *handle, int request, void *info);
+void *dlvsym(void *handle, const char *symbol, const char *version);
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* _DLFCN_H */

--- a/lib/nolibc/include/grp.h
+++ b/lib/nolibc/include/grp.h
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+
+#ifndef _GRP_H
+#define _GRP_H
+
+#include <uk/config.h>
+
+#if CONFIG_LIBPOSIX_USER
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define __NEED_size_t
+#define __NEED_gid_t
+
+#ifdef _GNU_SOURCE
+#define __NEED_FILE
+#endif
+
+#include <nolibc-internal/shareddefs.h>
+
+struct group {
+	char *gr_name;
+	char *gr_passwd;
+	gid_t gr_gid;
+	char **gr_mem;
+};
+
+struct group *getgrgid(gid_t gid);
+struct group *getgrnam(const char *name);
+int getgrgid_r(gid_t gid, struct group *grp,
+	       char *buffer, size_t bufsize, struct group **result);
+int getgrnam_r(const char *name, struct group *grp,
+	       char *buf, size_t size, struct group **result);
+
+#if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+struct group *getgrent(void);
+void endgrent(void);
+void setgrent(void);
+#endif
+
+#ifdef _GNU_SOURCE
+struct group *fgetgrent(FILE *stream);
+int putgrent(const struct group *grp, FILE *stream);
+#endif
+
+#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+int getgrouplist(const char *user, gid_t group, gid_t *groups, int *ngroup);
+int setgroups(size_t size, const gid_t *list);
+int initgroups(const char *user, gid_t group);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+#endif /*CONFIG_LIBPOSIX_USER*/
+#endif /*_GRP_H*/

--- a/lib/nolibc/include/stdio.h
+++ b/lib/nolibc/include/stdio.h
@@ -97,6 +97,8 @@ int puts(const char *s);
 #if CONFIG_HAVE_VFS
 void clearerr(FILE *stream);
 int rename(const char *oldpath, const char *newpath);
+int renameat(int oldfd, const char *oldname,
+	     int newfd, const char *newname, unsigned int flags);
 int feof(FILE *stream);
 int ferror(FILE *stream);
 int fseek(FILE *stream, long offset, int whence);
@@ -106,6 +108,11 @@ FILE *fdopen(int fd, const char *mode);
 size_t fread(void *ptr, size_t size, size_t nmemb, FILE *stream);
 size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
 #endif /* CONFIG_HAVE_VFS */
+
+#if CONFIG_LIBPOSIX_PROCESS
+FILE *popen(const char *command, const char *type);
+FILE *pclose(FILE *stream);
+#endif /* CONFIG_LIBPOSIX_PROCESS */
 
 #ifdef __STDIO_H_DEFINED_va_list
 #undef va_list

--- a/lib/nolibc/include/sys/resource.h
+++ b/lib/nolibc/include/sys/resource.h
@@ -1,0 +1,116 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+
+#ifndef	_SYS_RESOURCE_H
+#define	_SYS_RESOURCE_H
+
+#ifdef CONFIG_LIBPOSIX_PROCESS
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/time.h>
+
+#define __NEED_id_t
+
+#ifdef _GNU_SOURCE
+#define __NEED_pid_t
+#endif
+
+#include <nolibc-internal/shareddefs.h>
+
+typedef unsigned long long rlim_t;
+
+struct rlimit {
+	rlim_t rlim_cur;
+	rlim_t rlim_max;
+};
+
+struct rusage {
+	struct timeval ru_utime;
+	struct timeval ru_stime;
+	/* linux extentions, but useful */
+	long	ru_maxrss;
+	long	ru_ixrss;
+	long	ru_idrss;
+	long	ru_isrss;
+	long	ru_minflt;
+	long	ru_majflt;
+	long	ru_nswap;
+	long	ru_inblock;
+	long	ru_oublock;
+	long	ru_msgsnd;
+	long	ru_msgrcv;
+	long	ru_nsignals;
+	long	ru_nvcsw;
+	long	ru_nivcsw;
+};
+
+int getrlimit(int resource, struct rlimit *rlim);
+int setrlimit(int resource, const struct rlimit *rlim);
+int getrusage(int who, struct rusage *usage);
+
+int getpriority(int which, id_t who);
+int setpriority(int which, id_t who, int prio);
+
+#ifdef _GNU_SOURCE
+int prlimit(pid_t, int, const struct rlimit *, struct rlimit *);
+#define prlimit64 prlimit
+#endif
+
+#define PRIO_MIN (-20)
+#define PRIO_MAX 20
+
+#define PRIO_PROCESS 0
+#define PRIO_PGRP    1
+#define PRIO_USER    2
+
+#define RUSAGE_SELF     0
+#define RUSAGE_CHILDREN (-1)
+#define RUSAGE_THREAD   1
+
+#define RLIM_INFINITY (~0ULL)
+#define RLIM_SAVED_CUR RLIM_INFINITY
+#define RLIM_SAVED_MAX RLIM_INFINITY
+
+#define RLIMIT_CPU     0
+#define RLIMIT_FSIZE   1
+#define RLIMIT_DATA    2
+#define RLIMIT_STACK   3
+#define RLIMIT_CORE    4
+#ifndef RLIMIT_RSS
+#define RLIMIT_RSS     5
+#define RLIMIT_NPROC   6
+#define RLIMIT_NOFILE  7
+#define RLIMIT_MEMLOCK 8
+#define RLIMIT_AS      9
+#endif
+#define RLIMIT_LOCKS   10
+#define RLIMIT_SIGPENDING 11
+#define RLIMIT_MSGQUEUE 12
+#define RLIMIT_NICE    13
+#define RLIMIT_RTPRIO  14
+#define RLIMIT_NLIMITS 15
+
+#define RLIM_NLIMITS RLIMIT_NLIMITS
+
+#if defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)
+#define RLIM64_INFINITY RLIM_INFINITY
+#define RLIM64_SAVED_CUR RLIM_SAVED_CUR
+#define RLIM64_SAVED_MAX RLIM_SAVED_MAX
+#define getrlimit64 getrlimit
+#define setrlimit64 setrlimit
+#define rlimit64 rlimit
+#define rlim64_t rlim_t
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*CONFIG_LIBPOSIX_PROCESS*/
+#endif /*_SYS_RESOUCE_H*/

--- a/lib/nolibc/include/sys/utsname.h
+++ b/lib/nolibc/include/sys/utsname.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+
+#ifndef _SYS_UTSNAME_H
+#define _SYS_UTSNAME_H
+
+#ifdef CONFIG_LIBPOSIX_SYSINFO
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* #include <features.h> */
+
+struct utsname {
+	char sysname[65];
+	char nodename[65];
+	char release[65];
+	char version[65];
+	char machine[65];
+#ifdef _GNU_SOURCE
+	char domainname[65];
+#else
+	char __domainname[65];
+#endif
+};
+
+int uname(struct utsname *name);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* CONFIG_LIBPOSIX_SYSINFO */
+#endif /* _SYS_UTSNAME_H */

--- a/lib/nolibc/include/unistd.h
+++ b/lib/nolibc/include/unistd.h
@@ -65,6 +65,9 @@ extern "C" {
 long sysconf(int);
 int gethostname(char *name, size_t len);
 int sethostname(const char *name, size_t len);
+size_t confstr(int name, char *buf, size_t len);
+long fpathconf(int fd, int name);
+long pathconf(const char *path, int name);
 #endif
 
 #if CONFIG_HAVE_TIME
@@ -85,7 +88,21 @@ int execvpe(const char *file, char *const argv[],
 int execve(const char *filename, char *const argv[],
 		char *const envp[]);
 pid_t vfork(void);
-#endif
+pid_t getpgid(pid_t pid);
+pid_t getpgrp(void);
+pid_t getsid(pid_t pid);
+int setpgid(pid_t pid, pid_t pgid);
+pid_t setsid(void);
+pid_t getpid(void);
+pid_t getppid(void);
+#if UK_LIBC_SYSCALLS
+int setpgrp(void);
+int nice(int inc);
+pid_t tcgetpgrp(int fd);
+int tcsetpgrp(int df, pid_t pgrp);
+#endif /* UK_LIBC_SYSCALLS */
+
+#endif /* CONFIG_LIBPOSIX_PROCESS */
 
 #if CONFIG_LIBVFSCORE
 int close(int fd);
@@ -103,6 +120,15 @@ off_t lseek(int fd, off_t offset, int whence);
 int chdir(const char *path);
 int fchdir(int fd);
 int rmdir(const char *pathname);
+int access(const char *pathname, int mode);
+int chown(const char *path, uid_t owner, gid_t group);
+int faccessat(int dirfd, const char *pathname, int mode, int flags);
+int lchown(const char *path, uid_t owner, gid_t group);
+int link(const char *oldpath, const char *newpath);
+ssize_t readlink(const char *pathname, char *buf, size_t bufsize);
+ssize_t readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsize);
+int unlinkat(int dirfd, const char *pathname, int flags);
+
 #else /* !CONFIG_LIBVFSCORE */
 
 #if CONFIG_LIBPOSIX_FDTAB
@@ -120,6 +146,7 @@ int fsync(int fd);
 int fdatasync(int fd);
 off_t lseek(int fd, off_t offset, int whence);
 int ftruncate(int fd, off_t length);
+int fchown(int fd, uid_t owner, gid_t group);
 #endif /* CONFIG_LIBPOSIX_FDIO */
 
 #if CONFIG_LIBPOSIX_VFS_SYSCALLS
@@ -132,7 +159,15 @@ int rmdir(const char *pathname);
 char *getcwd(char *buf, size_t size);
 int symlink(const char *path, const char *linkpath);
 int truncate(const char *path, off_t length);
+int fchownat(int dfd, const char *path, uid_t owner, gid_t group, int flags);
+int linkat(int oldfd, const char *oldname,
+	   int newfd, const char *newname, int flags);
+int symlinkat(const char *path, int dfd, const char *linkname);
 #endif /* CONFIG_LIBPOSIX_VFS_SYSCALLS */
+
+#if CONFIG_LIBPOSIX_PIPE
+int pipe(int *pipefd);
+#endif
 #endif /* CONFIG_LIBPOSIX_FDTAB */
 
 #endif /* !CONFIG_LIBVFSCORE */
@@ -141,6 +176,22 @@ int truncate(const char *path, off_t length);
 unsigned int alarm(unsigned int seconds);
 int pause(void);
 #endif /* CONFIG_LIBUKSIGNAL */
+
+#if CONFIG_LIBPOSIX_USER
+gid_t getegid(void);
+uid_t geteuid(void);
+gid_t getgid(void);
+int getgroups(int size, gid_t *list);
+char *getlogin(void);
+int getlogin_r(char *buf, size_t bufsize);
+int setegid(gid_t egid);
+int setregid(gid_t rgid, gid_t egid);
+int setgid(gid_t gid);
+uid_t getuid(void);
+int seteuid(uid_t euid);
+int setreuid(uid_t ruid, uid_t euid);
+int setuid(uid_t uid);
+#endif /* CONFIG_LIBPOSIX_USER */
 
 #define STDIN_FILENO	0	/* standard input file descriptor */
 #define STDOUT_FILENO	1	/* standard output file descriptor */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes
This PR is an attempt to expose all libc functions stubbed / implemented by existing internal libraries as nolibc declarations. This would enable applications to compile without requiring syscall shim. The commit message for each file contain reference to the library which either implement or stubs those specific functions. 

Issue: #733 

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
