### PR TITLE
{plat, lib, drivers}: Fixups post-lcpu/pcpuvar rework

### DIFF
--- a/drivers/ukintctlr/xpic/ukintctlr.c
+++ b/drivers/ukintctlr/xpic/ukintctlr.c
@@ -75,7 +75,7 @@ static int configure_irq(struct uk_intctlr_irq *irq __unused)
 static int uk_intctlr_xpic_handle_irq(void *data)
 {
 	struct uk_lcpu_except_irq_ctx *ctx;
-	unsigned long irq;
+	__u32 irq;
 
 	ctx = data;
 	uk_intctlr_irq_handle(ctx);

--- a/lib/syscall_shim/uk_syscall_binary.c
+++ b/lib/syscall_shim/uk_syscall_binary.c
@@ -132,11 +132,12 @@ static void binary_syscall_debug_handler(struct uk_syscall_enter_ctx *enter_ctx)
 	_uk_printk(UK_PRINT_KLVL_DEBUG,
 		   uk_libid_self(), __STR_BASENAME__, __LINE__,
 		   "Binary system call request \"%s\" (%lu) at ip:%p (arg0=0x%lx, arg1=0x%lx, ...)\n",
-		   uk_syscall_name(execenv->regs.__syscall_rsyscall),
-		   execenv->regs.__syscall_rsyscall,
-		   (void *)execenv->regs.__syscall_rip,
-		   execenv->regs.__syscall_rarg0,
-		   execenv->regs.__syscall_rarg1);
+		   uk_syscall_name(_UK_EXECENV_REGS_GET(execenv,
+							__syscall_rsyscall)),
+		   _UK_EXECENV_REGS_GET(execenv, __syscall_rsyscall),
+		   (void *)_UK_EXECENV_REGS_GET(execenv, __syscall_rip),
+		   _UK_EXECENV_REGS_GET(execenv, __syscall_rarg0),
+		   _UK_EXECENV_REGS_GET(execenv, __syscall_rarg1));
 }
 
 uk_syscall_entertab_prio(binary_syscall_debug_handler, UK_PRIO_EARLIEST);

--- a/lib/ukintctlr/ukintctlr.c
+++ b/lib/ukintctlr/ukintctlr.c
@@ -152,7 +152,7 @@ extern unsigned long sched_have_pending_events;
 void uk_intctlr_irq_handle(struct uk_lcpu_except_irq_ctx *ctx)
 {
 	struct irq_handler *h;
-	unsigned long irq;
+	__u32 irq;
 	int i;
 
 	irq = uk_lcpu_except_irq_ctx_get_irq(ctx);

--- a/lib/uklcpu/arch/x86_64/include/uk/lcpu/arch/except.h
+++ b/lib/uklcpu/arch/x86_64/include/uk/lcpu/arch/except.h
@@ -36,7 +36,7 @@ uk_lcpu_x86_64_except_err_ctx_set_trapnr(struct uk_lcpu_except_err_ctx *ctx,
 		(struct uk_pal_except_err_ctx *)ctx, trapnr);
 }
 
-__isr static inline int
+__isr static inline __u64
 uk_lcpu_x86_64_except_err_ctx_get_error_code(
 		const struct uk_lcpu_except_err_ctx *ctx)
 {
@@ -46,7 +46,7 @@ uk_lcpu_x86_64_except_err_ctx_get_error_code(
 
 __isr static inline void
 uk_lcpu_x86_64_except_err_ctx_set_error_code(struct uk_lcpu_except_err_ctx *ctx,
-					     int error_code)
+					     __u64 error_code)
 {
 	uk_pal_x86_64_except_err_ctx_set_error_code(
 		(struct uk_pal_except_err_ctx *)ctx, error_code);

--- a/lib/uklcpu/include/uk/lcpu/except.h
+++ b/lib/uklcpu/include/uk/lcpu/except.h
@@ -126,7 +126,7 @@ uk_lcpu_except_irq_ctx_get_irq(const struct uk_lcpu_except_irq_ctx *ctx)
 
 __isr static inline void
 uk_lcpu_except_irq_ctx_set_irq(struct uk_lcpu_except_irq_ctx *ctx,
-			       __u64 irq)
+			       __u32 irq)
 {
 	uk_pal_except_irq_ctx_set_irq((struct uk_pal_except_irq_ctx *)ctx, irq);
 }

--- a/lib/uklcpu/include/uk/lcpu/pm.h
+++ b/lib/uklcpu/include/uk/lcpu/pm.h
@@ -33,8 +33,8 @@ struct uk_lcpu_pm_ops {
 	/**
 	 * Starts a secondary logical CPU.
 	 *
-	 * @param lcpu
-	 *   The secondary logical CPU to start
+	 * @param idx
+	 *   The logical index of the CPU to start
 	 * @return
 	 *   0 on success, !=0 on error
 	 */

--- a/lib/uklcpu/lcpu.c
+++ b/lib/uklcpu/lcpu.c
@@ -285,7 +285,10 @@ void __weak __noreturn uk_lcpu_entry_default(struct uk_lcpu *this_lcpu)
 			/* Besides interrupts in general, the halt can be
 			 * interrupted by calls to uk_lcpu_run().
 			 */
-			uk_lcpu_halt();
+			if (!pm_ops || !pm_ops->halt)
+				uk_arch_spinwait();
+			else
+				pm_ops->halt();
 		}
 	}
 }

