### PR TITLE
plat/kvm/arm: Fix exception stack switch

### DIFF
--- a/lib/ukreloc/arch/arm64/include/uk/asm/reloc.h
+++ b/lib/ukreloc/arch/arm64/include/uk/asm/reloc.h
@@ -10,20 +10,41 @@
 
 #ifdef __ASSEMBLY__
 
-/*
- * Macro to replace the non-relocation-friendly `ldr` instruction. The usage
- * is the same.
+/**
+ * Load symbol's value into register
  *
- * @param req The register into which to load the value of the symbol
- * @param sym The symbol whose value to place into the register
+ * Notice: "symbol value" refers to the contents in the symbol table, i.e.
+ *         an address or a constant, depending on the symbol type. To obtain
+ *         the value at the symbol's address, use ur_ldr instead.
+ *
+ * If the symbol is an absolute symbol, the value is loaded directly.
+ * Otherwise:
+ * - If relocation is enabled, uses PC-relative addressing (±4GiB for 4KiB pages)
+ * - If relocation is disabled uses literal load (no range constraints).
+ *
+ * @param req Target register
+ * @param sym Symbol whose address to load
  */
-.macro	ur_ldr	reg:req, sym:req
+.macro	ur_addr	reg:req, sym:req
 #if CONFIG_LIBUKRELOC
 	adrp	\reg, \sym
 	add	\reg, \reg, :lo12:\sym
 #else /* CONFIG_LIBUKRELOC */
 	ldr	\reg, =\sym
 #endif /* !CONFIG_LIBUKRELOC */
+.endm
+
+/**
+ * Dereference a symbol and load the resulting value into register
+ *
+ * Uses PC-relative addressing (±4GiB for 4KiB pages).
+ *
+ * @param req Target register
+ * @param sym Symbol to dereference
+ */
+.macro ur_ldr reg:req, sym:req
+	adrp	\reg, \sym
+	ldr	\reg, [\reg, :lo12:\sym]
 .endm
 
 #endif /* __ASSEMBLY__ */

--- a/plat/common/arm/lcpu_start.S
+++ b/plat/common/arm/lcpu_start.S
@@ -49,8 +49,8 @@ ENTRY(lcpu_start)
 	msr	contextidr_el1, xzr
 
 	/* Setup exception vector table address before enable MMU */
-	ur_ldr  x29, vector_table
-	msr     VBAR_EL1, x29
+	ur_addr	x29, vector_table
+	msr	VBAR_EL1, x29
 
 	/* Enable the mmu */
 	bl	start_mmu

--- a/plat/common/arm/thread_start64.S
+++ b/plat/common/arm/thread_start64.S
@@ -59,9 +59,9 @@
  * thread exit handler.
  */
 ENTRY(asm_thread_starter)
-	mov x2, sp
-	ldp x0, x1, [x2]			/* x1 = func, x0 = args */
-	ur_ldr  x30, uk_sched_thread_exit	/* Set thread exit handler */
+	mov	x2, sp
+	ldp	x0, x1, [x2]			/* x1 = func, x0 = args */
+	ur_addr	x30, uk_sched_thread_exit	/* Set thread exit handler */
 	br  x1					/* Jump to thread main func */
 ENDPROC(asm_thread_starter)
 
@@ -96,7 +96,7 @@ ENTRY(asm_ctx_switch)
 	 * Record the restore point for switch out thread to restore
 	 * its called-saved registers in next switch to time.
 	 */
-	ur_ldr  x30, restore_point
+	ur_addr  x30, restore_point
 
 	/* Save sp and restore point to previous context */
 	stp x2, x30, [x0]

--- a/plat/kvm/arm/entry64.S
+++ b/plat/kvm/arm/entry64.S
@@ -82,8 +82,8 @@ ENTRY(_libkvmplat_entry)
 	cbz	x19, 1f
 #endif /* !CONFIG_LIBUKRELOC */
 
-	ur_ldr	x0, _start_ram_addr
-	ur_ldr	x1, _end
+	ur_addr	x0, _start_ram_addr
+	ur_addr	x1, _end
 	sub	x1, x1, x0
 	bl	clean_and_invalidate_dcache_range
 
@@ -97,8 +97,8 @@ ENTRY(_libkvmplat_entry)
 #if CONFIG_LIBUKRELOC
 	b	1f
 0:
-	ur_ldr	x0, _start_ram_addr
-	ur_ldr	x1, _end
+	ur_addr	x0, _start_ram_addr
+	ur_addr	x1, _end
 	sub	x1, x1, x0
 	bl	invalidate_dcache_range
 #endif /* CONFIG_LIBUKRELOC */
@@ -107,7 +107,7 @@ ENTRY(_libkvmplat_entry)
 	 * avoid stale cache contents shadowing our changes once the MMU
 	 * and D-cache are enabled.
 	 */
-	ur_ldr	x26, lcpu_bootstack
+	ur_addr	x26, lcpu_bootstack
 	and	x26, x26, ~(__STACK_ALIGN_SIZE - 1)
 	mov	sp, x26
 	mov	x0, x26
@@ -123,7 +123,7 @@ ENTRY(_libkvmplat_entry)
 	bl      do_uk_reloc
 
 	/* Setup exception vector table address before enable MMU */
-	ur_ldr  x29, vector_table
+	ur_addr  x29, vector_table
 	msr VBAR_EL1, x29
 
 	/* Enable the mmu */
@@ -133,7 +133,7 @@ ENTRY(_libkvmplat_entry)
 #if defined(CONFIG_KVM_BOOT_PROTO_LXBOOT)
 	mov x0, x25      /* dtb in x0 */
 #elif defined(CONFIG_KVM_BOOT_PROTO_QEMU_VIRT)
-	ur_ldr  x0, _dtb /* dtb in x0 */
+	ur_addr  x0, _dtb /* dtb in x0 */
 #endif
 	bl	ukplat_bootinfo_fdt_setup
 	b	_ukplat_entry

--- a/plat/kvm/arm/pagetable64.S
+++ b/plat/kvm/arm/pagetable64.S
@@ -46,7 +46,7 @@ ENTRY(start_mmu)
 	dsb sy
 
 	/* Load ttbr0, pagetable starts from _end */
-	ur_ldr  x27, arm64_bpt_l3_pt0
+	ur_addr  x27, arm64_bpt_l3_pt0
 	msr ttbr0_el1, x27
 	isb
 
@@ -69,7 +69,7 @@ ENTRY(start_mmu)
 #else /* !CONFIG_HAVE_PAGING */
 	/* Get VIRT_BITS from id_aa64mmfr0_el1.PARange */
 	mrs x3, id_aa64mmfr0_el1
-	ur_ldr  x5, tcr_ips_bits
+	ur_addr  x5, tcr_ips_bits
 	ubfx x4, x3, #0, #4
 	ldrb w4, [x5, x4]
 	cmp x4, #52


### PR DESCRIPTION
Add missing dereference to fix an issue where stack switch would not be performed during exception entry. Notice that a two-step load is necessary, as a direct PC-relative load fails as symbol distance is > 4KiB.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
