### PR TITLE
fix(posix-process): guard signal flush with CONFIG_LIBPOSIX_PROCESS_SIGNAL

### DIFF
--- a/lib/posix-process/clone.c
+++ b/lib/posix-process/clone.c
@@ -557,6 +557,7 @@ int uk_clone(struct clone_args *cl_args, size_t cl_args_len,
 		 * pprocess pointer to it — so its queue may hold
 		 * entries the restored pprocess doesn't expect.
 		 */
+#if CONFIG_LIBPOSIX_PROCESS_SIGNAL
 		if (parent_pt->process && parent_pt->process->signal) {
 			struct uk_signal_pdesc *pd =
 				parent_pt->process->signal;
@@ -566,6 +567,7 @@ int uk_clone(struct clone_args *cl_args, size_t cl_args_len,
 					&pd->sigqueue.list_head[_i]);
 			pd->queued_count = 0;
 		}
+#endif
 #endif
 		memcpy((void *)parent_rsp, stack_save, vfork_save_sz);
 		uk_free(s->a, stack_save);


### PR DESCRIPTION
The vfork signal flush block in clone.c references pprocess->signal,
struct uk_signal_pdesc, and SIG_ARRAY_COUNT, which only exist when
CONFIG_LIBPOSIX_PROCESS_SIGNAL is enabled. Examples without signal
support (e.g. hostfs-posix-c) fail to build with undefined type errors.