### PR TITLE
plat/hyperlight: fix cpiovfs writes and IST re-entry corruption on CoW faults

### DIFF
--- a/lib/cpiovfs/cpiovfs.c
+++ b/lib/cpiovfs/cpiovfs.c
@@ -1,10 +1,11 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * cpiovfs: Read-only CPIO archive filesystem for Unikraft
+ * cpiovfs: CPIO archive filesystem for Unikraft
  *
- * Mounts a CPIO archive (from initrd) as a read-only filesystem,
- * serving file data directly from archive memory without extraction.
- * This eliminates the CPIO extraction overhead during boot.
+ * Mounts a CPIO archive (from initrd) serving file data directly from
+ * archive memory without extraction. Supports ephemeral in-memory
+ * directories and files (for mount points, temp files, etc.) while
+ * archive-backed content remains zero-copy.
  *
  * Copyright (c) 2025, Microsoft Corporation. All rights reserved.
  */
@@ -47,6 +48,8 @@ struct cpiovfs_node {
 	size_t size;
 	struct cpiovfs_node *child; /* first child (directories) */
 	struct cpiovfs_node *next;  /* next sibling */
+	int ephemeral;     /* 1 = in-memory node (data is malloc'd) */
+	size_t alloc;      /* allocated capacity for ephemeral files */
 };
 
 #define CPIOVFS_NODE(vp) ((struct cpiovfs_node *)(vp)->v_data)
@@ -475,47 +478,187 @@ cpiovfs_inactive(struct vnode *vp __unused)
 	return 0;
 }
 
+/* ---- Ephemeral write operations (in-memory, not backed by CPIO) ---- */
+
+static int
+cpiovfs_mkdir_impl(struct vnode *dvp, const char *name, mode_t mode)
+{
+	struct cpiovfs_node *dnp = dvp->v_data;
+	struct cpiovfs_node *np;
+	size_t len = strlen(name);
+
+	if (len > 255)
+		return ENAMETOOLONG;
+	if (!S_ISDIR(mode))
+		return EINVAL;
+
+	np = cpiovfs_add_child(dnp, name, len, VDIR, mode);
+	if (!np)
+		return ENOMEM;
+	np->ephemeral = 1;
+	return 0;
+}
+
+static int
+cpiovfs_create_impl(struct vnode *dvp, const char *name, mode_t mode)
+{
+	struct cpiovfs_node *dnp = dvp->v_data;
+	struct cpiovfs_node *np;
+	size_t len = strlen(name);
+
+	if (len > 255)
+		return ENAMETOOLONG;
+
+	np = cpiovfs_add_child(dnp, name, len, VREG, mode);
+	if (!np)
+		return ENOMEM;
+	np->ephemeral = 1;
+	return 0;
+}
+
+static int
+cpiovfs_write_impl(struct vnode *vp, struct uio *uio, int ioflag __unused)
+{
+	struct cpiovfs_node *np = vp->v_data;
+	size_t off, end, need;
+	char *newbuf;
+
+	if (!np->ephemeral)
+		return EROFS;
+	if (vp->v_type != VREG)
+		return EINVAL;
+	if (uio->uio_offset < 0)
+		return EINVAL;
+
+	off = (size_t)uio->uio_offset;
+	end = off + uio->uio_resid;
+
+	if (end > np->alloc) {
+		need = end < 4096 ? 4096 : end * 2;
+		newbuf = realloc((void *)np->data, need);
+		if (!newbuf)
+			return ENOMEM;
+		memset(newbuf + np->size, 0, need - np->size);
+		np->data = newbuf;
+		np->alloc = need;
+	}
+
+	int rc = vfscore_uiomove((void *)(np->data + off), uio->uio_resid, uio);
+	if (rc)
+		return rc;
+
+	if (end > np->size) {
+		np->size = end;
+		vp->v_size = end;
+	}
+	return 0;
+}
+
+static int
+cpiovfs_truncate_impl(struct vnode *vp, off_t length)
+{
+	struct cpiovfs_node *np = vp->v_data;
+
+	if (!np->ephemeral)
+		return EROFS;
+	if (vp->v_type != VREG)
+		return EINVAL;
+
+	if ((size_t)length > np->alloc) {
+		size_t need = (size_t)length < 4096 ? 4096 : (size_t)length;
+		char *newbuf = realloc((void *)np->data, need);
+		if (!newbuf)
+			return ENOMEM;
+		memset(newbuf + np->size, 0, need - np->size);
+		np->data = newbuf;
+		np->alloc = need;
+	}
+	np->size = (size_t)length;
+	vp->v_size = (size_t)length;
+	return 0;
+}
+
+static int
+cpiovfs_symlink_impl(struct vnode *dvp, const char *name, const char *link)
+{
+	struct cpiovfs_node *dnp = dvp->v_data;
+	struct cpiovfs_node *np;
+	size_t nlen = strlen(name);
+	size_t llen = strlen(link);
+
+	if (nlen > 255)
+		return ENAMETOOLONG;
+
+	np = cpiovfs_add_child(dnp, name, nlen, VLNK, S_IFLNK | 0777);
+	if (!np)
+		return ENOMEM;
+	np->ephemeral = 1;
+	np->data = strndup(link, llen);
+	if (!np->data)
+		return ENOMEM;
+	np->size = llen;
+	return 0;
+}
+
+static int
+cpiovfs_remove_impl(struct vnode *dvp, struct vnode *vp,
+		    const char *name __unused)
+{
+	struct cpiovfs_node *np = vp->v_data;
+
+	if (!np->ephemeral)
+		return EROFS;
+
+	struct cpiovfs_node *dnp = dvp->v_data;
+	struct cpiovfs_node **pp;
+	for (pp = &dnp->child; *pp; pp = &(*pp)->next) {
+		if (*pp == np) {
+			*pp = np->next;
+			if (np->data && np->alloc)
+				free((void *)np->data);
+			free(np->name);
+			free(np);
+			return 0;
+		}
+	}
+	return ENOENT;
+}
+
 #define cpiovfs_open      ((vnop_open_t)vfscore_vop_nullop)
 #define cpiovfs_close     ((vnop_close_t)vfscore_vop_nullop)
 #define cpiovfs_seek      ((vnop_seek_t)vfscore_vop_nullop)
 #define cpiovfs_fsync     ((vnop_fsync_t)vfscore_vop_nullop)
