### PR TITLE
support/scripts: Fixing size of ukplat_memregion_desc in mkbootinfo.py.

### DIFF
--- a/support/scripts/mkbootinfo.py
+++ b/support/scripts/mkbootinfo.py
@@ -60,7 +60,7 @@ def main():
         raise Exception("Unsupported architecture: {}".format(opt.arch))
 
     endianness = "big" if opt.big else "little"
-    mrd_size = 64 if opt.names else 32
+    mrd_size = 80 if opt.names else 48
 
     # Extract name of the unikernel binary for KERNEL segments
     if opt.names:


### PR DESCRIPTION
Commit ad52a90ffccb5bb6c3681d9d16d5b48e9d2dfc79 increased the size of ukplat_memregion_desc, however it didn't update the hardcoded size of the field in the script. This commit updates the size to match.

### Description of Changes

This change fixes a bug. The bug was:

mkbootinfo.py calculates the capacity of ukplat_memregion_desc structs by dividing the available space by the size of ukplat_memregion_desc. The size of that struct was hardcoded to be 32 (or 64 in case of embedded region names). These sizes are incorrect, and the actual sizes of the C structs is 48 (because it's aligned to 8 bytes), or 80 in case of a 36 byte region name.

This commit updates the hardcoded size to the correct ones. The struct can be viewed at include/uk/plat/memory.h.


### Related Work

N/A


### PR Checklist

 - [X ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ X] Tested your changes against relevant architectures and platforms;
 - [X ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [X ] Updated relevant documentation.
