### PR TITLE
lib/posix-time: Provide an implementation for the times function

### DIFF
--- a/lib/nolibc/musl-imported/include/sys/times.h
+++ b/lib/nolibc/musl-imported/include/sys/times.h
@@ -1,0 +1,25 @@
+#ifndef	_SYS_TIMES_H
+#define	_SYS_TIMES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define __NEED_clock_t
+#include <nolibc-internal/shareddefs.h>
+
+struct tms {
+	clock_t tms_utime;
+	clock_t tms_stime;
+	clock_t tms_cutime;
+	clock_t tms_cstime;
+};
+
+clock_t times (struct tms *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/lib/posix-time/exportsyms.uk
+++ b/lib/posix-time/exportsyms.uk
@@ -1,5 +1,6 @@
 uk_sys_nanosleep
 uk_sys_time
+uk_sys_times
 uk_sys_gettimeofday
 uk_sys_settimeofday
 uk_sys_clock_getres

--- a/lib/posix-time/include/uk/posix-time.h
+++ b/lib/posix-time/include/uk/posix-time.h
@@ -9,10 +9,12 @@
 
 #include <time.h>
 #include <sys/time.h>
+#include <sys/times.h>
 
 int uk_sys_nanosleep(const struct timespec *req, struct timespec *rem);
 
 time_t uk_sys_time(time_t *tloc);
+clock_t uk_sys_times(struct tms *buf);
 
 int uk_sys_gettimeofday(struct timeval *restrict tv, void *tz);
 int uk_sys_settimeofday(struct timeval *tv, void *tz);

--- a/lib/posix-time/time.c
+++ b/lib/posix-time/time.c
@@ -37,6 +37,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <sys/times.h>
 #include <uk/plat/time.h>
 #include <uk/config.h>
 #include <uk/print.h>
@@ -273,9 +274,26 @@ UK_SYSCALL_R_DEFINE(int, clock_nanosleep, clockid_t, clockid, int, flags,
 	return uk_sys_clock_nanosleep(clockid, flags, request, remain);
 }
 
-UK_SYSCALL_R_DEFINE(int, times, struct tm *, buf)
+clock_t uk_sys_times(struct tms *buf)
 {
-	return -ENOTSUP;
+	/* NOTE: We assume all system time is used by the current process */
+	const clock_t utime = ukplat_monotonic_clock() /
+			      (UKARCH_NSEC_PER_SEC / CLOCKS_PER_SEC);
+
+	if (buf) {
+		/* We don't track time spent in the kernel */
+		buf->tms_stime = 0;
+		buf->tms_utime = utime;
+		/* We don't track time spent per-process; report zero */
+		buf->tms_cutime = 0;
+		buf->tms_cstime = 0;
+	}
+	return utime;
+}
+
+UK_SYSCALL_R_DEFINE(clock_t, times, struct tms *, buf)
+{
+	return uk_sys_times(buf);
 }
 
 UK_SYSCALL_R_DEFINE(int, setitimer, int, which,


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

This change adds an implementation of the `times()` function/sycall, along with the corresponding header `<sys/times.h>` imported from musl.

Based on previous work by @jschlumpp .

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.
