### PR TITLE
lib/ukcpio: Continue extraction past end-of-archive markers

### DIFF
--- a/lib/ukcpio/cpio.c
+++ b/lib/ukcpio/cpio.c
@@ -417,6 +417,42 @@ extract_section(struct cpio_ilist *ilist,
 }
 
 /**
+ * Advances past an end-of-archive marker to the next archive in the buffer.
+ *
+ * The initramfs buffer format allows several cpio archives to be
+ * concatenated, separated by an arbitrary amount of zero padding; a
+ * "TRAILER!!!" record therefore only ends the archive it belongs to.
+ *
+ * @param headerp
+ *  Pointer to the trailer header; gets advanced to the next archive's first
+ *  header, or set to NULL if no further archive follows.
+ * @param eof
+ *  Pointer to the first byte after end of file.
+ */
+static void
+skip_to_next_archive(const struct uk_cpio_header **headerp, const char *eof)
+{
+	const struct uk_cpio_header *header = *headerp;
+	const char *next;
+
+	/* End-of-archive markers carry no data */
+	next = (const char *)UKCPIO_NEXT(header,
+					 UKCPIO_U32FIELD(header->namesize),
+					 UKCPIO_U32FIELD(header->filesize));
+	while (next < eof && !*next)
+		next++;
+	next = UKCPIO_ALIGN_UP(next);
+
+	/* Resume only if another archive actually follows */
+	if (next + sizeof(*header) > eof ||
+	    !ukcpio_valid_magic((const struct uk_cpio_header *)next)) {
+		*headerp = NULL;
+		return;
+	}
+	*headerp = (const struct uk_cpio_header *)next;
+}
+
+/**
  * Extracts a CPIO section to the dest directory.
  *
  * @param headerp
@@ -447,7 +483,13 @@ process_section(struct cpio_ilist *ilist,
 		return -UKCPIO_INVALID_HEADER;
 	}
 	if (unlikely(UKCPIO_ISLAST(header))) {
-		*headerp = NULL;
+		/*
+		 * Hard link tracking is archive-local: concatenated archives
+		 * are generated independently and reuse inode numbers, so
+		 * drop the list along with the archive that filled it.
+		 */
+		UK_SLIST_INIT(&ilist->elms);
+		skip_to_next_archive(headerp, eof);
 		return UKCPIO_SUCCESS;
 	}
 	return extract_section(ilist, headerp, fullpath, eof, prefixlen);
@@ -461,6 +503,7 @@ ukcpio_extract(const char *dest, const void *buf, size_t buflen)
 	};
 	enum ukcpio_error error = UKCPIO_SUCCESS;
 	const struct uk_cpio_header *header = buf;
+	const char *eof = (const char *)buf + buflen;
 	size_t max_alloc, destlen;
 	char pathbuf[PATH_MAX];
 	struct uk_alloc *a;
@@ -514,7 +557,7 @@ ukcpio_extract(const char *dest, const void *buf, size_t buflen)
 	while (header && error == UKCPIO_SUCCESS) {
 		error = process_section(&ilist,
 					&header, pathbuf,
-					(char *)header + buflen, destlen);
+					eof, destlen);
 	}
 
 	uk_free(a, region_base);


### PR DESCRIPTION
### Description of Changes

Fixes #1888.

**`TRAILER!!!` ended the whole buffer, not just its archive.** `process_section()` set `*headerp = NULL` on an end-of-archive marker, which terminated the `while (header && ...)` loop in `ukcpio_extract()`. The initramfs buffer format allows several cpio archives to be concatenated with arbitrary zero padding between them, so a trailer only ends the archive it belongs to. Every member after the first was dropped — and since the function still returned `UKCPIO_SUCCESS`, the loss was silent, which is how the reporter's bind-mount records disappeared inside the guest with no error anywhere.

**A second bug, found while fixing the first: `eof` slid forward with the cursor.** The `eof` argument was computed as `(char *)header + buflen` *inside* the loop, but `header` advances on every iteration, so `eof` tracked the cursor instead of marking the end of the buffer. That contradicts the parameter's own documentation ("Pointer to the first byte after end of file"), and it means the truncated-header guard `(char *)header >= eof` could never fire at all, with the remaining bounds checks evaluated against an ever-growing limit. This is not merely cosmetic: on a malformed buffer, ASan reports a heap-buffer-overflow read 90 bytes past the allocation, inside the `strcmp` that `UKCPIO_ISLAST` performs.

