### PR TITLE
Fix #1495: propagate CC environment variable from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -638,7 +638,12 @@ $(eval $(call verbose_include,$(CONFIG_UK_BASE)/arch/$(UK_FAMILY)/Compiler.uk))
 
 # Make variables (CC, etc...)
 LD		:= $(CONFIG_CROSS_COMPILE)$(CONFIG_COMPILER)
+# Allow CC to be set from environment variable
+ifneq ("$(origin CC)","undefined")
+CC		:= $(CC)
+else
 CC		:= $(CONFIG_CROSS_COMPILE)$(CONFIG_COMPILER)
+endif
 CPP		:= $(CC)
 CXX		:= $(CPP)
 GOC		:= $(CONFIG_CROSS_COMPILE)gccgo


### PR DESCRIPTION
### Description of Changes

This PR fixes issue #1505 where the CC environment variable was not
propagated by the Unikraft build system.

Previously, setting CC in the environment (e.g. CC=/usr/bin/clang or
CC=gcc-12) was ignored and the default compiler was always used.
This made it impossible to select alternative compilers directly.

The build system now correctly propagates the CC environment variable,
ensuring that the compiler explicitly specified by the user is used
during the build process.

The change is minimal and affects only the compiler selection logic,
without impacting existing defaults when CC is not defined.


### Related Work

N/A


### PR Checklist


 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.
