### PR TITLE
.github/workflows: Isolate static-analysis untrusted workflow

### DIFF
--- a/.github/actions/build-elfloader/action.yml
+++ b/.github/actions/build-elfloader/action.yml
@@ -1,0 +1,172 @@
+name: 'build-elfloader'
+description: 'Build app-elfloader against the checked out Unikraft tree and emit its compilation database.'
+
+inputs:
+  clang-version:
+    description: 'The version of clang to build with.'
+    required: true
+
+outputs:
+  logfile:
+    description: 'The JSON Compilation Database produced by the build.'
+    value: ${{ steps.paths.outputs.logfile }}
+
+runs:
+  using: composite
+  steps:
+    - name: "Fetch clang"
+      uses: KyleMayes/install-llvm-action@v2
+      with:
+        arch: 'x64'
+        version: ${{ inputs.clang-version }}
+
+    - name: "Fetch elfloader"
+      uses: actions/checkout@v4
+      with:
+        repository: unikraft/app-elfloader
+        fetch-depth: 1
+        path: _elfloader
+
+    - name: "Build elfloader"
+      uses: unikraft/kraftkit@staging
+      with:
+        loglevel: debug
+        workdir: _elfloader
+        plat: 'qemu'
+        arch: 'x86_64'
+        execute: false
+        toolchain: "CC=/github/workspace/llvm/bin/clang"
+        kraftfile: |
+          specification: '0.5'
+          name: elfloader
+          unikraft:
+            source: ../
+            kconfig:
+              CONFIG_APPELFLOADER_BRK: 'y'
+              CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
+              CONFIG_APPELFLOADER_STACK_NBPAGES: 128
+              CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'
+              CONFIG_APPELFLOADER_VFSEXEC: 'y'
+              CONFIG_APPELFLOADER_AUTOGEN_REPLACEEXIST: 'y'
+              # Unikraft options
+              CONFIG_HAVE_PAGING_DIRECTMAP: 'y'
+              CONFIG_HAVE_PAGING: 'y'
+              CONFIG_LIBPOSIX_ENVIRON_ENVP0: "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+              CONFIG_LIBPOSIX_ENVIRON_ENVP1: "LD_LIBRARY_PATH=/usr/local/lib:/usr/lib:/lib"
+              CONFIG_LIBPOSIX_ENVIRON_ENVP2: "LOGNAME=root"
+              CONFIG_LIBPOSIX_ENVIRON_ENVP3: "HOME=/root"
+              CONFIG_LIBPOSIX_ENVIRON_ENVP4: "PWD=/root"
+              CONFIG_LIBPOSIX_ENVIRON: 'y'
+              CONFIG_LIBPOSIX_ENVIRON_LIBPARAM: 'y'
+              CONFIG_LIBPOSIX_ENVIRON_LIBPARAM_MAXCOUNT: '64'
+              CONFIG_LIBPOSIX_TTY: 'y'
+              CONFIG_LIBPOSIX_TTY_SERIAL: 'y'
+              CONFIG_LIBPOSIX_TTY_STDIN_VOID: 'y'
+              CONFIG_LIBPOSIX_TTY_STDOUT_SERIAL: 'y'
+              CONFIG_LIBPOSIX_EVENTFD: 'y'
+              CONFIG_LIBPOSIX_FDIO: 'y'
+              CONFIG_LIBPOSIX_FDTAB: 'y'
+              CONFIG_LIBPOSIX_FUTEX: 'y'
+              CONFIG_LIBPOSIX_MMAP: 'y'
+              CONFIG_LIBPOSIX_NETLINK: 'y'
+              CONFIG_LIBPOSIX_PIPE: 'y'
+              CONFIG_LIBPOSIX_POLL: 'y'
+              CONFIG_LIBPOSIX_PROCESS: 'y'
+              CONFIG_LIBPOSIX_PROCESS_MULTITHREADING: 'y'
+              CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
+              CONFIG_LIBPOSIX_PROCESS_MAX_PID: '511'
+              CONFIG_LIBPOSIX_SOCKET: 'y'
+              CONFIG_LIBPOSIX_SYSINFO: 'y'
+              CONFIG_LIBPOSIX_TIME: 'y'
+              CONFIG_LIBPOSIX_TIMERFD: 'y'
+              CONFIG_LIBPOSIX_UNIXSOCKET: 'y'
+              CONFIG_LIBPOSIX_USER_GID: 0
+              CONFIG_LIBPOSIX_USER_GROUPNAME: "root"
+              CONFIG_LIBPOSIX_USER_UID: 0
+              CONFIG_LIBPOSIX_USER_USERNAME: "root"
+              CONFIG_LIBPOSIX_USER: 'y'
+              CONFIG_LIBSYSCALL_SHIM_HANDLER_ULTLS: 'y'
+              CONFIG_LIBSYSCALL_SHIM_HANDLER: 'y'
+              CONFIG_LIBSYSCALL_SHIM_LEGACY_VERBOSE: 'y'
+              CONFIG_LIBSYSCALL_SHIM: 'y'
+              CONFIG_LIBUKALLOCPOOL: 'y'
+              CONFIG_LIBUKBLKDEV_MAXNBQUEUES: '1'
+              CONFIG_LIBUKBLKDEV_DISPATCHERTHREADS: 'y'
+              CONFIG_LIBUKBLKDEV_SYNC_IO_BLOCKED_WAITING: 'y'
+              CONFIG_LIBUKBLKDEV: 'y'
+              CONFIG_LIBUKBOOT_BANNER_MINIMAL: 'y'
+              CONFIG_LIBUKBOOT_HEAP_BASE: '0x400000000'
+              CONFIG_LIBUKBOOT_MAINTHREAD: 'y'
+              CONFIG_LIBUKBOOT_SHUTDOWNREQ_HANDLER: 'y'
+              CONFIG_LIBUKCPIO: 'y'
+              CONFIG_LIBUKDEBUG_CRASH_SCREEN: 'y'
+              CONFIG_LIBUKDEBUG_ENABLE_ASSERT: 'y'
+              CONFIG_LIBUKDEBUG: 'y'
+              CONFIG_LIBUKFALLOC: 'y'
+              CONFIG_LIBUKMPI: 'n'
+              CONFIG_LIBUKSIGNAL: 'y'
+              CONFIG_LIBUKRANDOM_DEVFS: 'y'
+              CONFIG_LIBUKRANDOM: 'y'
+              CONFIG_LIBUKRANDOM_GETRANDOM: 'y'
+              CONFIG_LIBUKVMEM_PFR: 'y'
+              CONFIG_LIBUKVMEM_DEFAULT_BASE: '0x0000001000000000'
+              CONFIG_LIBUKVMEM_DEMAND_PAGE_IN_SIZE: 12
+              CONFIG_LIBUKVMEM_PAGEFAULT_HANDLER_PRIO: 4
+              CONFIG_LIBUKVMEM: 'y'
+              CONFIG_ELF_PHDRS_IN_PT_LOAD: 'y'
+              CONFIG_PAGING: 'y'
+              CONFIG_STACK_SIZE_PAGE_ORDER: 4 # 128 * 4K = 512K
+              CONFIG_UKPLAT_MEMREGION_MAX_COUNT: 64
+              # VFS stack & fstab
+              CONFIG_LIBVFSCORE: 'n'
+              CONFIG_LIBUKFILE_PSEUDO: 'y'
+              CONFIG_LIBPOSIX_VFS: 'y'
+              CONFIG_LIBPOSIX_VFS_SYSCALLS: 'y'
+              CONFIG_LIBPOSIX_VFS_FSTAB: 'y'
+              CONFIG_LIBPOSIX_VFS_FSTAB_MOUNT_DEV: 'y'
+              CONFIG_LIBPOSIX_VFS_FSTAB_BUILTIN: 'y'
+              #CONFIG_LIBPOSIX_VFS_FSTAB_BUILTIN_EINITRD: 'y'
+              # Volume support + runtime fstab
+              CONFIG_LIBPOSIX_VFS_FSTAB_USER: 'y'
+              CONFIG_LIBUKFS_VIRTIOFS: 'y'
+          libraries:
+            lwip:
+              version: staging
+              kconfig:
+                CONFIG_LWIP_TCP: 'y'
+                CONFIG_LWIP_UDP: 'y'
+                CONFIG_LWIP_RAW: 'y'
+                CONFIG_LWIP_WND_SCALE: 'y'
+                CONFIG_LWIP_TCP_KEEPALIVE: 'y'
+                CONFIG_LWIP_THREADS: 'y'
+                CONFIG_LWIP_HEAP: 'y'
+                CONFIG_LWIP_SOCKET: 'y'
+                CONFIG_LWIP_AUTOIFACE: 'y'
+                CONFIG_LWIP_NUM_TCPCON: 64
+                CONFIG_LWIP_NUM_TCPLISTENERS: 64
+                CONFIG_LWIP_ICMP: 'y'
+                CONFIG_LWIP_DHCP: 'n'
+                CONFIG_LWIP_DNS: 'n'
+            libelf:
+              version: staging
+              kconfig:
+                CONFIG_LIBELF: 'y'
+          compiler-rt:
+            version: staging
+          targets:
+            - platform: 'qemu'
+              architecture: 'x86_64'
+
+    # The compilation database refers to the sources through the container
+    # path the build ran under.Make that path resolves on the host too.
+    - name: "Create link"
+      shell: bash
+      run: |
+        sudo mkdir -p /github
+        sudo ln -sfn "${{ github.workspace }}" /github/workspace
+
+    - name: "Locate the compilation database"
+      id: paths
+      shell: bash
+      run: |
+        echo "logfile=${{ github.workspace }}/_elfloader/.unikraft/build/compile_commands.json" >> "$GITHUB_OUTPUT"

