### PR TITLE
lib/syscall_shim: Fix arm64 handler build with missing include

### DIFF
--- a/lib/syscall_shim/arch/arm64/syscall_handler.c
+++ b/lib/syscall_shim/arch/arm64/syscall_handler.c
@@ -4,6 +4,7 @@
  * You may not use this file except in compliance with the License.
  */
 
+#include <uk/arch/ctx.h>
 #include <uk/arch/types.h>
 #include <uk/event.h>
 #include <uk/lcpu.h>


### PR DESCRIPTION
Building with CONFIG_LIBSYSCALL_SHIM_HANDLER=y on arm64 fails with 'invalid use of undefined type struct ukarch_execenv' because syscall_handler.c uses the struct's members without including <uk/arch/ctx.h>, which defines it. Add the missing include.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes
Just adds `#include <uk/arch/ctx.h>` to `lib/syscall_shim/arch/arm64/syscall_handler.c`
<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work
https://github.com/unikraft/unikraft/issues/1869 -> issue
<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [+] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [+] Tested your changes against relevant architectures and platforms;
 - [+] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [~] Updated relevant documentation.
