### PR TITLE
lib/ukalloc: Improve calloc and realloc implementations

### DIFF
--- a/lib/ukalloc/alloc.c
+++ b/lib/ukalloc/alloc.c
@@ -497,12 +497,20 @@ int uk_posix_memalign_ifmalloc(struct uk_alloc *a,
 
 void *uk_realloc_compat(struct uk_alloc *a, void *ptr, __sz size)
 {
+	__sz copy_size;
 	void *retptr;
 
 	UK_ASSERT(a);
+
+	/* If ptr is NULL, realloc() behaves like malloc().
+	 * Invalid size is handled by malloc().
+	 */
 	if (!ptr)
 		return uk_malloc(a, size);
 
+	/* If size is zero and ptr is not NULL, realloc()
+	 * is equivalent to free().
+	 */
 	if (!size) {
 		uk_free(a, ptr);
 		return __NULL;
@@ -512,9 +520,23 @@ void *uk_realloc_compat(struct uk_alloc *a, void *ptr, __sz size)
 	if (!retptr)
 		return __NULL;
 
-	memcpy(retptr, ptr, size);
+	/* FIXME As pointed out in other functions, this allocator
+	 * does not provide a way to check whether the pointer was
+	 * return by a previous allocation..
+	 */
+
+	/* Get previous allocation's size and copy data.
+	 * Preserve the contents up to the minimum of old
+	 * and new size. If new size is larger than old size,
+	 * the added memory will not be initialized.
+	 */
+	copy_size = MIN(uk_getmallocsize(ptr), size);
+
+	/* No support for in-place expansion, so we always need to copy */
+	memcpy(retptr, ptr, copy_size);
 
 	uk_free(a, ptr);
+
 	return retptr;
 }
 
@@ -523,11 +545,16 @@ void *uk_calloc_compat(struct uk_alloc *a, __sz nmemb, __sz size)
 	void *ptr;
 	__sz tlen = nmemb * size;
 
+	UK_ASSERT(a);
+
+	/* check either nmemb or size is zero */
+	if (!tlen)
+		return __NULL;
+
 	/* check for overflow */
 	if (nmemb > (~(__sz)0)/size)
 		return __NULL;
 
-	UK_ASSERT(a);
 	ptr = uk_malloc(a, tlen);
 	if (!ptr)
 		return __NULL;


### PR DESCRIPTION
Zero-check `uk_calloc_compat()`'s `nmemb` and `size` parameters. Update `uk_realloc_compat()` to copy the correct number of bytes.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
