### PR TITLE
lib/nolibc: Define _SC_CLK_TCK

### DIFF
--- a/lib/nolibc/include/unistd.h
+++ b/lib/nolibc/include/unistd.h
@@ -54,6 +54,7 @@ extern "C" {
  * Sysconf name values
  */
 #if CONFIG_LIBPOSIX_SYSINFO
+#define _SC_CLK_TCK           2
 #define _SC_OPEN_MAX          4
 #define _SC_PAGE_SIZE        30
 #define _SC_PAGESIZE         _SC_PAGE_SIZE


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes
Follow-up to unikraft/unikraft#1877, which added handling for `_SC_CLK_TCK`
in `sysconf()`. `lib/nolibc/include/unistd.h` does not define the constant,
so any application building against nolibc now fails to compile:

```text
lib/posix-sysinfo/sysinfo.c:129:21: error: '_SC_CLK_TCK' undeclared
(first use in this function)
```

Define it as 2, matching glibc and musl and the numbering nolibc already
follows for the other `_SC_*` names it defines (`_SC_OPEN_MAX` 4,
`_SC_PAGE_SIZE` 30, `_SC_GETPW_R_SIZE_MAX` 70, `_SC_NPROCESSORS_CONF` 83).

Reported by @NgoHuy.

Tested with `catalog-core/c-hello`, which builds against nolibc, with
`LIBPOSIX_SYSINFO=y`: builds and boots with the define, fails as above
without it.


### Related Work

Follow-up to unikraft/unikraft#1877 (merged).

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
