### PR TITLE
feat(hostsock): add non-blocking readiness checks and event rescanning

### DIFF
--- a/lib/hostsock/hostsock.c
+++ b/lib/hostsock/hostsock.c
@@ -34,6 +34,7 @@
 /* Per-socket driver data. */
 struct hostsock_data {
 	uint32_t host_fd;
+	int nonblock;
 };
 
 /* Static per-call buffers. Not thread-safe; callers serialise via
@@ -427,6 +428,30 @@ static void json_to_sockaddr(const char *json, struct sockaddr *addr,
 	}
 }
 
+/* -------- tracked sockets for event rescan -------- */
+
+#define HOSTSOCK_MAX_TRACKED 64
+static posix_sock *tracked_socks[HOSTSOCK_MAX_TRACKED];
+static int tracked_count;
+
+static void hostsock_track(posix_sock *sock)
+{
+	if (tracked_count < HOSTSOCK_MAX_TRACKED)
+		tracked_socks[tracked_count++] = sock;
+}
+
+static void hostsock_untrack(posix_sock *sock)
+{
+	for (int i = 0; i < tracked_count; i++) {
+		if (tracked_socks[i] == sock) {
+			tracked_socks[i] = tracked_socks[--tracked_count];
+			return;
+		}
+	}
+}
+
+void hostsock_rescan_events(void);
+
 /* -------- socket operations -------- */
 
 static uint32_t get_host_fd(posix_sock *sock)