--- a/.github/actions/ci-versions/action.yml
+++ b/.github/actions/ci-versions/action.yml
@@ -1,0 +1,14 @@
+name: 'ci-versions'
+description: 'Export tool versions shared across CI workflows.'
+
+runs:
+  using: composite
+  steps:
+    - name: "Export versions"
+      shell: bash
+      run: |
+        set -eu
+        {
+          echo 'CLANG_VERSION=21'
+          echo 'CODECHECKER_VERSION=6.27.3'
+        } >> "$GITHUB_ENV"

--- a/.github/workflows/actcheck.yaml
+++ b/.github/workflows/actcheck.yaml
@@ -6,6 +6,7 @@ on:
     branches: [staging]
     paths:
       - '.github/workflows/**'
+      - '.github/actions/**'
 
 jobs:
   action-lint:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -191,6 +191,109 @@ jobs:
           - platform: ${{ matrix.plat }}
             architecture: ${{ matrix.arch }}
 
+  static-analysis:
+    name: static-analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Load configuration
+      uses: ./.github/actions/ci-versions
+
+    - name: Build elfloader
+      id: build
+      uses: ./.github/actions/build-elfloader
+      with:
+        clang-version: ${{ env.CLANG_VERSION }}
+
+    - name: Run static analysis
+      uses: whisperity/codechecker-analysis-action@v1
+      id: codechecker
+      with:
+        version: ${{ env.CODECHECKER_VERSION }}
+        llvm-version: 'ignore' # already installed by the `build` step
+        ignore-analyze-crashes: false
+        config: "${{ github.workspace }}/.codechecker.json"
+        logfile: ${{ steps.build.outputs.logfile }}
+
+        # Store and diff require credentials, so both are
+        # performed by the `static-analysis` workflow.
+        store: false
+        diff: false
+
+    - name: Export report hashes
+      env:
+        ANALYZE_OUTPUT: ${{ steps.codechecker.outputs.analyze-output }}
+      run: |
+        set -eu
+        # `parse` exits with 2 when the analysers emitted at least one report,
+        # which is the normal case here and not an error.
+        CodeChecker parse "$ANALYZE_OUTPUT" \
+          --export baseline \
+          --output "${{ github.workspace }}/reports.baseline" \
+          || [ $? -eq 2 ]
+        # No findings at all means `parse` writes nothing.
+        touch "${{ github.workspace }}/reports.baseline"
+        echo "Exported $(grep -c '' reports.baseline) report hashes."
+
+    - name: Upload report hashes
+      uses: actions/upload-artifact@v4
+      with:
+        name: codechecker-baseline
+        path: reports.baseline
+        if-no-files-found: error
+        retention-days: 7
+
+    - name: Export report details
+      continue-on-error: true
+      env:
+        ANALYZE_OUTPUT: ${{ steps.codechecker.outputs.analyze-output }}
+      run: |
+        set -eu
+        # Annotate hashes above with file, line, checker and message,
+        # so that `static-analysis` can name new findings in summary
+        echo '{"version": 1, "reports": []}' > "${{ github.workspace }}/reports.json"
+        CodeChecker parse "$ANALYZE_OUTPUT" \
+          --export json \
+          --output "${{ github.workspace }}/reports.json" \
+          --trim-path-prefix /github/workspace "$GITHUB_WORKSPACE" \
+          || [ $? -eq 2 ]
+        # Pass on the rendered fields only, nothing else.
+        jq -c '[(.reports // [])[] | {
+                 hash: .report_hash,
+                 file: .file.path,
+                 line: .line,
+                 checker: .checker_name,
+                 severity: .severity,
+                 message: .message
+               }]' "${{ github.workspace }}/reports.json" \
+          > "${{ github.workspace }}/findings.json"
+        echo "Exported details for $(jq length findings.json) reports."
+
+    - name: Upload report details
+      continue-on-error: true
+      uses: actions/upload-artifact@v4
+      with:
+        name: codechecker-findings
+        path: findings.json
+        if-no-files-found: error
+        retention-days: 7
+
+    - name: Upload full report
+      if: ${{ always() && steps.codechecker.outputs.result-html-dir != '' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: codechecker-report
+        path: |
+          ${{ steps.codechecker.outputs.result-html-dir }}
+          ${{ steps.codechecker.outputs.result-log }}
+        retention-days: 7
+
   catalog-tests:
     needs: [libc-test, self-test, helloworld]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/staging' && github.repository_owner == 'unikraft' }}

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -11,239 +11,287 @@ on:
     - cron: '0 0 * * *'
 
 permissions:
-  statuses: write
+  contents: read
 
 jobs:
-  analyze:
+  # Populates the baseline on the CodeChecker server.
+  # Executes on local branches only, via manual or
+  # scheduled worflow runs.
+  store:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - name: "Set commit status: pending"
-        if: ${{ github.event_name == 'workflow_run' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }} \
-            -f state=pending \
-            -f context="static analysis" \
-            -f description="Running static analysis..." \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || 'staging' }}
+          ref: staging
           submodules: recursive
 
