### PR TITLE
plat/kvm/x86: Do hardcoded ACPI port/value write as shutdown fallback

### DIFF
--- a/plat/kvm/x86/qemu.c
+++ b/plat/kvm/x86/qemu.c
@@ -33,9 +33,24 @@ __isr static inline void qemu_debug_exit(int value)
 	uk_arch_outw(QEMU_ISA_DEBUG_EXIT_PORT, value);
 }
 
+__isr static inline void _do_qemu_acpi_shutdown(void)
+{
+	/*
+	 * Perform an ACPI shutdown by writing (SLP_TYPa | SLP_EN) to PM1a_CNT.
+	 * Generally speaking, we'd have to jump through a lot of hoops to
+	 * collect those values, however, for QEMU, those are static. Should be
+	 * harmless if we're not running on QEMU, especially considering we're
+	 * already shutting down, so who cares if we crash.
+	 */
+	uk_arch_outw(0x604, 0x2000);
+}
+
 __isr static int qemu_exit(void)
 {
 	qemu_debug_exit(QEMU_ISA_DEBUG_EXIT_NO_CRASH);
+
+	/* Use QEMU hardcoded ACPI shutdown port/value as a fallback */
+	_do_qemu_acpi_shutdown();
 
 	/* Return error if writing to port failed as that should not return. */
 	return -EIO;
@@ -52,6 +67,9 @@ __isr static int qemu_crash(void)
 	 */
 	qemu_debug_exit(QEMU_ISA_DEBUG_EXIT_CRASH);
 	uk_arch_outb(QEMU_PVPANIC_EXIT_PORT, QEMU_PVPANIC_GUEST_PANICKED);
+
+	/* Use QEMU hardcoded ACPI shutdown port/value as a fallback */
+	_do_qemu_acpi_shutdown();
 
 	/* Return error if writing to port failed as that should not return. */
 	return -EIO;


### PR DESCRIPTION
Commit 93813332dd67 ("plat/kvm/x86: Register QEMU `isa-debug-exit` driver into `libukpm`") did not also migrate the QEMU-specific temporary hardcoded ACPI port/value write fallback for shutting down. Do so now. This is especially needed in case the `-isa-debug-exit` turns out to not be present or added to the QEMU command-line.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
