### PR TITLE
lib/posix-tty: Fix stdio initcalls without ukfs devfs

### DIFF
--- a/lib/posix-tty/serial.c
+++ b/lib/posix-tty/serial.c
@@ -168,5 +168,6 @@ setup_tty_globals:
 	return 0;
 }
 
-uk_rootfs_initcall_prio(init_tty_cons, 0x0, UK_FS_PRIO_FSAVAIL);
+uk_rootfs_initcall_prio(init_tty_cons, 0x0,
+			UK_PRIO_BEFORE(UK_PRIO_LATEST));
 #endif /* !CONFIG_LIBUKFS_DEVFS */

--- a/lib/posix-tty/tty.c
+++ b/lib/posix-tty/tty.c
@@ -145,9 +145,13 @@ static int init_posix_tty(struct uk_init_ctx *ictx __unused)
 }
 
 #if CONFIG_LIBPOSIX_TTY_SERIAL
+#if CONFIG_LIBPOSIX_TTY_DEVFS
 /* Must come after the handler in serial.c */
 uk_rootfs_initcall_prio(init_posix_tty, 0x0,
 			UK_PRIO_AFTER(UK_PRIO_AFTER(UK_FS_PRIO_FSAVAIL)));
+#else /* !CONFIG_LIBPOSIX_TTY_DEVFS */
+uk_rootfs_initcall_prio(init_posix_tty, 0x0, UK_PRIO_LATEST);
+#endif /* !CONFIG_LIBPOSIX_TTY_DEVFS */
 #else /* !CONFIG_LIBPOSIX_TTY_SERIAL */
 #if CONFIG_LIBPOSIX_TTY_DEVFS
 uk_rootfs_initcall_prio(init_posix_tty, 0x0, UK_FS_PRIO_FSAVAIL);


### PR DESCRIPTION
### Description of Changes

When `CONFIG_LIBUKFS_DEVFS` is disabled, `lib/posix-tty` still uses
`UK_FS_PRIO_FSAVAIL` to register the serial console and standard I/O
initializers. The priority macro is not included in this configuration, so its
token is pasted into non-numeric `.uk_inittab` section names. The final link
does not retain those sections, leaving file descriptors 0, 1, and 2
uninitialized.

Keep both initializers in the rootfs init class for the non-DEVFS path.
Register the console file initializer immediately before the latest rootfs
priority and the standard I/O initializer at the latest priority. This ensures
that library initialization has completed while preserving the required order
between console file creation and opening the standard descriptors.

The DEVFS-specific initialization order remains unchanged.

Fixes #1838.

### Related Work

The regression was introduced by #1795.

### Testing

- Built the Catalog `base` configuration for QEMU/x86_64 with
  `CONFIG_LIBUKFS_DEVFS=n`.
- Verified numeric `.uk_inittab48` and `.uk_inittab49` sections and retained
  `init_tty_cons` and `init_posix_tty` symbols.
- Ran `helloworld-gcc13.2` under QEMU TCG and observed `Bye, World!`.
- Built the same configuration with `CONFIG_LIBUKFS_DEVFS=y` and verified
  numeric `.uk_inittab43` and `.uk_inittab44` sections.
- Ran `support/scripts/checkpatch.uk` against the commit: 0 errors, 0 warnings.

### PR Checklist

- [x] Read the contribution guidelines regarding submitting new changes to the
  project.
- [x] Tested the changes against the relevant architecture, platform, and
  configuration variants.
- [x] Ran `checkpatch.uk` on the commit series before opening this PR.
- [x] Updated relevant documentation (not applicable: no public API or
  configuration change).

### Note

I investigated this issue and prepared the fix in collaboration with OpenAI
Codex (GPT-5.5). I reviewed and tested the resulting change. I am still
learning Unikraft internals and the project's contribution workflow, so please
point out anything incorrect or suggest a more appropriate implementation or
testing approach.
