### PR TITLE
arch/x86_64: Rename `EFLAGS` to `RFLAGS` and fix gdb stub `uk_lcpu_except_err_ctx` getter

### DIFF
--- a/arch/x86_64/include/uk/arch.h
+++ b/arch/x86_64/include/uk/arch.h
@@ -60,39 +60,39 @@
 /** SYSCALL/SYSRET instructions */
 #define UK_ARCH_CPUID3_SYSCALL			(1 << 11)
 
-/* EFLAGS register */
+/* RFLAGS register */
 /** Carry flag */
-#define UK_ARCH_EFLAGS_CF			(1 << 0)
+#define UK_ARCH_RFLAGS_CF			(1 << 0)
 /** Parity flag */
-#define UK_ARCH_EFLAGS_PF			(1 << 2)
+#define UK_ARCH_RFLAGS_PF			(1 << 2)
 /** Auxiliary flag */
-#define UK_ARCH_EFLAGS_AF			(1 << 4)
+#define UK_ARCH_RFLAGS_AF			(1 << 4)
 /** Zero flag */
-#define UK_ARCH_EFLAGS_ZF			(1 << 6)
+#define UK_ARCH_RFLAGS_ZF			(1 << 6)
 /** Sign flag */
-#define UK_ARCH_EFLAGS_SF			(1 << 7)
+#define UK_ARCH_RFLAGS_SF			(1 << 7)
 /** Trap flag */
-#define UK_ARCH_EFLAGS_TF			(1 << 8)
+#define UK_ARCH_RFLAGS_TF			(1 << 8)
 /** Interrupt flag */
-#define UK_ARCH_EFLAGS_IF			(1 << 9)
+#define UK_ARCH_RFLAGS_IF			(1 << 9)
 /** Direction flag */
-#define UK_ARCH_EFLAGS_DF			(1 << 10)
+#define UK_ARCH_RFLAGS_DF			(1 << 10)
 /** Overflow flag */
-#define UK_ARCH_EFLAGS_OF			(1 << 11)
+#define UK_ARCH_RFLAGS_OF			(1 << 11)
 /** Nested task flag */
-#define UK_ARCH_EFLAGS_NT			(1 << 14)
+#define UK_ARCH_RFLAGS_NT			(1 << 14)
 /** Resume flag */
-#define UK_ARCH_EFLAGS_RF			(1 << 16)
+#define UK_ARCH_RFLAGS_RF			(1 << 16)
 /** Virtual 8086 mode flag */
-#define UK_ARCH_EFLAGS_VM			(1 << 17)
+#define UK_ARCH_RFLAGS_VM			(1 << 17)
 /** Alignment check flag */
-#define UK_ARCH_EFLAGS_AC			(1 << 18)
+#define UK_ARCH_RFLAGS_AC			(1 << 18)
 /** Virtual interrupt flag */
-#define UK_ARCH_EFLAGS_VIF			(1 << 19)
+#define UK_ARCH_RFLAGS_VIF			(1 << 19)
 /** Virtual interrupt pending */
-#define UK_ARCH_EFLAGS_VIP			(1 << 20)
+#define UK_ARCH_RFLAGS_VIP			(1 << 20)
 /** ID flag */
-#define UK_ARCH_EFLAGS_ID			(1 << 21)
+#define UK_ARCH_RFLAGS_ID			(1 << 21)
 
 /* Basic CPU control in CR0 */
 /** Protection Enable */
@@ -149,7 +149,7 @@
 #define UK_ARCH_MSR_LSTAR			0xc0000082
 /** Compat mode SYSCALL target */
 #define UK_ARCH_MSR_CSTAR			0xc0000083
-/** EFLAGS mask for syscall */
+/** RFLAGS mask for syscall */
 #define UK_ARCH_MSR_SYSCALL_MASK		0xc0000084
 /** Page attribute table configuration */
 #define UK_ARCH_MSR_PAT				0x277

--- a/lib/syscall_shim/arch/x86_64/include/arch/syscall_prologue.h
+++ b/lib/syscall_shim/arch/x86_64/include/arch/syscall_prologue.h
@@ -57,7 +57,7 @@
 		" * the rsp we were given, plus 8.\n\t"			\
 		" */\n\t"						\
 		"addq   $8, (%rsp)\n\t"                                 \
-		"/* Push EFLAGS register. Additionally, since we\n\t"	\
+		"/* Push RFLAGS register. Additionally, since we\n\t"	\
 		" * pushed it with IRQs disabled, it won't have\n\t"	\
 		" * the corresponding bit flag set, making it look\n\t"	\
 		" * like the caller of the syscall had IRQs off,\n\t"	\
