### PR TITLE
plat/xen/arm: Fix mrd.pg_off calculation in _get_ramdisk

### DIFF
--- a/plat/xen/arm/setup64.c
+++ b/plat/xen/arm/setup64.c
@@ -245,7 +245,7 @@ static int _get_ramdisk(struct ukplat_bootinfo *bi, void *fdtp)
 
 	mrd.vbase = (__vaddr_t)to_virt(UK_PAGING_PAGE_ALIGN_DOWN(initrd_base));
 	mrd.pbase = (__paddr_t)mrd.vbase;
-	mrd.pg_off = initrd_base - mrd.pbase;
+	mrd.pg_off = initrd_base - UK_PAGING_PAGE_ALIGN_DOWN(initrd_base);
 	mrd.len = initrd_end - initrd_base;
 	mrd.pg_count = UK_PAGING_PAGE_COUNT(mrd.pg_off + mrd.len);
 	mrd.type = UKPLAT_MEMRT_INITRD;


### PR DESCRIPTION
When booting Unikraft on Xen (arm64) with ramdisk (initrd), the boot process hangs inside ukplat_memregion_list_coalesce() called from _init_mem() in plat/xen/arm/setup64.c. 

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

On AArch64 Xen with initrd, physical and virtual addresses were mixed up when calculating `pg_off`.
This caused `pg_off` to be computed incorrectly, leading to a boot hang when loading the ramdisk.

This patch calculates `pg_off` directly from the physical address, fixing the boot hang.

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

Issue : #1853 

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.