-      - name: "Fetch clang"
-        uses: KyleMayes/install-llvm-action@v2
-        with:
-          arch: 'x64'
-          version: '21'
-
-      - name: "Fetch elfloader"
-        uses: actions/checkout@v4
-        with:
-          repository: unikraft/app-elfloader
-          fetch-depth: 1
-          path: _elfloader
+      - name: "Load configuration"
+        uses: ./.github/actions/ci-versions
 
       - name: "Build elfloader"
-        uses: unikraft/kraftkit@staging
+        id: build
+        uses: ./.github/actions/build-elfloader
         with:
-          loglevel: debug
-          workdir: _elfloader
-          plat: 'qemu'
-          arch: 'x86_64'
-          execute: false
-          toolchain: "CC=/github/workspace/llvm/bin/clang"
-          kraftfile: |
-            specification: '0.5'
-            name: elfloader
-            unikraft:
-              source: ../
-              kconfig:
-                CONFIG_APPELFLOADER_BRK: 'y'
-                CONFIG_APPELFLOADER_CUSTOMAPPNAME: 'y'
-                CONFIG_APPELFLOADER_STACK_NBPAGES: 128
-                CONFIG_APPELFLOADER_VFSEXEC_EXECBIT: 'n'
-                CONFIG_APPELFLOADER_VFSEXEC: 'y'
-                CONFIG_APPELFLOADER_AUTOGEN_REPLACEEXIST: 'y'
-                # Unikraft options
-                CONFIG_HAVE_PAGING_DIRECTMAP: 'y'
-                CONFIG_HAVE_PAGING: 'y'
-                CONFIG_LIBPOSIX_ENVIRON_ENVP0: "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-                CONFIG_LIBPOSIX_ENVIRON_ENVP1: "LD_LIBRARY_PATH=/usr/local/lib:/usr/lib:/lib"
-                CONFIG_LIBPOSIX_ENVIRON_ENVP2: "LOGNAME=root"
-                CONFIG_LIBPOSIX_ENVIRON_ENVP3: "HOME=/root"
-                CONFIG_LIBPOSIX_ENVIRON_ENVP4: "PWD=/root"
-                CONFIG_LIBPOSIX_ENVIRON: 'y'
-                CONFIG_LIBPOSIX_ENVIRON_LIBPARAM: 'y'
-                CONFIG_LIBPOSIX_ENVIRON_LIBPARAM_MAXCOUNT: '64'
-                CONFIG_LIBPOSIX_TTY: 'y'
-                CONFIG_LIBPOSIX_TTY_SERIAL: 'y'
-                CONFIG_LIBPOSIX_TTY_STDIN_VOID: 'y'
-                CONFIG_LIBPOSIX_TTY_STDOUT_SERIAL: 'y'
-                CONFIG_LIBPOSIX_EVENTFD: 'y'
-                CONFIG_LIBPOSIX_FDIO: 'y'
-                CONFIG_LIBPOSIX_FDTAB: 'y'
-                CONFIG_LIBPOSIX_FUTEX: 'y'
-                CONFIG_LIBPOSIX_MMAP: 'y'
-                CONFIG_LIBPOSIX_NETLINK: 'y'
-                CONFIG_LIBPOSIX_PIPE: 'y'
-                CONFIG_LIBPOSIX_POLL: 'y'
-                CONFIG_LIBPOSIX_PROCESS: 'y'
-                CONFIG_LIBPOSIX_PROCESS_MULTITHREADING: 'y'
-                CONFIG_LIBPOSIX_PROCESS_ARCH_PRCTL: 'y'
-                CONFIG_LIBPOSIX_PROCESS_MAX_PID: '511'
-                CONFIG_LIBPOSIX_SOCKET: 'y'
-                CONFIG_LIBPOSIX_SYSINFO: 'y'
-                CONFIG_LIBPOSIX_TIME: 'y'
-                CONFIG_LIBPOSIX_TIMERFD: 'y'
-                CONFIG_LIBPOSIX_UNIXSOCKET: 'y'
-                CONFIG_LIBPOSIX_USER_GID: 0
-                CONFIG_LIBPOSIX_USER_GROUPNAME: "root"
-                CONFIG_LIBPOSIX_USER_UID: 0
-                CONFIG_LIBPOSIX_USER_USERNAME: "root"
-                CONFIG_LIBPOSIX_USER: 'y'
-                CONFIG_LIBSYSCALL_SHIM_HANDLER_ULTLS: 'y'
-                CONFIG_LIBSYSCALL_SHIM_HANDLER: 'y'
-                CONFIG_LIBSYSCALL_SHIM_LEGACY_VERBOSE: 'y'
-                CONFIG_LIBSYSCALL_SHIM: 'y'
-                CONFIG_LIBUKALLOCPOOL: 'y'
-                CONFIG_LIBUKBLKDEV_MAXNBQUEUES: '1'
-                CONFIG_LIBUKBLKDEV_DISPATCHERTHREADS: 'y'
-                CONFIG_LIBUKBLKDEV_SYNC_IO_BLOCKED_WAITING: 'y'
-                CONFIG_LIBUKBLKDEV: 'y'
-                CONFIG_LIBUKBOOT_BANNER_MINIMAL: 'y'
-                CONFIG_LIBUKBOOT_HEAP_BASE: '0x400000000'
-                CONFIG_LIBUKBOOT_MAINTHREAD: 'y'
-                CONFIG_LIBUKBOOT_SHUTDOWNREQ_HANDLER: 'y'
-                CONFIG_LIBUKCPIO: 'y'
-                CONFIG_LIBUKDEBUG_CRASH_SCREEN: 'y'
-                CONFIG_LIBUKDEBUG_ENABLE_ASSERT: 'y'
-                CONFIG_LIBUKDEBUG: 'y'
-                CONFIG_LIBUKFALLOC: 'y'
-                CONFIG_LIBUKMPI: 'n'
-                CONFIG_LIBUKSIGNAL: 'y'
-                CONFIG_LIBUKRANDOM_DEVFS: 'y'
-                CONFIG_LIBUKRANDOM: 'y'
-                CONFIG_LIBUKRANDOM_GETRANDOM: 'y'
-                CONFIG_LIBUKVMEM_PFR: 'y'
-                CONFIG_LIBUKVMEM_DEFAULT_BASE: '0x0000001000000000'
-                CONFIG_LIBUKVMEM_DEMAND_PAGE_IN_SIZE: 12
-                CONFIG_LIBUKVMEM_PAGEFAULT_HANDLER_PRIO: 4
-                CONFIG_LIBUKVMEM: 'y'
-                CONFIG_ELF_PHDRS_IN_PT_LOAD: 'y'
-                CONFIG_PAGING: 'y'
-                CONFIG_STACK_SIZE_PAGE_ORDER: 4 # 128 * 4K = 512K
-                CONFIG_UKPLAT_MEMREGION_MAX_COUNT: 64
-                # VFS stack & fstab
-                CONFIG_LIBVFSCORE: 'n'
-                CONFIG_LIBUKFILE_PSEUDO: 'y'
-                CONFIG_LIBPOSIX_VFS: 'y'
-                CONFIG_LIBPOSIX_VFS_SYSCALLS: 'y'
-                CONFIG_LIBPOSIX_VFS_FSTAB: 'y'
-                CONFIG_LIBPOSIX_VFS_FSTAB_MOUNT_DEV: 'y'
-                CONFIG_LIBPOSIX_VFS_FSTAB_BUILTIN: 'y'
-                #CONFIG_LIBPOSIX_VFS_FSTAB_BUILTIN_EINITRD: 'y'
-                # Volume support + runtime fstab
-                CONFIG_LIBPOSIX_VFS_FSTAB_USER: 'y'
-                CONFIG_LIBUKFS_VIRTIOFS: 'y'
-            libraries:
-              lwip:
-                version: staging
-                kconfig:
-                  CONFIG_LWIP_TCP: 'y'
-                  CONFIG_LWIP_UDP: 'y'
-                  CONFIG_LWIP_RAW: 'y'
-                  CONFIG_LWIP_WND_SCALE: 'y'
-                  CONFIG_LWIP_TCP_KEEPALIVE: 'y'
-                  CONFIG_LWIP_THREADS: 'y'
-                  CONFIG_LWIP_HEAP: 'y'
-                  CONFIG_LWIP_SOCKET: 'y'
-                  CONFIG_LWIP_AUTOIFACE: 'y'
-                  CONFIG_LWIP_NUM_TCPCON: 64
-                  CONFIG_LWIP_NUM_TCPLISTENERS: 64
-                  CONFIG_LWIP_ICMP: 'y'
-                  CONFIG_LWIP_DHCP: 'n'
-                  CONFIG_LWIP_DNS: 'n'
-              libelf:
-                version: staging
-                kconfig:
-                  CONFIG_LIBELF: 'y'
-            compiler-rt:
-              version: staging
-            targets:
-              - platform: 'qemu'
-                architecture: 'x86_64'
+          clang-version: ${{ env.CLANG_VERSION }}
 
