### PR TITLE
vfscore: fix const qualifier build warning in vfscore_ukopt_mkmp

### DIFF
--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -688,7 +688,7 @@ static inline int vfscore_mount_volume(const struct vfscore_volume *vv)
 		    vv->ukopts);
 
 	if (vv->ukopts & LIBVFSCORE_UKOPT_MKMP) {
-		rc = vfscore_ukopt_mkmp(path);
+		rc = vfscore_ukopt_mkmp((const char *)path);
 		if (unlikely(rc < 0))
 			return rc;
 	}

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1352,7 +1352,7 @@ sys_utimes(char *path, const struct timeval *times, int flags)
 		return EINVAL;
 
 	// Convert each element of timeval array to the timespec type
-	error = convert_timeval(&timespec_times[0], times ? times + 0 : NULL);
+	error = convert_timeval(&timespec_times[0], times ? &times[0] : NULL);
 	if (unlikely(error)) {
 		/*
 		 * convert_timeval calls clock_gettime which should not have
@@ -1368,7 +1368,7 @@ sys_utimes(char *path, const struct timeval *times, int flags)
 		return -error;
 	}
 
-	error = convert_timeval(&timespec_times[1], times ? times + 1 : NULL);
+	error = convert_timeval(&timespec_times[1], times ? &times[1] : NULL);
 	if (unlikely(error)) {
 		UK_ASSERT(error < 0);
 		return -error;


### PR DESCRIPTION
Fix build warning in vfscore_ukopt_mkmp

This PR fixes a compiler warning caused by discarding the const qualifier
when passing the path argument to vfscore_ukopt_mkmp().

The argument is explicitly cast to const char * to match the function
signature and eliminate the build warning.

Fixes #1510
Fixes #1509