### PR TITLE
plat/xen, drivers/pl011: Fix PL011 UART mapping on Xen/arm64

### DIFF
--- a/drivers/ukconsole/pl011/pl011.c
+++ b/drivers/ukconsole/pl011/pl011.c
@@ -16,6 +16,9 @@
 #include <uk/console/driver.h>
 #include <uk/compiler.h>
 #include <uk/errptr.h>
+#if CONFIG_PLAT_XEN
+#include <xen-arm/mm.h>
+#endif /* CONFIG_PLAT_XEN */
 
 #if CONFIG_LIBUKALLOC
 #include <uk/alloc.h>
@@ -284,7 +287,13 @@ static int fdt_get_device(struct pl011_device *dev, const void *dtb,
 
 	uk_console_init(&dev->dev, "PL011", &pl011_ops, 0,
 			UK_CONSOLE_CLASS_UART);
+#if CONFIG_PLAT_XEN
+	set_pgt_entry(&fixmap_pgtable[l2_pgt_idx(FIX_PL011_START)],
+		      ((reg_base & L2_MASK) | BLOCK_DEV_ATTR | L2_BLOCK));
+	dev->base = FIX_PL011_START + (reg_base & L2_OFFSET);
+#else
 	dev->base = reg_base;
+#endif /* CONFIG_PLAT_XEN */
 	dev->size = reg_size;
 
 	return 0;

--- a/drivers/ukconsole/pl011/pl011.c
+++ b/drivers/ukconsole/pl011/pl011.c
@@ -70,7 +70,7 @@
 #define REG_UARTICR_OFFSET	0x44
 
 static const char * const fdt_compatible[] = {
-	"arm,pl011", NULL
+	"arm,pl011", "arm,sbsa-uart", NULL
 };
 
 struct pl011_device {

--- a/plat/xen/include/xen-arm/mm.h
+++ b/plat/xen/include/xen-arm/mm.h
@@ -66,6 +66,7 @@ extern paddr_t _libxenplat_paddr_offset;
 
 #define SZ_2M           0x00200000
 
+#define FIXMAP_ENTRIES  (PAGE_SIZE / sizeof(lpae_t))
 #define PAGE_OFFSET     ((0xffffffffffffffff << (VA_BITS - 1))\
 						 & 0xffffffffffffffff)
 #define FIX_FDT_TOP     (PAGE_OFFSET)
@@ -78,6 +79,8 @@ extern paddr_t _libxenplat_paddr_offset;
 #define FIX_XS_START    (FIX_XS_TOP - SZ_2M)
 #define FIX_GNT_TOP     (FIX_XS_START)
 #define FIX_GNT_START   (FIX_GNT_TOP - SZ_2M)
+#define FIX_PL011_TOP   (FIX_GNT_START)
+#define FIX_PL011_START (FIX_PL011_TOP - SZ_2M)
 
 /*
  * Memory types available.
@@ -215,6 +218,7 @@ extern paddr_t _libxenplat_paddr_offset;
 #define map_frames(f, n) (NULL)
 
 #ifndef __ASSEMBLY__
+extern lpae_t fixmap_pgtable[FIXMAP_ENTRIES];
 void arch_mm_prepare(unsigned long *start_pfn_p, unsigned long *max_pfn_p);
 void set_pgt_entry(lpae_t *ptr, lpae_t val);
 #endif


### PR DESCRIPTION
On Xen/ARM64 dom0less boot, the unikernel crashes immediately with repeated data abort traps before any console output appears.

Root causes:

* In dom0less environment, HYPERVISOR_start_info is not initialized (remains 0x0). The xenconsole driver attempts to write pointer derived from start_info, which is NULL, triggering a data abort trap on every uk_pr_* / printk call.

* The PL011 UART driver uses the physical/IPA address from the FDT reg property directly as a virtual address (dev->base = reg_base). Under Xen, guest IPA is not identity-mapped to VA, so UART register accesses hit an incorrect virtual address.
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->
This series fixes PL011 UART initialization on Xen/arm64 dom0less guests.

On Xen, IPA cannot be used directly as a VA. The PL011 driver was using reg_base (IPA) directly as dev->base, causing a fault when accessing UART MMIO.

Patch 1 adds arm,sbsa-uart to the compatible string list so the PL011 driver can match the virtual PL011 node inserted by Xen in the guest DTB.

Patch 2 maps the UART MMIO through the fixmap page table when running on Xen, consistent with how other devices are mapped


### Related Work
Issue : https://github.com/unikraft/unikraft/issues/1882
<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->



### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.
