### PR TITLE
lib/posix-process: Fix `clone` dead check for `CLONE_THREAD`

### DIFF
--- a/lib/posix-process/clone.c
+++ b/lib/posix-process/clone.c
@@ -206,7 +206,10 @@ int uk_clone(struct clone_args *cl_args, size_t cl_args_len,
 #endif /* UK_DEBUG */
 
 #if !CONFIG_LIBPOSIX_PROCESS_MULTIPROCESS
-	if (unlikely(flags & !CLONE_THREAD)) {
+	/* Without multiprocess support we can only create threads, that is,
+	 * clones that share our process context.
+	 */
+	if (unlikely(!(flags & CLONE_THREAD))) {
 		uk_pr_err("Multiprocess support not enabled\n");
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
The `!` is misplaced and `!CLONE_THREAD` is always zero, therefore `flags & !CLONE_THREAD` is always 0, making the check dead. Fix it.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
