### PR TITLE
lib/vfscore: Mark as deprecated in Kconfig

### DIFF
--- a/lib/vfscore/Config.uk
+++ b/lib/vfscore/Config.uk
@@ -1,5 +1,5 @@
 menuconfig LIBVFSCORE
-	bool "vfscore: VFS Core Interface"
+	bool "vfscore: VFS Core Interface (DEPRECATED)"
 	default n
 	select LIBNOLIBC if !HAVE_LIBC
 	select LIBUKDEBUG
@@ -14,6 +14,9 @@ menuconfig LIBVFSCORE
 	select LIBPOSIX_PIPE
 	select LIBPOSIX_TTY
 	select HAVE_VFS
+	help
+		This legacy unikraft VFS stack is deprecated and will be removed
+		in a future version. Consider migrating workloads to posix-vfs.
 
 if LIBVFSCORE
 config LIBVFSCORE_NONLARGEFILE


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

This change adds text to vfscore's Kconfig option indicating that it is deprecated and will be removed in a future version.

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.
