### PR TITLE
perf(boot): unmap boot heap PTEs to enable demand paging on Hyperlight

### DIFF
--- a/lib/ukboot/boot.c
+++ b/lib/ukboot/boot.c
@@ -186,6 +186,17 @@ static struct uk_alloc *heap_init()
 	if (unlikely(rc))
 		return NULL;
 
+#ifdef CONFIG_PLAT_HYPERLIGHT
+	/* Hyperlight identity-maps the entire heap in the boot page tables
+	 * before the guest starts.  Tear down those PTEs so that the VMA's
+	 * demand-paging handler re-maps pages on first access — only
+	 * touched pages then carry PTEs, which keeps snapshots small.
+	 */
+	uk_paging_page_unmap(pt,
+			     heap_base + HEAP_INITIAL_LEN,
+			     alloc_pages - HEAP_INITIAL_PAGES, 0);
+#endif
+
 	rc = uk_alloc_addmem(a, (void *)(heap_base + HEAP_INITIAL_LEN),
 			     (alloc_pages - HEAP_INITIAL_PAGES) << UK_PAGING_PAGE_SHIFT);
 	if (unlikely(rc))


### PR DESCRIPTION
## Summary

- Hyperlight identity-maps the entire heap in the boot page tables before the guest starts. When `heap_init()` creates a demand-paged VMA via `uk_vma_map_anon()`, the existing boot PTEs remain — `vma_op_anon_fault()` never fires because every page is already "present"
- This means snapshot mechanisms that walk guest page tables see every heap page (including untouched zeroes), producing snapshots proportional to the full heap size rather than actual usage
- After creating the demand-paged heap VMA, explicitly unmap the boot-provided PTEs for the heap remainder (keeping the initial 16 bootstrap pages) so the VMA fault handler re-maps pages on first access
- Gated behind `CONFIG_PLAT_HYPERLIGHT` — no effect on other platforms
- Tested with Hyperlight + Python (pandas, docx): snapshot shrinks from 3.0 GiB to 654 MiB with a 1280 MiB heap