### PR TITLE
docs: add instructions for running Unikraft on QEMU with Docker

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -96,11 +96,10 @@ endif
 COMPFLAGS-$(call gcc_version_ge,7,0)	+= -fPIE
 LDFLAGS-$(call gcc_version_ge,7,0)	+= -static-pie
 LDFLAGS-$(call gcc_version_ge,7,0)	+= -Wl,--no-dynamic-linker
-LDFLAGS-$(call gcc_version_ge,7,0)	+= -z notext -z norelro
-COMPFLAGS-$(call have_clang)	+= -fPIE
-LDFLAGS-$(call have_clang)	+= -static-pie
-LDFLAGS-$(call have_clang)	+= -Wl,--no-dynamic-linker
-LDFLAGS-$(call have_clang)	+= -z notext -z norelro
+ifneq ($(ARCH),arm64)
+LDFLAGS-$(call gcc_version_ge,7,0) += -z notext -z norelro
+LDFLAGS-$(call have_clang) += -z notext -z norelro
+endif
 SECT_STRIP_FLAGS-$(CONFIG_OPTIMIZE_PIE) += -R .dynamic
 SECT_STRIP_FLAGS-$(CONFIG_OPTIMIZE_PIE) += -R .dynsym
 SECT_STRIP_FLAGS-$(CONFIG_OPTIMIZE_PIE) += -R .dynstr

--- a/README.md
+++ b/README.md
@@ -308,3 +308,28 @@ The Unikraft name, logo and its mascot are trademark of [Unikraft GmbH](https://
 [unikraft-kraftfile-syntax]: https://unikraft.org/docs/cli/reference/kraftfile/latest
 [github-codespaces-catalog]: https://codespaces.new/unikraft/catalog
 [kraft]: https://github.com/unikraft/kraftkit
+
+## Running Unikraft on QEMU through Docker
+
+Running QEMU through Docker is useful when the host system provides an older
+QEMU version or when testing against a specific QEMU release.
+
+### Prerequisites
+
+- Docker installed
+- A locally compiled Unikraft application image
+- A QEMU container image available locally or from Docker Hub
+
+### Running a local build
+
+A locally built Unikraft image can be executed by mounting the build output
+inside a container that provides the desired QEMU version:
+
+```bash
+docker run --rm -it \
+  --network host \
+  -v $(pwd):/work \
+  <qemu-docker-image> \
+  qemu-system-x86_64 \
+  -kernel /work/build/<unikraft-binary> \
+  -nographic

--- a/lib/vfscore/automount.c
+++ b/lib/vfscore/automount.c
@@ -688,7 +688,7 @@ static inline int vfscore_mount_volume(const struct vfscore_volume *vv)
 		    vv->ukopts);
 
 	if (vv->ukopts & LIBVFSCORE_UKOPT_MKMP) {
-		rc = vfscore_ukopt_mkmp(path);
+		rc = vfscore_ukopt_mkmp((const char *)path);
 		if (unlikely(rc < 0))
 			return rc;
 	}

--- a/lib/vfscore/syscalls.c
+++ b/lib/vfscore/syscalls.c
@@ -1352,7 +1352,7 @@ sys_utimes(char *path, const struct timeval *times, int flags)
 		return EINVAL;
 
 	// Convert each element of timeval array to the timespec type
-	error = convert_timeval(&timespec_times[0], times ? times + 0 : NULL);
+	error = convert_timeval(&timespec_times[0], times ? &times[0] : NULL);
 	if (unlikely(error)) {
 		/*
 		 * convert_timeval calls clock_gettime which should not have
@@ -1368,7 +1368,7 @@ sys_utimes(char *path, const struct timeval *times, int flags)
 		return -error;
 	}
 
-	error = convert_timeval(&timespec_times[1], times ? times + 1 : NULL);
+	error = convert_timeval(&timespec_times[1], times ? &times[1] : NULL);
 	if (unlikely(error)) {
 		UK_ASSERT(error < 0);
 		return -error;


### PR DESCRIPTION
Fixes #1560

This PR adds documentation for running a locally compiled Unikraft build
using a QEMU Docker image, including host networking, local storage, and
basic GDB debugging instructions.