### PR TITLE
lib/nolibc: Fix the definitions of `nlink_t` and `blksize_t` on ARM64

### DIFF
--- a/lib/nolibc/include/nolibc-internal/shareddefs.h
+++ b/lib/nolibc/include/nolibc-internal/shareddefs.h
@@ -119,7 +119,13 @@ typedef __u64 ino_t;
 #endif
 
 #if defined(__NEED_nlink_t) && !defined(__DEFINED_nlink_t)
+#if defined(CONFIG_ARCH_X86_64)
 typedef __u64 nlink_t;
+#elif defined(CONFIG_ARCH_ARM_64)
+typedef __u32 nlink_t;
+#else
+#error "nlink_t defined only on x86_64 and arm64"
+#endif
 #define __DEFINED_nlink_t
 #endif
 
@@ -129,7 +135,13 @@ typedef __s64 blkcnt_t;
 #endif
 
 #if defined(__NEED_blksize_t) && !defined(__DEFINED_blksize_t)
+#if defined(CONFIG_ARCH_X86_64)
 typedef long blksize_t;
+#elif defined(CONFIG_ARCH_ARM_64)
+typedef int blksize_t;
+#else
+#error "blksize_t defined only on x86_64 and arm64"
+#endif
 #define __DEFINED_blksize_t
 #endif
 


### PR DESCRIPTION
### Prerequisite checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): arm64
 - Platform(s): kvm (but not relevant, I think)
 - Application(s): elfloader


### Description of changes

Change the definitions of `nlink_t` and `blksize_t` so that they are 32-bit integers on arm64.
The definitions of types such as `nlink_t` and `blksize_t` should be compatible between Unikraft and Linux so that it's possible to load a Linux ELF on Unikraft.
The proposed change has been checked by compiling with `aarch64-linux-gnu-gcc` the following:

```
#include <stddef.h>
#include <sys/stat.h>

_Static_assert(sizeof(nlink_t) == 4);
_Static_assert(sizeof(__blksize_t) == 4);
```

Some [other changes](https://github.com/unikraft/unikraft-arm-bincompat/pull/1) are necessary so that the `struct stat` indeed matches Linux’s one.