### PR TITLE
plat/hyperlight: move INITRD_MAP_BASE past LAPIC MMIO region

### DIFF
--- a/plat/hyperlight/x86/setup.c
+++ b/plat/hyperlight/x86/setup.c
@@ -305,7 +305,7 @@ static void hyperlight_init_mem(struct ukplat_bootinfo *bi,
 	 * After cmdline extraction, init_data.size == 0 but the original
 	 * init_data had the size at (ptr + original_size - 8).
 	 */
-#define INITRD_MAP_BASE 0xC0000000ULL  /* Must match host INITRD_MAP_BASE */
+#define INITRD_MAP_BASE 0xFEF00000ULL  /* Must match host INITRD_MAP_BASE */
 	if (peb->init_data.size == 0 && g_peb->init_data.size >= 8) {
 		__u64 mapped_size = *(__u64 *)(
 			(__u8 *)g_peb->init_data.ptr + g_peb->init_data.size - 8


### PR DESCRIPTION
## Summary

- Moves `INITRD_MAP_BASE` from `0xC0000000` (3 GiB) to `0xFEF00000` (just past the LAPIC MMIO page at `0xFEE00000`)

When the initrd exceeds ~1 GiB, the mapping at `0xC0000000` spans the LAPIC MMIO region at `0xFEE00000`. On kernels where `KVM_CREATE_IRQCHIP` reserves that range, `KVM_SET_USER_MEMORY_REGION` rejects the mapping with `EEXIST`.

The corresponding host-side constant in hyperlight-unikraft will be updated in a follow-up PR there.

Fixes: microsoft/mxc#525

## Test plan

- Built the kernel with this change via `kraft-hyperlight build`
- Ran `pydriver-run` with the patched kernel + host against a ~1.07 GiB initrd
- Confirmed via `strace` that slot 2 maps at `guest_phys_addr=0xfef00000` (past the LAPIC)
- Guest boots and runs Python successfully