-#define cpiovfs_write     ((vnop_write_t)vfscore_vop_erofs)
-#define cpiovfs_create    ((vnop_create_t)vfscore_vop_erofs)
-#define cpiovfs_remove    ((vnop_remove_t)vfscore_vop_erofs)
 #define cpiovfs_rename    ((vnop_rename_t)vfscore_vop_erofs)
-#define cpiovfs_mkdir     ((vnop_mkdir_t)vfscore_vop_erofs)
 #define cpiovfs_rmdir     ((vnop_rmdir_t)vfscore_vop_erofs)
 #define cpiovfs_setattr   ((vnop_setattr_t)vfscore_vop_nullop)
-#define cpiovfs_truncate  ((vnop_truncate_t)vfscore_vop_erofs)
 #define cpiovfs_link      ((vnop_link_t)vfscore_vop_erofs)
 #define cpiovfs_fallocate ((vnop_fallocate_t)vfscore_vop_einval)
-#define cpiovfs_symlink   ((vnop_symlink_t)vfscore_vop_erofs)
 #define cpiovfs_poll      ((vnop_poll_t)vfscore_vop_einval)
 
 struct vnops cpiovfs_vnops = {
 	cpiovfs_open,
 	cpiovfs_close,
 	cpiovfs_read,
-	cpiovfs_write,
+	cpiovfs_write_impl,
 	cpiovfs_seek,
 	cpiovfs_ioctl,
 	cpiovfs_fsync,
 	cpiovfs_readdir,
 	cpiovfs_lookup,
-	cpiovfs_create,
-	cpiovfs_remove,
+	cpiovfs_create_impl,
+	cpiovfs_remove_impl,
 	cpiovfs_rename,
-	cpiovfs_mkdir,
+	cpiovfs_mkdir_impl,
 	cpiovfs_rmdir,
 	cpiovfs_getattr,
 	cpiovfs_setattr,
 	cpiovfs_inactive,
-	cpiovfs_truncate,
+	cpiovfs_truncate_impl,
 	cpiovfs_link,
 	(vnop_cache_t) NULL,
 	cpiovfs_fallocate,
 	cpiovfs_readlink,
-	cpiovfs_symlink,
+	cpiovfs_symlink_impl,
 	cpiovfs_poll,
 };
 

--- a/plat/hyperlight/cow.c
+++ b/plat/hyperlight/cow.c
@@ -541,7 +541,6 @@ static int hyperlight_cow_pf_handler(void *data)
 	__vaddr_t fault_addr;
 	int error_code;
 
-
 	if (!cow_initialized)
 		return UK_EVENT_NOT_HANDLED;
 

