### PR TITLE
lib/ukrandom: Seed the CSPRNG with the cmdline seed

### DIFF
--- a/lib/ukrandom/swrand.c
+++ b/lib/ukrandom/swrand.c
@@ -96,7 +96,7 @@ int uk_swrand_cmdline_init(struct uk_random_driver **drv)
 
 	ctx.driver = *drv;
 
-	chacha_init(&ctx.chacha, seedv, iv, 0);
+	chacha_init(&ctx.chacha, seedv_cmdl, iv, 0);
 
 	return 0;
 }


### PR DESCRIPTION
`uk_swrand_cmdline_init()` passed `seedv`, the local sentinel used only by the `memcmp()`, to `chacha_init()` instead of `seedv_cmdl`, which holds the parsed value. The CSPRNG was thus always keyed with `CHACHA_SEED_NOINIT`, making its output identical across boots.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.
