### PR TITLE
lib/vfscore: fix const correctness in vfscore_ukopt_mkmp API

### DIFF
--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -568,7 +568,7 @@ static int vfscore_extract_volume(const struct vfscore_volume *vv)
 #endif /* CONFIG_LIBUKCPIO */
 
 /* Handle `mkmp` Unikraft Mount Option */
-static int vfscore_ukopt_mkmp(const char *path_arg)
+static int vfscore_ukopt_mkmp(char *path_arg)
 {
 	char path[strlen(path_arg) + 1];
 	char *pos, *prev_pos;


### PR DESCRIPTION
Fixes #1510

This PR fixes a build warning caused by passing a const pointer to a function that expects a non-const pointer in vfscore_ukopt_mkmp.

The function signature has been updated to use const char *, ensuring proper const-correctness and eliminating the compiler warning.