### PR TITLE
lib/nolibc: Add _SC_CLK_TCK macro to unistd.h

### DIFF
--- a/lib/nolibc/include/unistd.h
+++ b/lib/nolibc/include/unistd.h
@@ -54,6 +54,7 @@ extern "C" {
  * Sysconf name values
  */
 #if CONFIG_LIBPOSIX_SYSINFO
+#define _SC_CLK_TCK           2
 #define _SC_OPEN_MAX          4
 #define _SC_PAGE_SIZE        30
 #define _SC_PAGESIZE         _SC_PAGE_SIZE


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

Commit 3898a16e36a5 ("lib/posix-sysinfo: Handle _SC_CLK_TCK in sysconf()") added support for _SC_CLK_TCK to sysconf() without ensuring nolibc provides the constant. This commit fixes the oversight, importing the value used by musl.


### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

https://github.com/unikraft/unikraft/pull/1877


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.
