### PR TITLE
lib/posix-time: Provide implementation of CLOCK_THREAD_CPUTIME_ID

### DIFF
--- a/lib/posix-time/time.c
+++ b/lib/posix-time/time.c
@@ -178,10 +178,14 @@ int uk_sys_clock_getres(clockid_t clk_id, struct timespec *tp)
 
 	switch (clk_id) {
 	case CLOCK_MONOTONIC:
+	case CLOCK_MONOTONIC_RAW:
 	case CLOCK_MONOTONIC_COARSE:
 	case CLOCK_REALTIME:
 	case CLOCK_REALTIME_COARSE:
 	case CLOCK_BOOTTIME:
+#if CONFIG_HAVE_SCHED
+	case CLOCK_THREAD_CPUTIME_ID:
+#endif /* CONFIG_HAVE_SCHED */
 		if (tp) {
 			tp->tv_sec = 0;
 			tp->tv_nsec = UKPLAT_TIME_TICK_NSEC;

--- a/lib/posix-time/time.c
+++ b/lib/posix-time/time.c
@@ -225,6 +225,12 @@ int uk_sys_clock_gettime(clockid_t clk_id, struct timespec *tp)
 	case CLOCK_REALTIME_COARSE:
 		now = ukplat_wall_clock();
 		break;
+#if CONFIG_HAVE_SCHED
+	case CLOCK_THREAD_CPUTIME_ID:
+		/* NOTE: exec_time does not account for current scheduled run */
+		now = uk_thread_current()->exec_time;
+		break;
+#endif /* CONFIG_HAVE_SCHED */
 	default:
 		error = EINVAL;
 		goto out_error;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

This change adds support for the `CLOCK_THREAD_CPUTIME_ID` clock type to `posix-time`.

Based on previous work by @jschlumpp .

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.
