### PR TITLE
Fix arm64 relro warning

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -96,11 +96,10 @@ endif
 COMPFLAGS-$(call gcc_version_ge,7,0)	+= -fPIE
 LDFLAGS-$(call gcc_version_ge,7,0)	+= -static-pie
 LDFLAGS-$(call gcc_version_ge,7,0)	+= -Wl,--no-dynamic-linker
-LDFLAGS-$(call gcc_version_ge,7,0)	+= -z notext -z norelro
-COMPFLAGS-$(call have_clang)	+= -fPIE
-LDFLAGS-$(call have_clang)	+= -static-pie
-LDFLAGS-$(call have_clang)	+= -Wl,--no-dynamic-linker
-LDFLAGS-$(call have_clang)	+= -z notext -z norelro
+ifneq ($(ARCH),arm64)
+LDFLAGS-$(call gcc_version_ge,7,0) += -z notext -z norelro
+LDFLAGS-$(call have_clang) += -z notext -z norelro
+endif
 SECT_STRIP_FLAGS-$(CONFIG_OPTIMIZE_PIE) += -R .dynamic
 SECT_STRIP_FLAGS-$(CONFIG_OPTIMIZE_PIE) += -R .dynsym
 SECT_STRIP_FLAGS-$(CONFIG_OPTIMIZE_PIE) += -R .dynstr

--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -688,7 +688,7 @@ static inline int vfscore_mount_volume(const struct vfscore_volume *vv)
 		    vv->ukopts);
 
 	if (vv->ukopts & LIBVFSCORE_UKOPT_MKMP) {
-		rc = vfscore_ukopt_mkmp(path);
+		rc = vfscore_ukopt_mkmp((const char *)path);
 		if (unlikely(rc < 0))
 			return rc;
 	}

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1352,7 +1352,7 @@ sys_utimes(char *path, const struct timeval *times, int flags)
 		return EINVAL;
 
 	// Convert each element of timeval array to the timespec type
-	error = convert_timeval(&timespec_times[0], times ? times + 0 : NULL);
+	error = convert_timeval(&timespec_times[0], times ? &times[0] : NULL);
 	if (unlikely(error)) {
 		/*
 		 * convert_timeval calls clock_gettime which should not have
@@ -1368,7 +1368,7 @@ sys_utimes(char *path, const struct timeval *times, int flags)
 		return -error;
 	}
 
-	error = convert_timeval(&timespec_times[1], times ? times + 1 : NULL);
+	error = convert_timeval(&timespec_times[1], times ? &times[1] : NULL);
 	if (unlikely(error)) {
 		UK_ASSERT(error < 0);
 		return -error;


### PR DESCRIPTION
Title:
build: skip RELRO linker flags for ARM64 to avoid linker warning

Description:
Fixes #1507

ARM64 builds emit the linker warning:
warning: -z relro ignored

This patch conditionally disables the RELRO linker flags
for ARM64 builds while keeping the behavior unchanged
for other architectures.