-      - name: "Create link"
-        run: |
-          sudo mkdir /github
-          sudo ln -s "${{ github.workspace }}" /github/workspace
-
-      - name: Run static analysis
+      - name: "Run static analysis"
         uses: whisperity/codechecker-analysis-action@v1
         id: codechecker
         with:
-          version: '6.27.3'
-          llvm-version: 'ignore' # already installed
+          version: ${{ env.CODECHECKER_VERSION }}
+          llvm-version: ignore # already installed by the `build` step
           ignore-analyze-crashes: false
           config: "${{ github.workspace }}/.codechecker.json"
-          logfile: "${{ github.workspace }}/_elfloader/.unikraft/build/compile_commands.json"
+          logfile: ${{ steps.build.outputs.logfile }}
 
-          store: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+          store: true
           store-url: 'https://codechecker.unikraft.org/unikraft'
           store-run-name: 'app-elfloader-qemu-x86_64'
           store-username: ${{ secrets.CODECHECKER_STORE_USER }}
           store-password: ${{ secrets.CODECHECKER_STORE_PASS }}
 
-          diff: ${{ github.event_name == 'workflow_run' }}
-          diff-url: 'https://codechecker.unikraft.org/unikraft'
-          diff-run-name: 'app-elfloader-qemu-x86_64'
-          diff-username: ${{ secrets.CODECHECKER_STORE_USER }}
-          diff-password: ${{ secrets.CODECHECKER_STORE_PASS }}
-
       - name: "Check results store status"
         if: ${{ steps.codechecker.outputs.store-successful == 'false' }}
         run: exit 1
 