@@ -65,7 +65,7 @@
 		" * manually set the flag.\n\t"				\
 		" */\n\t"						\
 		"pushfq\n\t"						\
-		"orq	$(" STRINGIFY(UK_ARCH_EFLAGS_IF) "), 0(%rsp)\n\t"\
+		"orq	$(" STRINGIFY(UK_ARCH_RFLAGS_IF) "), 0(%rsp)\n\t"\
 		"/* Push code segment, GDT code segment selector:\n\t"	\
 		" * [15: 3]: Selector Index - first GDT entry\n\t"	\
 		" * [ 2: 2]: Table Indicator - GDT, table 0\n\t"	\

--- a/lib/ukdebug/arch/x86_64/gdbsup.c
+++ b/lib/ukdebug/arch/x86_64/gdbsup.c
@@ -50,7 +50,7 @@ static int gdb_arch_debug_handler(void *data)
 
 	if ((r = gdb_arch_dbg_trap(5 /* SIGTRAP */,
 				   (struct uk_lcpu_regs *)
-				   uk_lcpu_except_err_ctx_get(ctx, REGS))) < 0)
+				   uk_lcpu_except_err_ctx_get_regs(ctx))) < 0)
 		return r;
 	else
 		return UK_EVENT_HANDLED;

--- a/plat/common/x86/syscall.S
+++ b/plat/common/x86/syscall.S
@@ -177,14 +177,14 @@ ENTRY(_ukplat_syscall)
 	 * `struct uk_lcpu_regs *` argument to the system call handler.
 	 */
 	/* We now have %ss and %rsp on the frame, finish classic trap frame */
-	/* Push EFLAGS register. Additionally, since we pushed it with IRQs
+	/* Push RFLAGS register. Additionally, since we pushed it with IRQs
 	 * disabled, it won't have the corresponding bit flag set, making it
 	 * look like the caller of the syscall had IRQs off, which no sane
 	 * application would do, therefore manually set the flag.
 	 */
 	pushfq			/* eflags */
 	.cfi_adjust_cfa_offset 8
-	orq	$UK_ARCH_EFLAGS_IF, 0(%rsp)
+	orq	$UK_ARCH_RFLAGS_IF, 0(%rsp)
 
 	/* cs */
 	pushq_cfi	$(UK_ARCH_GDT_DESC_OFFSET(UK_ARCH_GDT_DESC_CODE))

--- a/plat/kvm/x86/setup.c
+++ b/plat/kvm/x86/setup.c
@@ -79,9 +79,9 @@ static inline void _init_syscall(void)
 
 	/* Clear IF flag during an interrupt */
 	uk_arch_wrmsrl(UK_ARCH_MSR_SYSCALL_MASK,
-		       UK_ARCH_EFLAGS_TF | UK_ARCH_EFLAGS_DF |
-		       UK_ARCH_EFLAGS_IF | UK_ARCH_EFLAGS_AC |
-		       UK_ARCH_EFLAGS_NT);
+		       UK_ARCH_RFLAGS_TF | UK_ARCH_RFLAGS_DF |
+		       UK_ARCH_RFLAGS_IF | UK_ARCH_RFLAGS_AC |
+		       UK_ARCH_RFLAGS_NT);
 
 	uk_pr_info("SYSCALL entrance @ %p\n", _ukplat_syscall);
 }

--- a/plat/native/arch/x86_64/include/uk/plat/native/arch/except.h
+++ b/plat/native/arch/x86_64/include/uk/plat/native/arch/except.h
@@ -234,7 +234,7 @@ __isr static inline unsigned long uk_plat_native_save_irqf(void)
 	flags = uk_arch_rflags_get();
 	uk_arch_disable_irq();
 
-	return !!(flags & UK_ARCH_EFLAGS_IF);
+	return !!(flags & UK_ARCH_RFLAGS_IF);
 }
 
 /**
@@ -258,7 +258,7 @@ __isr static inline void uk_plat_native_restore_irqf(unsigned long flags)
  */
 __isr static inline int uk_plat_native_irqs_disabled(void)
 {
-	return !(uk_arch_rflags_get() & UK_ARCH_EFLAGS_IF);
+	return !(uk_arch_rflags_get() & UK_ARCH_RFLAGS_IF);
 }
 
 /**


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

Since these are 64-bit definitions and other parts of the codebase
refer to this register as `RFLAGS`, make things consistent and have
the architectural definitions use `RFLAGS` naming as well.

Also update the rest of the codebase accordingly.

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
