### PR TITLE
plat/hyperlight: fix idle thread to poll sockets via halt_irq PM ops

### DIFF
--- a/plat/hyperlight/shutdown.c
+++ b/plat/hyperlight/shutdown.c
@@ -12,6 +12,12 @@
 #include <hyperlight-x86/outb.h>
 #include <hyperlight-x86/dispatch.h>
 
+#ifdef CONFIG_HYPERLIGHT_HCALL
+#include <uk/lcpu.h>
+#include <uk/plat/time.h>
+#include <uk/plat/common/_time.h>
+#endif
+
 /* Push void result to the output buffer before halting.
  * This is needed because the application exits via uk_pm_shutdown,
  * bypassing the dispatch stub's output buffer push.
@@ -45,16 +51,36 @@ static int hyperlight_crash(void)
 	__builtin_unreachable();
 }
 
+#ifdef CONFIG_HYPERLIGHT_HCALL
+static void hyperlight_halt_irq(void)
+{
+	time_block_until((__snsec)ukplat_monotonic_clock() + 1000000000LL);
+}
+#endif
+
 static const struct uk_pm_ops hyperlight_pm_ops = {
 	.syshalt = hyperlight_halt,
 	.sysrestart = hyperlight_halt,
 	.syscrash = hyperlight_crash,
 };
 
+#ifdef CONFIG_HYPERLIGHT_HCALL
+static const struct uk_lcpu_pm_ops hyperlight_lcpu_pm_ops = {
+	.halt_irq = hyperlight_halt_irq,
+};
+#endif
+
 int hyperlight_register_pm_ops(struct ukplat_bootinfo __unused *bi)
 {
 	int rc = uk_pm_ops_register(&hyperlight_pm_ops);
 	return rc;
 }
+
+#ifdef CONFIG_HYPERLIGHT_HCALL
+void hyperlight_register_lcpu_pm_ops(void)
+{
+	uk_lcpu_pm_ops_register(&hyperlight_lcpu_pm_ops);
+}
+#endif
 
 UK_BOOT_EARLYTAB_ENTRY(hyperlight_register_pm_ops, UK_PRIO_EARLIEST);

--- a/plat/hyperlight/x86/lcpu.c
+++ b/plat/hyperlight/x86/lcpu.c
@@ -8,8 +8,6 @@
 #include <uk/arch/ctx.h>
 #include <uk/assert.h>
 #include <uk/lcpu.h>
-#include <uk/lcpu.h>
-
 
 void uk_lcpu_enable_irq(void)
 {
@@ -18,23 +16,6 @@ void uk_lcpu_enable_irq(void)
 
 void uk_lcpu_disable_irq(void)
 {
-	local_irq_disable();
-}
-
-void uk_lcpu_halt_irq(void)
-{
-	UK_ASSERT(uk_lcpu_irqs_disabled());
-
-	/*
-	 * We have to be careful when enabling interrupts before entering a
-	 * halt state. If we want to wait for an interrupt (e.g., a timer)
-	 * the interrupt may fire in the short window between sti and hlt and
-	 * we are going to halt forever. As sti only enables interrupts after
-	 * the following instruction, we can avoid the race condition by
-	 * ensuring that hlt immediately follows sti. There must be no
-	 * instruction in between.
-	 */
-	local_irq_enable_halt();
 	local_irq_disable();
 }
 

--- a/plat/hyperlight/x86/setup.c
+++ b/plat/hyperlight/x86/setup.c
@@ -491,7 +491,14 @@ void _ukplat_entry(struct ukplat_bootinfo *bi)
 
 	uk_boot_early_init(bi);
 
-
+	/* Re-register LCPU PM ops after early init so that Hyperlight's
+	 * halt_irq (which polls sockets via __hl_sleep) is not overwritten
+	 * by the native platform's HLT-based halt_irq.
+	 */
+	{
+		extern void hyperlight_register_lcpu_pm_ops(void);
+		hyperlight_register_lcpu_pm_ops();
+	}
 
 	/* Initialize IRQ controller */
 	rc = uk_intctlr_probe();


### PR DESCRIPTION
- Remove dead `uk_lcpu_halt_irq` from `plat/hyperlight/x86/lcpu.c` — it was shadowed by `lib/uklcpu/lcpu.c` and its HLT-based implementation prevented sockets from being polled during idle
- Register a `halt_irq` PM ops callback in `plat/hyperlight/shutdown.c` that calls `time_block_until()`, which polls sockets via `__hl_sleep` from the cooperative scheduler's idle thread
- Re-register after `uk_boot_early_init()` in `setup.c` so the native platform's HLT-based `halt_irq` doesn't overwrite it

When `urllib.request.urlopen()` is called without an explicit timeout, Python never sets `SO_RCVTIMEO`/`SO_SNDTIMEO`. The cooperative scheduler's idle thread then calls `uk_lcpu_halt_irq()` which was a no-op spinwait — sockets were never polled, so the connection hung indefinitely. This fix makes the idle thread poll sockets, matching the behavior when timeouts are set.