### PR TITLE
lib/ukpod: Fix undefined reference to 'UK_ASSERT'

### DIFF
--- a/lib/ukpod/Config.uk
+++ b/lib/ukpod/Config.uk
@@ -1,5 +1,6 @@
 menuconfig LIBUKPOD
 	bool "ukpod: Pages-on-Demand"
+	select LIBUKDEBUG
 
 if LIBUKPOD
 

--- a/lib/ukpod/anon.c
+++ b/lib/ukpod/anon.c
@@ -7,6 +7,7 @@
 /* Page I/O ops for anonymous memory */
 
 #include <uk/pod/anon.h>
+#include <uk/assert.h>
 
 /**
  * Page-in function for anonymous memory; fills pages with zeros.


### PR DESCRIPTION

### Description of Changes

Prevents the following error during linking:

    /usr/bin/ld: /workdir/build/libukpod.o: in function `uk_pod_anon_pagein':
    /sources/unikraft/lib/ukpod/anon.c:23:(.text+0x3e): undefined reference to `UK_ASSERT'


### Related Work

Introduction of lib/ukpod: d14b9a3e10ec37618b3935bddf943ba14b046afd

### PR Checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.