### PR TITLE
lib/uk9p: fix unsigned underflow when msize is too small

### DIFF
--- a/lib/uk9p/9p.c
+++ b/lib/uk9p/9p.c
@@ -39,6 +39,20 @@
 #include <uk/9pfid.h>
 #include <uk/trace.h>
 
+/*
+ * Protocol overhead for Rread:
+ *
+ *  size[4] + type[1] + tag[2] + count[4] = 11.
+ */
+#define UK_9P_RREAD_OVERHEAD	11
+
+/*
+ * Protocol overhead for Twrite:
+ *
+ *  size[4] + type[1] + tag[2] + fid[4] + offset[8] + count[4] = 23
+ */
+#define UK_9P_TWRITE_OVERHEAD	23
+
 UK_TRACEPOINT(uk_9p_trace_request_create, "");
 UK_TRACEPOINT(uk_9p_trace_request_allocated, "");
 UK_TRACEPOINT(uk_9p_trace_ready, "tag %u", uint16_t);
@@ -441,9 +455,11 @@ int64_t uk_9p_read(struct uk_9pdev *dev, struct uk_9pfid *fid,
 	struct uk_9preq *req;
 	int64_t rc;
 
+	if (dev->msize <= UK_9P_RREAD_OVERHEAD)
+		return -EINVAL;
 	if (fid->iounit != 0)
 		count = MIN(count, fid->iounit);
-	count = MIN(count, dev->msize - 11);
+	count = MIN(count, dev->msize - UK_9P_RREAD_OVERHEAD);
 
 	uk_pr_debug("TREAD fid %u offset %lu count %u\n", fid->fid,
 			offset, count);
@@ -456,7 +472,7 @@ int64_t uk_9p_read(struct uk_9pdev *dev, struct uk_9pfid *fid,
 		(rc = uk_9preq_write64(req, offset)) ||
 		(rc = uk_9preq_write32(req, count)) ||
 		(rc = send_and_wait_zc(dev, req, UK_9PREQ_ZCDIR_READ, buf,
-				       count, 11)) ||
+				       count, UK_9P_RREAD_OVERHEAD)) ||
 		(rc = uk_9preq_read32(req, &count)))
 		goto out;
 
@@ -475,9 +491,11 @@ int64_t uk_9p_write(struct uk_9pdev *dev, struct uk_9pfid *fid,
 	struct uk_9preq *req;
 	int64_t rc;
 
+	if (dev->msize <= UK_9P_TWRITE_OVERHEAD)
+		return -EINVAL;
 	if (fid->iounit != 0)
 		count = MIN(count, fid->iounit);
-	count = MIN(count, dev->msize - 23);
+	count = MIN(count, dev->msize - UK_9P_TWRITE_OVERHEAD);
 
 	uk_pr_debug("TWRITE fid %u offset %lu count %u\n", fid->fid,
 			offset, count);
@@ -489,7 +507,7 @@ int64_t uk_9p_write(struct uk_9pdev *dev, struct uk_9pfid *fid,
 		(rc = uk_9preq_write64(req, offset)) ||
 		(rc = uk_9preq_write32(req, count)) ||
 		(rc = send_and_wait_zc(dev, req, UK_9PREQ_ZCDIR_WRITE,
-				(void *)buf, count, 23)) ||
+				(void *)buf, count, UK_9P_TWRITE_OVERHEAD)) ||
 		(rc = uk_9preq_read32(req, &count)))
 		goto out;
 
@@ -590,9 +608,11 @@ int64_t uk_9p_readdir(struct uk_9pdev *dev, struct uk_9pfid *fid,
 	struct uk_9preq *req;
 	int64_t rc;
 
+	if (dev->msize <= UK_9P_RREAD_OVERHEAD)
+		return -EINVAL;
 	if (fid->iounit != 0)
 		count = MIN(count, fid->iounit);
-	count = MIN(count, dev->msize - 11);
+	count = MIN(count, dev->msize - UK_9P_RREAD_OVERHEAD);
 
 	uk_pr_debug("TREADDIR fid %u offset %lu count %u\n", fid->fid,
 			offset, count);
@@ -605,7 +625,7 @@ int64_t uk_9p_readdir(struct uk_9pdev *dev, struct uk_9pfid *fid,
 		(rc = uk_9preq_write64(req, offset)) ||
 		(rc = uk_9preq_write32(req, count)) ||
 		(rc = send_and_wait_zc(dev, req, UK_9PREQ_ZCDIR_READ, buf,
-				       count, 11)) ||
+				       count, UK_9P_RREAD_OVERHEAD)) ||
 		(rc = uk_9preq_read32(req, &count)))
 		goto out;
 


### PR DESCRIPTION
If the remote side negotiates an msize smaller than the fixed protocol overhead (11 bytes for `Rread`/`Rreaddir`, 23 bytes for `Twrite`), the subtraction `dev->msize - overhead` wraps around to a huge `uint32_t` value, effectively disabling the size cap and causing a buffer overflow.

Add named constants `UK_9P_RREAD_OVERHEAD` and `UK_9P_TWRITE_OVERHEAD` to document the magic numbers, and return `-EINVAL` early if `msize` is too small to carry any payload.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