--- a/lib/ukpal/arch/x86_64/include/uk/pal/arch/except.h
+++ b/lib/ukpal/arch/x86_64/include/uk/pal/arch/except.h
@@ -28,12 +28,12 @@ __isr void uk_pal_x86_64_except_err_ctx_set_trapnr(
 	struct uk_pal_except_err_ctx *ctx,
 	__u32 trapnr);
 
-__isr int uk_pal_except_err_ctx_get_error_code(
+__isr __u64 uk_pal_except_err_ctx_get_error_code(
 	const struct uk_pal_except_err_ctx *ctx);
 
 __isr void uk_pal_except_err_ctx_set_error_code(
 	struct uk_pal_except_err_ctx *ctx,
-	int error_code);
+	__u64 error_code);
 
 #ifdef __cplusplus
 }

--- a/lib/ukpal/include/uk/pal/except.h
+++ b/lib/ukpal/include/uk/pal/except.h
@@ -122,7 +122,7 @@ __isr __u64 uk_pal_except_irq_ctx_get_irq(
 
 __isr void uk_pal_except_irq_ctx_set_irq(
 	struct uk_pal_except_irq_ctx *ctx,
-	__u64 irq);
+	__u32 irq);
 
 /* Nested exception support */
 
@@ -203,7 +203,7 @@ __isr int uk_pal_except_init(void);
  * @param irq The IRQ to send to the CPU
  * @return 0 on success, negative errno on failure
  */
-int uk_pal_except_send_ipi(__u64 id, unsigned long irq);
+int uk_pal_except_send_ipi(__u64 id, __u32 irq);
 #endif /* CONFIG_HAVE_SMP */
 
 #ifdef __cplusplus

--- a/lib/ukpcpuvar/README.md
+++ b/lib/ukpcpuvar/README.md
@@ -135,6 +135,7 @@ The benefit is concrete and architecture-specific:
 
 - **arm64**: Even when the value is accessed via a literal pool (`ldr reg, =_uk_pcpuvar_tmpl_size`) which are generally unsafe in pre-relocation code, `ABSOLUTE()` still matters: an absolute symbol causes the assembler to resolve its entry in the literal pool to a plain integer at assemble/link time rather than emitting an `R_AARCH64_ABS64` relocation that needs runtime relocation.
   The net effect is the same zero-relocation property as on x86_64, again safe for early boot use.
+  An important note in the case of position-relative instructions that reference this symbol is that if we are linked at very high addresses, then the immediate would be too large for the instruction encoding and therefore the macros make use of an indirect pointer to this symbol, `_uk_pcpuvar_tmpl_size_ptr`.
 
 For a new architecture, as long as the per-CPU slot offset can be expressed as `idx * _uk_pcpuvar_tmpl_size` and that size is an absolute link-time constant, this same property will hold.
 

--- a/lib/ukpcpuvar/exportsyms.uk
+++ b/lib/ukpcpuvar/exportsyms.uk
@@ -1,2 +1,3 @@
 uk_pcpuvar_cpu_id
 uk_pcpuvar_cpu_idx
+_uk_pcpuvar_tmpl_size_ptr

