### PR TITLE
Fix #1495: propagate CC environment variable from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -638,7 +638,12 @@ $(eval $(call verbose_include,$(CONFIG_UK_BASE)/arch/$(UK_FAMILY)/Compiler.uk))
 
 # Make variables (CC, etc...)
 LD		:= $(CONFIG_CROSS_COMPILE)$(CONFIG_COMPILER)
+# Allow CC to be set from environment variable
+ifneq ("$(origin CC)","undefined")
+CC		:= $(CC)
+else
 CC		:= $(CONFIG_CROSS_COMPILE)$(CONFIG_COMPILER)
+endif
 CPP		:= $(CC)
 CXX		:= $(CPP)
 GOC		:= $(CONFIG_CROSS_COMPILE)gccgo


### PR DESCRIPTION
### Description of Changes

Fix #1495 : propagate CC environment variable in build system

This commit fixes an issue where the CC environment variable was not
propagated by the Unikraft build system, preventing users from selecting
an alternative compiler such as clang or newer GCC versions.

### Related Work

N/A

### PR Checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
