### PR TITLE
plat/*/pal: Add extern "C" guard to ectx.h for C++ compatibility

### DIFF
--- a/plat/native/pal/include/uk/plat/pal/ectx.h
+++ b/plat/native/pal/include/uk/plat/pal/ectx.h
@@ -25,6 +25,10 @@
 #if !__ASSEMBLY__
 struct uk_pal_ectx;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 __isr static inline void uk_pal_ectx_sanitize(struct uk_pal_ectx *state)
 {
 	uk_plat_native_ectx_sanitize((struct uk_plat_native_ectx *)state);
@@ -49,6 +53,10 @@ __isr static inline void uk_pal_ectx_assert_equal(struct uk_pal_ectx *state)
 {
 	uk_plat_native_ectx_assert_equal((struct uk_plat_native_ectx *)state);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !__ASSEMBLY__ */
 #endif /* __UK_PLAT_PAL_ECTX_H__ */

--- a/plat/xen/pal/include/uk/plat/pal/ectx.h
+++ b/plat/xen/pal/include/uk/plat/pal/ectx.h
@@ -25,6 +25,10 @@
 #if !__ASSEMBLY__
 struct uk_pal_ectx;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static inline void uk_pal_ectx_sanitize(struct uk_pal_ectx *state)
 {
 	uk_plat_native_ectx_sanitize((struct uk_plat_native_ectx *)state);
@@ -49,6 +53,10 @@ static inline void uk_pal_ectx_assert_equal(struct uk_pal_ectx *state)
 {
 	uk_plat_native_ectx_assert_equal((struct uk_plat_native_ectx *)state);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !__ASSEMBLY__ */
 #endif /* __UK_PLAT_PAL_ECTX_H__ */


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes
The `plat/native/pal/include/uk/plat/pal/ectx.h` and
`plat/xen/pal/include/uk/plat/pal/ectx.h` headers define
`uk_pal_ectx_*` functions as `static inline` without an `extern "C"`
guard. When these headers are included from C++ code (e.g., via
libcxxabi's cxa_guard.cpp -> uk/syscall.h -> uk/arch/ctx.h ->
uk/lcpu/ectx.h), the functions get C++ language linkage, conflicting
with the `extern "C"` declarations in `ukpal/include/uk/pal/ectx.h`.

This causes a build failure for any C++ application on both stable and
staging:
```
ukpal/include/uk/pal/ectx.h:63: error: conflicting declaration of
'void uk_pal_ectx_sanitize(uk_pal_ectx*)' with 'C' linkage
plat/native/pal/include/uk/plat/pal/ectx.h:28: note: previous
declaration with 'C++' linkage
```

Tested by applying the fix locally and building `helloworld-cpp` on both stable and staging both build successfully after this change.

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