-      - name: "Fail the job if new findings are introduced"
-        if: ${{ steps.codechecker.outputs.warnings-in-diff == 'true' }}
-        run: exit 1
+  # Reports whether a PR introduces new findings.
+  # Notice that this does not depend on success of the `integration` workflow,
+  # as failure may be called by an irrelevant job like libc-tests. Instead,
+  # it depends on the `codechecker-baseline` artifact, which is only uploaded
+  # when the analysis job succeeds.
+  diff:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read     # to download the artifact of the triggering run
+      contents: read    # to check out the version manifest
+      statuses: write   # to report back on the head commit
+    env:
+      CC_URL: 'https://codechecker.unikraft.org/unikraft'
+      CC_RUN_NAME: 'app-elfloader-qemu-x86_64'
+      BASELINE: '_baseline/reports.baseline'
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: "Fetch version manifest"
+        uses: actions/checkout@v4
+        with:
+          ref: staging
+          sparse-checkout: .github/actions/ci-versions
 
-      - name: "Set commit status: success"
-        if: ${{ always() && github.event_name == 'workflow_run' && !failure() && !cancelled() }}
+      - name: "Load configuration"
+        uses: ./.github/actions/ci-versions
+
+      - name: "Set commit status: pending"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }} \
+          gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
+            -f state=pending \
+            -f context="static analysis" \
+            -f description="Running static analysis..." \
+            -f target_url="${RUN_URL}"
+
+      - name: "Fetch report hashes"
+        uses: actions/download-artifact@v4
+        with:
+          name: codechecker-baseline
+          path: _baseline
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Validate report hashes"
+        run: |
+          set -eu
+          test -f "${BASELINE}"
+          if [ "$(wc -c < "${BASELINE}")" -gt 1048576 ]; then
+            echo "::error title=Static analysis::Report hash list is implausibly large."
+            exit 1
+          fi
+          # Anything other than a bare list of hashes means the producing job
+          # was tampered with; refuse to feed it to CodeChecker.
+          if grep -qvE '^[A-Za-z0-9._:-]{1,128}$' "${BASELINE}"; then
+            echo "::error title=Static analysis::Report hash list contains unexpected content."
+            exit 1
+          fi
+          echo "Comparing $(grep -c '' "${BASELINE}") report hashes against ${CC_RUN_NAME}."
+
+      # We only use CodeChecker to diff, fetch from pip to save some time
+      - name: "Install CodeChecker"
+        run: pip3 install "codechecker==${CODECHECKER_VERSION}"
+
+      - name: "Diff against the stored baseline"
+        id: diff
+        env:
+          CC_USER: ${{ secrets.CODECHECKER_STORE_USER }}
+          CC_PASS: ${{ secrets.CODECHECKER_STORE_PASS }}
+        run: |
+          set -eu
+          umask 0077
+          jq -n --arg url "${CC_URL}" --arg cred "${CC_USER}:${CC_PASS}" \
+            '{client_autologin: true, credentials: {($url): $cred}}' \
+            > ~/.codechecker.passwords.json
+
+          set +e
+          CodeChecker cmd diff --new \
+            --url "${CC_URL}" \
+            --basename "${CC_RUN_NAME}" \
+            --newname "${BASELINE}" \
+            2>&1 | tee diff.log
+          rc=${PIPESTATUS[0]}
+          set -e
+
+          rm -f ~/.codechecker.passwords.json
+
+          case "${rc}" in
+            0) echo "new-findings=false" >> "$GITHUB_OUTPUT" ;;
+            2) echo "new-findings=true"  >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error title=Static analysis::CodeChecker cmd diff failed with exit code ${rc}."
+               exit 1 ;;
+          esac
+
+      - name: "Fetch report details"
+        if: ${{ steps.diff.outputs.new-findings == 'true' }}
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: codechecker-findings
+          path: _details
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Fail the job on new findings"
+        if: ${{ steps.diff.outputs.new-findings == 'true' }}
+        env:
+          INTEGRATION_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -eu
+          # Fetch hashes and annotate with details.
+          sed -n 's/.*baseline report hashes: //p' diff.log \
+            | tr ', ' '\n\n' \
+            | grep -xE '[A-Za-z0-9._:-]{1,128}' \
+            | sort -u > new-hashes.txt || :
+
+          python3 - <<'EOF'
+          import json, os, re
+
+          HASH = re.compile(r'\A[A-Za-z0-9._:-]{1,128}\Z')
+          PATH = re.compile(r'\A[A-Za-z0-9._/+-]{1,200}\Z')
+          CHECKER = re.compile(r'\A[A-Za-z0-9._-]{1,128}\Z')
+          SEVERITY = re.compile(r'\A[A-Z]{1,16}\Z')
+          MAX_ROWS = 100
+
+          def clean(text):
+              """Render an untrusted message as inert markdown table-cell text."""
+              text = re.sub(r'[|`<>\[\]\\]', '', str(text))
+              text = ''.join(c for c in text if c.isprintable() or c.isspace())
+              text = re.sub(r'\s+', ' ', text).strip()
+              return (text[:157] + '...') if len(text) > 160 else text
+
+          def details(path):
+              """hash -> (file:line, checker, severity, message), or {} if unusable."""
+              try:
+                  if os.path.getsize(path) > 8 << 20:
+                      return {}
+                  with open(path, encoding='utf-8') as f:
+                      entries = json.load(f)
+                  if not isinstance(entries, list) or len(entries) > 50000:
+                      return {}
+              except (OSError, ValueError):
+                  return {}
+
+              out = {}
+              for e in entries:
+                  if not isinstance(e, dict):
+                      continue
+                  h, f, c = e.get('hash'), e.get('file'), e.get('checker')
+                  line, sev = e.get('line'), e.get('severity')
+                  if not (isinstance(h, str) and HASH.match(h)):
+                      continue
+                  if not (isinstance(f, str) and PATH.match(f)):
+                      continue
+                  if not (isinstance(c, str) and CHECKER.match(c)):
+                      continue
+                  if not (isinstance(line, int) and 0 <= line <= 10 ** 7):
+                      continue
+                  if not (isinstance(sev, str) and SEVERITY.match(sev)):
+                      sev = ''
+                  out[h] = ('%s:%d' % (f, line), c, sev, clean(e.get('message', '')))
+              return out
+
+          def main():
+              with open('new-hashes.txt', encoding='utf-8') as f:
+                  hashes = [h for h in (l.strip() for l in f) if h and HASH.match(h)]
+              known = details(os.path.join('_details', 'findings.json'))
+              out = []
+              w = out.append
+
+              w('## Static analysis findings')
+              w('')
+
+              if hashes:
+                  w('%d new finding(s):' % (len(hashes)))
+                  w('')
+                  w('| file:line | checker | severity | message |')
+                  w('|---|---|---|---|')
+                  for h in hashes[:MAX_ROWS]:
+                      if h in known:
+                          w('| %s | `%s` | %s | %s |' % known[h])
+                      else:
+                          # No usable annotation: still report the finding.
+                          w('| _unknown_ | `%s` | | details unavailable |' % h)
+                  w('')
+                  if len(hashes) > MAX_ROWS:
+                      w('_%d further report(s) not listed._' % (len(hashes) - MAX_ROWS))
+                      w('')
+              if not known:
+                  w('Report details were unavailable, so only hashes are shown. Look')
+                  w('them up in the `codechecker-report` artifact of the [`integration`')
+                  w('run](%s) that produced these results.'
+                    % os.environ.get('INTEGRATION_URL', ''))
+                  w('')
+
+              with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as f:
+                  f.write('\n'.join(out) + '\n')
+
+          main()
+          EOF
+          exit 1
+
+      - name: "Set commit status: success"
+        if: ${{ always() && !failure() && !cancelled() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
             -f state=success \
             -f context="static analysis" \
             -f description="Passed" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f target_url="${RUN_URL}"
 
       - name: "Set commit status: failure"
-        if: ${{ always() && github.event_name == 'workflow_run' && failure() }}
+        if: ${{ always() && failure() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }} \
+          gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
             -f state=failure \
             -f context="static analysis" \
             -f description="Failed" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f target_url="${RUN_URL}"
 
       - name: "Set commit status: canceled"
-        if: ${{ always() && github.event_name == 'workflow_run' && cancelled() }}
+        if: ${{ always() && cancelled() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }} \
+          gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
             -f state=failure \
             -f context="static analysis" \
             -f description="Canceled" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f target_url="${RUN_URL}"


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

Static analysis of pull requests used to run in a single privileged workflowjob that checked out the PR head and built it with the CodeChecker credentials in scope. Split it into two parts:

1. integration/static-analysis that builds and analyzes the PR code without relying on secrets, then uploads the resulting report hashes as artifacts.

2. static-analysis that fetches the artifacts, validates them, and diffs them against the baseline version stored in the remote database.

The elfloader build is migrated into a build-elfloader action that is shared by workflows. The clang/CodeChecker versions are moved into a ci-versions action.
<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

#1811 


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
