### PR TITLE
arch/include: detect cache line size at compile time

### DIFF
--- a/arch/include/uk/arch.h
+++ b/arch/include/uk/arch.h
@@ -13,10 +13,16 @@
 extern "C" {
 #endif
 
-/* FIXME: Hardcode for now. In practice this can be
- *        variable, define per platform instead.
+/**
+ * Use the compiler's knowledge of the target CPU cache line size if available.
+ * __GCC_DESTRUCTIVE_SIZE is set by GCC 12+ and Clang 15+ based on the
+ * -march/-mcpu flags. Falls back to previous hard-coded value of 64 bytes.
  */
+#ifdef __GCC_DESTRUCTIVE_SIZE
+#define UK_ARCH_CACHE_LINE_SIZE		__GCC_DESTRUCTIVE_SIZE
+#else
 #define UK_ARCH_CACHE_LINE_SIZE		64
+#endif
 
 #if !__ASSEMBLY__
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

Fixes issue #956. Previously, `UK_ARCH_CACHE_LINE_SIZE` was hardcoded to 64
bytes. This value may not hold true for all CPU architectures, potentially
incurring performance costs due to false sharing. As this macro is used to
define structs and ELF section layout at compile time, a run-time approach is
not appropriate.

This commit udpates the definition of `UK_ARCH_CACHE_LINE_SIZE` to
use `__GCC_DESTRUCTIVE_SIZE`, a macro produced by GCC 12+ and Clang 15+. Its value
is derived from the `-march` and `-mpcu` compiler flags, allowing
`UK_ARCH_CACHE_LINE_SIZE` to reflect the target CPU's cache line size.

**Note:** `__GCC_DESTRUCTIVE_SIZE` reflects a conservative upper bound for
false sharing prevention rather than the exact cache line size. For generic
targets (e.g. `-march=armv8-a`), this may be larger than the actual hardware
value (e.g. 256 bytes on ARM64). For named CPU targets (e.g.
`-mcpu=cortex-a76`), the value is accurate. The fallback of 64 bytes is
preserved for compilers that do not define `__GCC_DESTRUCTIVE_SIZE`. 

Tested with preprocessor across relevant targets:
```
$ echo "#ifdef __GCC_DESTRUCTIVE_SIZE
#define UK_ARCH_CACHE_LINE_SIZE __GCC_DESTRUCTIVE_SIZE
#else
#define UK_ARCH_CACHE_LINE_SIZE 64
#endif
int x = UK_ARCH_CACHE_LINE_SIZE;" | aarch64-linux-gnu-gcc -mcpu=cortex-a76 -E -
  | grep "^int"
int x = 64;

$ echo "..." | aarch64-linux-gnu-gcc -march=armv8-a -E - | grep "^int"
int x = 256;

$ echo "..." | gcc -march=corei7 -E - | grep "^int"
int x = 64;
```

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [X] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [X] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [X] Updated relevant documentation.