### PR TITLE
fix(posix-poll): guard epoll bypass with CONFIG_LIBPOSIX_PROCESS_MULTIPROCESS

### DIFF
--- a/lib/posix-poll/epoll.c
+++ b/lib/posix-poll/epoll.c
@@ -561,7 +561,7 @@ int uk_sys_epoll_pwait2(const struct uk_file *epf, struct epoll_event *events,
 	struct epoll_entry **list;
 	__nsec deadline;
 
-#if CONFIG_PLAT_HYPERLIGHT
+#if CONFIG_PLAT_HYPERLIGHT && CONFIG_LIBPOSIX_PROCESS_MULTIPROCESS
 #if CONFIG_LIBHOSTSOCK
 	extern int hostsock_rescan_events(void);
 #endif


### PR DESCRIPTION
The Hyperlight epoll bypass in `uk_sys_epoll_pwait2` was guarded only by
`CONFIG_PLAT_HYPERLIGHT`, activating it for all Hyperlight examples. This
causes two issues for examples that use `CONFIG_LIBPOSIX_POLL` but don't
need subprocess support:

- **Without `CONFIG_HYPERLIGHT_HCALL`** (dotnet, nodejs, powershell): the
  bypass calls `time_block_until()` which falls through to
  `uk_lcpu_halt_irq()` — this asserts IRQs are disabled, but epoll_pwait2
  runs in user context with IRQs enabled → crash.

- **With `CONFIG_HYPERLIGHT_HCALL`** (dotnet-http/Kestrel): the bypass's
  simplified epoll loop doesn't handle Kestrel's complex epoll patterns
  correctly, causing the server to hang during startup.

The bypass was added for vfork safety during subprocess support, so it
should only activate when `CONFIG_LIBPOSIX_PROCESS_MULTIPROCESS` is enabled.

Verified locally: dotnet and dotnet-http both pass with this guard.