### PR TITLE
lib/posix-socket: Fix allocation size in uk_socketpair_create()

### DIFF
--- a/lib/posix-socket/socket.c
+++ b/lib/posix-socket/socket.c
@@ -953,8 +953,8 @@ int uk_socketpair_create(int family, int type, int protocol,
 	if (unlikely(!d))
 		return -EAFNOSUPPORT;
 
-	al[0] = uk_malloc(d->allocator, sizeof(*al));
-	al[1] = uk_malloc(d->allocator, sizeof(*al));
+	al[0] = uk_malloc(d->allocator, sizeof(struct socket_alloc));
+	al[1] = uk_malloc(d->allocator, sizeof(struct socket_alloc));
 	if (unlikely(!al[0] || !al[1])) {
 		ret = -ENOMEM;
 		goto err_free;


### PR DESCRIPTION
`sizeof(*al)` evaluates to the size of a pointer rather than the size of `struct socket_alloc`, resulting in insufficient memory allocation for socket pairs. Use `sizeof(struct socket_alloc)` to allocate the correct amount of memory.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