@@ -438,6 +463,7 @@ static uint32_t get_host_fd(posix_sock *sock)
 static void *hostsock_create(struct posix_socket_driver *d,
 			     int family, int type, int protocol)
 {
+	int nonblock = (type & SOCK_NONBLOCK) ? 1 : 0;
 	int sock_type = type & ~SOCK_FLAGS;
 	int n = build_req(
 		"{\"name\":\"net_socket\",\"args\":"
@@ -458,9 +484,10 @@ static void *hostsock_create(struct posix_socket_driver *d,
 	if (!sd)
 		return ERR2PTR(-ENOMEM);
 	sd->host_fd = (uint32_t)fd;
+	sd->nonblock = nonblock;
 
-	uk_pr_debug("hostsock: create fd=%u (family=%d type=%d)\n",
-		    sd->host_fd, family, sock_type);
+	uk_pr_debug("hostsock: create fd=%u (family=%d type=%d nb=%d)\n",
+		    sd->host_fd, family, sock_type, nonblock);
 	return sd;
 }
 
@@ -485,11 +512,46 @@ static int hostsock_listen(posix_sock *sock, int backlog)
 	return rpc_exchange(n, NULL);
 }
 
+/* Check if a host socket has a pending event using net_poll(timeout=0). */
+static int hostsock_check_ready(uint32_t host_fd, int events)
+{
+	int n = build_req(
+		"{\"name\":\"net_poll\",\"args\":"
+		"{\"fds\":[{\"fd\":%u,\"events\":%d}],\"timeout_ms\":0}}",
+		host_fd, events);
+	if (n < 0)
+		return 0;
+	size_t resp_len;
+	if (rpc_exchange(n, &resp_len) < 0)
+		return 0;
+	long long revents = 0;
+	json_get_int(rpc_resp, "revents", &revents);
+	return (int)revents;
+}
+
 static void *hostsock_accept4(posix_sock *sock,
 			      struct sockaddr *restrict addr,
 			      socklen_t *restrict addr_len,
-			      int flags __attribute__((unused)))
+			      int flags)
 {
+	struct hostsock_data *listen_data = posix_sock_get_data(sock);
+
+	/*
+	 * Always check readiness before calling the host's blocking accept.
+	 * A blocking hcall freezes the entire VM (single vCPU), so we must
+	 * never let accept block on the host side.  Return EAGAIN and let
+	 * the Unikraft poll/epoll layer handle the wait.
+	 *
+	 * This also covers runtimes that set non-blocking mode via
+	 * fcntl(F_SETFL, O_NONBLOCK) rather than ioctl(FIONBIO) — fcntl
+	 * updates the uk_file flags but not our sd->nonblock field.
+	 */
+	{
+		int ready = hostsock_check_ready(listen_data->host_fd, 1);
+		if (!(ready & 1)) /* POLLIN */
+			return ERR2PTR(-EAGAIN);
+	}
+
 	int n = build_req(
 		"{\"name\":\"net_accept\",\"args\":{\"fd\":%u}}",
 		get_host_fd(sock));
@@ -507,11 +569,13 @@ static void *hostsock_accept4(posix_sock *sock,
 	if (!sd)
 		return ERR2PTR(-ENOMEM);
 	sd->host_fd = (uint32_t)new_fd;
+	sd->nonblock = (flags & SOCK_NONBLOCK) ? 1 : 0;
 
 	if (addr && addr_len)
 		json_to_sockaddr(rpc_resp, addr, addr_len);
 
-	uk_pr_debug("hostsock: accept -> fd=%u\n", sd->host_fd);
+	uk_pr_debug("hostsock: accept -> fd=%u (nb=%d)\n",
+		    sd->host_fd, sd->nonblock);
 	return sd;
 }
 
@@ -572,6 +636,17 @@ static ssize_t hostsock_recvfrom(posix_sock *sock,
 				 struct sockaddr *from,
 				 socklen_t *restrict fromlen)
 {
+	/*
+	 * Always check readiness — a blocking recv hcall would freeze the
+	 * entire VM.  See the comment in hostsock_accept4.
+	 */
+	{
+		struct hostsock_data *sd = posix_sock_get_data(sock);
+		int ready = hostsock_check_ready(sd->host_fd, 1);
+		if (!(ready & 1))
+			return -EAGAIN;
+	}
+
 	int n = build_req(
 		"{\"name\":\"net_recvfrom\",\"args\":"
 		"{\"fd\":%u,\"len\":%zu,\"flags\":%d}}",
@@ -767,15 +842,20 @@ static int hostsock_close(posix_sock *sock)
 	if (n >= 0)
 		rpc_exchange(n, NULL);
 
+	hostsock_untrack(sock);
 	struct posix_socket_driver *drv = posix_sock_get_driver(sock);
 	uk_free(drv->allocator, sd);
 	return 0;
 }
 
-static int hostsock_ioctl(posix_sock *sock __attribute__((unused)),
-			  int request __attribute__((unused)),
-			  void *argp __attribute__((unused)))
+static int hostsock_ioctl(posix_sock *sock, int request, void *argp)
 {
+	/* FIONBIO = 0x5421 on Linux */
+	if (request == 0x5421 && argp) {
+		struct hostsock_data *sd = posix_sock_get_data(sock);
+		sd->nonblock = (*(int *)argp) ? 1 : 0;
+		return 0;
+	}
 	return -ENOSYS;
 }
 
@@ -790,8 +870,32 @@ static int hostsock_socketpair(struct posix_socket_driver *d __attribute__((unus
 
 static void hostsock_poll_setup(posix_sock *sock)
 {
-	/* All I/O is synchronously blocked on the host, so always report ready. */
-	posix_sock_event_set(sock, UKFD_POLLIN | UKFD_POLLOUT);
+	uint32_t fd = get_host_fd(sock);
+	/* POLLIN=1, POLLOUT=4 — check real readiness via host poll(). */
+	int revents = hostsock_check_ready(fd, 1 | 4);
+	unsigned events = 0;
+	if (revents & 1)
+		events |= UKFD_POLLIN;
+	if (revents & 4)
+		events |= UKFD_POLLOUT;
+	posix_sock_event_set(sock, events);
+	hostsock_track(sock);
+}
+
+void hostsock_rescan_events(void)
+{
+	for (int i = 0; i < tracked_count; i++) {
+		posix_sock *sock = tracked_socks[i];
+		uint32_t fd = get_host_fd(sock);
+		int revents = hostsock_check_ready(fd, 1 | 4);
+		unsigned events = 0;
+		if (revents & 1)
+			events |= UKFD_POLLIN;
+		if (revents & 4)
+			events |= UKFD_POLLOUT;
+		if (events)
+			posix_sock_event_set(sock, events);
+	}
 }
 
 static struct posix_socket_ops hostsock_ops = {

--- a/plat/hyperlight/x86/time.c
+++ b/plat/hyperlight/x86/time.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include <uk/plat/time.h>
 #include <uk/lcpu.h>
 #include <uk/intctlr.h>
@@ -12,6 +13,7 @@
 #include <uk/atomic.h>
 #include <uk/arch/x86_64.h>
 #include <hyperlight-x86/setup.h>
+#include <hyperlight-x86/hcall.h>
 
 /* TSC frequency in Hz - will be calibrated at init */
 static __u64 tsc_freq;
@@ -88,14 +90,68 @@ __u32 ukplat_time_get_irq(void)
 	return 0;
 }
 
+#ifdef CONFIG_HYPERLIGHT_HCALL
+/*
+ * Call __hl_sleep via hcall. On the host this now also polls all sockets
+ * in the socket table, returning early with "socket_ready":true when a
+ * socket event occurs.  Returns 1 if sockets became ready, 0 otherwise.
+ */
+static int hyperlight_sleep_ns(__u64 ns)
+{
+	static char _req[128];
+	static char _resp[256];
+	__sz resp_len = 0;
+	int n = snprintf(_req, sizeof(_req),
+			 "{\"name\":\"__hl_sleep\",\"args\":{\"ns\":%llu}}",
+			 (unsigned long long)ns);
+	if (n < 0 || (__sz)n >= sizeof(_req))
+		return 0;
+	if (hyperlight_hcall((const __u8 *)_req, (__sz)n,
+			     (__u8 *)_resp, sizeof(_resp) - 1,
+			     &resp_len) < 0)
+		return 0;
+	_resp[resp_len] = '\0';
+	return strstr(_resp, "\"socket_ready\":true") != NULL;
+}
+
+#ifdef CONFIG_LIBHOSTSOCK
+extern void hostsock_rescan_events(void);
+#endif
+
+/* Block CPU until the specified time or pending events.
+ *
+ * Uses __hl_sleep instead of bare HLT so the host can simultaneously
+ * poll sockets and wake us early when network I/O is ready.
+ */
+void time_block_until(__snsec until)
+{
+	while ((__snsec) ukplat_monotonic_clock() < until) {
+		__snsec remaining = until - (__snsec)ukplat_monotonic_clock();
+		if (remaining <= 0)
+			break;
+
+		/* Cap each sleep at 100 ms to keep poll latency bounded. */
+		__u64 sleep_ns = (__u64)remaining;
+		if (sleep_ns > 100000000ULL)
+			sleep_ns = 100000000ULL;
+
+		if (hyperlight_sleep_ns(sleep_ns)) {
+#ifdef CONFIG_LIBHOSTSOCK
+			hostsock_rescan_events();
+#endif
+			break;
+		}
+	}
+}
+#else
 /* Block CPU until the specified time or pending events */
 void time_block_until(__snsec until)
 {
 	while ((__snsec) ukplat_monotonic_clock() < until) {
-		/* In Hyperlight, we just halt and wait for interrupt */
 		uk_lcpu_halt_irq();
 
 		if (uk_and_relax(&sched_have_pending_events, 0))
 			break;
 	}
 }
+#endif


### PR DESCRIPTION
## Summary

- Add `hostsock_check_ready()` helper that polls host socket readiness via `net_poll(timeout=0)` without blocking
- Make `hostsock_accept4` and `hostsock_recvfrom` always check readiness before issuing the host hcall, preventing a blocking hcall from freezing the single-vCPU VM
- Add socket tracking (`hostsock_track`/`hostsock_untrack`) and `hostsock_rescan_events()` so the epoll layer sees fresh readiness after `__hl_sleep` wakes
- Replace unconditional `posix_sock_event_set(POLLIN | POLLOUT)` in `poll_setup` with real host-side readiness
- Add `ioctl(FIONBIO)` handling to keep `sd->nonblock` in sync
- In `plat/hyperlight/x86/time.c`, call `hostsock_rescan_events()` after `__hl_sleep` returns so the scheduler sees updated socket state
- Guard `hyperlight_sleep_ns` and `hostsock_rescan_events` with `CONFIG_HYPERLIGHT_HCALL` / `CONFIG_LIBHOSTSOCK` so non-networking guests fall back to the original `uk_lcpu_halt_irq()` path

Previously, only sockets with `sd->nonblock` set were checked before accept/recv. Runtimes that set non-blocking mode via `fcntl(F_SETFL, O_NONBLOCK)` rather than `ioctl(FIONBIO)` (e.g., .NET Kestrel) left `sd->nonblock` at 0, causing the host hcall to block indefinitely and freeze the guest.

## Test plan

- [x] Go HTTP server (go-http example): sequential + concurrent requests
- [x] .NET Kestrel HTTP server (dotnet-http example): sequential + concurrent requests
- [x] Python echo server (networking-py example): TCP echo + HTTP GET
- [x] Non-networking guests unaffected: helloworld-c, rust, go, dotnet, dotnet-nativeaot, python, nodejs, shell, powershell, hostfs-posix-c, hostfs-posix-py
- [x] All cargo tests pass (including pyhl_runtime)