### PR TITLE
drivers/virtio: Fix UB in `virtio_c[read|write]_bytes`

### DIFF
--- a/drivers/virtio/include/virtio/virtio_config.h
+++ b/drivers/virtio/include/virtio/virtio_config.h
@@ -189,7 +189,8 @@ static inline void virtio_cwrite_bytes(const void *addr, const __u8 offset,
 
 	count  = len / type_len;
 	for (i = 0; i < count; i++) {
-		io_addr = (void *)addr + offset + (i * type_len);
+		io_addr = (void *)
+			  ((const char *)addr + offset + (i * type_len));
 		__iowmb();
 		switch (type_len) {
 		case 1:
@@ -216,7 +217,8 @@ static inline void virtio_cread_bytes(const void *addr, const __u8 offset,
 
 	count = len / type_len;
 	for (i = 0; i < count; i++) {
-		io_addr = (void *)addr + offset + (i * type_len);
+		io_addr = (void *)
+			  ((const char *)addr + offset + (i * type_len));
 		switch (type_len) {
 		case 1:
 			((__u8 *)buf)[i * type_len] = ioreg_read8(io_addr);


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

The `io_addr` calculation uses void pointer arithmetic. Fix it.

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
