### PR TITLE
support/scripts/ukgcov: Fix off-by-one line drop in gcov_serial_parse

### DIFF
--- a/support/scripts/ukgcov/gcov_serial_parse.py
+++ b/support/scripts/ukgcov/gcov_serial_parse.py
@@ -51,7 +51,7 @@ def main():
             if GCOV_BEGIN in line:
                 start_line = i + 1
             if GCOV_END in line:
-                end_line = i - 1
+                end_line = i
                 break
 
         if start_line > end_line:


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!
We welcome new changes, features, fixes, and more!
Please fill in this short form to indicate the status of your PR.

-->

### Description of Changes

<!--
Provide a detailed description of the changes made in this PR.

This should include, as applicable:
- Context & motivation (e.g., fixes bug X, introduces feature that enables Y, etc.)
- Overview of code changes (what has been changed and to what end)
- Public interface changes (library API(s), syscall API/ABI, Kconfig, etc.)
- Any other notable mentions regarding review, testing, and integration
-->
When slicing lines between `GCOV_BEGIN` and `GCOV_END`, end_line was set to i - 1 where i is the index of GCOV_END. Because Python slice notation lines[start:end] is exclusive of the end index, the line at i - 1 (the final data line) was always omitted from parsing, and single-line dumps produced an empty slice.

Fix this by setting `end_line = i` so the slice includes all data lines up to the end delimiter.

### Related Work

<!--
Link here any open PRs that this work depends on or which it will conflict with.
-->

N/A


### PR Checklist

<!--
Finally, review and mark prerequisites appropriately:
-->

 - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.uk`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.uk) on your commit series before opening this PR;
 - [x] Updated relevant documentation.
