### PR TITLE
lib/posix-process: Do not run `brk` handler on non-`vfork` calls

### DIFF
--- a/lib/posix-process/brk.c
+++ b/lib/posix-process/brk.c
@@ -59,6 +59,15 @@ static int pprocess_brk_init(void *arg)
 	UK_ASSERT(arg);
 
 	event_data = (struct posix_process_clone_event_data *)arg;
+
+	/**
+	 * Handler is meant to just initialize per-process brk once, at the
+	 * beginning. If this is not a process creation-related clone call
+	 * then ignore.
+	 */
+	if (!(event_data->cl_args->flags & CLONE_VFORK))
+		return 0;
+
 	pprocess = pid2pprocess(event_data->pid);
 
 	UK_ASSERT(!pprocess->brk_ctx.base);


### PR DESCRIPTION
Following commit bd191c39c196 ("lib/posix-process: Rework posix-process events"), clone handlers are now run on every clone syscall and is therefore their responsibility to adapt their behavior depending on clone flags.

If the clone invocation that lead to the call of the `brk` initialization does not have `CLONE_VFORK` set, then do not run the `brk` handler since we only want this to be run once, when a process is created through `vfork`/clone(..., CLONE_VFORK).

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