--- a/plat/hyperlight/dispatch.c
+++ b/plat/hyperlight/dispatch.c
@@ -184,19 +184,25 @@ void hyperlight_dispatch_push_void_result(void)
 /**
  * Prepare the CPU exception environment for dispatch after restore.
  *
- * After snapshot/restore, the kernel's IST stacks (in .bss) are CoW
- * (read-only).  Any CPU exception would try to push to a CoW IST
- * stack, triggering a #PF during delivery → double fault → triple
- * fault (silent VM reset).
+ * After snapshot/restore, all writable guest pages are CoW (read-only
+ * in guest PTEs with AVL_COW bit set).  The kernel has a C-level CoW
+ * handler (cow.c) registered on the page fault event that resolves
+ * heap CoW faults at runtime.  But the handler runs on IST2 (trap
+ * stack), and IST-related data structures (idt_ist_saved, cpu_idt,
+ * lcpu_except_stack) are in BSS — also CoW.  A CoW fault on a BSS
+ * page during exception delivery would nest before IST is disabled,
+ * corrupting the outer exception frame.
  *
  * Strategy:
  * 1. Save the kernel's IDTR
  * 2. Install a temporary IDT on the scratch stack with IST=0
  *    (exceptions push to current stack, which is scratch = writable)
  * 3. Restore MSRs (LSTAR, STAR, SFMASK, KERNEL_GS_BASE)
- * 4. Pre-fault the kernel's IST stacks by writing to them
- *    (CoW faults resolved by temp IDT handler on scratch stack)
- * 5. Reload the kernel's IDT (IST stacks now writable)
+ * 4. Pre-fault the entire kernel rw- section (.data + .bss) so the
+ *    exception infrastructure (IST stacks, IDT, cow_initialized, etc.)
+ *    is writable before the kernel IDT is restored
+ * 5. Reload the kernel's IDT — heap CoW faults are now handled by the
+ *    C-level cow_handle_fault() via the page fault event chain
  */
 static void hyperlight_dispatch_prepare(void)
 {
@@ -238,59 +244,21 @@ static void hyperlight_dispatch_prepare(void)
 	wrmsr(MSR_SFMASK, g_saved_sfmask);
 	wrmsr(MSR_KERNEL_GS_BASE, g_saved_kernel_gs_base);
 
-	/* 4. Pre-fault kernel IST stacks.
-	 * Read IST addresses from the TSS (found via GDT + TR).
-	 * Write to the top 2 pages of each to trigger CoW resolution.
+	/* 4. Pre-fault the entire kernel rw- section (.data + .bss).
+	 * This resolves CoW on all kernel-internal pages (IST stacks,
+	 * IDT entries, CoW handler state, scheduler data, etc.) so the
+	 * kernel exception handler can safely run after IDT restore.
 	 */
 	{
-		struct {
-			__u16 limit;
-			__u64 base;
-		} __attribute__((packed)) gdtr;
-		__asm__ volatile("sgdt %0" : "=m"(gdtr));
-
-		__u16 tr;
-		__asm__ volatile("str %0" : "=r"(tr));
-
-		__u8 *gdt = (__u8 *)gdtr.base;
-		__u8 *tss_desc = gdt + (tr & ~0x7);
-		__u64 tss_base =
-			((__u64)tss_desc[2]) |
-			((__u64)tss_desc[3] << 8) |
-			((__u64)tss_desc[4] << 16) |
-			((__u64)tss_desc[7] << 24) |
-			((__u64)*(__u32 *)(tss_desc + 8) << 32);
-
-		/* TSS layout: IST1 @ +36, IST2 @ +44, IST3 @ +52 */
-		__u64 ist1 = *(volatile __u64 *)(tss_base + 36);
-		__u64 ist2 = *(volatile __u64 *)(tss_base + 44);
-		__u64 ist3 = *(volatile __u64 *)(tss_base + 52);
-
-		/* Pre-fault top 2 pages of each IST stack */
-		if (ist1) {
-			*(volatile __u64 *)(ist1 - 8) = 0;
-			*(volatile __u64 *)(ist1 - 4096) = 0;
-		}
-		if (ist2) {
-			*(volatile __u64 *)(ist2 - 8) = 0;
-			*(volatile __u64 *)(ist2 - 4096) = 0;
-		}
-		if (ist3) {
-			*(volatile __u64 *)(ist3 - 8) = 0;
-			*(volatile __u64 *)(ist3 - 4096) = 0;
-		}
+		extern char _data[], _end[];
+		__u64 start = ((__u64)_data) & ~0xFFFULL;
+		__u64 end = ((__u64)_end + 0xFFF) & ~0xFFFULL;
+		for (__u64 p = start; p < end; p += 0x1000)
+			*(volatile __u8 *)p = *(volatile __u8 *)p;
 	}
 
-	/* 5. Reload the kernel's IDT (IST stacks now writable) */
+	/* 5. Reload the kernel's IDT */
 	__asm__ volatile("lidt %0" : : "m"(saved_idtr));
-
-	/* 6. Reset nested exception counter.
-	 * Must happen AFTER step 5: this writes to .bss which is CoW.
-	 * With the kernel's IDT restored (and IST stacks now writable),
-	 * any CoW fault from this write is handled correctly.
-	 */
-	
-	
 }
 
 /* Dispatch entry/exit */

