### PR TITLE
plat/kvm: Remove stale `ELF64_TO_32` in favor of `multiboot` config

### DIFF
--- a/plat/kvm/Config.uk
+++ b/plat/kvm/Config.uk
@@ -14,7 +14,6 @@ menuconfig PLAT_KVM
 	select HAVE_FDT if ARCH_ARM_64
 	imply LIBFDT if ARCH_ARM_64
 	imply LIBUKOFW if ARCH_ARM_64
-	select ELF64_TO_32 if ARCH_X86_64
 	select LIBUKRELOC if OPTIMIZE_PIE
 	select HAVE_PAGING
 	select LIBUKPLAT_NATIVE_PAL

--- a/plat/kvm/Linker.uk
+++ b/plat/kvm/Linker.uk
@@ -2,7 +2,6 @@ ifeq (x86_64,$(CONFIG_UK_ARCH))
 ifeq ($(CONFIG_KVM_BOOT_PROTO_MULTIBOOT),y)
 KVM_LDFLAGS-y += -Wl,-m,elf_x86_64
 KVM_LDFLAGS-y += -Wl,--entry=_multiboot_entry
-ELF64_TO_32 = y
 else ifeq ($(CONFIG_KVM_BOOT_PROTO_LXBOOT),y)
 KVM_LDFLAGS-y += -Wl,--entry=_lxboot_entry
 else ifeq ($(CONFIG_KVM_BOOT_PROTO_EFI_STUB),y)
@@ -82,7 +81,7 @@ $(KVM_IMAGE): $(KVM_IMAGE).dbg
 				"Empty loadable segment detected|section.*lma.*adjusted to.*" || \
 				true; })
 	$(call build_bootinfo,$@)
-ifeq ($(ELF64_TO_32),y)
+ifeq ($(CONFIG_KVM_BOOT_PROTO_MULTIBOOT),y)
 	$(call build_multiboot,$@)
 endif
 ifeq ($(CONFIG_KVM_BOOT_PROTO_EFI_STUB),y)


### PR DESCRIPTION
This `ELF64_TO_32` was introduced back when the python script that creates ELF32-equivalent for Multiboot booting was added. It has been since renamed to `multiboot.py` because it's the only boot protocol that has this requirement and this `ELF64_TO_32` should have been deleted along with it and replaced with the multiboot config instead. Do so now.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
