### PR TITLE
lib/ukfile: Fix premature file finalization in uk_file_release()

### DIFF
--- a/lib/ukfile/include/uk/file.h
+++ b/lib/ukfile/include/uk/file.h
@@ -440,7 +440,7 @@ void uk_file_release(const struct uk_file *f)
 
 	if (r)
 		f->_release(f, r);
-	if (r | UK_SWREFCOUNT_LAST_STRONG)
+	if (r & UK_SWREFCOUNT_LAST_STRONG)
 		uk_file_refcnt_finalize(f->refcnt);
 }
 


### PR DESCRIPTION
 This PR fixes a critical bitwise operator typo in uk_file_release() that caused registered file finalizers to be executed prematurely on every file reference release.

In uk_file_release(), because UK_SWREFCOUNT_LAST_STRONG is defined as 2 (representing the release of the last strong reference), the bitwise OR operator caused the expression r | 2 to always evaluate to a non-zero value evaluating to true, making the conditional branch execute unconditionally on every reference release, even when active strong references to the file were still held.

This caused applications such as Nginx to prematurely unregister the listening socket from the epoll monitoring set and stop accepting new requests.

Fixes: b5f3ef9e719f ("lib/ukfile: Ensure finalizers run after destructor").

### Description of Changes

The bitwise operator `|` is replaced with `&` to ensure it correctly checks the returned code with the defined macro.

### Testing

I verified the fix by building the Nginx unikernel against the patched Unikraft core:
* Before the fix: Running wrk against Nginx completed about 3 runs, afterwards locked up the server and resulting in subsequent requests getting `No route to host` message error.
* After the fix: Nginx remains fully responsive and successfully handles consecutive rounds of concurrent wrk requests without dropping the listening socket.

### Related Work

N/A

### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.