--- a/plat/native/arch/x86_64/except.c
+++ b/plat/native/arch/x86_64/except.c
@@ -273,6 +273,27 @@ void uk_plat_native_except_err_handler(int trapnr,
 	struct uk_plat_native_except_err_ctx ctx;
 	int rc;
 
+#if CONFIG_PLAT_HYPERLIGHT
+	extern __uptr hyperlight_kernel_fsbase;
+	__u64 saved_fsbase = 0;
+	if (hyperlight_kernel_fsbase) {
+		saved_fsbase = uk_arch_x86_64_rdmsrl(0xC0000100);
+		uk_arch_x86_64_wrmsrl(0xC0000100, hyperlight_kernel_fsbase);
+	}
+	/* Clear IST for page fault entry to prevent IST re-entry corruption.
+	 * Nested page faults (e.g. CoW resolution) will use the current stack
+	 * instead of reloading IST2 and overwriting the saved frame.
+	 */
+	__u8 saved_pf_ist = 0;
+	{
+		__u32 idx = 0; /* single CPU in Hyperlight */
+		struct uk_arch_x86_64_seg_gate_desc64 *pf_desc =
+			&cpu_idt[idx][UK_ARCH_X86_64_TRAPNUM_PAGE_FAULT];
+		saved_pf_ist = pf_desc->ist;
+		pf_desc->ist = 0;
+	}
+#endif
+
 	ctx = (struct uk_plat_native_except_err_ctx){
 		.regs = regs,
 		.trapnr = trapnr,
@@ -285,8 +306,18 @@ void uk_plat_native_except_err_handler(int trapnr,
 	rc = uk_raise_event_ptr(trap_event_table[trapnr], &ctx);
 	if (unlikely(rc < 0))
 		uk_pr_crit("event handler returned error: %d\n", rc);
-	else if (rc != UK_EVENT_NOT_HANDLED)
+	else if (rc != UK_EVENT_NOT_HANDLED) {
+#if CONFIG_PLAT_HYPERLIGHT
+		{
+			__u32 idx = 0;
+			cpu_idt[idx][UK_ARCH_X86_64_TRAPNUM_PAGE_FAULT].ist =
+				saved_pf_ist;
+		}
+		if (saved_fsbase)
+			uk_arch_x86_64_wrmsrl(0xC0000100, saved_fsbase);
+#endif
 		return;
+	}
 
 	if (trap_event_table[trapnr] ==
 		UK_EVENT_PTR(UK_PLAT_NATIVE_EXCEPT_EVENT_UNHANDLED))


### PR DESCRIPTION
## Summary

Fixes two bugs that prevented cpiovfs from being used as the sole root filesystem (replacing ramfs) on the Hyperlight platform.

### 1. cpiovfs write support (`lib/cpiovfs/cpiovfs.c`)

cpiovfs was strictly read-only — all write vnops were wired to `vfscore_vop_erofs`. Workloads that need to create temp files, directories, or symlinks (Python, .NET, PowerShell, Node.js) required a separate ramfs mount for `/tmp`.

Add ephemeral in-memory write support: nodes created at runtime are flagged `ephemeral = 1` with `malloc`'d backing storage, while CPIO-backed content remains zero-copy. Implements `mkdir`, `create`, `write`, `truncate`, `symlink`, and `remove` for ephemeral nodes; archive-backed nodes still return `EROFS` on write.

### 2. IST re-entry prevention (`plat/native/arch/x86_64/except.c`)

After snapshot/restore, all guest pages are CoW. A page fault on a BSS page (e.g., IST stack, IDT, scheduler state) during exception delivery would nest: the CPU reloads IST2 for the nested `#PF`, overwriting the outer exception's saved frame — causing corruption and eventual triple fault.

Fix: on `#PF` entry, save and clear the page fault IDT entry's IST field so nested faults use the current stack instead of reloading IST2. Restore the original IST on return. Also save/restore `FS_BASE` for TLS consistency during exception handling.

### 3. Broader pre-fault strategy (`plat/hyperlight/dispatch.c`)

Replace the fragile per-IST-stack pre-fault with a sweep of the entire kernel `.data`+`.bss` section (`_data[]` to `_end[]`). This resolves CoW on all kernel-internal pages — IST stacks, IDT entries, CoW handler state, scheduler data — before restoring the kernel IDT, eliminating the class of nested-fault bugs entirely.

### 4. Minor cleanup (`plat/hyperlight/cow.c`)

Remove stray blank line.