### PR TITLE
plat/kvm/x86: fix SMP boot on x86 KVM

### DIFF
--- a/plat/common/include/uk/plat/common/memory.h
+++ b/plat/common/include/uk/plat/common/memory.h
@@ -189,6 +189,10 @@ extern void *x86_start16_begin[];
 extern void *x86_start16_end[];
 extern __uptr x86_start16_addr; /* target address */
 
+#ifndef X86_VIDEO_MEM_START
+#define X86_VIDEO_MEM_START	0xA0000UL
+#endif
+
 static inline int
 ukplat_memregion_alloc_sipi_vect(void)
 {

--- a/plat/common/x86/lcpu.c
+++ b/plat/common/x86/lcpu.c
@@ -43,6 +43,7 @@
 #include <x86/traps.h>
 #include <x86/delay.h>
 #include <uk/plat/common/acpi.h>
+#include <uk/plat/common/memory.h>
 
 #include <uk/plat/lcpu.h>
 #include <uk/plat/common/lcpu.h>
@@ -243,11 +244,15 @@ int lcpu_arch_mp_init(void *arg __unused)
 	}
 	UK_ASSERT(bsp_found);
 
-	/* Allocate an mrd for the SIPI vector */
-	rc = ukplat_memregion_alloc_sipi_vect();
-	if (unlikely(rc)) {
-		uk_pr_err("Could not allocate mrd for the SIPI vector(%d)", rc);
-		return rc;
+	/* Allocate an mrd for the SIPI vector (skip if already allocated
+	 * in early boot before paging init)
+	 */
+	if (!x86_start16_addr) {
+		rc = ukplat_memregion_alloc_sipi_vect();
+		if (unlikely(rc)) {
+			uk_pr_err("SIPI vector alloc failed: %d\n", rc);
+			return rc;
+		}
 	}
 
 	/* Copy AP startup code to target address in first 1MiB */

--- a/plat/kvm/x86/lcpu_start.S
+++ b/plat/kvm/x86/lcpu_start.S
@@ -351,6 +351,13 @@ no_avx:
 no_fsgsbase:
 #endif /* !__FSGSBASE__ */
 
+	/* Set GS base to lcpu struct pointer (RBP) so that
+	 * per-LCPU variables work before lcpu_init() runs.
+	 * Without this, traps_table_init() crashes on SMP builds
+	 * because ukplat_per_lcpu_current() calls rdgsbase().
+	 */
+	wrgsbase %rbp
+
 #if CONFIG_HAVE_X86PKU
 	/* Enable memory protection keys (PKU) */
 	LCPU_ENABLE_PKU no_pku

--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -17,6 +17,7 @@
 #include <uk/assert.h>
 #include <uk/essentials.h>
 #include <uk/intctlr.h>
+#include <uk/plat/common/memory.h>
 
 #include <uk/plat/lcpu.h>
 #include <uk/plat/common/lcpu.h>
@@ -59,6 +60,19 @@ void _ukplat_entry(struct lcpu *lcpu, struct ukplat_bootinfo *bi)
 	rc = uk_intctlr_probe();
 	if (unlikely(rc))
 		UK_CRASH("Interrupt controller init failed: %d\n", rc);
+
+#if defined(CONFIG_HAVE_SMP)
+	/* Allocate SIPI vector region FIRST, before boot stack, so it gets
+	 * a low physical address (< 0x10000). The 16-bit AP trampoline code
+	 * uses 16-bit relocations that break if the SIPI vector is above
+	 * 64KB. Must also be before paging init, because paging init sets
+	 * vbase=__U64_MAX on unmapped free regions, which fails the
+	 * UK_ASSERT_VALID_FREE_MRD page alignment check.
+	 */
+	rc = ukplat_memregion_alloc_sipi_vect();
+	if (unlikely(rc))
+		UK_CRASH("SIPI vector alloc failed: %d\n", rc);
+#endif
 
 	/* Allocate boot stack */
 	bstack = ukplat_memregion_alloc(__STACK_SIZE, UKPLAT_MEMRT_STACK,


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

Fix three issues preventing AP startup with CONFIG_HAVE_SMP on x86 KVM:

- Add fallback define for X86_VIDEO_MEM_START in memory.h and missing include in lcpu.c so SMP builds compile.

- Move SIPI vector allocation before the boot stack so it lands below 64KB. The 16-bit trampoline relocations wrap above 0xFFFF, causing the AP to triple-fault.

- Set GS base (wrgsbase) in lcpu_start64 before jumping to the entry function. Without it, traps_lcpu_init() dereferences NULL via rdgsbase().

Tested with QEMU -smp 2.

```sh
$ make -j$(nproc)
  ...
  CC      libkvmplat: paging.isr.o
  CC      libkvmplat: lcpu.x86_common.o
In file included from .../plat/common/paging.c:44:
.../plat/common/include/uk/plat/common/memory.h: In function 'ukplat_memregion_alloc_sipi_vect':
.../plat/common/include/uk/plat/common/memory.h:204:42: error: 'X86_VIDEO_MEM_START' undeclared (first use in this function); did you mean 'X86_BIOS_ROM_START'?
  204 |                      x86_start16_addr >= X86_VIDEO_MEM_START))
      |                                          ^~~~~~~~~~~~~~~~~~~
.../plat/common/x86/lcpu.c: In function 'lcpu_arch_mp_init':
.../plat/common/x86/lcpu.c:247:14: error: implicit declaration of function 'ukplat_memregion_alloc_sipi_vect'
  247 |         rc = ukplat_memregion_alloc_sipi_vect();
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make: *** Error 2
```

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [X] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
