### PR TITLE
build: Set explicit C/C++ standard to gnu17/gnu++17

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -6,6 +6,11 @@
 
 COMPFLAGS    += -nostdlib
 COMPFLAGS    += -U __linux__ -U __FreeBSD__ -U __sun__ -nostdinc
+
+CFLAGS-$(call have_gcc)       += -std=gnu17
+CFLAGS-$(call have_clang)     += -std=gnu17
+CXXFLAGS-$(call have_gcc)     += -std=gnu++17
+CXXFLAGS-$(call have_clang)   += -std=gnu++17
 COMPFLAGS-$(call have_gcc)	+= -fno-tree-sra -fno-split-stack
 
 ifneq ($(HAVE_STACKPROTECTOR),y)


### PR DESCRIPTION
GCC 15 defaults to gnu23 which enforces strict function prototype checking. The K&R-style declaration `func()` now means "no arguments" instead of "unspecified arguments", causing compilation failures when constructor functions are called with arguments in lib/ukboot.

This commit explicitly sets `-std=gnu17` for C and `-std=gnu++17` for C++ to maintain consistent behavior across compiler versions and fix compilation with GCC 15+.

The fix is applied globally for both GCC and Clang to ensure future-proofing when Clang also defaults to C23.
FIxes:https://github.com/unikraft/unikraft/issues/1643

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
