### PR TITLE
include/uk: fix C++ compatibility in kernel headers

### DIFF
--- a/include/uk/arch/types.h
+++ b/include/uk/arch/types.h
@@ -248,7 +248,11 @@ typedef __u64 __paddr_t;
 #endif
 
 #ifndef __NULL
+#ifdef __cplusplus
+#define __NULL nullptr
+#else
 #define __NULL ((void *) 0)
+#endif 
 #endif
 
 typedef char *caddr_t; /* core address */

--- a/include/uk/list.h
+++ b/include/uk/list.h
@@ -141,13 +141,13 @@ uk_list_del_init(struct uk_list_head *entry)
 	(!uk_list_empty(ptr) ? uk_list_last_entry(ptr, type, member) : NULL)
 
 #define	uk_list_next_entry(ptr, member)					\
-	uk_list_entry(((ptr)->member.next), typeof(*(ptr)), member)
+	uk_list_entry(((ptr)->member.next), __typeof__(*(ptr)), member)
 
 #define	uk_list_safe_reset_next(ptr, n, member) \
 	((n) = uk_list_next_entry(ptr, member))
 
 #define	uk_list_prev_entry(ptr, member)					\
-	uk_list_entry(((ptr)->member.prev), typeof(*(ptr)), member)
+	uk_list_entry(((ptr)->member.prev), __typeof__(*(ptr)), member)
 
 #define	uk_list_for_each(p, head)				\
 	for (p = (head)->next; p != (head); p = (p)->next)
@@ -156,44 +156,44 @@ uk_list_del_init(struct uk_list_head *entry)
 	for (p = (head)->next, n = (p)->next; p != (head); p = n, n = (p)->next)
 
 #define uk_list_for_each_entry(p, h, field)				\
-	for (p = uk_list_entry((h)->next, typeof(*p), field);		\
+	for (p = uk_list_entry((h)->next, __typeof__(*p), field);	\
 	     &(p)->field != (h);					\
-	     p = uk_list_entry((p)->field.next, typeof(*p), field))
+	     p = uk_list_entry((p)->field.next, __typeof__(*p), field))
 
 #define uk_list_for_each_entry_safe(p, n, h, field)			\
-	for (p = uk_list_entry((h)->next, typeof(*p), field),		\
-		     n = uk_list_entry((p)->field.next, typeof(*p), field); \
+	for (p = uk_list_entry((h)->next, __typeof__(*p), field),	\
+		     n = uk_list_entry((p)->field.next, __typeof__(*p), field);\
 	     &(p)->field != (h);					\
-	     p = n, n = uk_list_entry(n->field.next, typeof(*n), field))
+	     p = n, n = uk_list_entry(n->field.next, __typeof__(*n), field))
 
 #define	uk_list_for_each_entry_from(p, h, field) \
 	for ( ; &(p)->field != (h); \
-	    p = uk_list_entry((p)->field.next, typeof(*p), field))
+	    p = uk_list_entry((p)->field.next, __typeof__(*p), field))
 
 #define	uk_list_for_each_entry_continue(p, h, field)			\
 	for (p = uk_list_next_entry((p), field); &(p)->field != (h);	\
 	    p = uk_list_next_entry((p), field))
 
 #define	uk_list_for_each_entry_safe_from(pos, n, head, member)		\
-	for (n = uk_list_entry((pos)->member.next, typeof(*pos), member); \
+	for (n = uk_list_entry((pos)->member.next, __typeof__(*pos), member); \
 	     &(pos)->member != (head);					\
-	     pos = n, n = uk_list_entry(n->member.next, typeof(*n), member))
+	     pos = n, n = uk_list_entry(n->member.next, __typeof__(*n), member))
 
 #define	uk_list_for_each_entry_reverse(p, h, field)			\
-	for (p = uk_list_entry((h)->prev, typeof(*p), field);		\
+	for (p = uk_list_entry((h)->prev, __typeof__(*p), field);	\
 	     &(p)->field != (h);					\
-	     p = uk_list_entry((p)->field.prev, typeof(*p), field))
+	     p = uk_list_entry((p)->field.prev, __typeof__(*p), field))
 
 #define	uk_list_for_each_entry_safe_reverse(p, n, h, field)		\
-	for (p = uk_list_entry((h)->prev, typeof(*p), field),		\
-		     n = uk_list_entry((p)->field.prev, typeof(*p), field); \
+	for (p = uk_list_entry((h)->prev, __typeof__(*p), field),	\
+		     n = uk_list_entry((p)->field.prev, __typeof__(*p), field);\
 	     &(p)->field != (h);					\
-	     p = n, n = uk_list_entry(n->field.prev, typeof(*n), field))
+	     p = n, n = uk_list_entry(n->field.prev, __typeof__(*n), field))
 
 #define	uk_list_for_each_entry_continue_reverse(p, h, field)		\
-	for (p = uk_list_entry((p)->field.prev, typeof(*p), field);	\
+	for (p = uk_list_entry((p)->field.prev, __typeof__(*p), field);	\
 	     &(p)->field != (h);					\
-	     p = uk_list_entry((p)->field.prev, typeof(*p), field))
+	     p = uk_list_entry((p)->field.prev, __typeof__(*p), field))
 
 #define	uk_list_for_each_prev(p, h) for (p = (h)->prev; p != (h); p = (p)->prev)
 

--- a/plat/native/pal/include/uk/plat/pal/ectx.h
+++ b/plat/native/pal/include/uk/plat/pal/ectx.h
@@ -23,6 +23,10 @@
 	UK_PLAT_NATIVE_ECTX_ALIGN
 
 #if !__ASSEMBLY__
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 struct uk_pal_ectx;
 
 __isr static inline void uk_pal_ectx_sanitize(struct uk_pal_ectx *state)
@@ -50,5 +54,8 @@ __isr static inline void uk_pal_ectx_assert_equal(struct uk_pal_ectx *state)
 	uk_plat_native_ectx_assert_equal((struct uk_plat_native_ectx *)state);
 }
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 #endif /* !__ASSEMBLY__ */
 #endif /* __UK_PLAT_PAL_ECTX_H__ */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->
Unikraft's internal headers are exposed to C++ translation units when libraries such as lib-click compile with -std=c++11.

- uk/list.h: Replaced typeof with __typeof__ in all list-iteration macros. typeof is a GNU C extension not available in strict C++ mode; __typeof__ is the portable GCC built-in that works in both C and C++.

- uk/arch/types.h: Define __NULL as nullptr in C++ context. Assigning ((void *)0) to a typed pointer is valid in C but illegal in C++11.

- plat/native/pal/include/uk/plat/pal/ectx.h: Added extern "C" guards. Without them, the five __isr static inline functions acquire C++ linkage, conflicting with their C-linkage re-declaration in lib/ukpal/include/uk/pal/ectx.h.

Tested by building catalog-core/click and catalog-core/cpp-hello which both previously failed to compile.

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [X] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [X] Updated relevant documentation. (I don't think a change to documentation is necessary.)
