### PR TITLE
lib/posix-sysinfo: Handle _SC_CLK_TCK in sysconf()

### DIFF
--- a/lib/posix-sysinfo/sysinfo.c
+++ b/lib/posix-sysinfo/sysinfo.c
@@ -36,6 +36,7 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/utsname.h>
+#include <time.h>
 #include <uk/essentials.h>
 #include <uk/config.h>
 #include <sys/sysinfo.h>
@@ -125,6 +126,8 @@ long sysconf(int name)
 
 	if (name == _SC_PAGESIZE)
 		return __PAGE_SIZE;
+	if (name == _SC_CLK_TCK)
+		return CLOCKS_PER_SEC;
 
 #ifdef CONFIG_LIBPOSIX_USER
 	if (name == _SC_GETPW_R_SIZE_MAX)


### PR DESCRIPTION
sysconf() did not handle _SC_CLK_TCK and fell through to the default return value of 0. CPython 3.13 queries this value while initializing the posix module and fails fatally when it is not positive, which prevents any Python application from starting:

  RuntimeError: cannot read ticks_per_second
  Fatal Python error: _PyImport_InitExternal: external importer
  setup failed

Return 100, which is the value musl reports for _SC_CLK_TCK on Linux.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

`sysconf()` in `lib/posix-sysinfo` handles a small set of names and falls
through to a default return value of 0 for everything else. `_SC_CLK_TCK`
was not among the handled names, so it returned 0.

CPython 3.13 reads `_SC_CLK_TCK` while initializing the `posix` module and
treats a non-positive result as a fatal error. As a result, no Python
application can start:

```text
RuntimeError: cannot read ticks_per_second
Fatal Python error: _PyImport_InitExternal: external importer setup failed
```

This adds a case for `_SC_CLK_TCK` returning 100, matching the value musl
reports on Linux. The change is two lines and does not affect any other
`sysconf()` name.

I found this while upgrading `lib-python3` to 3.13 as part of GSoC'26.
Reproduced with `catalog-core/python3-hello` on `qemu/x86_64`: before the
change the unikernel boots but Python aborts during interpreter startup,
after it `hello.py` runs and prints its output.

If deriving the value from a configuration option is preferred over a
constant, I'm happy to rework it.

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