--- a/lib/ukpcpuvar/include/uk/pcpuvar.h
+++ b/lib/ukpcpuvar/include/uk/pcpuvar.h
@@ -36,6 +36,16 @@ extern __uk_pcpuvar __u64 uk_pcpuvar_cpu_id;
 extern __uk_pcpuvar __u64 uk_pcpuvar_cpu_idx;
 
 /**
+ * Indirect pointer to the per-CPU section template size absolute symbol.
+ * This is important to have as whenever we are linked to exist at a very
+ * high address, the position-relative instructions that would otherwise be
+ * used to access the absolute symbol directly would need to use a very
+ * large immediate which does not fit the instruction encoding so use
+ * an indirect pointer instead.
+ */
+extern char *const volatile _uk_pcpuvar_tmpl_size_ptr;
+
+/**
  * Get lvalue reference to a specific CPU's copy of a per-CPU variable.
  *
  * @param _idx
@@ -47,7 +57,7 @@ extern __uk_pcpuvar __u64 uk_pcpuvar_cpu_idx;
  */
 #define __uk_pcpuvar_lval(_idx, _sym)					\
 	(*(__typeof__(_sym) *)						\
-	 ((__u8 *)&(_sym) + (((__sz)&_uk_pcpuvar_tmpl_size) * (_idx))))
+	 ((__u8 *)&(_sym) + (((__sz)_uk_pcpuvar_tmpl_size_ptr) * (_idx))))
 
 #define _uk_pcpuvar_lval(_idx, _sym)					\
 	__uk_pcpuvar_lval(_idx, _sym)

--- a/lib/ukpcpuvar/pcpuvar.c
+++ b/lib/ukpcpuvar/pcpuvar.c
@@ -11,3 +11,5 @@ __uk_pcpuvar __u64 uk_pcpuvar_cpu_id;
 
 /** Linear index of the current CPU in the per-CPU array */
 __uk_pcpuvar __u64 uk_pcpuvar_cpu_idx;
+
+char *const volatile _uk_pcpuvar_tmpl_size_ptr = _uk_pcpuvar_tmpl_size;

--- a/lib/ukvmem/arch/x86_64/pagefault.c
+++ b/lib/ukvmem/arch/x86_64/pagefault.c
@@ -24,7 +24,8 @@ static int vmem_arch_pagefault(void *data)
 	};
 	unsigned int faulttype;
 	struct uk_vas *vas;
-	int rc, error_code;
+	__u64 error_code;
+	int rc;
 
 	error_code = uk_lcpu_x86_64_except_err_ctx_get_error_code(ctx);
 	if (error_code & UK_ARCH_X86_64_PF_EC_WR)
@@ -46,7 +47,7 @@ static int vmem_arch_pagefault(void *data)
 		vas = uk_vas_get_active();
 		if (unlikely(vas && !(vas->flags & UK_VAS_FLAG_NO_PAGING)))
 			uk_pr_debug("Cannot handle %s page fault at 0x%"
-				    __PRIvaddr " (ec: 0x%x): %s (%d).\n",
+				    __PRIvaddr " (ec: 0x%lx): %s (%d).\n",
 				    faultstr[faulttype &
 					    UK_VMA_FAULT_ACCESSTYPE],
 				    vaddr,

--- a/plat/native/arch/x86_64/except.c
+++ b/plat/native/arch/x86_64/except.c
@@ -309,7 +309,7 @@ trap_halt:
 UK_EVENT(UK_PLAT_NATIVE_EXCEPT_EVENT_IRQ);
 
 void uk_plat_native_except_irq_handler(struct uk_plat_native_regs *regs,
-				       unsigned long irq)
+				       __u32 irq)
 {
 	struct uk_plat_native_except_irq_ctx ctx;
 #if CONFIG_LIBUKPLAT_NATIVE_ECTX_ISR_ASSERTIONS
@@ -692,7 +692,7 @@ static inline int x2apic_enable(void)
 	return 0;
 }
 
