### PR TITLE
lib/posix-futex: implement futex_requeue

### DIFF
--- a/lib/posix-futex/futex.c
+++ b/lib/posix-futex/futex.c
@@ -266,6 +266,72 @@ static int futex_cmp_requeue(uint32_t *uaddr, uint32_t val, uint32_t val2,
 }
 
 /**
+ * Requeue waiters from uaddr to uaddr2.
+ *
+ * Requeue waiters on uaddr to uaddr2. Wakes up a maximum of val waiters that
+ * are waiting on the futex at uaddr.  If there are more than val waiters, then
+ * the remaining waiters are removed from the wait queue of the source futex at
+ * uaddr and added to the wait queue of the target futex at uaddr2. The val2
+ * argument specifies an upper limit on the number of waiters that are requeued
+ * to the futex at uaddr2.
+ *
+ * @param uaddr		Source futex user address
+ * @param val		Number of waiters to wake
+ * @param val2		Number of waiters to requeue (0-INT_MAX)
+ * @param uaddr2	Target futex user address
+ *
+ * @return
+ *	>=0: on success, the number of tasks woken;
+ *	<0: on error
+ */
+static int futex_requeue(uint32_t *uaddr, uint32_t val, uint32_t val2,
+			     uint32_t *uaddr2)
+{
+	unsigned long irqf;
+	struct uk_list_head *itr, *tmp;
+	struct uk_futex *f;
+	int woken_uaddr1 = 0;
+	uint32_t waiters_uaddr2 = 0;
+
+	/* Wake up val waiters on uaddr */
+	if (val)
+		woken_uaddr1 = futex_wake(uaddr, val);
+
+	if (!val2)
+		return woken_uaddr1;
+
+	if (uaddr == uaddr2)
+		return woken_uaddr1;
+
+	uk_spin_lock_irqsave(&futex_list_lock, irqf);
+
+	/* Requeue val2 waiters on uaddr2 */
+	uk_list_for_each_safe(itr, tmp, &futex_list) {
+		f = uk_list_entry(itr, struct uk_futex, list_node);
+
+		if (f->uaddr == uaddr) {
+			/* Requeue thread to uaddr2.
+			 * Re-added node may be revisited during
+			 * iteration, but f->uaddr is now uaddr2
+			 * so it won't match again.
+			 * uaddr == uaddr2 case is guarded above.
+			 */
+			uk_list_del(&f->list_node);
+			f->uaddr = uaddr2;
+			uk_list_add_tail(&f->list_node, &futex_list);
+
+			/* Requeue at most val2 threads */
+			if (++waiters_uaddr2 >= val2)
+				break;
+		}
+	}
+
+	uk_spin_unlock_irqrestore(&futex_list_lock, irqf);
+
+	return woken_uaddr1;
+}
+
+/**
  * According to man pages, there exists no libc wrapper for futex
  *
  * @param uaddr		Source futex user address
@@ -332,8 +398,11 @@ UK_LLSYSCALL_R_DEFINE(int, futex, uint32_t *, uaddr, int, futex_op,
 		return futex_wake(uaddr, val);
 
 	case FUTEX_FD:
-	case FUTEX_REQUEUE:
 		return -ENOSYS;
+
+	case FUTEX_REQUEUE:
+		return futex_requeue(uaddr, val,
+				     (unsigned long)timeout, uaddr2);
 
 	case FUTEX_CMP_REQUEUE:
 		return futex_cmp_requeue(uaddr, val, (unsigned long)timeout,

--- a/lib/posix-futex/futex.c
+++ b/lib/posix-futex/futex.c
@@ -113,11 +113,9 @@ static int futex_wait(uint32_t *uaddr, uint32_t val, const __nsec *timeout)
 			val, uaddr);
 
 	/* Enqueue thread to wait list */
-	irqf = uk_lcpu_save_irqf();
-	uk_spin_lock(&futex_list_lock);
+	uk_spin_lock_irqsave(&futex_list_lock, irqf);
 	uk_list_add_tail(&f.list_node, &futex_list);