The two are coupled — fixing the trailer handling without fixing `eof` would walk further through a buffer whose bounds checks are disarmed — so they are fixed together.

**The change.** `eof` is computed once from `buf` and `buflen` and passed down unchanged. On a trailer, `skip_to_next_archive()` advances past the marker, skips zero padding, re-aligns, and resumes only if a valid magic header follows within bounds; otherwise it stops cleanly, since reaching the real end of the buffer is not an error.

**Hard link tracking is reset at the marker.** The buffer format states that the tuple buffer is reset at an end-of-archive marker precisely so that independently generated archives can be concatenated, and `init/initramfs.c` in Linux calls `free_hash()` on seeing `TRAILER!!!`. Without the reset, a file in a later archive is hard-linked to whatever happened to share its inode number in an earlier one — the inode tracking added in #1683 is archive-local by design. This is one line, and it is load-bearing: with it removed, the second archive's file silently gets the first archive's contents (evidence below).

**Testing.** `lib/ukcpio/tests/` does not exist, so there is no in-repo suite to extend. Rather than ship test code I could not compile or run, I built a host harness that compiles `lib/ukcpio/cpio.c` unmodified against stubs for the unikraft APIs it uses, with `-fsanitize=address -Wall -Wextra`, and synthesizes multi-member buffers in memory. Happy to contribute a `uktest` suite as a follow-up on a machine with the toolchain, if you would like one.

Against unmodified `staging`:

```
  test 'single': PASSED                       <- harness validates itself
  test 'multi'
    ok: ukcpio_extract returned 0 as expected  <- silent
    ok: a.txt present, content "AAA"
    FAIL: b.txt is MISSING
  test 'multi': FAILED

  ==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x50d000000126
  READ of size 1 at 0x50d000000126 thread T0
      #0 in strcmp
      #1 in process_section cpio.c:449
      #2 in ukcpio_extract cpio.c:515
  0x50d000000126 is located 90 bytes after 140-byte region
```

With this patch, all seven cases pass with no ASan reports: `single`, `multi` (both files, correct contents), `truncated` (now correctly returns `-UKCPIO_INVALID_HEADER` and logs `Truncated CPIO header`), `hardlink`, and three adversarial cases written against the new code — `tail-exact` (buffer ends flush with the trailer), `tail-junk` (200 bytes of `0xAA` after it), and `tail-short-magic` (a 4-byte truncated magic, since `ukcpio_valid_magic()` memcmps 6 and the bounds check must precede it). Those last three also pass on unmodified `staging`, which is the no-regression evidence: single-archive buffers with trailing garbage behave exactly as they do today.

Deleting only the `UK_SLIST_INIT` line from this patch reproduces the hard link corruption:

```
    FAIL: second.txt content is "FIRST", expected "SECOND"
```

**One adjacent finding, deliberately not fixed here.** The guard at `cpio.c:440` reads `UKCPIO_FILENAME(header) > eof`, which admits the `==` case: a header ending exactly at the buffer end passes, and the `UKCPIO_ISLAST` `strcmp` then reads at least one byte out of bounds. Changing `>` to `>=` closes it, but it is a distinct bug from the one reported and I would rather not fold it in silently. Say the word and I will send it separately, or add it here.

Thanks to @kastakhov for the report.

Disclosure: I use AI assistance in my work, and I review and verify everything before it goes out.

### Related Work

N/A — no open PR touches `lib/ukcpio`. The inode tracking this interacts with landed in #1683.

### PR Checklist

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.

On the second box, deliberately left unticked: I have no cross-toolchain or KVM here, so this was never built by the unikraft build system or booted on any platform. It is verified by the host harness described above, and by `checkpatch.uk` (`0 errors, 0 warnings, 0 checks`). I did not want to tick a box I cannot stand behind — please treat a real build as outstanding.