-static inline void x2apic_send_ipi(int irqno, int dest)
+static inline void x2apic_send_ipi(__u32 irqno, __u64 dest)
 {
 	__u32 eax;
 
@@ -709,7 +709,7 @@ static inline void x2apic_send_ipi(int irqno, int dest)
 #define apic_enable		x2apic_enable
 #define apic_send_ipi		x2apic_send_ipi
 
-int uk_plat_native_except_send_ipi(__u64 id, unsigned long irq)
+int uk_plat_native_except_send_ipi(__u64 id, __u32 irq)
 {
 	apic_send_ipi(irq, id);
 	return 0;

--- a/plat/native/arch/x86_64/except.c
+++ b/plat/native/arch/x86_64/except.c
@@ -268,7 +268,7 @@ static struct uk_event *trap_event_table[] = {
 
 void uk_plat_native_except_err_handler(int trapnr,
 				       struct uk_plat_native_regs *regs,
-				       unsigned long error_code)
+				       __u64 error_code)
 {
 	struct uk_plat_native_except_err_ctx ctx;
 	int rc;

--- a/plat/native/arch/x86_64/include/uk/plat/native/arch/except.h
+++ b/plat/native/arch/x86_64/include/uk/plat/native/arch/except.h
@@ -52,7 +52,7 @@ struct uk_plat_native_except_err_ctx {
 	/* x86 exception vector number (0-31) */
 	__u32 trapnr;
 	/* Hardware error code (only valid for #PF, #GP, #TS, etc.) */
-	int error_code;
+	__u64 error_code;
 	/* Set by handler if exception unrecoverable */
 	int handler_err;
 	/* CPU registers at exception time */
@@ -92,7 +92,7 @@ uk_plat_native_x86_64_except_err_ctx_set_trapnr(
 	ctx->trapnr = trapnr;
 }
 
-__isr static inline int
+__isr static inline __u64
 uk_plat_native_x86_64_except_err_ctx_get_error_code(
 	const struct uk_plat_native_except_err_ctx *ctx)
 {
@@ -102,7 +102,7 @@ uk_plat_native_x86_64_except_err_ctx_get_error_code(
 __isr static inline void
 uk_plat_native_x86_64_except_err_ctx_set_error_code(
 	struct uk_plat_native_except_err_ctx *ctx,
-	int error_code)
+	__u64 error_code)
 {
 	ctx->error_code = error_code;
 }

--- a/plat/native/arch/x86_64/include/uk/plat/native/arch/except.h
+++ b/plat/native/arch/x86_64/include/uk/plat/native/arch/except.h
@@ -160,7 +160,7 @@ struct uk_plat_native_except_irq_ctx {
 	/* CPU registers at IRQ time */
 	struct uk_plat_native_regs *regs;
 	/* x86 interrupt vector number */
-	__u64 irq;
+	__u32 irq;
 };
 
 /* IRQ context accessors */
@@ -179,7 +179,7 @@ uk_plat_native_except_irq_ctx_set_regs(
 	ctx->regs = regs;
 }
 
-__isr static inline __u64
+__isr static inline __u32
 uk_plat_native_except_irq_ctx_get_irq(
 	const struct uk_plat_native_except_irq_ctx *ctx)
 {
@@ -189,7 +189,7 @@ uk_plat_native_except_irq_ctx_get_irq(
 __isr static inline void
 uk_plat_native_except_irq_ctx_set_irq(
 	struct uk_plat_native_except_irq_ctx *ctx,
-	__u64 irq)
+	__u32 irq)
 {
 	ctx->irq = irq;
 }
@@ -298,7 +298,7 @@ __isr void uk_plat_native_except_pop_nested(void);
  * @param irq The IRQ to send to the CPU
  * @return 0 on success, negative errno on failure
  */
-int uk_plat_native_except_send_ipi(__u64 id, unsigned long irq);
+int uk_plat_native_except_send_ipi(__u64 id, __u32 irq);
 #endif /* CONFIG_HAVE_SMP */
 #endif /* CONFIG_LIBUKPLAT_NATIVE_EXCEPT */
 

--- a/plat/native/include/uk/plat/native/except.h
+++ b/plat/native/include/uk/plat/native/except.h
@@ -103,12 +103,12 @@ __isr void uk_plat_native_except_irq_ctx_set_regs(
 	struct uk_plat_native_except_irq_ctx *ctx,
 	struct uk_plat_native_regs *regs);
 
-__isr __u64 uk_plat_native_except_irq_ctx_get_irq(
+__isr __u32 uk_plat_native_except_irq_ctx_get_irq(
 	const struct uk_plat_native_except_irq_ctx *ctx);
 
 __isr void uk_plat_native_except_irq_ctx_set_irq(
 	struct uk_plat_native_except_irq_ctx *ctx,
-	__u64 irq);
+	__u32 irq);
 
 #if CONFIG_LIBUKPLAT_NATIVE_EXCEPT
 /* IRQ control */

--- a/plat/native/pal/arch/x86_64/include/uk/plat/pal/arch/except.h
+++ b/plat/native/pal/arch/x86_64/include/uk/plat/pal/arch/except.h
@@ -35,7 +35,7 @@ uk_pal_x86_64_except_err_ctx_set_trapnr(struct uk_pal_except_err_ctx *ctx,
 		(struct uk_plat_native_except_err_ctx *)ctx, trapnr);
 }
 
-__isr static inline int
+__isr static inline __u64
 uk_pal_x86_64_except_err_ctx_get_error_code(
 		const struct uk_pal_except_err_ctx *ctx)
 {
@@ -45,7 +45,7 @@ uk_pal_x86_64_except_err_ctx_get_error_code(
 
 __isr static inline void
 uk_pal_x86_64_except_err_ctx_set_error_code(struct uk_pal_except_err_ctx *ctx,
-					    int error_code)
+					    __u64 error_code)
 {
 	uk_plat_native_x86_64_except_err_ctx_set_error_code(
 		(struct uk_plat_native_except_err_ctx *)ctx, error_code);

--- a/plat/native/pal/include/uk/plat/pal/except.h
+++ b/plat/native/pal/include/uk/plat/pal/except.h
@@ -125,7 +125,7 @@ uk_pal_except_irq_ctx_get_irq(const struct uk_pal_except_irq_ctx *ctx)
 
 __isr static inline void
 uk_pal_except_irq_ctx_set_irq(struct uk_pal_except_irq_ctx *ctx,
-			      __u64 irq)
+			      __u32 irq)
 {
 	uk_plat_native_except_irq_ctx_set_irq(
 		(struct uk_plat_native_except_irq_ctx *)ctx, irq);
@@ -182,7 +182,7 @@ __isr static inline int uk_pal_except_init(void)
 }
 
 #if CONFIG_HAVE_SMP
-static inline int uk_pal_except_send_ipi(__u64 id, unsigned long irq)
+static inline int uk_pal_except_send_ipi(__u64 id, __u32 irq)
 {
 	return uk_plat_native_except_send_ipi(id, irq);
 }

--- a/plat/xen/arch/x86_64/include/uk/plat/xen/arch/except.h
+++ b/plat/xen/arch/x86_64/include/uk/plat/xen/arch/except.h
@@ -153,7 +153,7 @@ struct uk_plat_xen_except_irq_ctx {
 	/* CPU registers at IRQ time */
 	struct uk_plat_native_regs *regs;
 	/* x86 interrupt vector number */
-	__u64 irq;
+	__u32 irq;
 };
 
 /* IRQ context accessors */
@@ -181,7 +181,7 @@ __u64 uk_plat_xen_except_irq_ctx_get_irq(
 
 __isr static inline
 void uk_plat_xen_except_irq_ctx_set_irq(
-	struct uk_plat_xen_except_irq_ctx *ctx, __u64 irq)
+	struct uk_plat_xen_except_irq_ctx *ctx, __u32 irq)
 {
 	ctx->irq = irq;
 }

--- a/plat/xen/arch/x86_64/include/uk/plat/xen/arch/except.h
+++ b/plat/xen/arch/x86_64/include/uk/plat/xen/arch/except.h
@@ -50,7 +50,7 @@ struct uk_plat_xen_except_err_ctx {
 	/* x86 exception vector number (0-31) */
 	__u32 trapnr;
 	/* Hardware error code (only valid for #PF, #GP, #TS, etc.) */
-	int error_code;
+	__u64 error_code;
 	/* Set by handler if exception unrecoverable */
 	int handler_err;
 	/* CPU registers at exception time */
@@ -89,7 +89,7 @@ void uk_plat_xen_x86_64_except_err_ctx_set_trapnr(
 }
 
 __isr static inline
-int uk_plat_xen_x86_64_except_err_ctx_get_error_code(
+__u64 uk_plat_xen_x86_64_except_err_ctx_get_error_code(
 	const struct uk_plat_xen_except_err_ctx *ctx)
 {
 	return ctx->error_code;
@@ -97,21 +97,7 @@ int uk_plat_xen_x86_64_except_err_ctx_get_error_code(
 
 __isr static inline
 void uk_plat_xen_x86_64_except_err_ctx_set_error_code(
-	struct uk_plat_xen_except_err_ctx *ctx, int error_code)
-{
-	ctx->error_code = error_code;
-}
-
-__isr static inline
-int uk_plat_xen_except_err_ctx_get_error_code(
-	const struct uk_plat_xen_except_err_ctx *ctx)
-{
-	return ctx->error_code;
-}
-
-__isr static inline
-void uk_plat_xen_except_err_ctx_set_error_code(
-	struct uk_plat_xen_except_err_ctx *ctx, int error_code)
+	struct uk_plat_xen_except_err_ctx *ctx, __u64 error_code)
 {
 	ctx->error_code = error_code;
 }

--- a/plat/xen/events.c
+++ b/plat/xen/events.c
@@ -58,7 +58,7 @@ typedef struct _ev_action_t {
 
 struct uk_event_irq_data {
 	struct uk_lcpu_regs *regs;
-	unsigned long irq;
+	__u32 irq;
 };
 
 static ev_action_t ev_actions[NR_EVS];

--- a/plat/xen/include/uk/plat/xen/except.h
+++ b/plat/xen/include/uk/plat/xen/except.h
@@ -108,7 +108,7 @@ __u64 uk_plat_xen_except_irq_ctx_get_irq(
 
 void uk_plat_xen_except_irq_ctx_set_irq(
 	struct uk_plat_xen_except_irq_ctx *ctx,
-	__u64 irq);
+	__u32 irq);
 
 /* IRQ control */
 

--- a/plat/xen/include/xen-x86/traps.h
+++ b/plat/xen/include/xen-x86/traps.h
@@ -85,11 +85,6 @@ DECLARE_ASM_TRAP(HYPERVISOR_CALLBACK);
 /* Trap init routine; to be called at startup */
 void xen_traps_init(void);
 
-/* Generic trap handler */
-void uk_plat_xen_except_err_handler(unsigned int num,
-				    struct uk_lcpu_regs *regs,
-				    unsigned long errcode);
-
 /* Failsafe trap handler that pops the stack and returns */
 void asm_failsafe_callback(void);
 

--- a/plat/xen/pal/include/uk/plat/pal/except.h
+++ b/plat/xen/pal/include/uk/plat/pal/except.h
@@ -131,7 +131,7 @@ __u64 uk_pal_except_irq_ctx_get_irq(const struct uk_pal_except_irq_ctx *ctx)
 
 static inline
 void uk_pal_except_irq_ctx_set_irq(struct uk_pal_except_irq_ctx *ctx,
-				__u64 irq)
+				__u32 irq)
 {
 	uk_plat_xen_except_irq_ctx_set_irq(
 		(struct uk_plat_xen_except_irq_ctx *)ctx, irq);

--- a/plat/xen/x86/traps.c
+++ b/plat/xen/x86/traps.c
@@ -177,7 +177,7 @@ static unsigned long read_cr2(void)
 
 void uk_plat_xen_except_err_handler(unsigned int trapnr,
 				    struct uk_lcpu_regs *regs,
-				    unsigned long error_code)
+				    __u64 error_code)
 {
 	struct uk_plat_xen_except_err_ctx ctx;
 	int rc;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

This series collects six minor fixups following the recent uklcpu/pcpuvar rework.

The comment for the lcpu pm start op is updated and the halting loop is fixed to correctly just halt. Before it would also implicitly disable IRQs prior to halting which was wrong and would completely kill any activity on the CPU.

Since Unikraft exclusively targets 64-bit platforms, `error_code` fields and parameters across exception structs are unified to __u64, replacing the inconsistent mix of unsigned long and int. Similarly done to `irq`, we resort to a more lower level and precise type, `__u32`. A strace build regression introduced by fb7c796534a2 — which updated the binary syscall handler but missed the strace path — is also fixed by applying the _UK_EXECENV_REGS_GET accessors consistently.

Finally, an indirect pointer _uk_pcpuvar_tmpl_size_ptr is introduced for accessing the template size, avoiding R_AARCH64_ADR_PREL_PG_HI21 truncation errors when the image is linked at a high virtual address (like is the case for Xen ARM64 PVH).


### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