-	uk_spin_unlock(&futex_list_lock);
-	uk_lcpu_restore_irqf(irqf);
+	uk_spin_unlock_irqrestore(&futex_list_lock, irqf);
 
 	if (timeout) {
 		/* Block at most until `timeout` nanosecs */
@@ -132,8 +130,7 @@ static int futex_wait(uint32_t *uaddr, uint32_t val, const __nsec *timeout)
 	uk_sched_yield();
 
 	uk_pr_debug("FUTEX_WAIT: Woke up (uaddr: %p)\n", uaddr);
-	irqf = uk_lcpu_save_irqf();
-	uk_spin_lock(&futex_list_lock);
+	uk_spin_lock_irqsave(&futex_list_lock, irqf);
 
 	/* If the futex is still in the wait list, then it timed out */
 	uk_list_for_each_safe(itr, tmp, &futex_list) {
@@ -142,15 +139,13 @@ static int futex_wait(uint32_t *uaddr, uint32_t val, const __nsec *timeout)
 		if (f_tmp->uaddr == uaddr && f_tmp->thread == current) {
 			/* Remove the thread from the futex list */
 			uk_list_del(&f_tmp->list_node);
-			uk_spin_unlock(&futex_list_lock);
-			uk_lcpu_restore_irqf(irqf);
+			uk_spin_unlock_irqrestore(&futex_list_lock, irqf);
 
 			uk_pr_debug("FUTEX_WAIT: Woke up because of timeout\n");
 			return -ETIMEDOUT;
 		}
 	}
-	uk_spin_unlock(&futex_list_lock);
-	uk_lcpu_restore_irqf(irqf);
+	uk_spin_unlock_irqrestore(&futex_list_lock, irqf);
 
 	return 0;
 }
@@ -175,8 +170,7 @@ static int futex_wake(uint32_t *uaddr, uint32_t val)
 	struct uk_futex *f;
 	uint32_t count = 0;
 
-	irqf = uk_lcpu_save_irqf();
-	uk_spin_lock(&futex_list_lock);
+	uk_spin_lock_irqsave(&futex_list_lock, irqf);
 
 	uk_list_for_each_safe(itr, tmp, &futex_list) {
 		f = uk_list_entry(itr, struct uk_futex, list_node);
@@ -196,8 +190,7 @@ static int futex_wake(uint32_t *uaddr, uint32_t val)
 		}
 	}
 
-	uk_spin_unlock(&futex_list_lock);
-	uk_lcpu_restore_irqf(irqf);
+	uk_spin_unlock_irqrestore(&futex_list_lock, irqf);
 
 	return (int) count;
 }
@@ -240,8 +233,7 @@ static int futex_cmp_requeue(uint32_t *uaddr, uint32_t val, uint32_t val2,
 	if (!val2)
 		return woken_uaddr1;
 
-	irqf = uk_lcpu_save_irqf();
-	uk_spin_lock(&futex_list_lock);
+	uk_spin_lock_irqsave(&futex_list_lock, irqf);
 
 	/* Requeue val2 waiters on uaddr2 */
 	uk_list_for_each_safe(itr, tmp, &futex_list) {
@@ -259,8 +251,7 @@ static int futex_cmp_requeue(uint32_t *uaddr, uint32_t val, uint32_t val2,
 		}
 	}
 
-	uk_spin_unlock(&futex_list_lock);
-	uk_lcpu_restore_irqf(irqf);
+	uk_spin_unlock_irqrestore(&futex_list_lock, irqf);
 
 	return woken_uaddr1 + waiters_uaddr2;
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->
Tied to discussion [1844: FUTEX_REQUEUE](https://github.com/orgs/unikraft/discussions/1844)

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->
- lib/posix-futex/futex.c:
    - Add support for FUTEX_REQUEUE operation which wakes up to val waiters on uaddr and requeues up to val2 remaining waiters to uaddr2.
    - Refactor futex_wait, futex_wake, and futex_cmp_requeue to use uk_spin_lock_irqsave/uk_spin_unlock_irqrestore instead of the separate uk_lcpu_save_irqf + uk_spin_lock pattern.

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [✅] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [✅] Tested your changes against relevant architectures and platforms;
 - [✅] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [✅] Updated relevant documentation.
