### PR TITLE
lib/ukboot: Replace usage of stale ukdebug print option

### DIFF
--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -489,7 +489,7 @@ int do_main(int argc, char *argv[])
 		(*ctorfn)(argc, argv);
 	}
 
-#if CONFIG_LIBUKDEBUG_PRINTK_INFO
+#if CONFIG_LIBUKPRINT_KLVL_INFO
 #if CONFIG_LIBPOSIX_ENVIRON
 	envp = environ;
 	if (envp) {
@@ -508,7 +508,7 @@ int do_main(int argc, char *argv[])
 			uk_pr_info(", ");
 	}
 	uk_pr_info("])\n");
-#endif /* CONFIG_LIBUKDEBUG_PRINTK_INFO */
+#endif /* CONFIG_LIBUKPRINT_KLVL_INFO */
 
 	ret = main(argc, argv);
 	uk_pr_info("main returned %d\n", ret);


### PR DESCRIPTION
### Description of Changes

'CONFIG_LIBUKDEBUG_PRINTK_INFO' was removed/relocated in commit 2093a4fbbba9e105d12c9e788413604a9f2dd481.

Use its equivalent in lib/ukprint 'CONFIG_LIBUKPRINT_KLVL_INFO', added in commit 663a4a8e661abc4170abce778d013391d40215bb.

### Related Work

N/A

### PR Checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
