### PR TITLE
lib/ukcpio: Fix off-by-1 bug in directory rename

### DIFF
--- a/lib/ukcpio/cpio.c
+++ b/lib/ukcpio/cpio.c
@@ -140,7 +140,7 @@ try_rm_nonempty_dir(const char *path)
 	char newpath[PATH_MAX];
 	char *newend = newpath + strlcpy(newpath, path, PATH_MAX);
 
-	if (unlikely(newend - newpath + 2 > PATH_MAX)) {
+	if (unlikely(newend - newpath + 2 >= PATH_MAX)) {
 		uk_pr_err("Cannot rename %s, path too long\n", path);
 		return -ENAMETOOLONG;
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

Previously an off-by-1 bug when building the rename path could cause 1 byte of stack corruption for paths of length PATH_MAX - 2. This change fixes the error.

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
