### PR TITLE
lib/ukallocbbuddy: Switch memory region size error to debug

### DIFF
--- a/lib/ukallocbbuddy/bbuddy.c
+++ b/lib/ukallocbbuddy/bbuddy.c
@@ -565,9 +565,10 @@ static int bbuddy_addmem(struct uk_alloc *a, void *base, size_t len)
 	 */
 	if (range < round_pgup(sizeof(*memr) + BYTES_PER_MAPWORD) +
 			__PAGE_SIZE) {
-		uk_pr_err("%"__PRIuptr": Failed to add memory region %"__PRIuptr"-%"__PRIuptr": Not enough space after applying page alignments\n",
-			  (uintptr_t) a, (uintptr_t) base,
-			  (uintptr_t) base + (uintptr_t) len);
+		uk_pr_debug("%"__PRIuptr": Failed to add memory region %"__PRIuptr \
+            "-%"__PRIuptr": Not enough space after applying page alignments\n",
+            (uintptr_t) a, (uintptr_t) base,
+            (uintptr_t) base + (uintptr_t) len);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes


When the system boots, some memory regions are too small to be managed by the buddy allocator because they cannot fit the required metadata (header and bitmap) plus at least one page of data. Currently, this results in an ERR message that clutters the boot log, even though the system continues to boot normally using other, larger memory regions.

Changed the log level from uk_pr_err to uk_pr_debug in lib/ukallocbuddy/bbuddy.c at line 568.

Verified on x86_64/QEMU with Nginx. The boot log no longer shows the error message, providing a cleaner startup experience.


### Related Work

Closes #1505

### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
