### PR TITLE
{lib/ukdebug, support/scripts}: Fix uk tracepoint bugs

### DIFF
--- a/lib/ukdebug/include/uk/trace.h
+++ b/lib/ukdebug/include/uk/trace.h
@@ -169,11 +169,18 @@ static inline void __uk_trace_save_arg(char **pbuff,
 #define __UK_TRACE_ARG_TYPES(n, ...)					\
 	{ UK_FOREACH(__UK_TRACE_GET_TYPE_FOREACH, __VA_ARGS__) }
 
+#if defined(__arm__) || defined(__aarch64__)
+#define __UK_TRACEPOINTS_SECTION \
+	__attribute((__section__(".uk_tracepoints_list,\"\",%note//")))
+#else
+#define __UK_TRACEPOINTS_SECTION \
+	__attribute((__section__(".uk_tracepoints_list,\"\",@note#")))
+#endif
+
 #define __UK_TRACE_REG(NR, regname, trace_name, fmt, ...)	\
 	UK_CTASSERT(sizeof(#trace_name) < 255);			\
 	UK_CTASSERT(sizeof(fmt) < 255);				\
-	__attribute((__section__(				\
-		".uk_tracepoints_list,\"\",@note#")))		\
+	__UK_TRACEPOINTS_SECTION				\
 	static struct {						\
 		uint32_t magic;					\
 		uint32_t size;					\

--- a/lib/ukdebug/trace.c
+++ b/lib/ukdebug/trace.c
@@ -42,7 +42,6 @@ char uk_trace_buffer[CONFIG_LIBUKDEBUG_TRACE_BUFFER_SIZE];
 size_t uk_trace_buffer_free = CONFIG_LIBUKDEBUG_TRACE_BUFFER_SIZE;
 char *uk_trace_buffer_writep = uk_trace_buffer;
 
-
 /* Store a string in format "key = value" in the section
  * .uk_trace_keyvals. This can be anything what you want trace.py
  * script to know about, and what you do not want to consume any space
@@ -53,10 +52,16 @@ char *uk_trace_buffer_writep = uk_trace_buffer;
  *
  *     $ readelf -p .uk_trace_keyvals <your_image.gdb>
  */
-#define TRACE_DEFINE_KEY(key, val)			\
-	__attribute((__section__(			\
-		".uk_trace_keyvals,\"\",@note#")))	\
-	static const char key[] __used =		\
-		#key " = " #val
+#if defined(__arm__) || defined(__aarch64__)
+#define __UK_TRACE_KEYVALS_SECTION                                             \
+	__attribute((__section__(".uk_trace_keyvals,\"\",%note//")))
+#else
+#define __UK_TRACE_KEYVALS_SECTION                                             \
+	__attribute((__section__(".uk_trace_keyvals,\"\",@note#")))
+#endif
+
+#define TRACE_DEFINE_KEY(key, val)                                             \
+	__UK_TRACE_KEYVALS_SECTION                                             \
+	static const char key[] __used = #key " = " #val
 
 TRACE_DEFINE_KEY(format_version, 1);

--- a/support/scripts/uk-gdb.py
+++ b/support/scripts/uk-gdb.py
@@ -36,10 +36,11 @@ import os
 import sys
 import tempfile
 import shutil
-import uk_trace.parse as parse
 
 scripts_dir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(scripts_dir)
+
+import uk_trace.parse as parse
 
 type_char = gdb.lookup_type("char")
 type_void = gdb.lookup_type("void")
@@ -80,7 +81,6 @@ def save_traces(out):
     # versions should just have modifications at the very end to keep
     # compatibility with previously collected data.
     pickler.dump(parse.get_keyvals(elf))
-    pickler.dump(elf)
     pickler.dump(PTR_SIZE)
     # We are saving raw trace buffer here. Another option is to pickle
     # already parsed samples. But in the chosen case it is a lot

--- a/support/scripts/uk_trace/parse.py
+++ b/support/scripts/uk_trace/parse.py
@@ -207,9 +207,10 @@ def get_tp_definitions(tp_data, ptr_size):
 
 def get_tp_sections(elf):
     f = tempfile.NamedTemporaryFile()
-    objcopy_cmd = "objcopy -O binary %s " % elf
-    objcopy_cmd += "--only-section=.uk_tracepoints_list " + f.name
-    objcopy_cmd = objcopy_cmd.split()
+    # NOTE: When reading a cross-architecture ELF file, make sure the objcopy utility supports that architecture.
+    objcopy_cmd = ["objcopy",
+                   "--dump-section", ".uk_tracepoints_list=" + f.name,
+                   elf, "/dev/null"]
     subprocess.check_call(objcopy_cmd)
     return f.read()
 

--- a/support/scripts/uk_trace/parse.py
+++ b/support/scripts/uk_trace/parse.py
@@ -39,8 +39,6 @@ TP_HEADER_MAGIC = "TRhd"
 TP_DEF_MAGIC = "TPde"
 UK_TRACE_ARG_INT = 0
 UK_TRACE_ARG_STRING = 1
-# Not sure why gcc aligns data on 32 bytes
-__STRUCT_ALIGNMENT = 32
 
 FORMAT_VERSION = 1
 
@@ -116,7 +114,7 @@ class sample_parser:
             if tp.types[i] == UK_TRACE_ARG_STRING:
                 args += [self.data.unpack_string()]
             else:
-                args += [self.data.unpack_int(tp.sizes[i])]
+                args += [self.data.unpack_int(tp.sizes[i], tp.signed[i])]
 
         return tp_sample(tp, time, tuple(args))
 
@@ -142,15 +140,15 @@ class unpacker:
         (ret,) = self.unpack(fmt)
         return ret.decode()
 
-    def unpack_int(self, size):
+    def unpack_int(self, size, signed=False):
         if size == 1:
-            fmt = "B"
+            fmt = "b" if signed else "B"
         elif size == 2:
-            fmt = "H"
+            fmt = "h" if signed else "H"
         elif size == 4:
-            fmt = "I"
+            fmt = "i" if signed else "I"
         elif size == 8:
-            fmt = "Q"
+            fmt = "q" if signed else "Q"
         (ret,) = self.unpack(fmt)
         return ret
 
@@ -159,12 +157,13 @@ class unpacker:
 
 
 class tp_definition:
-    def __init__(self, name, args_nr, fmt, sizes, types):
+    def __init__(self, name, args_nr, fmt, sizes, types, signed=None):
         self.name = name
         self.args_nr = args_nr
         self.fmt = fmt
         self.sizes = sizes
         self.types = types
+        self.signed = signed if signed is not None else [False] * args_nr
 
     def __str__(self):
         return "%s %s" % (self.name, self.fmt)
@@ -176,10 +175,17 @@ def get_tp_definitions(tp_data, ptr_size):
 
     ret = dict()
 
+    # Find the first entry by scanning for the TP_DEF_MAGIC string
+    while data.pos < len(data.data) - 4:
+        if data.data[data.pos:data.pos+4] == TP_DEF_MAGIC.encode():
+            break
+        data.pos += 1
+
     while True:
-        data.align_pos(__STRUCT_ALIGNMENT)
+        entry_start = data.pos
+
         try:
-            magic, _, cookie, args_nr, name_len, fmt_len = data.unpack(
+            magic, size, cookie, args_nr, name_len, fmt_len = data.unpack(
                 "4sIQBBB"
             )
         except EndOfBuffer:
@@ -197,10 +203,86 @@ def get_tp_definitions(tp_data, ptr_size):
         name = name[:-1].decode()
         fmt = fmt[:-1].decode()
 
-        # Convert from c-printf format into python one
+        # Determine signed-ness of each integer argument from the format string
+        # Per printf(3): %[flags][width][.precision][length]specifier
+        #
+        # Length modifiers: hh, h, l, ll, z, t, j, q
+        # Signed specifiers: d, i
+        # Unsigned specifiers: u, o, x, X
+        # Pointer: p (always unsigned, size = ptr_size)
+
+        _FLAGS = r"[#0\- +']*"
+        _WIDTH = r'(?:\*|\d+)?'
+        _PRECISION  = r'(?:\.(?:\*|\d+))?'
+        _LEN   = r'(?:hh|h|ll|l|z|t|j|q)?'
+        _FWP   = _FLAGS + _WIDTH + _PRECISION  # flags + width + precision (optional)
+
+        _FMT_SPEC_RE = re.compile(
+            r'%%'                       # literal %% (skip, consumes no arg) (group 0)
+            r'|%' + _FWP +             # optional (group 0)
+            r'(hh|h|ll|l|z|t|j|q)?'    # length modifier (group 1)
+            r'([diouxXs])'              # conversion specifier (group 2)
+            r'|%p'                      # pointer (no length modifier) (group 0)
+        )
+
+        # Validate: the number of format specifiers must match args_nr
+        num_specifiers = sum(
+            1 for m in _FMT_SPEC_RE.finditer(fmt)
+            if m.group(0) != '%%'
+        )
+        assert num_specifiers == args_nr, (
+            "Format specifier count mismatch: fmt has %d, args_nr is %d for '%s'"
+            % (num_specifiers, args_nr, name)
+        )
+
+        # Now safely determine signed-ness for each argument
+        is_arg_signed = [False for _ in range(args_nr)]
+        fmt_tmp = fmt
+        for i in range(args_nr):
+            # Skip any literal %% before looking for the real specifier
+            while True:
+                m = _FMT_SPEC_RE.search(fmt_tmp)
+                if not m:
+                    break
+                if m.group(0) == '%%':
+                    fmt_tmp = fmt_tmp[m.end():]
+                    continue
+                break
+
+            if types[i] == UK_TRACE_ARG_STRING:
+                if m and m.group(2) == 's':
+                    fmt_tmp = fmt_tmp[m.end():]
+            else:
+                if m:
+                    conv = m.group(2)  # None if matched %p branch
+                    if conv and conv != 's':
+                        is_arg_signed[i] = conv in ('d', 'i')
+                    else: # %p case
+                        is_arg_signed[i] = False
+                    fmt_tmp = fmt_tmp[m.end():]
+
+        # Convert C printf format specifiers into Python equivalents.
+        # Strip length modifiers while preserving flags, width, and precision.
+        _FWP_CAP = '(' + _FLAGS + _WIDTH + _PRECISION + ')'  # capturing version
+
+        # Hex/octal: strip length modifier, keep the rest
+        fmt = re.sub(r'%' + _FWP_CAP + _LEN + r'([xXo])', r'%\1\2', fmt)
+
+        # Decimal (d, i, u): strip length modifier, normalize to %d
+        fmt = re.sub(r'%' + _FWP_CAP + _LEN + r'[diu]', r'%\1d', fmt)
+
+        # %p has no length modifier per spec; simple replace at the end
         fmt = fmt.replace("%p", ptr_fmt)
 
-        ret[cookie] = tp_definition(name, args_nr, fmt, sizes, types)
+        ret[cookie] = tp_definition(name, args_nr, fmt, sizes, types,
+                                    is_arg_signed)
+
+        # Use size field to jump to next entry
+        data.pos = entry_start + size
+
+        # Skip any zero-padding (compiler alignment between entries)
+        while data.pos < len(data.data) and data.data[data.pos] == 0:
+            data.pos += 1
 
     return ret
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

(NOTE: Tied to the issue #1897)  
  
Fix UK_TRACEPOINT infrastructure bugs  
  
Following 7 issues prevent tracepoint data from being collected and parsed:  
  
1. Section attribute syntax: The `.uk_tracepoints_list` and `.uk_trace_keyvals`
   sections use `,"",@note#` which is a GNU assembler x86 trick where `#` starts a comment.
   ARM64 assembler rejects this with:
   "Error: junk at end of line, first unrecognized character is '#'"

2. `uk-gdb.py` cannot import uk_trace, causing ModuleNotFoundError: No module named 'uk_trace'

3.  The tracepoint section retriever uses `objcopy -O binary` to extract the `.uk_tracepoints_list` section. 
    However, this silently skips the section because it is a GNU-as NOTE section, which has the NON-ALLOC attribute.

4. String value is treated as integer, when a `pickle` format file (which is saved via `uk trace save` in GDB helper script) is loaded:
   `parse.py` uses `elf` (which is an elf file path) in a `%d` formatting operation 
   This causes the parser to fail with: TypeError: %d format: a real number is required, not str

5. Tracepoint definition parser: `parse.py` assumes 32-byte alignment between
   entries in `.uk_tracepoints_list`. This is not guaranteed by any attribute or
   linker script, and fails on ARM64 where GCC uses different padding.

6. Signed integers printed as unsigned: All integer trace arguments are
   unpacked using unsigned struct formats (B/H/I/Q), causing signed values
   like -1 to be displayed as 4294967295. The tracepoint type system only
   distinguishes INT vs STRING, so signed-ness must be determined from the
   format string.

7. Format string conversion causes Python ValueError: `parse.py` only converted
   `%p` via str.replace() Specifiers with flags, width, length, or precision
   (e.g., `%#08lx`, `%016llX`, `%04lld`) were not handled, causing Python ValueError 
   at runtime because Python's `%` formatting does not recognize C length
   modifiers.
  
This PR resolves the above issues.   

- Regarding [1] (`trace.h`, `trace.c`): Added `__UK_TRACEPOINTS_SECTION` and `__UK_TRACE_KEYVALS_SECTION` macros that use a GNU-as arm trick where `//` starts a comment on ARM/ARM64 and retain the `@note#` syntax on x86.
- Regarding [2] (`uk-gdb.py`): Moved `import uk_trace` after appending the script dir to sys.path. 
- Regarding [3] (`parse.py`): Used `objcopy --dump-section` instead, which extracts the section contents regardless of its ALLOC/NON-ALLOC attribute. 
- Regarding [4] (`uk-gdb.py`): The ELF path was not used after loading, so removed it from the pickle dump. 
- Regarding [5] (`parse.py`): Removed `__STRUCT_ALIGNMENT` constant. Made a logic scanning for `TP_DEF_MAGIC` to locate the first entry and use each entry's size field to jump to the next. Also, if there is any zero-padding, the parser consumes it.  
- Regarding [6] (`parse.py`): Parsed each argument's format specifier the per `printf(3)` man page to determine signed-ness: `d`/`i` are signed, `u`/`o`/`x`/`X`/`p` are unsigned. Added a 'signed' parameter to `unpack_int()` and stored per-argument signedness in `tp_definition`. Validated that the number of format specifiers matches `args_nr`. 
- Regarding [7] (`parse.py`): Replaced `str.replace()` format conversion with regex-based substitution that strips length modifiers (`hh`/`h`/`l`/`ll`/`z`/`t`/`j`/`q`) while preserving flags, width, and precision. Handled `%p` separately since it has no length modifier per the man page spec.
  
I believe this PR\
closes #1897, and\
closes #1426.  

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A  
No any other PRs that this PR depends on or it will conflict with.  


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.
