### PR TITLE
plat/native: Fix arm64 build error for cpp apps

### DIFF
--- a/plat/native/pal/arch/arm64/include/uk/plat/pal/arch/except.h
+++ b/plat/native/pal/arch/arm64/include/uk/plat/pal/arch/except.h
@@ -41,7 +41,8 @@ __isr static inline void
 uk_pal_arm64_except_err_ctx_set_eid(struct uk_pal_except_err_ctx *ctx, int eid)
 {
 	uk_plat_native_arm64_except_err_ctx_set_eid(
-		(struct uk_plat_native_except_err_ctx *)ctx, eid);
+		(struct uk_plat_native_except_err_ctx *)ctx,
+		(enum uk_plat_native_arm64_except_id)eid);
 }
 
 __isr static inline __u64

--- a/plat/xen/arch/arm64/include/uk/plat/xen/arch/except.h
+++ b/plat/xen/arch/arm64/include/uk/plat/xen/arch/except.h
@@ -54,7 +54,8 @@ void uk_plat_xen_arm64_except_err_ctx_set_eid(
 	struct uk_plat_xen_except_err_ctx *ctx, int eid)
 {
 	uk_plat_native_arm64_except_err_ctx_set_eid(
-		(struct uk_plat_native_except_err_ctx *)ctx, eid);
+		(struct uk_plat_native_except_err_ctx *)ctx,
+		(enum uk_plat_native_arm64_except_id)eid);
 }
 
 __isr static inline


### PR DESCRIPTION
Builds of C++ apps for ARM64 fail. The ARM64 wrapper passes an int to a function whose parameter is an enum. C performs the int to enum conversion implicitly, but C++ does not, so the build fails.

### Description of Changes

Fix by explicitly making the conversion from int to enum in both plat/native/pal/arch/arm64/include/uk/plat/pal/arch/except.h:45 and plat/xen/arch/arm64/include/uk/plat/xen/arch/except.h:57.

### Related Work

Issue #1874

### PR Checklist

 - [X] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [X] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
